### PR TITLE
Added map icons

### DIFF
--- a/connector/src/main/java/org/geysermc/connector/network/translators/item/translators/nbt/MapItemTranslator.java
+++ b/connector/src/main/java/org/geysermc/connector/network/translators/item/translators/nbt/MapItemTranslator.java
@@ -25,6 +25,7 @@
 
 package org.geysermc.connector.network.translators.item.translators.nbt;
 
+import com.github.steveice10.opennbt.tag.builtin.ByteTag;
 import com.github.steveice10.opennbt.tag.builtin.CompoundTag;
 import com.github.steveice10.opennbt.tag.builtin.IntTag;
 import com.github.steveice10.opennbt.tag.builtin.StringTag;
@@ -42,6 +43,7 @@ public class MapItemTranslator extends NbtItemStackTranslator {
         if (mapId != null) {
             itemTag.put(new StringTag("map_uuid", mapId.getValue().toString()));
             itemTag.put(new IntTag("map_name_index", mapId.getValue()));
+            itemTag.put(new ByteTag("map_display_players", (byte) 1));
             itemTag.remove("map");
         }
     }

--- a/connector/src/main/java/org/geysermc/connector/network/translators/java/world/JavaMapDataTranslator.java
+++ b/connector/src/main/java/org/geysermc/connector/network/translators/java/world/JavaMapDataTranslator.java
@@ -25,9 +25,17 @@
 
 package org.geysermc.connector.network.translators.java.world;
 
+import com.fasterxml.jackson.databind.ObjectMapper;
 import com.github.steveice10.mc.protocol.data.game.world.map.MapData;
+import com.github.steveice10.mc.protocol.data.game.world.map.MapIcon;
+import com.github.steveice10.mc.protocol.data.game.world.map.MapIconType;
 import com.github.steveice10.mc.protocol.packet.ingame.server.world.ServerMapDataPacket;
+import com.nukkitx.protocol.bedrock.data.MapDecoration;
+import com.nukkitx.protocol.bedrock.data.MapTrackedObject;
 import com.nukkitx.protocol.bedrock.packet.ClientboundMapItemDataPacket;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import org.geysermc.connector.GeyserConnector;
 import org.geysermc.connector.network.session.GeyserSession;
 import org.geysermc.connector.network.translators.PacketTranslator;
 import org.geysermc.connector.network.translators.Translator;
@@ -60,8 +68,141 @@ public class JavaMapDataTranslator extends PacketTranslator<ServerMapDataPacket>
             }
 
             mapItemDataPacket.setColors(colors);
+
+        }
+
+        try {
+            GeyserConnector.getInstance().getLogger().debug(new ObjectMapper().writeValueAsString(packet.getIcons()));
+        } catch (Exception e) { }
+
+        // Bedrock needs a tracked entity id
+        int id = 0;
+        for (MapIcon icon : packet.getIcons()) {
+            BedrockMapIcon bedrockMapIcon = new BedrockMapIcon(icon.getIconType());
+
+            mapItemDataPacket.getTrackedObjects().add(new MapTrackedObject(id));
+            mapItemDataPacket.getDecorations().add(new MapDecoration(bedrockMapIcon.getImageID(), icon.getIconRotation(), icon.getCenterX(), icon.getCenterZ(), "", bedrockMapIcon.getImageColour()));
+            id++;
         }
 
         session.getUpstream().getSession().sendPacket(mapItemDataPacket);
