### PR TITLE
Add enchantment table book visual on chunk load

### DIFF
--- a/connector/src/main/java/org/geysermc/connector/utils/BlockEntityUtils.java
+++ b/connector/src/main/java/org/geysermc/connector/utils/BlockEntityUtils.java
@@ -22,6 +22,10 @@ public class BlockEntityUtils {
         if (id.contains("EnderChest"))
             return "EnderChest";
 
+        if (id.contains("enchanting_table")) {
+            return "EnchantTable";
+        }
+
         id = id.toLowerCase()
             .replace("minecraft:", "")
             .replace("_", " ");


### PR DESCRIPTION
Java's block entity ID is enchantment_table whereas Bedrock's is EnchantTable; this commit adds an exception to the block entity regex as such.