### PR TITLE
Added hacky version fix, to allow 1.14.60 clients

### DIFF
--- a/connector/src/main/java/org/geysermc/connector/network/ConnectorServerEventHandler.java
+++ b/connector/src/main/java/org/geysermc/connector/network/ConnectorServerEventHandler.java
@@ -62,8 +62,8 @@ public class ConnectorServerEventHandler implements BedrockServerEventHandler {
         pong.setEdition("MCPE");
         pong.setGameType("Default");
         pong.setNintendoLimited(false);
-        pong.setProtocolVersion(GeyserConnector.BEDROCK_PACKET_CODEC.getProtocolVersion());
-        pong.setVersion(GeyserConnector.BEDROCK_PACKET_CODEC.getMinecraftVersion());
+        pong.setProtocolVersion(390);
+        pong.setVersion("1.14.60");
         pong.setIpv4Port(config.getBedrock().getPort());
         if (connector.getConfig().isPingPassthrough() && serverInfo != null) {
             String[] motd = MessageUtils.getBedrockMessage(serverInfo.getDescription()).split("\n");

--- a/connector/src/main/java/org/geysermc/connector/network/UpstreamPacketHandler.java
+++ b/connector/src/main/java/org/geysermc/connector/network/UpstreamPacketHandler.java
@@ -46,7 +46,7 @@ public class UpstreamPacketHandler extends LoggingPacketHandler {
 
     @Override
     public boolean handle(LoginPacket loginPacket) {
-        if (loginPacket.getProtocolVersion() != GeyserConnector.BEDROCK_PACKET_CODEC.getProtocolVersion()) {
+        if (loginPacket.getProtocolVersion() != 390) {
             session.getUpstream().disconnect("Unsupported Bedrock version. Are you running an outdated version?");
             return true;
         }


### PR DESCRIPTION
I wouldn't recommend using this but it is a temporary bypass for 1.14.60 clients to connect. Download it from `Checks > Artifacts`.