### PR TITLE
Added warning message if chat message is longer than 256 characters.

### DIFF
--- a/connector/src/main/java/org/geysermc/connector/network/translators/bedrock/BedrockCommandRequestTranslator.java
+++ b/connector/src/main/java/org/geysermc/connector/network/translators/bedrock/BedrockCommandRequestTranslator.java
@@ -48,7 +48,9 @@ public class BedrockCommandRequestTranslator extends PacketTranslator<CommandReq
         } else {
             String message = packet.getCommand().trim();
 
-            if (MessageUtils.isTooLong(message, session)) { return; }
+            if (MessageUtils.isTooLong(message, session)) {
+                return;
+            }
 
             ClientChatPacket chatPacket = new ClientChatPacket(message);
             session.getDownstream().getSession().send(chatPacket);

--- a/connector/src/main/java/org/geysermc/connector/network/translators/bedrock/BedrockCommandRequestTranslator.java
+++ b/connector/src/main/java/org/geysermc/connector/network/translators/bedrock/BedrockCommandRequestTranslator.java
@@ -34,6 +34,7 @@ import org.geysermc.connector.network.translators.Translator;
 
 import com.github.steveice10.mc.protocol.packet.ingame.client.ClientChatPacket;
 import com.nukkitx.protocol.bedrock.packet.CommandRequestPacket;
+import org.geysermc.connector.utils.MessageUtils;
 
 @Translator(packet = CommandRequestPacket.class)
 public class BedrockCommandRequestTranslator extends PacketTranslator<CommandRequestPacket> {
@@ -47,10 +48,7 @@ public class BedrockCommandRequestTranslator extends PacketTranslator<CommandReq
         } else {
             String message = packet.getCommand().trim();
 
-            if (message.length() > 256) {
-                session.sendMessage("Your message is bigger than 256 characters (" + message.length() + ") so it has not been sent.");
-                return;
-            }
+            if (MessageUtils.isTooLong(message, session)) { return; }
 
             ClientChatPacket chatPacket = new ClientChatPacket(message);
             session.getDownstream().getSession().send(chatPacket);

--- a/connector/src/main/java/org/geysermc/connector/network/translators/bedrock/BedrockCommandRequestTranslator.java
+++ b/connector/src/main/java/org/geysermc/connector/network/translators/bedrock/BedrockCommandRequestTranslator.java
@@ -45,7 +45,14 @@ public class BedrockCommandRequestTranslator extends PacketTranslator<CommandReq
         if (session.getConnector().getPlatformType() == PlatformType.STANDALONE && command.startsWith("geyser ") && commandMap.getCommands().containsKey(command.split(" ")[1])) {
             commandMap.runCommand(session, command);
         } else {
-            ClientChatPacket chatPacket = new ClientChatPacket(packet.getCommand());
+            String message = packet.getCommand().trim();
+
+            if (message.length() > 256) {
+                session.sendMessage("Your message is bigger than 256 characters (" + message.length() + ") so it has not been sent.");
+                return;
+            }
+
+            ClientChatPacket chatPacket = new ClientChatPacket(message);
             session.getDownstream().getSession().send(chatPacket);
         }
     }

--- a/connector/src/main/java/org/geysermc/connector/network/translators/bedrock/BedrockTextTranslator.java
+++ b/connector/src/main/java/org/geysermc/connector/network/translators/bedrock/BedrockTextTranslator.java
@@ -41,7 +41,9 @@ public class BedrockTextTranslator extends PacketTranslator<TextPacket> {
         if (packet.getMessage().charAt(0) == '.') {
             String message = packet.getMessage().replace(".", "/").trim();
 
-            if (MessageUtils.isTooLong(message, session)) { return; }
+            if (MessageUtils.isTooLong(message, session)) {
+                return;
+            }
 
             ClientChatPacket chatPacket = new ClientChatPacket(message);
             session.getDownstream().getSession().send(chatPacket);
@@ -50,7 +52,9 @@ public class BedrockTextTranslator extends PacketTranslator<TextPacket> {
 
         String message = packet.getMessage().trim();
 
-        if (MessageUtils.isTooLong(message, session)) { return; }
+        if (MessageUtils.isTooLong(message, session)) {
+            return;
+        }
 
         ClientChatPacket chatPacket = new ClientChatPacket(message);
         session.getDownstream().getSession().send(chatPacket);

--- a/connector/src/main/java/org/geysermc/connector/network/translators/bedrock/BedrockTextTranslator.java
+++ b/connector/src/main/java/org/geysermc/connector/network/translators/bedrock/BedrockTextTranslator.java
@@ -31,6 +31,7 @@ import org.geysermc.connector.network.translators.Translator;
 
 import com.github.steveice10.mc.protocol.packet.ingame.client.ClientChatPacket;
 import com.nukkitx.protocol.bedrock.packet.TextPacket;
+import org.geysermc.connector.utils.MessageUtils;
 
 @Translator(packet = TextPacket.class)
 public class BedrockTextTranslator extends PacketTranslator<TextPacket> {
@@ -40,10 +41,7 @@ public class BedrockTextTranslator extends PacketTranslator<TextPacket> {
         if (packet.getMessage().charAt(0) == '.') {
             String message = packet.getMessage().replace(".", "/").trim();
 
-            if (message.length() > 256) {
-                session.sendMessage("Your message is bigger than 256 characters (" + message.length() + ") so it has not been sent.");
-                return;
-            }
+            if (MessageUtils.isTooLong(message, session)) { return; }
 
             ClientChatPacket chatPacket = new ClientChatPacket(message);
             session.getDownstream().getSession().send(chatPacket);
@@ -52,10 +50,7 @@ public class BedrockTextTranslator extends PacketTranslator<TextPacket> {
 
         String message = packet.getMessage().trim();
 
-        if (message.length() > 256) {
-            session.sendMessage("Your message is bigger than 256 characters (" + message.length() + ") so it has not been sent.");
-            return;
-        }
+        if (MessageUtils.isTooLong(message, session)) { return; }
 
         ClientChatPacket chatPacket = new ClientChatPacket(message);
         session.getDownstream().getSession().send(chatPacket);

--- a/connector/src/main/java/org/geysermc/connector/network/translators/bedrock/BedrockTextTranslator.java
+++ b/connector/src/main/java/org/geysermc/connector/network/translators/bedrock/BedrockTextTranslator.java
@@ -38,12 +38,26 @@ public class BedrockTextTranslator extends PacketTranslator<TextPacket> {
     @Override
     public void translate(TextPacket packet, GeyserSession session) {
         if (packet.getMessage().charAt(0) == '.') {
-            ClientChatPacket chatPacket = new ClientChatPacket(packet.getMessage().replace(".", "/"));
+            String message = packet.getMessage().replace(".", "/").trim();
+
+            if (message.length() > 256) {
+                session.sendMessage("Your message is bigger than 256 characters (" + message.length() + ") so it has not been sent.");
+                return;
+            }
+
+            ClientChatPacket chatPacket = new ClientChatPacket(message);
             session.getDownstream().getSession().send(chatPacket);
             return;
         }
 
-        ClientChatPacket chatPacket = new ClientChatPacket(packet.getMessage());
+        String message = packet.getMessage().trim();
+
+        if (message.length() > 256) {
+            session.sendMessage("Your message is bigger than 256 characters (" + message.length() + ") so it has not been sent.");
+            return;
+        }
+
+        ClientChatPacket chatPacket = new ClientChatPacket(message);
         session.getDownstream().getSession().send(chatPacket);
     }
 }

--- a/connector/src/main/java/org/geysermc/connector/utils/MessageUtils.java
+++ b/connector/src/main/java/org/geysermc/connector/utils/MessageUtils.java
@@ -32,6 +32,7 @@ import com.google.gson.JsonElement;
 import com.google.gson.JsonObject;
 import com.google.gson.JsonParser;
 import com.google.gson.JsonPrimitive;
+import org.geysermc.connector.network.session.GeyserSession;
 
 import java.util.*;
 import java.util.regex.Matcher;
@@ -289,5 +290,15 @@ public class MessageUtils {
             }
         }
         return "";
+    }
+
+    public static boolean isTooLong(String message, GeyserSession session) {
+        if (message.length() > 256) {
+            // TODO: Add Geyser localization and translate this based on language
+            session.sendMessage("Your message is bigger than 256 characters (" + message.length() + ") so it has not been sent.");
+            return false;
+        }
+
+        return true;
     }
 }


### PR DESCRIPTION
Fixes getting kicked if the bedrock client send a message to the server over 256 chars instead, sends them a warning message. `Your message is bigger than 256 characters (%LEN%) so it has not been sent.`