+    }
+
+    @Getter
+    @AllArgsConstructor
+    class BedrockMapIcon {
+        private int imageID;
+        private int imageColour;
+
+        public BedrockMapIcon(MapIconType type) {
+            imageID = 0;
+            imageColour = -1;
+
+            switch (type) {
+                case WHITE_ARROW:
+                    imageID = 0;
+                    break;
+                case GREEN_ARROW: // For item frames
+                    imageID = 7; // Displays as an item frame normal green markers are 1
+                    break;
+                case RED_ARROW:
+                    imageID = 2;
+                    break;
+                case BLUE_ARROW:
+                    imageID = 3;
+                    break;
+                case TREASURE_MARKER:
+                    imageID = 4;
+                    break;
+                case RED_POINTER:
+                    imageID = 5;
+                    break;
+                case WHITE_CIRCLE:
+                    imageID = 6;
+                    break;
+                case SMALL_WHITE_CIRCLE:
+                    imageID = 13;
+                    break;
+                case MANSION:
+                    imageID = 14;
+                    break;
+                case TEMPLE:
+                    imageID = 15;
+                    break;
+                case WHITE_BANNER:
+                    imageColour = toARGB(255, 255, 255);
+                    imageID = 13;
+                    break;
+                case ORANGE_BANNER:
+                    imageColour = toARGB(249, 128, 29);
+                    imageID = 13;
+                    break;
+                case MAGENTA_BANNER:
+                    imageColour = toARGB(199, 78, 189);
+                    imageID = 13;
+                    break;
+                case LIGHT_BLUE_BANNER:
+                    imageColour = toARGB(58, 179, 218);
+                    imageID = 13;
+                    break;
+                case YELLOW_BANNER:
+                    imageColour = toARGB(254, 216, 61);
+                    imageID = 13;
+                    break;
+                case LIME_BANNER:
+                    imageColour = toARGB(128, 199, 31);
+                    imageID = 13;
+                    break;
+                case PINK_BANNER:
+                    imageColour = toARGB(243, 139, 170);
+                    imageID = 13;
+                    break;
+                case GRAY_BANNER:
+                    imageColour = toARGB(71, 79, 82);
+                    imageID = 13;
+                    break;
+                case LIGHT_GRAY_BANNER:
+                    imageColour = toARGB(157, 157, 151);
+                    imageID = 13;
+                    break;
+                case CYAN_BANNER:
+                    imageColour = toARGB(22, 156, 156);
+                    imageID = 13;
+                    break;
+                case PURPLE_BANNER:
+                    imageColour = toARGB(137, 50, 184);
+                    imageID = 13;
+                    break;
+                case BLUE_BANNER:
+                    imageColour = toARGB(60, 68, 170);
+                    imageID = 13;
+                    break;
+                case BROWN_BANNER:
+                    imageColour = toARGB(131, 84, 50);
+                    imageID = 13;
+                    break;
+                case GREEN_BANNER:
+                    imageColour = toARGB(94, 124, 22);
+                    imageID = 13;
+                    break;
+                case RED_BANNER:
+                    imageColour = toARGB(176, 46, 38);
+                    imageID = 13;
+                    break;
+                case BLACK_BANNER:
+                    imageColour = toARGB(29, 29, 33);
+                    imageID = 13;
+                    break;
+            }
+        }
+
+        public int toARGB(int red, int green, int blue) {
+            int alpha = 255;
+
+            return ((alpha & 0xFF) << 24) |
+                    ((red & 0xFF) << 16) |
+                    ((green & 0xFF) << 8) |
+                    ((blue & 0xFF) << 0);
+        }
     }
 }

--- a/connector/src/main/java/org/geysermc/connector/network/translators/java/world/JavaMapDataTranslator.java
+++ b/connector/src/main/java/org/geysermc/connector/network/translators/java/world/JavaMapDataTranslator.java
@@ -25,20 +25,16 @@
 
 package org.geysermc.connector.network.translators.java.world;
 
-import com.fasterxml.jackson.databind.ObjectMapper;
 import com.github.steveice10.mc.protocol.data.game.world.map.MapData;
 import com.github.steveice10.mc.protocol.data.game.world.map.MapIcon;
-import com.github.steveice10.mc.protocol.data.game.world.map.MapIconType;
 import com.github.steveice10.mc.protocol.packet.ingame.server.world.ServerMapDataPacket;
 import com.nukkitx.protocol.bedrock.data.MapDecoration;
 import com.nukkitx.protocol.bedrock.data.MapTrackedObject;
 import com.nukkitx.protocol.bedrock.packet.ClientboundMapItemDataPacket;
-import lombok.AllArgsConstructor;
-import lombok.Getter;
-import org.geysermc.connector.GeyserConnector;
 import org.geysermc.connector.network.session.GeyserSession;
 import org.geysermc.connector.network.translators.PacketTranslator;
 import org.geysermc.connector.network.translators.Translator;
