### PR TITLE
Kick players on shutdown and fix window not closing on standalone

### DIFF
--- a/bootstrap/standalone/src/main/java/org/geysermc/platform/standalone/console/GeyserLogger.java
+++ b/bootstrap/standalone/src/main/java/org/geysermc/platform/standalone/console/GeyserLogger.java
@@ -52,7 +52,7 @@ public class GeyserLogger extends SimpleTerminalConsole implements IGeyserLogger
 
     @Override
     protected void shutdown() {
-        GeyserConnector.getInstance().shutdown();
+        GeyserConnector.getInstance().getBootstrap().onDisable();
     }
 
     @Override

--- a/connector/src/main/java/org/geysermc/connector/GeyserConnector.java
+++ b/connector/src/main/java/org/geysermc/connector/GeyserConnector.java
@@ -143,7 +143,7 @@ public class GeyserConnector {
         shuttingDown = true;
 
         if (players.size() >= 1) {
-            bootstrap.getGeyserLogger().info("Kicking " + (players.size() / 3) + " player(s)");
+            bootstrap.getGeyserLogger().info("Kicking " + players.size() + " player(s)");
 
             for (GeyserSession playerSession : players.values()) {
                 playerSession.disconnect("Geyser Proxy shutting down.");

--- a/connector/src/main/java/org/geysermc/connector/GeyserConnector.java
+++ b/connector/src/main/java/org/geysermc/connector/GeyserConnector.java
@@ -143,7 +143,7 @@ public class GeyserConnector {
         shuttingDown = true;
 
         if (players.size() >= 1) {
-            bootstrap.getGeyserLogger().info("Kicking " + (players.size() / 3) + " players");
+            bootstrap.getGeyserLogger().info("Kicking " + (players.size() / 3) + " player(s)");
 
             for (GeyserSession playerSession : players.values()) {
                 playerSession.disconnect("Geyser Proxy shutting down.");

--- a/connector/src/main/java/org/geysermc/connector/GeyserConnector.java
+++ b/connector/src/main/java/org/geysermc/connector/GeyserConnector.java
@@ -143,7 +143,7 @@ public class GeyserConnector {
         shuttingDown = true;
 
         if (players.size() >= 1) {
-            bootstrap.getGeyserLogger().info("Kicking " + players.size() + " players");
+            bootstrap.getGeyserLogger().info("Kicking " + (players.size() / 3) + " players");
 
             for (GeyserSession playerSession : players.values()) {
                 playerSession.disconnect("Geyser Proxy shutting down.");
@@ -155,7 +155,6 @@ public class GeyserConnector {
                     // Simulate a long-running Job
                     try {
                         while (true) {
-                            bootstrap.getGeyserLogger().info("Current entries: " + players.size());
                             if (players.size() == 0) {
                                 return;
                             }

--- a/connector/src/main/java/org/geysermc/connector/command/defaults/StopCommand.java
+++ b/connector/src/main/java/org/geysermc/connector/command/defaults/StopCommand.java
@@ -48,6 +48,11 @@ public class StopCommand extends GeyserCommand {
         if (!sender.isConsole() && connector.getPlatformType() == PlatformType.STANDALONE) {
             return;
         }
+
         connector.shutdown();
+
+        if (connector.getPlatformType() == PlatformType.STANDALONE) {
+            System.exit(0);
+        }
     }
 }


### PR DESCRIPTION
Kick the players when the server is shutting down and closes the server window on standalone when using `/geyser shutdown`

Fixes https://github.com/GeyserMC/Geyser/issues/253