### PR TITLE
Add some elder guardian properties

### DIFF
--- a/connector/src/main/java/org/geysermc/connector/entity/living/monster/ElderGuardianEntity.java
+++ b/connector/src/main/java/org/geysermc/connector/entity/living/monster/ElderGuardianEntity.java
@@ -1,0 +1,41 @@
+/*
+ * Copyright (c) 2019-2020 GeyserMC. http://geysermc.org
+ *
+ *  Permission is hereby granted, free of charge, to any person obtaining a copy
+ *  of this software and associated documentation files (the "Software"), to deal
+ *  in the Software without restriction, including without limitation the rights
+ *  to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ *  copies of the Software, and to permit persons to whom the Software is
+ *  furnished to do so, subject to the following conditions:
+ *
+ *  The above copyright notice and this permission notice shall be included in
+ *  all copies or substantial portions of the Software.
+ *
+ *  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ *  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ *  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ *  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ *  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ *  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ *  THE SOFTWARE.
+ *
+ *  @author GeyserMC
+ *  @link https://github.com/GeyserMC/Geyser
+ *
+ */
+
+package org.geysermc.connector.entity.living.monster;
+
+import com.nukkitx.math.vector.Vector3f;
+import com.nukkitx.protocol.bedrock.data.EntityFlag;
+import org.geysermc.connector.entity.type.EntityType;
+
+public class ElderGuardianEntity extends GuardianEntity {
+
+    public ElderGuardianEntity(long entityId, long geyserId, EntityType entityType, Vector3f position, Vector3f motion, Vector3f rotation) {
+        super(entityId, geyserId, entityType, position, motion, rotation);
+        // Otherwise it just looks like a normal guardian but bigger
+        metadata.getFlags().setFlag(EntityFlag.ELDER, true);
+    }
+
+}

--- a/connector/src/main/java/org/geysermc/connector/entity/type/EntityType.java
+++ b/connector/src/main/java/org/geysermc/connector/entity/type/EntityType.java
@@ -82,7 +82,7 @@ public enum EntityType {
     HUSK(ZombieEntity.class, 47, 1.8f, 0.6f, 0.6f, 1.62f),
     WITHER_SKELETON(AbstractSkeletonEntity.class, 48, 2.4f, 0.7f),
     GUARDIAN(GuardianEntity.class, 49, 0.85f),
-    ELDER_GUARDIAN(GuardianEntity.class, 50, 1.9975f),
+    ELDER_GUARDIAN(ElderGuardianEntity.class, 50, 1.9975f),
     NPC(PlayerEntity.class, 51, 1.8f, 0.6f, 0.6f, 1.62f),
     WITHER(WitherEntity.class, 52, 3.5f, 0.9f),
     ENDER_DRAGON(EnderDragonEntity.class, 53, 4f, 13f),

--- a/connector/src/main/java/org/geysermc/connector/network/translators/java/world/JavaNotifyClientTranslator.java
+++ b/connector/src/main/java/org/geysermc/connector/network/translators/java/world/JavaNotifyClientTranslator.java
@@ -31,10 +31,7 @@ import com.github.steveice10.mc.protocol.data.game.world.notify.EnterCreditsValu
 import com.github.steveice10.mc.protocol.packet.ingame.client.ClientRequestPacket;
 import com.github.steveice10.mc.protocol.packet.ingame.server.world.ServerNotifyClientPacket;
 import com.nukkitx.math.vector.Vector3f;
-import com.nukkitx.protocol.bedrock.data.EntityDataMap;
-import com.nukkitx.protocol.bedrock.data.EntityFlag;
-import com.nukkitx.protocol.bedrock.data.LevelEventType;
-import com.nukkitx.protocol.bedrock.data.PlayerPermission;
+import com.nukkitx.protocol.bedrock.data.*;
 import com.nukkitx.protocol.bedrock.packet.*;
 import it.unimi.dsi.fastutil.objects.ObjectOpenHashSet;
 import org.geysermc.connector.entity.Entity;
@@ -124,6 +121,12 @@ public class JavaNotifyClientTranslator extends PacketTranslator<ServerNotifyCli
                         break;
                 }
                 break;
+            case AFFECTED_BY_ELDER_GUARDIAN:
+                EntityEventPacket eventPacket = new EntityEventPacket();
+                eventPacket.setType(EntityEventType.ELDER_GUARDIAN_CURSE);
+                eventPacket.setData(0);
+                eventPacket.setRuntimeEntityId(entity.getGeyserId());
+                session.sendUpstreamPacket(eventPacket);
             default:
                 break;
         }


### PR DESCRIPTION
- Adds the ELDER flag to all elder guardians, so they look like elder guardians and not giant regular guardians.
- Translates AFFECTED_BY_ELDER_GUARDIAN in JavaNotifyClientTranslator to add the elder guardian curse event.