### PR TITLE
Request additional information for bug reports

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -31,7 +31,7 @@ assignees: ''
 <!--- Give us the exact output from /version. Saying "latest" does not help us at all. -->
 
 **Geyser Version**
-<!--- Give us the exact build number as well as branch if applicable. Saying "latest" does not help us at all. -->
+<!--- Give us the exact build number as well as branch if applicable. Saying "latest" does not help us at all. Please also include if you are running the standalone version, or specify which plugin version you are using. If your issue is a connection problem, please specify if you are using the Floodgate plugin. -->
 
 **Minecraft: Bedrock Edition Version**
 <!-- The version of your Minecraft: Bedrock Edition client you tested with. -->

--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -37,4 +37,4 @@ assignees: ''
 <!-- The version of your Minecraft: Bedrock Edition client you tested with. -->
 
 **Additional Context**
-<!--- Add any other context about the problem here. --->
+<!--- Add any other context about the problem here. Include any plugins on the Minecraft server that may cause problems. --->


### PR DESCRIPTION
Specify if you're using the plugin or standalone version, as well as Floodgate if applicable.