### PR TITLE
Prevents animations from being sent to the server before the player has spawned

### DIFF
--- a/connector/src/main/java/org/geysermc/connector/network/translators/bedrock/BedrockAnimateTranslator.java
+++ b/connector/src/main/java/org/geysermc/connector/network/translators/bedrock/BedrockAnimateTranslator.java
@@ -41,7 +41,9 @@ public class BedrockAnimateTranslator extends PacketTranslator<AnimatePacket> {
     @Override
     public void translate(AnimatePacket packet, GeyserSession session) {
         // Stop the player sending animations before they have fully spawned into the server
-        if (!session.isSpawned()) { return; }
+        if (!session.isSpawned()) {
+            return;
+        }
 
         switch (packet.getAction()) {
             case SWING_ARM:

--- a/connector/src/main/java/org/geysermc/connector/network/translators/bedrock/BedrockAnimateTranslator.java
+++ b/connector/src/main/java/org/geysermc/connector/network/translators/bedrock/BedrockAnimateTranslator.java
@@ -25,6 +25,7 @@
 
 package org.geysermc.connector.network.translators.bedrock;
 
+import org.geysermc.connector.GeyserConnector;
 import org.geysermc.connector.network.session.GeyserSession;
 import org.geysermc.connector.network.translators.PacketTranslator;
 import org.geysermc.connector.network.translators.Translator;
@@ -40,6 +41,9 @@ public class BedrockAnimateTranslator extends PacketTranslator<AnimatePacket> {
 
     @Override
     public void translate(AnimatePacket packet, GeyserSession session) {
+        // Stop the player sending animations before they have fully spawned into the server
+        if (!session.isSpawned()) { return; }
+
         switch (packet.getAction()) {
             case SWING_ARM:
                 // Delay so entity damage can be processed first

--- a/connector/src/main/java/org/geysermc/connector/network/translators/bedrock/BedrockAnimateTranslator.java
+++ b/connector/src/main/java/org/geysermc/connector/network/translators/bedrock/BedrockAnimateTranslator.java
@@ -25,7 +25,6 @@
 
 package org.geysermc.connector.network.translators.bedrock;
 
-import org.geysermc.connector.GeyserConnector;
 import org.geysermc.connector.network.session.GeyserSession;
 import org.geysermc.connector.network.translators.PacketTranslator;
 import org.geysermc.connector.network.translators.Translator;


### PR DESCRIPTION
Just stops the player from being kicked by sending animations before they have spawned.

Fixes: https://github.com/GeyserMC/Geyser/issues/329