### PR TITLE
Kick the user on incorrect login info

### DIFF
--- a/connector/src/main/java/org/geysermc/connector/network/session/GeyserSession.java
+++ b/connector/src/main/java/org/geysermc/connector/network/session/GeyserSession.java
@@ -26,6 +26,7 @@
 package org.geysermc.connector.network.session;
 
 import com.github.steveice10.mc.auth.data.GameProfile;
+import com.github.steveice10.mc.auth.exception.request.InvalidCredentialsException;
 import com.github.steveice10.mc.auth.exception.request.RequestException;
 import com.github.steveice10.mc.protocol.MinecraftProtocol;
 import com.github.steveice10.mc.protocol.data.game.entity.player.GameMode;
@@ -281,6 +282,9 @@ public class GeyserSession implements CommandSender {
 
                 downstream.getSession().connect();
                 connector.addPlayer(this);
+            } catch (InvalidCredentialsException e) {
+                connector.getLogger().info("User '" + username + "' entered invalid login info, kicking.");
+                disconnect("Invalid/incorrect login info");
             } catch (RequestException ex) {
                 ex.printStackTrace();
             }


### PR DESCRIPTION
Kicks the user if an InvalidCredentialsException happens when logging into the sent mojang accounts.

Fixes: https://github.com/GeyserMC/Geyser/issues/221