### PR TITLE
Chat/Skin fixes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -222,6 +222,7 @@ nbdist/
 # End of https://www.gitignore.io/api/git,java,maven,eclipse,netbeans,jetbrains+all
 
 ### Geyser ###
+run/
 config.yml
 logs/
 public-key.pem

--- a/connector/src/main/java/org/geysermc/connector/network/translators/java/JavaJoinGameTranslator.java
+++ b/connector/src/main/java/org/geysermc/connector/network/translators/java/JavaJoinGameTranslator.java
@@ -25,6 +25,10 @@
 
 package org.geysermc.connector.network.translators.java;
 
+import com.github.steveice10.mc.protocol.data.game.entity.player.Hand;
+import com.github.steveice10.mc.protocol.data.game.setting.ChatVisibility;
+import com.github.steveice10.mc.protocol.data.game.setting.SkinPart;
+import com.github.steveice10.mc.protocol.packet.ingame.client.ClientSettingsPacket;
 import org.geysermc.connector.entity.PlayerEntity;
 import org.geysermc.connector.network.session.GeyserSession;
 import org.geysermc.connector.network.translators.PacketTranslator;
@@ -37,6 +41,9 @@ import com.nukkitx.protocol.bedrock.packet.AdventureSettingsPacket;
 import com.nukkitx.protocol.bedrock.packet.PlayStatusPacket;
 import com.nukkitx.protocol.bedrock.packet.SetEntityDataPacket;
 import com.nukkitx.protocol.bedrock.packet.SetPlayerGameTypePacket;
