### PR TITLE
Fixed players not getting removed from the players map on disconnect

### DIFF
--- a/connector/src/main/java/org/geysermc/connector/GeyserConnector.java
+++ b/connector/src/main/java/org/geysermc/connector/GeyserConnector.java
@@ -63,7 +63,7 @@ public class GeyserConnector {
     public static final String NAME = "Geyser";
     public static final String VERSION = "1.0-SNAPSHOT";
 
-    private final Map<UUID, GeyserSession> players = new HashMap<>();
+    private final Map<InetSocketAddress, GeyserSession> players = new HashMap<>();
 
     private static GeyserConnector instance;
 
@@ -189,11 +189,11 @@ public class GeyserConnector {
     }
 
     public void addPlayer(GeyserSession player) {
-        players.put(player.getAuthData().getUUID(), player);
+        players.put(player.getSocketAddress(), player);
     }
 
     public void removePlayer(GeyserSession player) {
-        players.remove(player.getAuthData().getUUID());
+        players.remove(player.getSocketAddress());
     }
 
     public static GeyserConnector start(PlatformType platformType, IGeyserBootstrap bootstrap) {


### PR DESCRIPTION
Fixes a bug caused by https://github.com/GeyserMC/Geyser/commit/ade40d5a8b34e848b9c71d16427317e429bc6f07
Changes made because https://github.com/GeyserMC/Geyser/blob/master/connector/src/main/java/org/geysermc/connector/network/ConnectorServerEventHandler.java#L93 requests the player based on InetSocketAddress and is the only use of the keys from the players map