### PR TITLE
Fix client not letting you connect to a full server

### DIFF
--- a/connector/src/main/java/org/geysermc/connector/network/ConnectorServerEventHandler.java
+++ b/connector/src/main/java/org/geysermc/connector/network/ConnectorServerEventHandler.java
@@ -80,6 +80,13 @@ public class ConnectorServerEventHandler implements BedrockServerEventHandler {
             pong.setMotd(config.getBedrock().getMotd1());
             pong.setMotd(config.getBedrock().getMotd2());
         }
+
+        //Bedrock will not even attempt a connection if the client thinks the server is full
+        //so we have to fake it not being full
+        if (pong.getPlayerCount() >= pong.getMaximumPlayerCount()) {
+            pong.setMaximumPlayerCount(pong.getPlayerCount() + 1);
+        }
+
         return pong;
     }
 


### PR DESCRIPTION
Bedrock will not even attempt a connection if the client thinks the server is full so we have to fake it not being full. 80% of servers will never run into this issue but this is here to protect them if they do.