### PR TITLE
Fix maps spamming error in console

### DIFF
--- a/connector/src/main/java/org/geysermc/connector/network/translators/java/world/JavaMapDataTranslator.java
+++ b/connector/src/main/java/org/geysermc/connector/network/translators/java/world/JavaMapDataTranslator.java
@@ -40,10 +40,7 @@ public class JavaMapDataTranslator extends PacketTranslator<ServerMapDataPacket>
         ClientboundMapItemDataPacket mapItemDataPacket = new ClientboundMapItemDataPacket();
 
         mapItemDataPacket.setUniqueMapId(packet.getMapId());
-        if (session.getLastDimPacket() == null) {
-            System.out.println("Dimension is null");
-            mapItemDataPacket.setDimensionId(0);
-        } else mapItemDataPacket.setDimensionId(session.getLastDimPacket().getDimension());
+        mapItemDataPacket.setDimensionId(session.getPlayerEntity().getDimension());
         mapItemDataPacket.setLocked(packet.isLocked());
         mapItemDataPacket.setScale(packet.getScale());
 

--- a/connector/src/main/java/org/geysermc/connector/network/translators/java/world/JavaMapDataTranslator.java
+++ b/connector/src/main/java/org/geysermc/connector/network/translators/java/world/JavaMapDataTranslator.java
@@ -40,7 +40,10 @@ public class JavaMapDataTranslator extends PacketTranslator<ServerMapDataPacket>
         ClientboundMapItemDataPacket mapItemDataPacket = new ClientboundMapItemDataPacket();
 
         mapItemDataPacket.setUniqueMapId(packet.getMapId());
-        mapItemDataPacket.setDimensionId(session.getLastDimPacket().getDimension());
+        if (session.getLastDimPacket() == null) {
+            System.out.println("Dimension is null");
+            mapItemDataPacket.setDimensionId(0);
+        } else mapItemDataPacket.setDimensionId(session.getLastDimPacket().getDimension());
         mapItemDataPacket.setLocked(packet.isLocked());
         mapItemDataPacket.setScale(packet.getScale());
 


### PR DESCRIPTION
Maps can now be used (and don't spam errors in the console) but they have a strong, white tint on them.