### PR TITLE
Fixed colour and style formatting for some messages

### DIFF
--- a/connector/src/main/java/org/geysermc/connector/utils/MessageUtils.java
+++ b/connector/src/main/java/org/geysermc/connector/utils/MessageUtils.java
@@ -58,7 +58,7 @@ public class MessageUtils {
                     strings.add(" - no permission or invalid command!");
                 }
 
-                List<String> furtherParams = getTranslationParams(translation.getTranslationParams());
+                List<String> furtherParams = getTranslationParams(translation.getTranslationParams(), locale);
                 if (locale != null) {
                     strings.add(insertParams(LocaleUtils.getLocaleString(translation.getTranslationKey(), locale), furtherParams));
                 }else{
@@ -96,7 +96,11 @@ public class MessageUtils {
             messageText = LocaleUtils.getLocaleString(messageText, locale);
         }
 
-        StringBuilder builder = new StringBuilder(messageText);
+        StringBuilder builder = new StringBuilder();
+        builder.append(getFormat(message.getStyle().getFormats()));
+        builder.append(getColorOrParent(message.getStyle()));
+        builder.append(messageText);
+
         for (Message msg : message.getExtra()) {
             builder.append(getFormat(msg.getStyle().getFormats()));
             builder.append(getColorOrParent(msg.getStyle()));
@@ -139,8 +143,8 @@ public class MessageUtils {
     private static String getColorOrParent(MessageStyle style) {
         ChatColor chatColor = style.getColor();
 
-        if (chatColor == ChatColor.NONE) {
-            return getColor(style.getParent().getColor());
+        if (chatColor == ChatColor.NONE && style.getParent() != null) {
+            return getColorOrParent(style.getParent());
         }
 
         return getColor(chatColor);


### PR DESCRIPTION
Fixes some messages resetting formatting because it wasn't their direct parent that set the colour, and the odd translation message wasn't getting translated.
![image](https://user-images.githubusercontent.com/5401186/79163169-72c1d380-7dd6-11ea-8ce3-5cac1948c798.png)
