### PR TITLE
Break for loop in GeyserBukkitBlockPlaceListener when a player is found

### DIFF
--- a/bootstrap/bukkit/src/main/java/org/geysermc/platform/bukkit/world/GeyserBukkitBlockPlaceListener.java
+++ b/bootstrap/bukkit/src/main/java/org/geysermc/platform/bukkit/world/GeyserBukkitBlockPlaceListener.java
@@ -56,6 +56,7 @@ public class GeyserBukkitBlockPlaceListener implements Listener {
                 session.sendUpstreamPacket(placeBlockSoundPacket);
                 session.setLastBlockPlacePosition(null);
                 session.setLastBlockPlacedId(null);
+                break;
             }
         }
     }


### PR DESCRIPTION
No need to keep searching when a player is found.