### PR TITLE
Disabled attempted rendering of the globe pattern

### DIFF
--- a/connector/src/main/java/org/geysermc/connector/network/translators/block/entity/BannerBlockEntityTranslator.java
+++ b/connector/src/main/java/org/geysermc/connector/network/translators/block/entity/BannerBlockEntityTranslator.java
@@ -56,7 +56,10 @@ public class BannerBlockEntityTranslator extends BlockEntityTranslator implement
         List<com.nukkitx.nbt.tag.CompoundTag> tagsList = new ArrayList<>();
         if (tag.contains("Patterns")) {
             for (com.github.steveice10.opennbt.tag.builtin.Tag patternTag : patterns.getValue()) {
-                tagsList.add(getPattern((CompoundTag) patternTag));
+                com.nukkitx.nbt.tag.CompoundTag newPatternTag = getPattern((CompoundTag) patternTag);
+                if (newPatternTag != null) {
+                    tagsList.add(newPatternTag);
+                }
             }
             com.nukkitx.nbt.tag.ListTag<com.nukkitx.nbt.tag.CompoundTag> bedrockPatterns =
                     new com.nukkitx.nbt.tag.ListTag<>("Patterns", com.nukkitx.nbt.tag.CompoundTag.class, tagsList);
@@ -82,10 +85,23 @@ public class BannerBlockEntityTranslator extends BlockEntityTranslator implement
         return tagBuilder.buildRootTag();
     }
 
+    /**
+     * Convert the Java edition pattern nbt to Bedrock edition, null if the pattern doesn't exist
+     *
+     * @param pattern Java edition pattern nbt
+     * @return The Bedrock edition format pattern nbt
+     */
     protected com.nukkitx.nbt.tag.CompoundTag getPattern(CompoundTag pattern) {
+        String patternName = (String) pattern.get("Pattern").getValue();
+
+        // Return null if its the globe pattern as it doesn't exist on bedrock
+        if (patternName.equals("glb")) {
+            return null;
+        }
+
         return CompoundTagBuilder.builder()
                 .intTag("Color", 15 - (int) pattern.get("Color").getValue())
-                .stringTag("Pattern", (String) pattern.get("Pattern").getValue())
+                .stringTag("Pattern", patternName)
                 .buildRootTag();
     }
 }


### PR DESCRIPTION
Skips the globe banner pattern tag on banners because Bedrock edition clients don't have it so it just renders as a big coloured square.
Fixes: https://github.com/GeyserMC/Geyser/issues/235
Also needs https://github.com/GeyserMC/mappings/pull/10 merging to fix the background colours