### PR TITLE
Added a docker container IP warning

### DIFF
--- a/connector/src/main/java/org/geysermc/connector/GeyserConnector.java
+++ b/connector/src/main/java/org/geysermc/connector/GeyserConnector.java
@@ -40,6 +40,7 @@ import org.geysermc.connector.network.session.GeyserSession;
 import org.geysermc.connector.network.translators.Translators;
 import org.geysermc.connector.network.translators.world.WorldManager;
 import org.geysermc.connector.thread.PingPassthroughThread;
+import org.geysermc.connector.utils.DockerCheck;
 import org.geysermc.connector.utils.Toolbox;
 
 import java.net.InetSocketAddress;
@@ -101,6 +102,10 @@ public class GeyserConnector {
 
         Toolbox.init();
         Translators.start();
+
+        if (platformType != PlatformType.STANDALONE) {
+            DockerCheck.Check(bootstrap);
+        }
 
         remoteServer = new RemoteServer(config.getRemote().getAddress(), config.getRemote().getPort());
         authType = AuthType.getByName(config.getRemote().getAuthType());

--- a/connector/src/main/java/org/geysermc/connector/GeyserConnector.java
+++ b/connector/src/main/java/org/geysermc/connector/GeyserConnector.java
@@ -104,7 +104,7 @@ public class GeyserConnector {
         Translators.start();
 
         if (platformType != PlatformType.STANDALONE) {
-            DockerCheck.Check(bootstrap);
+            DockerCheck.check(bootstrap);
         }
 
         remoteServer = new RemoteServer(config.getRemote().getAddress(), config.getRemote().getPort());

--- a/connector/src/main/java/org/geysermc/connector/utils/DockerCheck.java
+++ b/connector/src/main/java/org/geysermc/connector/utils/DockerCheck.java
@@ -1,0 +1,73 @@
+/*
+ * Copyright (c) 2019-2020 GeyserMC. http://geysermc.org
+ *
+ *  Permission is hereby granted, free of charge, to any person obtaining a copy
+ *  of this software and associated documentation files (the "Software"), to deal
+ *  in the Software without restriction, including without limitation the rights
+ *  to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ *  copies of the Software, and to permit persons to whom the Software is
+ *  furnished to do so, subject to the following conditions:
+ *
+ *  The above copyright notice and this permission notice shall be included in
+ *  all copies or substantial portions of the Software.
+ *
+ *  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ *  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ *  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ *  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ *  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ *  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ *  THE SOFTWARE.
+ *
+ *  @author GeyserMC
+ *  @link https://github.com/GeyserMC/Geyser
+ *
+ */
+
+package org.geysermc.connector.utils;
+
+import org.geysermc.connector.bootstrap.GeyserBootstrap;
+
+import java.io.BufferedReader;
+import java.io.InputStreamReader;
+import java.net.InetAddress;
+
+public class DockerCheck {
+    public static void Check(GeyserBootstrap bootstrap) {
+        try {
+            String OS = System.getProperty("os.name").toLowerCase();
+            String ipAddress = InetAddress.getLocalHost().getHostAddress();
+
+            // Check if the user is already using the recommended IP
+            if (ipAddress.equals(bootstrap.getGeyserConfig().getRemote().getAddress())) {
+                return;
+            }
+
+            if (OS.indexOf("nix") >= 0 || OS.indexOf("nux") >= 0 || OS.indexOf("aix") > 0) {
+                bootstrap.getGeyserLogger().debug("We are on a unix system, checking for docker...");
+
+                ProcessBuilder processBuilder = new ProcessBuilder();
+                processBuilder.command("bash", "-c", "cat /proc/1/cgroup");
+
+                Process process = processBuilder.start();
+
+                StringBuilder output = new StringBuilder();
+
+                BufferedReader reader = new BufferedReader(new InputStreamReader(process.getInputStream()));
+
+                String line;
+                while ((line = reader.readLine()) != null) {
+                    output.append(line + "\n");
+                }
+
+                int exitVal = process.waitFor();
+                if (exitVal == 0) {
+                    if (output.toString().contains("docker")) {
+                        bootstrap.getGeyserLogger().warning("You are most likely in a docker container, this may cause connection issues from geyser to java");
+                        bootstrap.getGeyserLogger().warning("We recommended using the following IP as the remote address: " + ipAddress);
+                    }
+                }
+            }
+        } catch (Exception e) { } // Ignore any errors, inc ip failed to fetch, process could not run or access denied
+    }
+}

--- a/connector/src/main/java/org/geysermc/connector/utils/DockerCheck.java
+++ b/connector/src/main/java/org/geysermc/connector/utils/DockerCheck.java
@@ -33,7 +33,7 @@ import java.nio.file.Files;
 import java.nio.file.Paths;
 
 public class DockerCheck {
-    public static void Check(GeyserBootstrap bootstrap) {
+    public static void check(GeyserBootstrap bootstrap) {
         try {
             String OS = System.getProperty("os.name").toLowerCase();
             String ipAddress = InetAddress.getLocalHost().getHostAddress();

--- a/connector/src/main/java/org/geysermc/connector/utils/DockerCheck.java
+++ b/connector/src/main/java/org/geysermc/connector/utils/DockerCheck.java
@@ -28,9 +28,9 @@ package org.geysermc.connector.utils;
 
 import org.geysermc.connector.bootstrap.GeyserBootstrap;
 
-import java.io.BufferedReader;
-import java.io.InputStreamReader;
 import java.net.InetAddress;
+import java.nio.file.Files;
+import java.nio.file.Paths;
 
 public class DockerCheck {
     public static void Check(GeyserBootstrap bootstrap) {
@@ -46,26 +46,11 @@ public class DockerCheck {
             if (OS.indexOf("nix") >= 0 || OS.indexOf("nux") >= 0 || OS.indexOf("aix") > 0) {
                 bootstrap.getGeyserLogger().debug("We are on a Unix system, checking for Docker...");
 
-                ProcessBuilder processBuilder = new ProcessBuilder();
-                processBuilder.command("bash", "-c", "cat /proc/1/cgroup");
+                String output = new String(Files.readAllBytes(Paths.get("/proc/1/cgroup")));
 
-                Process process = processBuilder.start();
-
-                StringBuilder output = new StringBuilder();
-
-                BufferedReader reader = new BufferedReader(new InputStreamReader(process.getInputStream()));
-
-                String line;
-                while ((line = reader.readLine()) != null) {
-                    output.append(line + "\n");
-                }
-
-                int exitVal = process.waitFor();
-                if (exitVal == 0) {
-                    if (output.toString().contains("docker")) {
-                        bootstrap.getGeyserLogger().warning("You are most likely in a Docker container, this may cause connection issues from Geyser to the Java server");
-                        bootstrap.getGeyserLogger().warning("We recommended using the following IP as the remote address: " + ipAddress);
-                    }
+                if (output.contains("docker")) {
+                    bootstrap.getGeyserLogger().warning("You are most likely in a Docker container, this may cause connection issues from Geyser to the Java server");
+                    bootstrap.getGeyserLogger().warning("We recommended using the following IP as the remote address: " + ipAddress);
                 }
             }
         } catch (Exception e) { } // Ignore any errors, inc ip failed to fetch, process could not run or access denied

--- a/connector/src/main/java/org/geysermc/connector/utils/DockerCheck.java
+++ b/connector/src/main/java/org/geysermc/connector/utils/DockerCheck.java
@@ -44,7 +44,7 @@ public class DockerCheck {
             }
 
             if (OS.indexOf("nix") >= 0 || OS.indexOf("nux") >= 0 || OS.indexOf("aix") > 0) {
-                bootstrap.getGeyserLogger().debug("We are on a unix system, checking for docker...");
+                bootstrap.getGeyserLogger().debug("We are on a Unix system, checking for Docker...");
 
                 ProcessBuilder processBuilder = new ProcessBuilder();
                 processBuilder.command("bash", "-c", "cat /proc/1/cgroup");
@@ -63,7 +63,7 @@ public class DockerCheck {
                 int exitVal = process.waitFor();
                 if (exitVal == 0) {
                     if (output.toString().contains("docker")) {
-                        bootstrap.getGeyserLogger().warning("You are most likely in a docker container, this may cause connection issues from geyser to java");
+                        bootstrap.getGeyserLogger().warning("You are most likely in a Docker container, this may cause connection issues from Geyser to the Java server");
                         bootstrap.getGeyserLogger().warning("We recommended using the following IP as the remote address: " + ipAddress);
                     }
                 }


### PR DESCRIPTION
Adds a warning if the plugin versions detect they are inside a docker container on a Unix/Linux system and the remote address is not the same as the docker IP. This lets users know what IP to use in certain instances such as when using Pterodactyl Panel when the default doesn't work.

![image](https://user-images.githubusercontent.com/5401186/82153505-c5702e80-985f-11ea-943b-9dbcc4447d5e.png)