+import org.geysermc.connector.utils.BedrockMapIcon;
 import org.geysermc.connector.utils.MapColor;
 
 @Translator(packet = ServerMapDataPacket.class)
@@ -68,141 +64,18 @@ public class JavaMapDataTranslator extends PacketTranslator<ServerMapDataPacket>
             }
 
             mapItemDataPacket.setColors(colors);
-
         }
 
-        try {
-            GeyserConnector.getInstance().getLogger().debug(new ObjectMapper().writeValueAsString(packet.getIcons()));
-        } catch (Exception e) { }
-
-        // Bedrock needs a tracked entity id
+        // Bedrock needs an entity id to display an icon
         int id = 0;
         for (MapIcon icon : packet.getIcons()) {
-            BedrockMapIcon bedrockMapIcon = new BedrockMapIcon(icon.getIconType());
+            BedrockMapIcon bedrockMapIcon = BedrockMapIcon.fromType(icon.getIconType());
 
             mapItemDataPacket.getTrackedObjects().add(new MapTrackedObject(id));
-            mapItemDataPacket.getDecorations().add(new MapDecoration(bedrockMapIcon.getImageID(), icon.getIconRotation(), icon.getCenterX(), icon.getCenterZ(), "", bedrockMapIcon.getImageColour()));
+            mapItemDataPacket.getDecorations().add(new MapDecoration(bedrockMapIcon.getIconID(), icon.getIconRotation(), icon.getCenterX(), icon.getCenterZ(), "", bedrockMapIcon.toARGB()));
             id++;
         }
 
         session.getUpstream().getSession().sendPacket(mapItemDataPacket);
-    }
-
-    @Getter
-    @AllArgsConstructor
-    class BedrockMapIcon {
-        private int imageID;
-        private int imageColour;
-
-        public BedrockMapIcon(MapIconType type) {
-            imageID = 0;
-            imageColour = -1;
-
-            switch (type) {
-                case WHITE_ARROW:
-                    imageID = 0;
-                    break;
-                case GREEN_ARROW: // For item frames
-                    imageID = 7; // Displays as an item frame normal green markers are 1
-                    break;
-                case RED_ARROW:
-                    imageID = 2;
-                    break;
-                case BLUE_ARROW:
-                    imageID = 3;
-                    break;
-                case TREASURE_MARKER:
-                    imageID = 4;
-                    break;
-                case RED_POINTER:
-                    imageID = 5;
-                    break;
-                case WHITE_CIRCLE:
-                    imageID = 6;
-                    break;
-                case SMALL_WHITE_CIRCLE:
-                    imageID = 13;
-                    break;
-                case MANSION:
-                    imageID = 14;
-                    break;
-                case TEMPLE:
-                    imageID = 15;
-                    break;
-                case WHITE_BANNER:
-                    imageColour = toARGB(255, 255, 255);
-                    imageID = 13;
-                    break;
-                case ORANGE_BANNER:
-                    imageColour = toARGB(249, 128, 29);
-                    imageID = 13;
-                    break;
-                case MAGENTA_BANNER:
-                    imageColour = toARGB(199, 78, 189);
-                    imageID = 13;
-                    break;
-                case LIGHT_BLUE_BANNER:
-                    imageColour = toARGB(58, 179, 218);
-                    imageID = 13;
-                    break;
-                case YELLOW_BANNER:
-                    imageColour = toARGB(254, 216, 61);
-                    imageID = 13;
-                    break;
-                case LIME_BANNER:
-                    imageColour = toARGB(128, 199, 31);
-                    imageID = 13;
-                    break;
-                case PINK_BANNER:
-                    imageColour = toARGB(243, 139, 170);
-                    imageID = 13;
-                    break;
-                case GRAY_BANNER:
-                    imageColour = toARGB(71, 79, 82);
-                    imageID = 13;
-                    break;
-                case LIGHT_GRAY_BANNER:
-                    imageColour = toARGB(157, 157, 151);
-                    imageID = 13;
-                    break;
-                case CYAN_BANNER:
-                    imageColour = toARGB(22, 156, 156);
-                    imageID = 13;
-                    break;
-                case PURPLE_BANNER:
-                    imageColour = toARGB(137, 50, 184);
-                    imageID = 13;
-                    break;
-                case BLUE_BANNER:
-                    imageColour = toARGB(60, 68, 170);
-                    imageID = 13;
-                    break;
-                case BROWN_BANNER:
-                    imageColour = toARGB(131, 84, 50);
-                    imageID = 13;
-                    break;
-                case GREEN_BANNER:
-                    imageColour = toARGB(94, 124, 22);
-                    imageID = 13;
-                    break;
-                case RED_BANNER:
-                    imageColour = toARGB(176, 46, 38);
-                    imageID = 13;
-                    break;
-                case BLACK_BANNER:
-                    imageColour = toARGB(29, 29, 33);
-                    imageID = 13;
-                    break;
-            }
-        }
-
-        public int toARGB(int red, int green, int blue) {
-            int alpha = 255;
-
-            return ((alpha & 0xFF) << 24) |
-                    ((red & 0xFF) << 16) |
-                    ((green & 0xFF) << 8) |
-                    ((blue & 0xFF) << 0);
-        }
     }
 }

