### PR TITLE
Fallback to ViaVersion to convert block state

### DIFF
--- a/bootstrap/bukkit/pom.xml
+++ b/bootstrap/bukkit/pom.xml
@@ -26,7 +26,7 @@
         <dependency>
             <groupId>us.myles</groupId>
             <artifactId>viaversion</artifactId>
-            <version>2.2.3</version>
+            <version>3.0.0-SNAPSHOT</version>
             <scope>provided</scope>
         </dependency>
     </dependencies>

--- a/bootstrap/bukkit/pom.xml
+++ b/bootstrap/bukkit/pom.xml
@@ -23,6 +23,12 @@
             <version>1.14-R0.1-SNAPSHOT</version>
             <scope>provided</scope>
         </dependency>
+        <dependency>
+            <groupId>us.myles</groupId>
+            <artifactId>viaversion</artifactId>
+            <version>2.2.3</version>
+            <scope>provided</scope>
+        </dependency>
     </dependencies>
     <build>
         <finalName>${outputName}-Bukkit</finalName>

--- a/bootstrap/bukkit/src/main/java/org/geysermc/platform/bukkit/GeyserBukkitPlugin.java
+++ b/bootstrap/bukkit/src/main/java/org/geysermc/platform/bukkit/GeyserBukkitPlugin.java
@@ -73,7 +73,7 @@ public class GeyserBukkitPlugin extends JavaPlugin implements GeyserBootstrap {
         this.connector = GeyserConnector.start(PlatformType.BUKKIT, this);
 
         this.geyserCommandManager = new GeyserBukkitCommandManager(this, connector);
-        this.geyserWorldManager = new GeyserBukkitWorldManager();
+        this.geyserWorldManager = new GeyserBukkitWorldManager(Bukkit.getPluginManager().getPlugin("ViaVersion") != null);
 
         this.getCommand("geyser").setExecutor(new GeyserBukkitCommandExecutor(connector));
     }

--- a/bootstrap/bukkit/src/main/java/org/geysermc/platform/bukkit/GeyserBukkitPlugin.java
+++ b/bootstrap/bukkit/src/main/java/org/geysermc/platform/bukkit/GeyserBukkitPlugin.java
@@ -35,6 +35,7 @@ import org.geysermc.connector.network.translators.world.WorldManager;
 import org.geysermc.platform.bukkit.command.GeyserBukkitCommandExecutor;
 import org.geysermc.platform.bukkit.command.GeyserBukkitCommandManager;
 import org.geysermc.platform.bukkit.world.GeyserBukkitWorldManager;
+import us.myles.ViaVersion.api.Via;
 
 import java.util.UUID;
 
@@ -73,7 +74,18 @@ public class GeyserBukkitPlugin extends JavaPlugin implements GeyserBootstrap {
         this.connector = GeyserConnector.start(PlatformType.BUKKIT, this);
 
         this.geyserCommandManager = new GeyserBukkitCommandManager(this, connector);
-        this.geyserWorldManager = new GeyserBukkitWorldManager(Bukkit.getPluginManager().getPlugin("ViaVersion") != null);
+
+        boolean isViaVersion = false;
+        if (Bukkit.getPluginManager().getPlugin("ViaVersion") != null) {
+            // TODO: Update if ViaVersion updates or Minecraft updates
+            if (!Via.getAPI().getVersion().equals("3.0.0-SNAPSHOT") && !Bukkit.getServer().getVersion().contains("1.15.2")) {
+                geyserLogger.info("ViaVersion detected but not ViaVersion-ABSTRACTION. Please update your ViaVersion plugin for compatibility with Geyser. You can safely ignore this message if you are on 1.13 or above.");
+            } else {
+                isViaVersion = true;
+            }
+        }
+
+        this.geyserWorldManager = new GeyserBukkitWorldManager(isViaVersion);
 
         this.getCommand("geyser").setExecutor(new GeyserBukkitCommandExecutor(connector));
     }

