### PR TITLE
Removed descriptions from commands

### DIFF
--- a/connector/src/main/java/org/geysermc/connector/network/translators/java/JavaServerDeclareCommandsTranslator.java
+++ b/connector/src/main/java/org/geysermc/connector/network/translators/java/JavaServerDeclareCommandsTranslator.java
@@ -84,7 +84,7 @@ public class JavaServerDeclareCommandsTranslator extends PacketTranslator<Server
             CommandParamData[][] params = getParams(commandID, packet.getNodes()[commandID], packet.getNodes());
 
             // Build the completed command and add it to the final list
-            CommandData data = new CommandData(commandName, "A Java server command", flags, (byte) 0, aliases, params);
+            CommandData data = new CommandData(commandName, "", flags, (byte) 0, aliases, params);
             commandData.add(data);
         }
 


### PR DESCRIPTION
Removes the static description of `A Java server command` from the commands, this is what it looks like now:
![image](https://user-images.githubusercontent.com/5401186/79685140-335c1280-822e-11ea-8632-8b7926deefae.png)
