### PR TITLE
Fixed error when certain items are spawned from the creative inventory

### DIFF
--- a/connector/src/main/java/org/geysermc/connector/network/translators/ItemStackTranslator.java
+++ b/connector/src/main/java/org/geysermc/connector/network/translators/ItemStackTranslator.java
@@ -54,7 +54,7 @@ public abstract class ItemStackTranslator {
     public ItemStack translateToJava(ItemData itemData, ItemEntry itemEntry) {
         if (itemData == null) return null;
         if (itemData.getTag() == null) {
-            return new ItemStack(itemEntry.getJavaId(), itemData.getCount());
+            return new ItemStack(itemEntry.getJavaId(), itemData.getCount(), new com.github.steveice10.opennbt.tag.builtin.CompoundTag(""));
         }
         return new ItemStack(itemEntry.getJavaId(), itemData.getCount(), this.translateToJavaNBT(itemData.getTag()));
     }


### PR DESCRIPTION
Items such as potions can now be spawned from the creative inventory and they don't disappear