### PR TITLE
Add doDaylightCycle gamerule support

### DIFF
--- a/connector/pom.xml
+++ b/connector/pom.xml
@@ -68,6 +68,12 @@
         </dependency>
         <dependency>
             <groupId>com.nukkitx.fastutil</groupId>
+            <artifactId>fastutil-long-boolean-maps</artifactId>
+            <version>8.3.1</version>
+            <scope>compile</scope>
+        </dependency>
+        <dependency>
+            <groupId>com.nukkitx.fastutil</groupId>
             <artifactId>fastutil-object-long-maps</artifactId>
             <version>8.3.1</version>
             <scope>compile</scope>

--- a/connector/pom.xml
+++ b/connector/pom.xml
@@ -68,12 +68,6 @@
         </dependency>
         <dependency>
             <groupId>com.nukkitx.fastutil</groupId>
-            <artifactId>fastutil-long-boolean-maps</artifactId>
-            <version>8.3.1</version>
-            <scope>compile</scope>
-        </dependency>
-        <dependency>
-            <groupId>com.nukkitx.fastutil</groupId>
             <artifactId>fastutil-object-long-maps</artifactId>
             <version>8.3.1</version>
             <scope>compile</scope>

--- a/connector/src/main/java/org/geysermc/connector/network/translators/java/world/JavaUpdateTimeTranslator.java
+++ b/connector/src/main/java/org/geysermc/connector/network/translators/java/world/JavaUpdateTimeTranslator.java
@@ -40,9 +40,7 @@ import com.nukkitx.protocol.bedrock.packet.SetTimePacket;
 
 @Translator(packet = ServerUpdateTimePacket.class)
 public class JavaUpdateTimeTranslator extends PacketTranslator<ServerUpdateTimePacket> {
-
-    // doDaylightCycle per-player for multi-world support
-    //static Long2BooleanMap daylightCycles = new Long2BooleanOpenHashMap();
+    
     // If negative, the last time is stored so we know it's not some plugin behavior doing weird things.
     // Per-player for multi-world support
     static Long2LongMap lastRecordedTimes = new Long2LongOpenHashMap();
@@ -52,7 +50,6 @@ public class JavaUpdateTimeTranslator extends PacketTranslator<ServerUpdateTimeP
 
         // Bedrock sends a GameRulesChangedPacket if there is no daylight cycle
         // Java just sends a negative long if there is no daylight cycle
-        //boolean doDayLightCycle = daylightCycles.getOrDefault(session.getPlayerEntity().getEntityId(), true);
         long lastTime = lastRecordedTimes.getOrDefault(session.getPlayerEntity().getEntityId(), 0);
         long time = packet.getTime();
 

--- a/connector/src/main/java/org/geysermc/connector/network/translators/java/world/JavaUpdateTimeTranslator.java
+++ b/connector/src/main/java/org/geysermc/connector/network/translators/java/world/JavaUpdateTimeTranslator.java
@@ -25,6 +25,10 @@
 
 package org.geysermc.connector.network.translators.java.world;
 
+import com.nukkitx.protocol.bedrock.data.GameRuleData;
+import com.nukkitx.protocol.bedrock.packet.GameRulesChangedPacket;
+import it.unimi.dsi.fastutil.longs.Long2BooleanMap;
+import it.unimi.dsi.fastutil.longs.Long2BooleanOpenHashMap;
 import org.geysermc.connector.network.session.GeyserSession;
 import org.geysermc.connector.network.translators.PacketTranslator;
 import org.geysermc.connector.network.translators.Translator;
@@ -35,11 +39,38 @@ import com.nukkitx.protocol.bedrock.packet.SetTimePacket;
 @Translator(packet = ServerUpdateTimePacket.class)
 public class JavaUpdateTimeTranslator extends PacketTranslator<ServerUpdateTimePacket> {
 
+    // doDaylightCycle per-player for multi-world support
+    static Long2BooleanMap daylightCycles = new Long2BooleanOpenHashMap();
+
     @Override
     public void translate(ServerUpdateTimePacket packet, GeyserSession session) {
+
+        boolean doDayLightCycle = daylightCycles.getOrDefault(session.getPlayerEntity().getEntityId(), true);
+        long time = packet.getTime();
+
+        if ((!doDayLightCycle && time > 0) || (doDayLightCycle && time < 0)) {
+            // doDaylightCycle is different than the client and we don't know
+            // Time is set either way as a reference point for the current time
+            setTime(time, session);
+            setDoDayLightGamerule(session, !doDayLightCycle);
+        } else if (time > 0) {
+            // doDaylightCycle is true and we know
+            setTime(time, session);
+        }
+    }
+
+    private void setTime(long time, GeyserSession session) {
         // https://minecraft.gamepedia.com/Day-night_cycle#24-hour_Minecraft_day
         SetTimePacket setTimePacket = new SetTimePacket();
-        setTimePacket.setTime((int) Math.abs(packet.getTime()) % 24000);
+        setTimePacket.setTime((int) Math.abs(time) % 24000);
         session.getUpstream().sendPacket(setTimePacket);
     }
+
+    private void setDoDayLightGamerule(GeyserSession session, boolean doCycle) {
+        GameRulesChangedPacket gameRulesChangedPacket = new GameRulesChangedPacket();
+        gameRulesChangedPacket.getGameRules().add(new GameRuleData<>("dodaylightcycle", doCycle));
+        session.getUpstream().sendPacket(gameRulesChangedPacket);
+        daylightCycles.put(session.getPlayerEntity().getEntityId(), doCycle);
+    }
+
 }

--- a/connector/src/main/java/org/geysermc/connector/network/translators/java/world/JavaUpdateTimeTranslator.java
+++ b/connector/src/main/java/org/geysermc/connector/network/translators/java/world/JavaUpdateTimeTranslator.java
@@ -27,8 +27,6 @@ package org.geysermc.connector.network.translators.java.world;
 
 import com.nukkitx.protocol.bedrock.data.GameRuleData;
 import com.nukkitx.protocol.bedrock.packet.GameRulesChangedPacket;
-import it.unimi.dsi.fastutil.longs.Long2BooleanMap;
-import it.unimi.dsi.fastutil.longs.Long2BooleanOpenHashMap;
 import it.unimi.dsi.fastutil.longs.Long2LongMap;
 import it.unimi.dsi.fastutil.longs.Long2LongOpenHashMap;
 import org.geysermc.connector.network.session.GeyserSession;
@@ -40,7 +38,7 @@ import com.nukkitx.protocol.bedrock.packet.SetTimePacket;
 
 @Translator(packet = ServerUpdateTimePacket.class)
 public class JavaUpdateTimeTranslator extends PacketTranslator<ServerUpdateTimePacket> {
-    
+
     // If negative, the last time is stored so we know it's not some plugin behavior doing weird things.
     // Per-player for multi-world support
     static Long2LongMap lastRecordedTimes = new Long2LongOpenHashMap();

--- a/connector/src/main/java/org/geysermc/connector/network/translators/java/world/JavaUpdateTimeTranslator.java
+++ b/connector/src/main/java/org/geysermc/connector/network/translators/java/world/JavaUpdateTimeTranslator.java
@@ -59,7 +59,7 @@ public class JavaUpdateTimeTranslator extends PacketTranslator<ServerUpdateTimeP
             // TODO: Performance efficient to always do this?
             lastRecordedTimes.put(session.getPlayerEntity().getEntityId(), time);
         }
-        if (lastTime < 0 && time > 0) {
+        if (lastTime < 0 && time >= 0) {
             setDoDayLightGamerule(session, true);
         } else if (lastTime != time && time < 0) {
             setDoDayLightGamerule(session, false);


### PR DESCRIPTION
This properly freezes the time for Bedrock clients instead of having the sun move back to the correct position every second or so if `doDaylightCycle` is false.