### PR TITLE
Exclude original jars

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -15,7 +15,7 @@ pipeline {
             }
             post {
                 success {
-                    archiveArtifacts artifacts: 'target/*.jar, bootstrap/bukkit/target/*.jar, bootstrap/bungeecord/target/*.jar, bootstrap/sponge/target/*.jar, bootstrap/standalone/target/*.jar, bootstrap/velocity/target/*.jar', fingerprint: true
+                    archiveArtifacts artifacts: 'bootstrap/**/target/*.jar', excludes: 'bootstrap/**/target/original-*.jar', fingerprint: true
                 }
             }
         }


### PR DESCRIPTION
Exclude original jars from Jenkins archiving. Many new users have not been sure which jar to download so it's in our best interest to remove them since they are useless.