### PR TITLE
Fix map colors, remove unnecessary array stream

### DIFF
--- a/connector/pom.xml
+++ b/connector/pom.xml
@@ -33,7 +33,7 @@
         <dependency>
             <groupId>com.nukkitx.protocol</groupId>
             <artifactId>bedrock-v390</artifactId>
-            <version>2.5.5</version>
+            <version>2.5.6-SNAPSHOT</version>
             <scope>compile</scope>
             <exclusions>
                 <exclusion>

--- a/connector/src/main/java/org/geysermc/connector/network/translators/java/world/JavaMapDataTranslator.java
+++ b/connector/src/main/java/org/geysermc/connector/network/translators/java/world/JavaMapDataTranslator.java
@@ -51,13 +51,12 @@ public class JavaMapDataTranslator extends PacketTranslator<ServerMapDataPacket>
             mapItemDataPacket.setWidth(data.getColumns());
             mapItemDataPacket.setHeight(data.getRows());
 
-            // Every int entry is an ARGB color
+            // Every int entry is an ABGR color
             int[] colors = new int[data.getData().length];
 
             int idx = 0;
             for (byte colorId : data.getData()) {
-                colors[idx] = MapColor.fromId(colorId).toARGB();
-                idx++;
+                colors[idx++] = MapColor.fromId(colorId & 0xFF).toABGR();
             }
 
             mapItemDataPacket.setColors(colors);

--- a/connector/src/main/java/org/geysermc/connector/utils/MapColor.java
+++ b/connector/src/main/java/org/geysermc/connector/utils/MapColor.java
@@ -1,7 +1,5 @@
 package org.geysermc.connector.utils;
 
-import java.util.Arrays;
-
 public enum MapColor {
     COLOR_0(-1, -1, -1),
     COLOR_1(-1, -1, -1),
@@ -212,6 +210,8 @@ public enum MapColor {
     COLOR_206(37, 22, 16),
     COLOR_207(19, 11, 8);
 
+    private static final MapColor[] VALUES = values();
+
     private final int red;
     private final int green;
     private final int blue;
@@ -222,23 +222,18 @@ public enum MapColor {
         this.blue = blue;
     }
 
-    int getId() {
-        return ordinal();
-    }
-
     public static MapColor fromId(int id) {
-        return Arrays.stream(values()).filter(color -> color.getId() == id).findFirst().orElse(COLOR_0);
+        return id >= 0 && id < VALUES.length ? VALUES[id] : COLOR_0;
     }
 
-    public int toARGB() {
+    public int toABGR() {
         int alpha = 255;
         if (red == -1 && green == -1 && blue == -1)
             alpha = 0; // transparent
 
-        long result = red & 0xff;
-        result |= (green & 0xff) << 8;
-        result |= (blue & 0xff) << 16;
-        result |= (alpha & 0xff) << 24;
-        return (int) (result & 0xFFFFFFFFL);
+        return ((alpha & 0xFF) << 24) |
+               ((blue & 0xFF) << 16) |
+               ((green & 0xFF) << 8) |
+               ((red & 0xFF) << 0);
     }
 }


### PR DESCRIPTION
There were two main issues with the map colors:
The java edition colors were incorrectly interpreted as an signed byte.
The bedrock edition should be encoded as an unsigned int, but were implicitly casted to a long in the NukkitX protocol/network dependency. This is fixed by updating to the newest version of the NukkitX protocol.

Also removed the array stream which wasn't necessary nor made anything any simpler.