### PR TITLE
Add switch for dealing with ChatColor.NONE

### DIFF
--- a/connector/src/main/java/org/geysermc/connector/utils/MessageUtils.java
+++ b/connector/src/main/java/org/geysermc/connector/utils/MessageUtils.java
@@ -154,6 +154,7 @@ public class MessageUtils {
                 base += "f";
                 break;
             case RESET:
+            case NONE:
                 base += "r";
                 break;
             default:


### PR DESCRIPTION
In-game chat uses ChatColor.NONE for handling reset of text. This pull requests assigns it to the same case as RESET. 
Fixes #224. 