### PR TITLE
Replace illusioners with pillagers

### DIFF
--- a/connector/src/main/java/org/geysermc/connector/entity/type/EntityType.java
+++ b/connector/src/main/java/org/geysermc/connector/entity/type/EntityType.java
@@ -152,7 +152,12 @@ public enum EntityType {
     /**
      * Item frames are handled differently since they are a block in Bedrock.
      */
-    ITEM_FRAME(ItemFrameEntity.class, 0, 0, 0);
+    ITEM_FRAME(ItemFrameEntity.class, 0, 0, 0),
+
+    /**
+     * Not an entity in Bedrock, so we replace it with a Pillager
+     */
+    ILLUSIONER(AbstractIllagerEntity.class, 114, 1.8f, 0.6f, 0.6f, 1.62f, "minecraft:pillager");
 
     private Class<? extends Entity> entityClass;
     private final int type;


### PR DESCRIPTION
Illusioners do not exist in Bedrock edition; this commit replaces them with pillagers so they can be somewhat replicated.