### PR TITLE
Fixed unusable space being off by 1

### DIFF
--- a/connector/src/main/java/org/geysermc/connector/network/translators/inventory/updater/ChestInventoryUpdater.java
+++ b/connector/src/main/java/org/geysermc/connector/network/translators/inventory/updater/ChestInventoryUpdater.java
@@ -48,7 +48,7 @@ public class ChestInventoryUpdater extends InventoryUpdater {
 
         ItemData[] bedrockItems = new ItemData[paddedSize];
         for (int i = 0; i < bedrockItems.length; i++) {
-            if (i <= translator.size) {
+            if (i < translator.size) {
                 bedrockItems[i] = Translators.getItemTranslator().translateToBedrock(session, inventory.getItem(i));
             } else {
                 bedrockItems[i] = UNUSUABLE_SPACE_BLOCK;


### PR DESCRIPTION
Fixes the unusable slot item being off by 1 in inventories.
Before:
![image](https://user-images.githubusercontent.com/5401186/81996558-3be51480-9645-11ea-8f4b-b6b2c0cefc01.png)

After:
![image](https://user-images.githubusercontent.com/5401186/81996510-2374fa00-9645-11ea-8ee9-10c812c1e61b.png)
