### PR TITLE
Add visual support for enchantment table book

### DIFF
--- a/connector/src/main/java/org/geysermc/connector/network/translators/world/block/BlockStateValues.java
+++ b/connector/src/main/java/org/geysermc/connector/network/translators/world/block/BlockStateValues.java
@@ -48,6 +48,7 @@ public class BlockStateValues {
     private static final Object2IntMap<BlockState> BANNER_COLORS = new Object2IntOpenHashMap<>();
     private static final Object2ByteMap<BlockState> BED_COLORS = new Object2ByteOpenHashMap<>();
     private static final Int2ObjectMap<DoubleChestValue> DOUBLE_CHEST_VALUES = new Int2ObjectOpenHashMap<>();
+    private static int ENCHANTMENT_TABLE_ID = 0;
     private static final Int2ObjectMap<String> FLOWER_POT_VALUES = new Int2ObjectOpenHashMap<>();
     private static final Map<String, CompoundTag> FLOWER_POT_BLOCKS = new HashMap<>();
     private static final Object2IntMap<BlockState> NOTEBLOCK_PITCHES = new Object2IntOpenHashMap<>();
@@ -81,6 +82,11 @@ public class BlockStateValues {
                     (entry.getValue().get("z") != null && entry.getValue().get("z").asBoolean()));
             boolean isLeft = (entry.getValue().get("double_chest_position").asText().contains("left"));
             DOUBLE_CHEST_VALUES.put(javaBlockState.getId(), new DoubleChestValue(isX, isDirectionPositive, isLeft));
+            return;
+        }
+
+        if (entry.getKey().equals("minecraft:enchanting_table")) {
+            ENCHANTMENT_TABLE_ID = javaBlockState.getId();
             return;
         }
 
@@ -153,6 +159,13 @@ public class BlockStateValues {
      */
     public static Int2ObjectMap<DoubleChestValue> getDoubleChestValues() {
         return DOUBLE_CHEST_VALUES;
+    }
+
+    /**
+     * @return The Java block state ID of the enchantment table
+     */
+    public static int getEnchantmentTableId() {
+        return ENCHANTMENT_TABLE_ID;
     }
 
     /**

--- a/connector/src/main/java/org/geysermc/connector/network/translators/world/block/entity/EnchantmentTableBlockEntityTranslator.java
+++ b/connector/src/main/java/org/geysermc/connector/network/translators/world/block/entity/EnchantmentTableBlockEntityTranslator.java
@@ -28,37 +28,35 @@ package org.geysermc.connector.network.translators.world.block.entity;
 
 import com.github.steveice10.mc.protocol.data.game.world.block.BlockState;
 import com.nukkitx.math.vector.Vector3i;
+import com.nukkitx.nbt.CompoundTagBuilder;
 import com.nukkitx.nbt.tag.CompoundTag;
 import org.geysermc.connector.network.session.GeyserSession;
+import org.geysermc.connector.network.translators.world.block.BlockStateValues;
+import org.geysermc.connector.utils.BlockEntityUtils;
 
 /**
- * Implemented only if a block is a block entity in Bedrock and not Java Edition.
+ * The enchantment table requires a block entity tag in order to show the floating book
  */
-public interface BedrockOnlyBlockEntity {
+public class EnchantmentTableBlockEntityTranslator implements BedrockOnlyBlockEntity, RequiresBlockState {
 
-    /**
-     * Update the block on Bedrock Edition.
-     * @param session GeyserSession.
-     * @param blockState The Java block state.
-     * @param position The Bedrock block position.
-     */
-    void updateBlock(GeyserSession session, BlockState blockState, Vector3i position);
+    @Override
+    public boolean isBlock(BlockState blockState) {
+        return BlockStateValues.getEnchantmentTableId() != 0 && blockState.getId() == BlockStateValues.getEnchantmentTableId();
+    }
 
-    /**
-     * Get the tag of the Bedrock-only block entity
-     * @param position Bedrock position of block.
-     * @param blockState Java BlockState of block.
-     * @return Bedrock tag, or null if not a Bedrock-only Block Entity
-     */
-    static CompoundTag getTag(Vector3i position, BlockState blockState) {
-        // The reason this mess of code exists is because there's so few, and the piston is updated differently
-        if (new FlowerPotBlockEntityTranslator().isBlock(blockState)) {
-            return FlowerPotBlockEntityTranslator.getTag(blockState, position);
-        } else if (PistonBlockEntityTranslator.isBlock(blockState)) {
-            return PistonBlockEntityTranslator.getTag(blockState, position);
-        } else if (new EnchantmentTableBlockEntityTranslator().isBlock(blockState)) {
-            return EnchantmentTableBlockEntityTranslator.getTag(position);
-        }
-        return null;
+    @Override
+    public void updateBlock(GeyserSession session, BlockState blockState, Vector3i position) {
+        BlockEntityUtils.updateBlockEntity(session, getTag(position), position);
+    }
+
+    public static CompoundTag getTag(Vector3i position) {
+        CompoundTagBuilder tagBuilder = CompoundTagBuilder.builder()
+                .intTag("x", position.getX())
+                .intTag("y", position.getY())
+                .intTag("z", position.getZ())
+                .byteTag("isMovable", (byte) 1)
+                .stringTag("id", "EnchantTable")
+                .floatTag("rott", 0.0f);
+        return tagBuilder.buildRootTag();
     }
 }

--- a/connector/src/main/java/org/geysermc/connector/utils/ChunkUtils.java
+++ b/connector/src/main/java/org/geysermc/connector/utils/ChunkUtils.java
@@ -87,19 +87,19 @@ public class ChunkUtils {
                         BlockState blockState = chunk.get(x, y, z);
                         int id = BlockTranslator.getBedrockBlockId(blockState);
 
+                        Position pos = new ChunkPosition(column.getX(), column.getZ()).getBlock(x, (chunkY << 4) + y, z);
+
                         // Check to see if the name is in BlockTranslator.getBlockEntityString, and therefore must be handled differently
                         if (BlockTranslator.getBlockEntityString(blockState) != null) {
-                            Position pos = new ChunkPosition(column.getX(), column.getZ()).getBlock(x, (chunkY << 4) + y, z);
                             blockEntityPositions.put(pos, blockState);
                         }
 
                         section.getBlockStorageArray()[0].setFullBlock(ChunkSection.blockPosition(x, y, z), id);
 
-                        // Check if block is piston or flower - only block entities in Bedrock
-                        if (BlockStateValues.getFlowerPotValues().containsKey(blockState.getId()) ||
-                                BlockStateValues.getPistonValues().containsKey(blockState.getId())) {
-                            Position pos = new ChunkPosition(column.getX(), column.getZ()).getBlock(x, (chunkY << 4) + y, z);
-                            bedrockOnlyBlockEntities.add(BedrockOnlyBlockEntity.getTag(Vector3i.from(pos.getX(), pos.getY(), pos.getZ()), blockState));
+                        // Check for block entities that only exist on Bedrock
+                        com.nukkitx.nbt.tag.CompoundTag tag = BedrockOnlyBlockEntity.getTag(Vector3i.from(pos.getX(), pos.getY(), pos.getZ()), blockState);
+                        if (tag != null) {
+                            bedrockOnlyBlockEntities.add(tag);
                         }
 
                         if (BlockTranslator.isWaterlogged(blockState)) {


### PR DESCRIPTION
This commit adds support for the floating book above the enchantment table, which is part of the block entity of the enchantment book.