### PR TITLE
Implement bed colors

### DIFF
--- a/connector/pom.xml
+++ b/connector/pom.xml
@@ -49,6 +49,12 @@
             <scope>compile</scope>
         </dependency>
         <dependency>
+            <groupId>com.nukkitx.fastutil</groupId>
+            <artifactId>fastutil-object-byte-maps</artifactId>
+            <version>8.3.1</version>
+            <scope>compile</scope>
+        </dependency>
+        <dependency>
             <groupId>com.github.steveice10</groupId>
             <artifactId>opennbt</artifactId>
             <version>1.4-SNAPSHOT</version>

--- a/connector/src/main/java/org/geysermc/connector/network/translators/block/BlockTranslator.java
+++ b/connector/src/main/java/org/geysermc/connector/network/translators/block/BlockTranslator.java
@@ -105,46 +105,11 @@ public class BlockTranslator {
 
             // If the Java ID is bed, signal that it needs a tag to show color
             // The color is in the namespace ID in Java Edition but it's a tag in Bedrock.
-            byte bedcolor = -1;
-            if (javaId.contains("_bed[")) {
-                if (javaId.contains("minecraft:white")) {
-                    bedcolor = 0;
-                } else if (javaId.contains("minecraft:orange")) {
-                    bedcolor = 1;
-                } else if (javaId.contains("minecraft:magenta")) {
-                    bedcolor = 2;
-                } else if (javaId.contains("minecraft:light_blue")) {
-                    bedcolor = 3;
-                } else if (javaId.contains("minecraft:yellow")) {
-                    bedcolor = 4;
-                } else if (javaId.contains("minecraft:lime")) {
-                    bedcolor = 5;
-                } else if (javaId.contains("minecraft:pink")) {
-                    bedcolor = 6;
-                } else if (javaId.contains("minecraft:gray")) {
-                    bedcolor = 7;
-                } else if (javaId.contains("minecraft:light_gray")) {
-                    bedcolor = 8;
-                } else if (javaId.contains("minecraft:cyan")) {
-                    bedcolor = 9;
-                } else if (javaId.contains("minecraft:purple")) {
-                    bedcolor = 10;
-                } else if (javaId.contains("minecraft:blue")) {
-                    bedcolor = 11;
-                } else if (javaId.contains("minecraft:brown")) {
-                    bedcolor = 12;
-                } else if (javaId.contains("minecraft:green")) {
-                    bedcolor = 13;
-                } else if (javaId.contains("minecraft:red")) {
-                    bedcolor = 14;
-                } else if (javaId.contains("minecraft:black")) {
-                    bedcolor = 15;
-                }
-
-            }
-            // -1 is used throughout the code to indicate no bed color.
-            if (bedcolor > -1) {
-                BEDCOLORS.put(javaBlockState, bedcolor);
+            JsonNode bedColor = entry.getValue().get("bed_color");
+            if (bedColor != null) {
+                System.out.println(bedColor.intValue());
+                // Converting to byte because the final tag value is a byte. bedColor.binaryValue() returns an array
+                BEDCOLORS.put(javaBlockState, (byte) bedColor.intValue());
             }
 
             if ("minecraft:water[level=0]".equals(javaId)) {

--- a/connector/src/main/java/org/geysermc/connector/network/translators/block/BlockTranslator.java
+++ b/connector/src/main/java/org/geysermc/connector/network/translators/block/BlockTranslator.java
@@ -50,6 +50,7 @@ public class BlockTranslator {
     private static final Int2ObjectMap<BlockState> BEDROCK_TO_JAVA_BLOCK_MAP = new Int2ObjectOpenHashMap<>();
     private static final Map<String, BlockState> JAVA_ID_BLOCK_MAP = new HashMap<>();
     private static final IntSet WATERLOGGED = new IntOpenHashSet();
+    private static final Map<BlockState, Byte> BEDCOLORS = new HashMap<>();
 
     private static final Map<BlockState, String> JAVA_ID_TO_BLOCK_ENTITY_MAP = new HashMap<>();
 
@@ -99,6 +100,50 @@ public class BlockTranslator {
 
             if (javaId.contains("sign[")) {
                 JAVA_ID_TO_BLOCK_ENTITY_MAP.put(javaBlockState, javaId);
+            }
+
+            // If the Java ID is bed, signal that it needs a tag to show color
+            // The color is in the namespace ID in Java Edition but it's a tag in Bedrock.
+            byte bedcolor = -1;
+            if (javaId.contains("_bed[")) {
+                if (javaId.contains("minecraft:white")) {
+                    bedcolor = 0;
+                } else if (javaId.contains("minecraft:orange")) {
+                    bedcolor = 1;
+                } else if (javaId.contains("minecraft:magenta")) {
+                    bedcolor = 2;
+                } else if (javaId.contains("minecraft:light_blue")) {
+                    bedcolor = 3;
+                } else if (javaId.contains("minecraft:yellow")) {
+                    bedcolor = 4;
+                } else if (javaId.contains("minecraft:lime")) {
+                    bedcolor = 5;
+                } else if (javaId.contains("minecraft:pink")) {
+                    bedcolor = 6;
+                } else if (javaId.contains("minecraft:gray")) {
+                    bedcolor = 7;
+                } else if (javaId.contains("minecraft:light_gray")) {
+                    bedcolor = 8;
+                } else if (javaId.contains("minecraft:cyan")) {
+                    bedcolor = 9;
+                } else if (javaId.contains("minecraft:purple")) {
+                    bedcolor = 10;
+                } else if (javaId.contains("minecraft:blue")) {
+                    bedcolor = 11;
+                } else if (javaId.contains("minecraft:brown")) {
+                    bedcolor = 12;
+                } else if (javaId.contains("minecraft:green")) {
+                    bedcolor = 13;
+                } else if (javaId.contains("minecraft:red")) {
+                    bedcolor = 14;
+                } else if (javaId.contains("minecraft:black")) {
+                    bedcolor = 15;
+                }
+
+            }
+            // -1 is used throughout the code to indicate no bed color.
+            if (bedcolor > -1) {
+                BEDCOLORS.put(javaBlockState, bedcolor);
             }
 
             if ("minecraft:water[level=0]".equals(javaId)) {
@@ -195,6 +240,13 @@ public class BlockTranslator {
 
     public static boolean isWaterlogged(BlockState state) {
         return WATERLOGGED.contains(state.getId());
+    }
+
+    public static byte getBedColor(BlockState state) {
+        if (BEDCOLORS.containsKey(state)) {
+            return BEDCOLORS.get(state);
+        }
+        return -1;
     }
 
     public static BlockState getJavaWaterloggedState(int bedrockId) {

--- a/connector/src/main/java/org/geysermc/connector/network/translators/block/BlockTranslator.java
+++ b/connector/src/main/java/org/geysermc/connector/network/translators/block/BlockTranslator.java
@@ -107,7 +107,6 @@ public class BlockTranslator {
             // The color is in the namespace ID in Java Edition but it's a tag in Bedrock.
             JsonNode bedColor = entry.getValue().get("bed_color");
             if (bedColor != null) {
-                System.out.println(bedColor.intValue());
                 // Converting to byte because the final tag value is a byte. bedColor.binaryValue() returns an array
                 BEDCOLORS.put(javaBlockState, (byte) bedColor.intValue());
             }

--- a/connector/src/main/java/org/geysermc/connector/network/translators/block/BlockTranslator.java
+++ b/connector/src/main/java/org/geysermc/connector/network/translators/block/BlockTranslator.java
@@ -35,6 +35,7 @@ import com.nukkitx.nbt.tag.ListTag;
 import gnu.trove.map.TObjectIntMap;
 import gnu.trove.map.hash.TObjectIntHashMap;
 import it.unimi.dsi.fastutil.ints.*;
+import it.unimi.dsi.fastutil.objects.*;
 import org.geysermc.connector.GeyserConnector;
 import org.geysermc.connector.utils.Toolbox;
 
@@ -50,7 +51,7 @@ public class BlockTranslator {
     private static final Int2ObjectMap<BlockState> BEDROCK_TO_JAVA_BLOCK_MAP = new Int2ObjectOpenHashMap<>();
     private static final Map<String, BlockState> JAVA_ID_BLOCK_MAP = new HashMap<>();
     private static final IntSet WATERLOGGED = new IntOpenHashSet();
-    private static final Map<BlockState, Byte> BEDCOLORS = new HashMap<>();
+    private static final Object2ByteOpenHashMap<BlockState> BEDCOLORS = new Object2ByteOpenHashMap<>();
 
     private static final Map<BlockState, String> JAVA_ID_TO_BLOCK_ENTITY_MAP = new HashMap<>();
 
@@ -244,7 +245,7 @@ public class BlockTranslator {
 
     public static byte getBedColor(BlockState state) {
         if (BEDCOLORS.containsKey(state)) {
-            return BEDCOLORS.get(state);
+            return BEDCOLORS.getByte(state);
         }
         return -1;
     }

--- a/connector/src/main/java/org/geysermc/connector/network/translators/block/BlockTranslator.java
+++ b/connector/src/main/java/org/geysermc/connector/network/translators/block/BlockTranslator.java
@@ -51,7 +51,7 @@ public class BlockTranslator {
     private static final Int2ObjectMap<BlockState> BEDROCK_TO_JAVA_BLOCK_MAP = new Int2ObjectOpenHashMap<>();
     private static final Map<String, BlockState> JAVA_ID_BLOCK_MAP = new HashMap<>();
     private static final IntSet WATERLOGGED = new IntOpenHashSet();
-    private static final Object2ByteOpenHashMap<BlockState> BEDCOLORS = new Object2ByteOpenHashMap<>();
+    private static final Object2ByteOpenHashMap<BlockState> BED_COLORS = new Object2ByteOpenHashMap<>();
 
     private static final Map<BlockState, String> JAVA_ID_TO_BLOCK_ENTITY_MAP = new HashMap<>();
 
@@ -108,7 +108,7 @@ public class BlockTranslator {
             JsonNode bedColor = entry.getValue().get("bed_color");
             if (bedColor != null) {
                 // Converting to byte because the final tag value is a byte. bedColor.binaryValue() returns an array
-                BEDCOLORS.put(javaBlockState, (byte) bedColor.intValue());
+                BED_COLORS.put(javaBlockState, (byte) bedColor.intValue());
             }
 
             if ("minecraft:water[level=0]".equals(javaId)) {
@@ -208,8 +208,8 @@ public class BlockTranslator {
     }
 
     public static byte getBedColor(BlockState state) {
-        if (BEDCOLORS.containsKey(state)) {
-            return BEDCOLORS.getByte(state);
+        if (BED_COLORS.containsKey(state)) {
+            return BED_COLORS.getByte(state);
         }
         return -1;
     }

--- a/connector/src/main/java/org/geysermc/connector/network/translators/block/entity/BedBlockEntityTranslator.java
+++ b/connector/src/main/java/org/geysermc/connector/network/translators/block/entity/BedBlockEntityTranslator.java
@@ -1,0 +1,41 @@
+package org.geysermc.connector.network.translators.block.entity;
+
+import com.github.steveice10.mc.protocol.data.game.entity.metadata.Position;
+import com.github.steveice10.mc.protocol.data.game.world.block.BlockState;
+import com.nukkitx.math.vector.Vector3i;
+import com.nukkitx.nbt.CompoundTagBuilder;
+import org.geysermc.connector.network.session.GeyserSession;
+import org.geysermc.connector.network.translators.block.BlockTranslator;
+import org.geysermc.connector.utils.BlockEntityUtils;
+
+import java.util.concurrent.TimeUnit;
+
+public class BedBlockEntityTranslator {
+
+    public static void checkForBedColor(GeyserSession session, BlockState blockState, Vector3i position) {
+        byte bedcolor = BlockTranslator.getBedColor(blockState);
+        // If Bed Color is not -1 then it is indeed a bed with a color.
+        if (bedcolor > -1) {
+            Position pos = new Position(position.getX(), position.getY(), position.getZ());
+            com.nukkitx.nbt.tag.CompoundTag finalbedTag = getBedTag(bedcolor, pos);
+            // Delay needed, otherwise newly placed beds will not get their color
+            // Delay is not needed for beds already placed on login
+            session.getConnector().getGeneralThreadPool().schedule(() ->
+                            BlockEntityUtils.updateBlockEntity(session, finalbedTag, pos),
+                    500,
+                    TimeUnit.MILLISECONDS
+            );
+        }
+    }
+
+    public static com.nukkitx.nbt.tag.CompoundTag getBedTag(byte bedcolor, Position pos) {
+        CompoundTagBuilder tagBuilder = CompoundTagBuilder.builder()
+                .intTag("x", pos.getX())
+                .intTag("y", pos.getY())
+                .intTag("z", pos.getZ())
+                .stringTag("id", "Bed");
+        tagBuilder.byteTag("color", bedcolor);
+        return tagBuilder.buildRootTag();
+    }
+
+}

--- a/connector/src/main/java/org/geysermc/connector/network/translators/java/world/JavaChunkDataTranslator.java
+++ b/connector/src/main/java/org/geysermc/connector/network/translators/java/world/JavaChunkDataTranslator.java
@@ -105,7 +105,16 @@ public class JavaChunkDataTranslator extends PacketTranslator<ServerChunkDataPac
 
                         ChunkUtils.updateBlock(session, new BlockState(blockEntityEntry.getIntKey()), new Position(x, y, z));
                     }
+
+                    for (Int2ObjectMap.Entry<CompoundTag> blockEntityEntry: chunkData.beds.int2ObjectEntrySet()) {
+                        int x = blockEntityEntry.getValue().getInt("x");
+                        int y = blockEntityEntry.getValue().getInt("y");
+                        int z = blockEntityEntry.getValue().getInt("z");
+
+                        ChunkUtils.updateBlock(session, new BlockState(blockEntityEntry.getIntKey()), new Position(x, y, z));
+                    }
                     chunkData.signs.clear();
+                    chunkData.beds.clear();
                 } else {
                     final int xOffset = packet.getColumn().getX() << 4;
                     final int zOffset = packet.getColumn().getZ() << 4;

--- a/connector/src/main/java/org/geysermc/connector/utils/ChunkUtils.java
+++ b/connector/src/main/java/org/geysermc/connector/utils/ChunkUtils.java
@@ -83,7 +83,6 @@ public class ChunkUtils {
                         if (BlockTranslator.isWaterlogged(blockState)) {
                             section.getBlockStorageArray()[1].setFullBlock(ChunkSection.blockPosition(x, y, z), BEDROCK_WATER_ID);
                         }
-
                     }
                 }
             }
@@ -137,7 +136,6 @@ public class ChunkUtils {
         // Since Java stores bed colors as part of the namespaced ID and Bedrock stores it as a tag
         // This is the only place I could find that interacts with the Java block state and block updates
         BedBlockEntityTranslator.checkForBedColor(session, blockState, position);
-
     }
 
     public static void sendEmptyChunks(GeyserSession session, Vector3i position, int radius, boolean forceUpdate) {


### PR DESCRIPTION
Java Edition includes the bed color in the namespaced ID; in Bedrock edition it's one of the tag values as a block entity. This code involves creating a table between block states and bed color numbers and looking that up on chunk load or block update.

Do note that the color update is not instant when placing a new bed; this is unavoidable in the current code, otherwise the block update will not be received by the client in time.

Fixes #222.