--- a/bootstrap/bukkit/src/main/java/org/geysermc/platform/bukkit/world/GeyserBukkitWorldManager.java
+++ b/bootstrap/bukkit/src/main/java/org/geysermc/platform/bukkit/world/GeyserBukkitWorldManager.java
@@ -58,10 +58,10 @@ public class GeyserBukkitWorldManager extends WorldManager {
                 // Black magic that gets the old block state ID
                 int oldBlockId = (block.getType().getId() << 4) | (block.getData() & 0xF);
                 // Convert block state from old version -> 1.13 -> 1.13.1 -> 1.14 -> 1.15
-                int thirteenBlockId = us.myles.ViaVersion.protocols.protocol1_13to1_12_2.data.MappingData.blockMappings.getNewBlock(oldBlockId);
+                int thirteenBlockId = us.myles.ViaVersion.protocols.protocol1_13to1_12_2.data.MappingData.blockMappings.getNewId(oldBlockId);
                 int thirteenPointOneBlockId = Protocol1_13_1To1_13.getNewBlockStateId(thirteenBlockId);
-                int fourteenBlockId = us.myles.ViaVersion.protocols.protocol1_14to1_13_2.data.MappingData.blockStateMappings.getNewBlock(thirteenPointOneBlockId);
-                return new BlockState(MappingData.blockStateMappings.getNewBlock(fourteenBlockId));
+                int fourteenBlockId = us.myles.ViaVersion.protocols.protocol1_14to1_13_2.data.MappingData.blockStateMappings.getNewId(thirteenPointOneBlockId);
+                return new BlockState(MappingData.blockStateMappings.getNewId(fourteenBlockId));
             } else {
                 return BlockTranslator.AIR;
             }

--- a/bootstrap/bukkit/src/main/java/org/geysermc/platform/bukkit/world/GeyserBukkitWorldManager.java
+++ b/bootstrap/bukkit/src/main/java/org/geysermc/platform/bukkit/world/GeyserBukkitWorldManager.java
@@ -40,8 +40,9 @@ import us.myles.ViaVersion.protocols.protocol1_15to1_14_4.data.MappingData;
 @AllArgsConstructor
 public class GeyserBukkitWorldManager extends WorldManager {
 
-    // Since ProtocolSupport isn't supported (at least with Floodgate) as of the time of this code, you need ViaVersion to connect to an older server.
-    // However, there is a possibility that Geyser can connect to a server without ViaVersion on Spigot, so this is the precaution
+    private final boolean isLegacy;
+    // You need ViaVersion to connect to an older server with Geyser.
+    // However, we still check for ViaVersion in case there's some other way that gets Geyser on a pre-1.13 Bukkit server
     private final boolean isViaVersion;
 
     @Override
@@ -50,9 +51,7 @@ public class GeyserBukkitWorldManager extends WorldManager {
         if (session.getPlayerEntity() == null) {
             return BlockTranslator.AIR;
         }
-        try {
-            return BlockTranslator.getJavaIdBlockMap().get(Bukkit.getPlayer(session.getPlayerEntity().getUsername()).getWorld().getBlockAt(x, y, z).getBlockData().getAsString());
-        } catch (NoSuchMethodError ex) {
+        if (isLegacy) {
             if (isViaVersion) {
                 Block block = Bukkit.getPlayer(session.getPlayerEntity().getUsername()).getWorld().getBlockAt(x, y, z);
                 // Black magic that gets the old block state ID
@@ -66,5 +65,6 @@ public class GeyserBukkitWorldManager extends WorldManager {
                 return BlockTranslator.AIR;
             }
         }
+        return BlockTranslator.getJavaIdBlockMap().get(Bukkit.getPlayer(session.getPlayerEntity().getUsername()).getWorld().getBlockAt(x, y, z).getBlockData().getAsString());
     }
 }

--- a/bootstrap/bukkit/src/main/resources/plugin.yml
+++ b/bootstrap/bukkit/src/main/resources/plugin.yml
@@ -3,6 +3,7 @@ name: ${outputName}-Bukkit
 author: ${project.organization.name}
 website: ${project.organization.url}
 version: ${project.version}
+softdepend: ["ViaVersion"]
 commands:
   geyser:
     description: The main command for Geyser.

--- a/pom.xml
+++ b/pom.xml
@@ -67,6 +67,10 @@
                 <enabled>true</enabled>
             </snapshots>
         </repository>
+        <repository>
+            <id>viaversion-repo</id>
+            <url>https://repo.viaversion.com</url>
+        </repository>
     </repositories>
 
     <distributionManagement>


### PR DESCRIPTION
Since most users will be using ViaVersion if their server version is below 1.13, this code uses ViaVersion's code to get the correct block state for chunk caching on Bukkit. (And if ViaVersion is not installed, the air block state should be returned instead of giving a NPE)