--- a/connector/src/main/java/org/geysermc/connector/utils/BedrockMapIcon.java
+++ b/connector/src/main/java/org/geysermc/connector/utils/BedrockMapIcon.java
@@ -1,0 +1,118 @@
+/*
+ * Copyright (c) 2019-2020 GeyserMC. http://geysermc.org
+ *
+ *  Permission is hereby granted, free of charge, to any person obtaining a copy
+ *  of this software and associated documentation files (the "Software"), to deal
+ *  in the Software without restriction, including without limitation the rights
+ *  to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ *  copies of the Software, and to permit persons to whom the Software is
+ *  furnished to do so, subject to the following conditions:
+ *
+ *  The above copyright notice and this permission notice shall be included in
+ *  all copies or substantial portions of the Software.
+ *
+ *  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ *  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ *  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ *  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ *  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ *  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ *  THE SOFTWARE.
+ *
+ *  @author GeyserMC
+ *  @link https://github.com/GeyserMC/Geyser
+ *
+ */
+
+package org.geysermc.connector.utils;
+
+import com.github.steveice10.mc.protocol.data.game.world.map.MapIconType;
+import lombok.Getter;
+
+public enum BedrockMapIcon {
+    ICON_WHITE_ARROW(MapIconType.WHITE_ARROW, 0),
+    ICON_ITEM_FRAME(MapIconType.GREEN_ARROW, 7),
+    ICON_RED_ARROW(MapIconType.RED_ARROW, 2),
+    ICON_BLUE_ARROW(MapIconType.BLUE_ARROW, 3),
+    ICON_TREASURE_MARKER(MapIconType.TREASURE_MARKER, 4),
+    ICON_RED_POINTER(MapIconType.RED_POINTER, 5),
+    ICON_WHITE_CIRCLE(MapIconType.WHITE_CIRCLE, 6),
+    ICON_SMALL_WHITE_CIRCLE(MapIconType.SMALL_WHITE_CIRCLE, 13),
+    ICON_MANSION(MapIconType.MANSION, 14),
+    ICON_TEMPLE(MapIconType.TEMPLE, 15),
+    ICON_WHITE_BANNER(MapIconType.WHITE_BANNER, 13, 255, 255, 255),
+    ICON_ORANGE_BANNER(MapIconType.ORANGE_BANNER, 13, 249, 128, 29),
+    ICON_MAGENTA_BANNER(MapIconType.MAGENTA_BANNER, 13, 199, 78, 189),
+    ICON_LIGHT_BLUE_BANNER(MapIconType.LIGHT_BLUE_BANNER, 13, 58, 179, 218),
+    ICON_YELLOW_BANNER(MapIconType.YELLOW_BANNER, 13, 254, 216, 61),
+    ICON_LIME_BANNER(MapIconType.LIME_BANNER, 13, 128, 199, 31),
+    ICON_PINK_BANNER(MapIconType.PINK_BANNER, 13, 243, 139, 170),
+    ICON_GRAY_BANNER(MapIconType.GRAY_BANNER, 13, 71, 79, 82),
+    ICON_LIGHT_GRAY_BANNER(MapIconType.LIGHT_GRAY_BANNER, 13, 157, 157, 151),
+    ICON_CYAN_BANNER(MapIconType.CYAN_BANNER, 13, 22, 156, 156),
+    ICON_PURPLE_BANNER(MapIconType.PURPLE_BANNER, 13, 137, 50, 184),
+    ICON_BLUE_BANNER(MapIconType.BLUE_BANNER, 13, 60, 68, 170),
+    ICON_BROWN_BANNER(MapIconType.BROWN_BANNER, 13, 131, 84, 50),
+    ICON_GREEN_BANNER(MapIconType.GREEN_BANNER, 13, 94, 124, 22),
+    ICON_RED_BANNER(MapIconType.RED_BANNER, 13, 176, 46, 38),
+    ICON_BLACK_BANNER(MapIconType.BLACK_BANNER, 13, 29, 29, 33);
+
+    private static final BedrockMapIcon[] VALUES = values();
+
+    private MapIconType iconType;
+
+    @Getter
+    private int iconID;
+
+    private int red;
+    private int green;
+    private int blue;
+
+    BedrockMapIcon(MapIconType iconType, int iconID) {
+        this.iconType = iconType;
+        this.iconID = iconID;
+
+        this.red = 255;
+        this.green = 255;
+        this.blue = 255;
+    }
+
+    BedrockMapIcon(MapIconType iconType, int iconID, int red, int green, int blue) {
+        this.iconType = iconType;
+        this.iconID = iconID;
+
+        this.red = red;
+        this.green = green;
+        this.blue = blue;
+    }
+
+    /**
+     * Get the BedrockMapIcon for the Java MapIconType
+     *
+     * @param iconType A MapIconType
+     * @return The mapping for a BedrockMapIcon
+     */
+    public static BedrockMapIcon fromType(MapIconType iconType) {
+        for (BedrockMapIcon icon : VALUES) {
+            if (icon.iconType.equals(iconType)) {
+                return icon;
+            }
+        }
+
+        return null;
+    }
+
+    /**
+     * Get the ARGB value of a BedrockMapIcon
+     *
+     * @return ARGB as an int
+     */
+    public int toARGB() {
+        int alpha = 255;
+
+        return ((alpha & 0xFF) << 24) |
+                ((red & 0xFF) << 16) |
+                ((green & 0xFF) << 8) |
+                ((blue & 0xFF) << 0);
+    }
+}

