### PR TITLE
Add entity checks for Hypixel

### DIFF
--- a/connector/src/main/java/org/geysermc/connector/entity/living/animal/tameable/CatEntity.java
+++ b/connector/src/main/java/org/geysermc/connector/entity/living/animal/tameable/CatEntity.java
@@ -41,27 +41,30 @@ public class CatEntity extends TameableEntity {
     @Override
     public void updateBedrockMetadata(EntityMetadata entityMetadata, GeyserSession session) {
         if (entityMetadata.getId() == 18) {
-            // Different colors in Java and Bedrock for some reason
-            int variantColor;
-            switch ((int) entityMetadata.getValue()) {
-                case 0:
-                    variantColor = 8;
-                    break;
-                case 8:
-                    variantColor = 0;
-                    break;
-                case 9:
-                    variantColor = 10;
-                    break;
-                case 10:
-                    variantColor = 9;
-                    break;
-                default:
-                    variantColor = (int) entityMetadata.getValue();
+            // Ensure it's an int because of Hypixel shenanigans
+            if (entityMetadata.getValue() instanceof Integer) {
+                // Different colors in Java and Bedrock for some reason
+                int variantColor;
+                switch ((int) entityMetadata.getValue()) {
+                    case 0:
+                        variantColor = 8;
+                        break;
+                    case 8:
+                        variantColor = 0;
+                        break;
+                    case 9:
+                        variantColor = 10;
+                        break;
+                    case 10:
+                        variantColor = 9;
+                        break;
+                    default:
+                        variantColor = (int) entityMetadata.getValue();
+                }
+                metadata.put(EntityData.VARIANT, variantColor);
             }
-            metadata.put(EntityData.VARIANT, variantColor);
         }
-        if (entityMetadata.getId() == 21) {
+        if (entityMetadata.getId() == 21 && entityMetadata.getValue() instanceof Integer) {
             // Needed or else wild cats are a red color
             if (metadata.getFlags().getFlag(EntityFlag.TAMED)) {
                 metadata.put(EntityData.COLOR, (byte) (int) entityMetadata.getValue());

--- a/connector/src/main/java/org/geysermc/connector/entity/living/animal/tameable/WolfEntity.java
+++ b/connector/src/main/java/org/geysermc/connector/entity/living/animal/tameable/WolfEntity.java
@@ -41,12 +41,13 @@ public class WolfEntity extends TameableEntity {
     @Override
     public void updateBedrockMetadata(EntityMetadata entityMetadata, GeyserSession session) {
         // "Begging" on wiki.vg, "Interested" in Nukkit - the tilt of the head
-        if (entityMetadata.getId() == 18) {
+        // Ensure it's a boolean because of Hypixel shenanigans
+        if (entityMetadata.getId() == 18 && entityMetadata.getValue() instanceof Boolean) {
             metadata.getFlags().setFlag(EntityFlag.INTERESTED, (boolean) entityMetadata.getValue());
         }
 
         //Reset wolf color
-        if (entityMetadata.getId() == 16) {
+        if (entityMetadata.getId() == 16 && entityMetadata.getValue() instanceof Byte) {
             byte xd = (byte) entityMetadata.getValue();
             boolean angry = (xd & 0x02) == 0x02;
             if (angry) {
@@ -56,7 +57,7 @@ public class WolfEntity extends TameableEntity {
 
         // Wolf collar color
         // Relies on EntityData.OWNER_EID being set in TameableEntity.java
-        if (entityMetadata.getId() == 19 && !metadata.getFlags().getFlag(EntityFlag.ANGRY)) {
+        if (entityMetadata.getId() == 19 && !metadata.getFlags().getFlag(EntityFlag.ANGRY) && entityMetadata.getValue() instanceof Integer) {
             metadata.put(EntityData.COLOR, (byte) (int) entityMetadata.getValue());
         }
         super.updateBedrockMetadata(entityMetadata, session);


### PR DESCRIPTION
Hypixel likes to send funny values for cats and wolves - this prevents any errors in the console by not processing if they are an incorrect value.

Hypixel crashes are fixed with #474.