### PR TITLE
Add unusable inventory space message

### DIFF
--- a/connector/src/main/java/org/geysermc/connector/network/translators/inventory/BaseInventoryTranslator.java
+++ b/connector/src/main/java/org/geysermc/connector/network/translators/inventory/BaseInventoryTranslator.java
@@ -25,19 +25,12 @@
 
 package org.geysermc.connector.network.translators.inventory;
 
-import com.nukkitx.nbt.CompoundTagBuilder;
-import com.nukkitx.nbt.tag.StringTag;
 import com.nukkitx.protocol.bedrock.data.ContainerId;
 import com.nukkitx.protocol.bedrock.data.InventoryActionData;
-import com.nukkitx.protocol.bedrock.data.ItemData;
-import org.geysermc.common.ChatColor;
 import org.geysermc.connector.inventory.Inventory;
 import org.geysermc.connector.network.session.GeyserSession;
 import org.geysermc.connector.network.translators.inventory.action.InventoryActionDataTranslator;
 
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.Collections;
 import java.util.List;
 
 public abstract class BaseInventoryTranslator extends InventoryTranslator{

--- a/connector/src/main/java/org/geysermc/connector/network/translators/inventory/BaseInventoryTranslator.java
+++ b/connector/src/main/java/org/geysermc/connector/network/translators/inventory/BaseInventoryTranslator.java
@@ -25,12 +25,19 @@
 
 package org.geysermc.connector.network.translators.inventory;
 
+import com.nukkitx.nbt.CompoundTagBuilder;
+import com.nukkitx.nbt.tag.StringTag;
 import com.nukkitx.protocol.bedrock.data.ContainerId;
 import com.nukkitx.protocol.bedrock.data.InventoryActionData;
+import com.nukkitx.protocol.bedrock.data.ItemData;
+import org.geysermc.common.ChatColor;
 import org.geysermc.connector.inventory.Inventory;
 import org.geysermc.connector.network.session.GeyserSession;
 import org.geysermc.connector.network.translators.inventory.action.InventoryActionDataTranslator;
 
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
 import java.util.List;
 
 public abstract class BaseInventoryTranslator extends InventoryTranslator{

--- a/connector/src/main/java/org/geysermc/connector/network/translators/inventory/PlayerInventoryTranslator.java
+++ b/connector/src/main/java/org/geysermc/connector/network/translators/inventory/PlayerInventoryTranslator.java
@@ -45,6 +45,8 @@ import org.geysermc.connector.utils.Toolbox;
 import java.util.List;
 
 public class PlayerInventoryTranslator extends InventoryTranslator {
+    private static final ItemData UNUSUABLE_CRAFTING_SPACE_BLOCK = InventoryUtils.createUnusableSpaceBlock(
+            "The creative crafting grid is\nunavailable in Java Edition");
 
     public PlayerInventoryTranslator() {
         super(46);
@@ -98,7 +100,7 @@ public class PlayerInventoryTranslator extends InventoryTranslator {
             slotPacket.setSlot(i + 27);
 
             if (session.getGameMode() == GameMode.CREATIVE) {
-                slotPacket.setItem(Translators.getItemTranslator().translateToBedrock(session, new ItemStack(Toolbox.BARRIER_INDEX)));
+                slotPacket.setItem(UNUSUABLE_CRAFTING_SPACE_BLOCK);
             }else{
                 slotPacket.setItem(Translators.getItemTranslator().translateToBedrock(session, inventory.getItem(i)));
             }

--- a/connector/src/main/java/org/geysermc/connector/network/translators/inventory/updater/ChestInventoryUpdater.java
+++ b/connector/src/main/java/org/geysermc/connector/network/translators/inventory/updater/ChestInventoryUpdater.java
@@ -33,9 +33,13 @@ import org.geysermc.connector.inventory.Inventory;
 import org.geysermc.connector.network.session.GeyserSession;
 import org.geysermc.connector.network.translators.Translators;
 import org.geysermc.connector.network.translators.inventory.InventoryTranslator;
+import org.geysermc.connector.utils.InventoryUtils;
 
 @AllArgsConstructor
 public class ChestInventoryUpdater extends InventoryUpdater {
+    private static final ItemData UNUSUABLE_SPACE_BLOCK = InventoryUtils.createUnusableSpaceBlock(
+            "This slot does not exist in the inventory\non Java Edition, as there is less\nrows than possible in Bedrock");
+
     private final int paddedSize;
 
     @Override
@@ -47,7 +51,7 @@ public class ChestInventoryUpdater extends InventoryUpdater {
             if (i <= translator.size) {
                 bedrockItems[i] = Translators.getItemTranslator().translateToBedrock(session, inventory.getItem(i));
             } else {
-                bedrockItems[i] = ItemData.AIR;
+                bedrockItems[i] = UNUSUABLE_SPACE_BLOCK;
             }
         }
 

--- a/connector/src/main/java/org/geysermc/connector/utils/InventoryUtils.java
+++ b/connector/src/main/java/org/geysermc/connector/utils/InventoryUtils.java
@@ -27,9 +27,12 @@ package org.geysermc.connector.utils;
 
 import com.github.steveice10.mc.protocol.data.game.entity.metadata.ItemStack;
 import com.github.steveice10.opennbt.tag.builtin.CompoundTag;
+import com.nukkitx.nbt.CompoundTagBuilder;
+import com.nukkitx.nbt.tag.StringTag;
 import com.nukkitx.protocol.bedrock.data.ContainerId;
 import com.nukkitx.protocol.bedrock.data.ItemData;
 import com.nukkitx.protocol.bedrock.packet.InventorySlotPacket;
+import org.geysermc.common.ChatColor;
 import org.geysermc.connector.GeyserConnector;
 import org.geysermc.connector.inventory.Inventory;
 import org.geysermc.connector.network.session.GeyserSession;
@@ -37,6 +40,7 @@ import org.geysermc.connector.network.translators.Translators;
 import org.geysermc.connector.network.translators.inventory.DoubleChestInventoryTranslator;
 import org.geysermc.connector.network.translators.inventory.InventoryTranslator;
 
+import java.util.Collections;
 import java.util.Objects;
 import java.util.concurrent.TimeUnit;
 
@@ -97,5 +101,20 @@ public class InventoryUtils {
         if (item1 == null || item2 == null)
             return false;
         return item1.equals(item2, false, true, true);
+    }
+
+    /**
+     * Returns a barrier block with custom name and lore to explain why
+     * part of the inventory is unusable.
+     */
+    public static ItemData createUnusableSpaceBlock(String description) {
+        CompoundTagBuilder root = CompoundTagBuilder.builder();
+        CompoundTagBuilder display = CompoundTagBuilder.builder();
+
+        display.stringTag("Name", ChatColor.RESET + "Unusable inventory space");
+        display.listTag("Lore", StringTag.class, Collections.singletonList(new StringTag("", ChatColor.RESET + ChatColor.DARK_PURPLE + description)));
+
+        root.tag(display.build("display"));
+        return ItemData.of(-161, (short) 0, 1, root.buildRootTag());
     }
 }

--- a/connector/src/main/java/org/geysermc/connector/utils/InventoryUtils.java
+++ b/connector/src/main/java/org/geysermc/connector/utils/InventoryUtils.java
@@ -115,6 +115,6 @@ public class InventoryUtils {
         display.listTag("Lore", StringTag.class, Collections.singletonList(new StringTag("", ChatColor.RESET + ChatColor.DARK_PURPLE + description)));
 
         root.tag(display.build("display"));
-        return ItemData.of(-161, (short) 0, 1, root.buildRootTag());
+        return ItemData.of(Toolbox.ITEM_ENTRIES.get(Toolbox.BARRIER_INDEX).getBedrockId(), (short) 0, 1, root.buildRootTag());
     }
 }


### PR DESCRIPTION
### Introduction
This pull request adds display tags to the barrier blocks in the creative crafting inventory to explain that it is unusable. It also sets unusable space in a chest to barriers with a description.

The description for the chest is pretty bad so feel free to modify it, just remember you need to add the newlines in yourself because bedrock doesnt wrap the text.

![image](https://user-images.githubusercontent.com/32024335/81094409-5e678700-8efb-11ea-9179-3056ebc1a724.png)