--- a/connector/src/main/java/org/geysermc/connector/utils/MapColor.java
+++ b/connector/src/main/java/org/geysermc/connector/utils/MapColor.java
@@ -1,3 +1,29 @@
+/*
+ * Copyright (c) 2019-2020 GeyserMC. http://geysermc.org
+ *
+ *  Permission is hereby granted, free of charge, to any person obtaining a copy
+ *  of this software and associated documentation files (the "Software"), to deal
+ *  in the Software without restriction, including without limitation the rights
+ *  to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ *  copies of the Software, and to permit persons to whom the Software is
+ *  furnished to do so, subject to the following conditions:
+ *
+ *  The above copyright notice and this permission notice shall be included in
+ *  all copies or substantial portions of the Software.
+ *
+ *  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ *  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ *  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ *  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ *  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ *  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ *  THE SOFTWARE.
+ *
+ *  @author GeyserMC
+ *  @link https://github.com/GeyserMC/Geyser
+ *
+ */
+
 package org.geysermc.connector.utils;
 
 public enum MapColor {


### PR DESCRIPTION
Closes: https://github.com/GeyserMC/Geyser/issues/507

All icons show, item frames are mapped to the bedrock item frame texture and banners are mapped as coloured dots. No marker names are displayed as bedrock doesn't display them.
![image](https://user-images.githubusercontent.com/5401186/82097083-20881100-96fa-11ea-8407-746d6efa42c3.png)
