### PR TITLE
Fixed non-ping passthrough player count being multiplied by 3

### DIFF
--- a/connector/src/main/java/org/geysermc/connector/network/ConnectorServerEventHandler.java
+++ b/connector/src/main/java/org/geysermc/connector/network/ConnectorServerEventHandler.java
@@ -75,7 +75,7 @@ public class ConnectorServerEventHandler implements BedrockServerEventHandler {
             pong.setPlayerCount(serverInfo.getPlayerInfo().getOnlinePlayers());
             pong.setMaximumPlayerCount(serverInfo.getPlayerInfo().getMaxPlayers());
         } else {
-            pong.setPlayerCount(connector.getPlayers().size());
+            pong.setPlayerCount(connector.getPlayers().size() / 3);
             pong.setMaximumPlayerCount(config.getMaxPlayers());
             pong.setMotd(config.getBedrock().getMotd1());
             pong.setMotd(config.getBedrock().getMotd2());


### PR DESCRIPTION
If ping passthrough is disabled on the Geyser config then the player count is no longer multiplied by 3.