### PR TITLE
Adds an option to disable the movement check.

### DIFF
--- a/connector/src/main/java/org/geysermc/connector/configuration/GeyserConfiguration.java
+++ b/connector/src/main/java/org/geysermc/connector/configuration/GeyserConfiguration.java
@@ -54,5 +54,9 @@ public class GeyserConfiguration {
     @JsonProperty("allow-third-party-capes")
     private boolean allowThirdPartyCapes;
 
+    @JsonProperty("movement-check")
+    private boolean movementCheck;
+
     private MetricInfo metrics;
+
 }

--- a/connector/src/main/java/org/geysermc/connector/network/translators/bedrock/BedrockMovePlayerTranslator.java
+++ b/connector/src/main/java/org/geysermc/connector/network/translators/bedrock/BedrockMovePlayerTranslator.java
@@ -31,6 +31,8 @@ import com.nukkitx.math.vector.Vector3f;
 import com.nukkitx.protocol.bedrock.packet.MoveEntityAbsolutePacket;
 import com.nukkitx.protocol.bedrock.packet.MovePlayerPacket;
 import com.nukkitx.protocol.bedrock.packet.SetEntityDataPacket;
+import org.geysermc.api.Geyser;
+import org.geysermc.connector.GeyserConnector;
 import org.geysermc.connector.entity.Entity;
 import org.geysermc.connector.entity.PlayerEntity;
 import org.geysermc.connector.entity.type.EntityType;
@@ -38,7 +40,9 @@ import org.geysermc.connector.network.session.GeyserSession;
 import org.geysermc.connector.network.translators.PacketTranslator;
 import org.geysermc.connector.network.translators.block.BlockEntry;
 
+
 public class BedrockMovePlayerTranslator extends PacketTranslator<MovePlayerPacket> {
+
     @Override
     public void translate(MovePlayerPacket packet, GeyserSession session) {
         PlayerEntity entity = session.getPlayerEntity();
@@ -55,11 +59,12 @@ public class BedrockMovePlayerTranslator extends PacketTranslator<MovePlayerPack
             session.getUpstream().sendPacketImmediately(moveEntityBack);
             return;
         }
-
-        if (!isValidMove(session, packet.getMode(), entity.getPosition(), packet.getPosition())) {
-            session.getConnector().getLogger().info("Recalculating position...");
-            recalculatePosition(session, entity, entity.getPosition());
-            return;
+        if (((GeyserConnector)Geyser.getConnector()).getConfig().isMovementCheck()) {
+            if (!isValidMove(session, packet.getMode(), entity.getPosition(), packet.getPosition())) {
+                session.getConnector().getLogger().info("Recalculating position...");
+                recalculatePosition(session, entity, entity.getPosition());
+                return;
+            }
         }
 
         double javaY = packet.getPosition().getY() - EntityType.PLAYER.getOffset();

--- a/connector/src/main/java/org/geysermc/connector/network/translators/bedrock/BedrockMovePlayerTranslator.java
+++ b/connector/src/main/java/org/geysermc/connector/network/translators/bedrock/BedrockMovePlayerTranslator.java
@@ -59,7 +59,7 @@ public class BedrockMovePlayerTranslator extends PacketTranslator<MovePlayerPack
             session.getUpstream().sendPacketImmediately(moveEntityBack);
             return;
         }
-        if (((GeyserConnector)Geyser.getConnector()).getConfig().isMovementCheck()) {
+        if (session.getConnector().getConfig().isMovementCheck()) {
             if (!isValidMove(session, packet.getMode(), entity.getPosition(), packet.getPosition())) {
                 session.getConnector().getLogger().info("Recalculating position...");
                 recalculatePosition(session, entity, entity.getPosition());

--- a/connector/src/main/resources/config.yml
+++ b/connector/src/main/resources/config.yml
@@ -53,6 +53,10 @@ general-thread-pool: 32
 # OptiFine capes, LabyMod capes, 5Zig capes and MinecraftCapes
 allow-third-party-capes: true
 
+# If Geyser should verify player movement speed. Default: true
+# Disabling this might cause issues with players being thrown in the air while logging in.
+movement-check: true
+
 # bStats is a stat tracker that is entirely anonymous and tracks only basic information
 # about Geyser, such as how many people are online, how many servers are using Geyser,
 # what OS is being used, etc. You can learn more about bStats here: https://bstats.org/.


### PR DESCRIPTION
Adds an option to disable the movement-checking, as the java server has movement checking on its own and its redundant. Defaults to true (movement-check enabled), so nothing changes if you do not edit the config.

Literally my first java code, probably ugly D: