### PR TITLE
Don't load floodgate if it isn't needed (Velocity)

### DIFF
--- a/bootstrap/velocity/src/main/java/org/geysermc/platform/velocity/GeyserVelocityConfiguration.java
+++ b/bootstrap/velocity/src/main/java/org/geysermc/platform/velocity/GeyserVelocityConfiguration.java
@@ -79,7 +79,7 @@ public class GeyserVelocityConfiguration implements GeyserConfiguration {
 
     public void loadFloodgate(GeyserVelocityPlugin plugin, ProxyServer proxyServer, File dataFolder) {
         Optional<PluginContainer> floodgate = proxyServer.getPluginManager().getPlugin("floodgate");
-        floodgateKey = FloodgateKeyLoader.getKey(plugin.getGeyserLogger(), this, Paths.get(dataFolder.toString(), floodgateKeyFile.isEmpty() ? floodgateKeyFile : "public-key.pem"), floodgate.get(), Paths.get("plugins/floodgate/"));
+        floodgate.ifPresent(it -> floodgateKey = FloodgateKeyLoader.getKey(plugin.getGeyserLogger(), this, Paths.get(dataFolder.toString(), floodgateKeyFile.isEmpty() ? floodgateKeyFile : "public-key.pem"), it, Paths.get("plugins/floodgate/")));
     }
 
     @Override


### PR DESCRIPTION
This simply doesn't load floodgate if floodgate can't be found in the plugins. (It originally didn't check to see if the Option had a present object, and an option will throw an exception if they have no present object.)