### PR TITLE
Fix trader llamas not appearing; add llama metadata

### DIFF
--- a/connector/src/main/java/org/geysermc/connector/entity/living/animal/horse/LlamaEntity.java
+++ b/connector/src/main/java/org/geysermc/connector/entity/living/animal/horse/LlamaEntity.java
@@ -48,7 +48,7 @@ public class LlamaEntity extends ChestedHorseEntity {
             metadata.put(EntityData.STRENGTH, entityMetadata.getValue());
         }
         // Color of the llama
-        else if (entityMetadata.getId() == 21) {
+        if (entityMetadata.getId() == 21) {
             metadata.put(EntityData.VARIANT, entityMetadata.getValue());
         }
         super.updateBedrockMetadata(entityMetadata, session);

--- a/connector/src/main/java/org/geysermc/connector/entity/living/animal/horse/LlamaEntity.java
+++ b/connector/src/main/java/org/geysermc/connector/entity/living/animal/horse/LlamaEntity.java
@@ -25,12 +25,32 @@
 
 package org.geysermc.connector.entity.living.animal.horse;
 
+import com.github.steveice10.mc.protocol.data.game.entity.metadata.EntityMetadata;
+import com.github.steveice10.mc.protocol.data.game.world.block.BlockState;
 import com.nukkitx.math.vector.Vector3f;
+import com.nukkitx.protocol.bedrock.data.EntityData;
+import com.nukkitx.protocol.bedrock.data.ItemData;
+import com.nukkitx.protocol.bedrock.packet.MobArmorEquipmentPacket;
 import org.geysermc.connector.entity.type.EntityType;
+import org.geysermc.connector.network.session.GeyserSession;
+import org.geysermc.connector.network.translators.block.BlockTranslator;
 
 public class LlamaEntity extends ChestedHorseEntity {
 
     public LlamaEntity(long entityId, long geyserId, EntityType entityType, Vector3f position, Vector3f motion, Vector3f rotation) {
         super(entityId, geyserId, entityType, position, motion, rotation);
+    }
+
+    @Override
+    public void updateBedrockMetadata(EntityMetadata entityMetadata, GeyserSession session) {
+        // Strength
+        if (entityMetadata.getId() == 19) {
+            metadata.put(EntityData.STRENGTH, entityMetadata.getValue());
+        }
+        // Color of the llama
+        else if (entityMetadata.getId() == 21) {
+            metadata.put(EntityData.VARIANT, entityMetadata.getValue());
+        }
+        super.updateBedrockMetadata(entityMetadata, session);
     }
 }

--- a/connector/src/main/java/org/geysermc/connector/entity/living/animal/horse/TraderLlamaEntity.java
+++ b/connector/src/main/java/org/geysermc/connector/entity/living/animal/horse/TraderLlamaEntity.java
@@ -1,0 +1,36 @@
+package org.geysermc.connector.entity.living.animal.horse;
+
+import com.nukkitx.math.vector.Vector3f;
+import com.nukkitx.protocol.bedrock.data.EntityData;
+import com.nukkitx.protocol.bedrock.packet.AddEntityPacket;
+import org.geysermc.connector.entity.type.EntityType;
+import org.geysermc.connector.network.session.GeyserSession;
+
+public class TraderLlamaEntity extends LlamaEntity {
+
+    public TraderLlamaEntity(long entityId, long geyserId, EntityType entityType, Vector3f position, Vector3f motion, Vector3f rotation) {
+        super(entityId, geyserId, entityType, position, motion, rotation);
+    }
+
+    @Override
+    public void spawnEntity(GeyserSession session) {
+        // The trader llama is a separate entity from the llama in Java but a normal llama with extra metadata in Bedrock.
+        AddEntityPacket addEntityPacket = new AddEntityPacket();
+        addEntityPacket.setIdentifier("minecraft:llama");
+        addEntityPacket.setRuntimeEntityId(geyserId);
+        addEntityPacket.setUniqueEntityId(geyserId);
+        addEntityPacket.setPosition(position);
+        addEntityPacket.setMotion(motion);
+        addEntityPacket.setRotation(getBedrockRotation());
+        addEntityPacket.setEntityType(entityType.getType());
+        addEntityPacket.getMetadata().putAll(metadata);
+        // Here's the difference
+        addEntityPacket.getMetadata().put(EntityData.MARK_VARIANT, 1);
+
+        valid = true;
+        session.getUpstream().sendPacket(addEntityPacket);
+
+        session.getConnector().getLogger().debug("Spawned entity " + entityType + " at location " + position + " with id " + geyserId + " (java id " + entityId + ")");
+    }
+
+}

--- a/connector/src/main/java/org/geysermc/connector/entity/living/animal/horse/TraderLlamaEntity.java
+++ b/connector/src/main/java/org/geysermc/connector/entity/living/animal/horse/TraderLlamaEntity.java
@@ -1,3 +1,28 @@
+/*
+ * Copyright (c) 2019-2020 GeyserMC. http://geysermc.org
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ *
+ * @author GeyserMC
+ * @link https://github.com/GeyserMC/Geyser
+ */
+
 package org.geysermc.connector.entity.living.animal.horse;
 
 import com.nukkitx.math.vector.Vector3f;

--- a/connector/src/main/java/org/geysermc/connector/entity/type/EntityType.java
+++ b/connector/src/main/java/org/geysermc/connector/entity/type/EntityType.java
@@ -31,10 +31,7 @@ import org.geysermc.connector.entity.living.*;
 import org.geysermc.connector.entity.living.animal.*;
 import org.geysermc.connector.entity.living.animal.tameable.CatEntity;
 import org.geysermc.connector.entity.living.animal.tameable.TameableEntity;
-import org.geysermc.connector.entity.living.animal.horse.AbstractHorseEntity;
-import org.geysermc.connector.entity.living.animal.horse.ChestedHorseEntity;
-import org.geysermc.connector.entity.living.animal.horse.HorseEntity;
-import org.geysermc.connector.entity.living.animal.horse.LlamaEntity;
+import org.geysermc.connector.entity.living.animal.horse.*;
 import org.geysermc.connector.entity.living.animal.tameable.WolfEntity;
 import org.geysermc.connector.entity.living.monster.*;
 import org.geysermc.connector.entity.living.monster.raid.AbstractIllagerEntity;
@@ -64,7 +61,7 @@ public enum EntityType {
     ZOMBIE_HORSE(AbstractHorseEntity.class, 27, 1.6f, 1.3965f),
     POLAR_BEAR(PolarBearEntity.class, 28, 1.4f, 1.3f),
     LLAMA(LlamaEntity.class, 29, 1.87f, 0.9f),
-    TRADER_LLAMA(LlamaEntity.class, 29, 1.187f, 0.9f),
+    TRADER_LLAMA(TraderLlamaEntity.class, 29, 1.187f, 0.9f),
     PARROT(TameableEntity.class, 30, 0.9f, 0.5f),
     DOLPHIN(WaterEntity.class, 31, 0.6f, 0.9f),
     ZOMBIE(ZombieEntity.class, 32, 1.8f, 0.6f, 0.6f, 1.62f),


### PR DESCRIPTION
Trader llamas would not appear since in Java the trader llama and the normal llama are different entities, whereas in Bedrock they are the same entity with minor metadata differences. This PR also adds support for the llama color variants (as well as the strength metadata which should not be relevant until inventories are worked on for them)