### PR TITLE
Fix Floodgate players causing errors on Bukkit.

### DIFF
--- a/connector/src/main/java/org/geysermc/connector/network/session/GeyserSession.java
+++ b/connector/src/main/java/org/geysermc/connector/network/session/GeyserSession.java
@@ -34,6 +34,7 @@ import com.github.steveice10.mc.protocol.packet.ingame.client.world.ClientTelepo
 import com.github.steveice10.mc.protocol.data.game.world.block.BlockState;
 import com.github.steveice10.mc.protocol.packet.ingame.server.ServerRespawnPacket;
 import com.github.steveice10.mc.protocol.packet.handshake.client.HandshakePacket;
+import com.github.steveice10.mc.protocol.packet.login.server.LoginSuccessPacket;
 import com.github.steveice10.packetlib.Client;
 import com.github.steveice10.packetlib.event.session.*;
 import com.github.steveice10.packetlib.packet.Packet;
@@ -327,6 +328,13 @@ public class GeyserSession implements CommandSender {
                             } else if (lastDimPacket != null) {
                                 Registry.JAVA.translate(lastDimPacket.getClass(), lastDimPacket, GeyserSession.this);
                                 lastDimPacket = null;
+                            }
+
+                            // Required, or else Floodgate players break with Bukkit chunk caching
+                            if (event.getPacket() instanceof LoginSuccessPacket) {
+                                GameProfile profile = ((LoginSuccessPacket) event.getPacket()).getProfile();
+                                playerEntity.setUsername(profile.getName());
+                                playerEntity.setUuid(profile.getId());
                             }
 
                             Registry.JAVA.translate(event.getPacket().getClass(), event.getPacket(), GeyserSession.this);


### PR DESCRIPTION
This adds the UUID and username from the LoginSuccessPacket in order to stop NPEs from occurring when trying to retrieve a cached block from Bukkit. Thanks to @Tim203 for finding the solution.