+
+import java.util.Arrays;
+import java.util.List;
 
 @Translator(packet = ServerJoinGamePacket.class)
 public class JavaJoinGameTranslator extends PacketTranslator<ServerJoinGamePacket> {
@@ -66,6 +73,11 @@ public class JavaJoinGameTranslator extends PacketTranslator<ServerJoinGamePacke
         session.getUpstream().sendPacket(entityDataPacket);
 
         session.setRenderDistance(packet.getViewDistance());
+
+        //We need to send our skin parts to the server otherwise java sees us with no hat, jacket etc
+        List<SkinPart> skinParts = Arrays.asList(SkinPart.values());
+        ClientSettingsPacket clientSettingsPacket = new ClientSettingsPacket("en_GB", (byte) session.getRenderDistance(), ChatVisibility.FULL, true, skinParts, Hand.MAIN_HAND);
+        session.getDownstream().getSession().send(clientSettingsPacket);
 
         if (DimensionUtils.javaToBedrock(packet.getDimension()) != entity.getDimension()) {
             DimensionUtils.switchDimension(session, packet.getDimension());

--- a/connector/src/main/java/org/geysermc/connector/network/translators/java/JavaJoinGameTranslator.java
+++ b/connector/src/main/java/org/geysermc/connector/network/translators/java/JavaJoinGameTranslator.java
@@ -74,9 +74,10 @@ public class JavaJoinGameTranslator extends PacketTranslator<ServerJoinGamePacke
 
         session.setRenderDistance(packet.getViewDistance());
 
-        //We need to send our skin parts to the server otherwise java sees us with no hat, jacket etc
+        // We need to send our skin parts to the server otherwise java sees us with no hat, jacket etc
+        String locale = session.getClientData().getLanguageCode();
         List<SkinPart> skinParts = Arrays.asList(SkinPart.values());
-        ClientSettingsPacket clientSettingsPacket = new ClientSettingsPacket("en_GB", (byte) session.getRenderDistance(), ChatVisibility.FULL, true, skinParts, Hand.MAIN_HAND);
+        ClientSettingsPacket clientSettingsPacket = new ClientSettingsPacket(locale, (byte) session.getRenderDistance(), ChatVisibility.FULL, true, skinParts, Hand.MAIN_HAND);
         session.getDownstream().getSession().send(clientSettingsPacket);
 
         if (DimensionUtils.javaToBedrock(packet.getDimension()) != entity.getDimension()) {

--- a/connector/src/main/java/org/geysermc/connector/utils/MessageUtils.java
+++ b/connector/src/main/java/org/geysermc/connector/utils/MessageUtils.java
@@ -102,7 +102,7 @@ public class MessageUtils {
         builder.append(getFormat(message.getStyle().getFormats()));
         builder.append(getColorOrParent(message.getStyle()));
         builder.append(messageText);
-        builder.append("\u00a7r"); //Mimic Java text by resetting formats
+        builder.append("\u00a7r"); // Mimic Java text by resetting formats
 
         for (Message msg : message.getExtra()) {
             builder.append(getFormat(msg.getStyle().getFormats()));

--- a/connector/src/main/java/org/geysermc/connector/utils/MessageUtils.java
+++ b/connector/src/main/java/org/geysermc/connector/utils/MessageUtils.java
@@ -27,15 +27,18 @@ package org.geysermc.connector.utils;
 
 import com.github.steveice10.mc.protocol.data.game.scoreboard.TeamColor;
 import com.github.steveice10.mc.protocol.data.message.*;
-import com.google.gson.*;
+import com.github.steveice10.opennbt.tag.builtin.StringTag;
+import com.google.gson.JsonArray;
+import com.google.gson.JsonElement;
+import com.google.gson.JsonObject;
+import com.google.gson.JsonParser;
+import com.google.gson.JsonPrimitive;
 import net.kyori.text.Component;
 import net.kyori.text.serializer.gson.GsonComponentSerializer;
 import net.kyori.text.serializer.legacy.LegacyComponentSerializer;
 import org.geysermc.connector.network.session.GeyserSession;
 
-import java.util.ArrayList;
-import java.util.Collections;
-import java.util.List;
+import java.util.*;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
@@ -102,7 +105,6 @@ public class MessageUtils {
         builder.append(getFormat(message.getStyle().getFormats()));
         builder.append(getColorOrParent(message.getStyle()));
         builder.append(messageText);
-        builder.append("\u00a7r"); // Mimic Java text by resetting formats
 
         for (Message msg : message.getExtra()) {
             builder.append(getFormat(msg.getStyle().getFormats()));

--- a/connector/src/main/java/org/geysermc/connector/utils/MessageUtils.java
+++ b/connector/src/main/java/org/geysermc/connector/utils/MessageUtils.java
@@ -27,18 +27,15 @@ package org.geysermc.connector.utils;
 
 import com.github.steveice10.mc.protocol.data.game.scoreboard.TeamColor;
 import com.github.steveice10.mc.protocol.data.message.*;
-import com.github.steveice10.opennbt.tag.builtin.StringTag;
-import com.google.gson.JsonArray;
-import com.google.gson.JsonElement;
-import com.google.gson.JsonObject;
-import com.google.gson.JsonParser;
-import com.google.gson.JsonPrimitive;
+import com.google.gson.*;
 import net.kyori.text.Component;
 import net.kyori.text.serializer.gson.GsonComponentSerializer;
 import net.kyori.text.serializer.legacy.LegacyComponentSerializer;
 import org.geysermc.connector.network.session.GeyserSession;
 
-import java.util.*;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
@@ -105,6 +102,7 @@ public class MessageUtils {
         builder.append(getFormat(message.getStyle().getFormats()));
         builder.append(getColorOrParent(message.getStyle()));
         builder.append(messageText);
+        builder.append("\u00a7r"); //Mimic Java text by resetting formats
 
         for (Message msg : message.getExtra()) {
             builder.append(getFormat(msg.getStyle().getFormats()));

--- a/connector/src/main/java/org/geysermc/connector/utils/MessageUtils.java
+++ b/connector/src/main/java/org/geysermc/connector/utils/MessageUtils.java
@@ -114,7 +114,6 @@ public class MessageUtils {
                 builder.append(getTranslatedBedrockMessage(msg, locale, isTranslationMessage));
             }
         }
-        builder.append("\u00a7r"); // Mimic Java text by resetting formats
         return builder.toString();
     }
 


### PR DESCRIPTION
Made MessageUtils mimic java chat behavior. This clears formatting at the end of a message so the next message doesn't have that formatting.
Send ClientSettingsPacket when player joins a server. Mainly needed to show the bedrock players hat, jacket, cape etc otherwise they appear with no layers.
Added run folder to .gitignore so Geyser can be run in a different folder when debugging to keep things cleaner...