### PR TITLE
Add entity event for drowning

### DIFF
--- a/connector/src/main/java/org/geysermc/connector/network/translators/java/entity/JavaEntityStatusTranslator.java
+++ b/connector/src/main/java/org/geysermc/connector/network/translators/java/entity/JavaEntityStatusTranslator.java
@@ -49,6 +49,8 @@ public class JavaEntityStatusTranslator extends PacketTranslator<ServerEntitySta
         EntityEventPacket entityEventPacket = new EntityEventPacket();
         entityEventPacket.setRuntimeEntityId(entity.getGeyserId());
         switch (packet.getStatus()) {
+            case LIVING_DROWN:
+                entityEventPacket.setData(9);
             case LIVING_HURT:
             case LIVING_HURT_SWEET_BERRY_BUSH:
                 entityEventPacket.setType(EntityEventType.HURT_ANIMATION);


### PR DESCRIPTION
This commit translates Java's LIVING_DROWN entity status to Bedrock's HURT_ANIMATION (allows for sound and proper effects when drowning).