### PR TITLE
[WIP] Attempt to use ViaVersion to cache blocks

### DIFF
--- a/bootstrap/bukkit/pom.xml
+++ b/bootstrap/bukkit/pom.xml
@@ -23,6 +23,11 @@
             <version>1.14-R0.1-SNAPSHOT</version>
             <scope>provided</scope>
         </dependency>
+        <dependency>
+            <groupId>us.myles</groupId>
+            <artifactId>viaversion</artifactId>
+            <version>2.2.3</version>
+        </dependency>
     </dependencies>
     <build>
         <finalName>${outputName}-Bukkit</finalName>

--- a/bootstrap/bukkit/pom.xml
+++ b/bootstrap/bukkit/pom.xml
@@ -27,6 +27,7 @@
             <groupId>us.myles</groupId>
             <artifactId>viaversion</artifactId>
             <version>2.2.3</version>
+            <scope>provided</scope>
         </dependency>
     </dependencies>
     <build>

--- a/bootstrap/bukkit/src/main/java/org/geysermc/platform/bukkit/GeyserBukkitPlugin.java
+++ b/bootstrap/bukkit/src/main/java/org/geysermc/platform/bukkit/GeyserBukkitPlugin.java
@@ -35,6 +35,7 @@ import org.geysermc.connector.network.translators.world.WorldManager;
 import org.geysermc.platform.bukkit.command.GeyserBukkitCommandExecutor;
 import org.geysermc.platform.bukkit.command.GeyserBukkitCommandManager;
 import org.geysermc.platform.bukkit.world.GeyserBukkitWorldManager;
+import us.myles.ViaVersion.api.Via;
 
 import java.util.UUID;
 
@@ -73,7 +74,7 @@ public class GeyserBukkitPlugin extends JavaPlugin implements GeyserBootstrap {
         this.connector = GeyserConnector.start(PlatformType.BUKKIT, this);
 
         this.geyserCommandManager = new GeyserBukkitCommandManager(this, connector);
-        this.geyserWorldManager = new GeyserBukkitWorldManager();
+        this.geyserWorldManager = new GeyserBukkitWorldManager(getGeyserLogger());
 
         this.getCommand("geyser").setExecutor(new GeyserBukkitCommandExecutor(connector));
     }

--- a/bootstrap/bukkit/src/main/java/org/geysermc/platform/bukkit/world/GeyserBukkitWorldManager.java
+++ b/bootstrap/bukkit/src/main/java/org/geysermc/platform/bukkit/world/GeyserBukkitWorldManager.java
@@ -58,9 +58,6 @@ public class GeyserBukkitWorldManager extends WorldManager {
                     if (blockStates.length == 1) {
                         name = blockStates[0];
                     } else {
-                        for (int i = 0; i < blockStates.length; i++) {
-                            System.out.println("Data mapping: " + blockStates[i]);
-                        }
                         int data = Bukkit.getPlayer(session.getPlayerEntity().getUsername()).getWorld().getBlockAt(x, y, z).getData();
                         if (data <= blockStates.length) {
                             name = blockStates[data];

--- a/bootstrap/bukkit/src/main/resources/plugin.yml
+++ b/bootstrap/bukkit/src/main/resources/plugin.yml
@@ -3,6 +3,7 @@ name: ${outputName}-Bukkit
 author: ${project.organization.name}
 website: ${project.organization.url}
 version: ${project.version}
+softdepend: ["ViaVersion"]
 commands:
   geyser:
     description: The main command for Geyser.

--- a/pom.xml
+++ b/pom.xml
@@ -67,6 +67,10 @@
                 <enabled>true</enabled>
             </snapshots>
         </repository>
+        <repository>
+            <id>viaversion-repo</id>
+            <url>https://repo.viaversion.com</url>
+        </repository>
     </repositories>
 
     <distributionManagement>


### PR DESCRIPTION
Since server owners need ViaVersion installed if they use Geyser with a version lower than 1.13, I attempted to use it to get the block states we need to cache chunks. It gets maybe half of the blocks, but anything with extra block states I don't know how to figure out. 
If anything, you can take away the catch of the NoSuchMethodError so older Bukkit players stop getting the spam error.