### PR TITLE
Added java -> bedrock lang conversions

### DIFF
--- a/connector/src/main/java/org/geysermc/connector/network/translators/java/JavaChatTranslator.java
+++ b/connector/src/main/java/org/geysermc/connector/network/translators/java/JavaChatTranslator.java
@@ -62,7 +62,7 @@ public class JavaChatTranslator extends PacketTranslator<ServerChatPacket> {
             textPacket.setType(TextPacket.Type.TRANSLATION);
             textPacket.setNeedsTranslation(true);
             textPacket.setParameters(MessageUtils.getTranslationParams(((TranslationMessage) packet.getMessage()).getTranslationParams()));
-            textPacket.setMessage(MessageUtils.getBedrockMessage(packet.getMessage()));
+            textPacket.setMessage(MessageUtils.getBedrockMessageWithTranslate(packet.getMessage(), true));
         } else {
             textPacket.setNeedsTranslation(false);
             textPacket.setMessage(MessageUtils.getBedrockMessage(packet.getMessage()));

--- a/connector/src/main/java/org/geysermc/connector/utils/MessageUtils.java
+++ b/connector/src/main/java/org/geysermc/connector/utils/MessageUtils.java
@@ -25,6 +25,7 @@
 
 package org.geysermc.connector.utils;
 
+import com.fasterxml.jackson.databind.JsonNode;
 import com.github.steveice10.mc.protocol.data.game.scoreboard.TeamColor;
 import com.github.steveice10.mc.protocol.data.message.ChatColor;
 import com.github.steveice10.mc.protocol.data.message.ChatFormat;
@@ -36,11 +37,28 @@ import com.google.gson.JsonObject;
 import com.google.gson.JsonParser;
 import com.google.gson.JsonPrimitive;
 
-import java.util.ArrayList;
-import java.util.Collections;
-import java.util.List;
+import java.io.InputStream;
+import java.util.*;
 
 public class MessageUtils {
+    private static final HashMap<String, String> LANG_MAPPINGS = new HashMap<>();
+
+    static {
+        /* Load the language mappings */
+        InputStream stream = Toolbox.getResource("mappings/lang.json");
+        JsonNode lang;
+        try {
+            lang = Toolbox.JSON_MAPPER.readTree(stream);
+        } catch (Exception e) {
+            throw new AssertionError("Unable to load Java lang mappings", e);
+        }
+
+        Iterator<Map.Entry<String, JsonNode>> langIterator = lang.fields();
+        while (langIterator.hasNext()) {
+            Map.Entry<String, JsonNode> entry = langIterator.next();
+            LANG_MAPPINGS.put(entry.getKey(), entry.getValue().asText());
+        }
+    }
 
     public static List<String> getTranslationParams(Message[] messages) {
         List<String> strings = new ArrayList<>();
@@ -100,33 +118,7 @@ public class MessageUtils {
     }
 
     private static String getLangConversion(String messageText) {
-        switch (messageText)  {
-            case "block.minecraft.bed.occupied":
-                return "tile.bed.occupied";
-            case "block.minecraft.bed.too_far_away":
-                return "tile.bed.tooFar";
-            case "block.minecraft.bed.not_safe":
-                return "tile.bed.notSafe";
-            case "block.minecraft.bed.no_sleep":
-                return "tile.bed.noSleep";
-            case "block.minecraft.bed.not_valid":
-                return "tile.bed.notValid";
-            case "block.minecraft.bed.set_spawn":
-                return "tile.bed.respawnSet";
-
-            case "chat.type.advancement.task":
-            case "chat.type.advancement.challenge":
-            case "chat.type.advancement.goal":
-                return "chat.type.achievement";
-
-            case "commands.teleport.success.entity.single":
-                return "commands.tp.success";
-            case "commands.teleport.success.location.single":
-                return "commands.tp.success.coordinates";
-
-            default:
-                return messageText;
-        }
+        return LANG_MAPPINGS.getOrDefault(messageText, messageText);
     }
 
     public static String getBedrockMessage(Message message) {

--- a/connector/src/main/java/org/geysermc/connector/utils/MessageUtils.java
+++ b/connector/src/main/java/org/geysermc/connector/utils/MessageUtils.java
@@ -115,7 +115,14 @@ public class MessageUtils {
                 return "tile.bed.respawnSet";
 
             case "chat.type.advancement.task":
+            case "chat.type.advancement.challenge":
+            case "chat.type.advancement.goal":
                 return "chat.type.achievement";
+
+            case "commands.teleport.success.entity.single":
+                return "commands.tp.success";
+            case "commands.teleport.success.location.single":
+                return "commands.tp.success.coordinates";
 
             default:
                 return messageText;

--- a/connector/src/main/java/org/geysermc/connector/utils/MessageUtils.java
+++ b/connector/src/main/java/org/geysermc/connector/utils/MessageUtils.java
@@ -76,14 +76,19 @@ public class MessageUtils {
                 + "%" + message.getTranslationKey();
     }
 
-    public static String getBedrockMessage(Message message) {
+    public static String getBedrockMessageWithTranslate(Message message, boolean convertLangStrings) {
         JsonParser parser = new JsonParser();
         if (isMessage(message.getText())) {
             JsonObject object = parser.parse(message.getText()).getAsJsonObject();
             message = Message.fromJson(formatJson(object));
         }
 
-        StringBuilder builder = new StringBuilder(message.getText());
+        String messageText = message.getText();
+        if (convertLangStrings) {
+            messageText = getLangConversion(messageText);
+        }
+
+        StringBuilder builder = new StringBuilder(messageText);
         for (Message msg : message.getExtra()) {
             builder.append(getFormat(msg.getStyle().getFormats()));
             builder.append(getColor(msg.getStyle().getColor()));
@@ -92,6 +97,33 @@ public class MessageUtils {
             }
         }
         return builder.toString();
+    }
+
+    private static String getLangConversion(String messageText) {
+        switch (messageText)  {
+            case "block.minecraft.bed.occupied":
+                return "tile.bed.occupied";
+            case "block.minecraft.bed.too_far_away":
+                return "tile.bed.tooFar";
+            case "block.minecraft.bed.not_safe":
+                return "tile.bed.notSafe";
+            case "block.minecraft.bed.no_sleep":
+                return "tile.bed.noSleep";
+            case "block.minecraft.bed.not_valid":
+                return "tile.bed.notValid";
+            case "block.minecraft.bed.set_spawn":
+                return "tile.bed.respawnSet";
+
+            case "chat.type.advancement.task":
+                return "chat.type.achievement";
+
+            default:
+                return messageText;
+        }
+    }
+
+    public static String getBedrockMessage(Message message) {
+        return getBedrockMessageWithTranslate(message, false);
     }
 
     private static String getColor(ChatColor color) {


### PR DESCRIPTION
Made a few modifications to allow us to map language strings seen in chat from java edition to bedrock edition so we get nicer messages.

Only done a few at the moment, any more string noticed are welcome.

Mappings PR: https://github.com/GeyserMC/mappings/pull/7

Edit:
Working on a new locale conversion using the native Minecraft locale files based on the client's request. https://github.com/GeyserMC/Geyser/pull/270