### PR TITLE
Add option for disabling command suggestions; add config version

### DIFF
--- a/bootstrap/bukkit/src/main/java/org/geysermc/platform/bukkit/GeyserBukkitConfiguration.java
+++ b/bootstrap/bukkit/src/main/java/org/geysermc/platform/bukkit/GeyserBukkitConfiguration.java
@@ -87,6 +87,11 @@ public class GeyserBukkitConfiguration implements GeyserConfiguration {
     }
 
     @Override
+    public boolean isCommandSuggestions() {
+        return config.getBoolean("command-suggestions", true);
+    }
+
+    @Override
     public boolean isPingPassthrough() {
         return config.getBoolean("ping-passthrough", false);
     }
@@ -202,5 +207,10 @@ public class GeyserBukkitConfiguration implements GeyserConfiguration {
         public String getUniqueId() {
             return config.getString("metrics.uuid", "generateduuid");
         }
+    }
+
+    @Override
+    public int getConfigVersion() {
+        return config.getInt("config-version", 0);
     }
 }

--- a/bootstrap/bukkit/src/main/java/org/geysermc/platform/bukkit/GeyserBukkitPlugin.java
+++ b/bootstrap/bukkit/src/main/java/org/geysermc/platform/bukkit/GeyserBukkitPlugin.java
@@ -56,7 +56,7 @@ public class GeyserBukkitPlugin extends JavaPlugin implements GeyserBootstrap {
         saveDefaultConfig();
 
         this.geyserConfig = new GeyserBukkitConfiguration(getDataFolder(), getConfig());
-        GeyserConfiguration.CheckGeyserConfiguration(geyserConfig, geyserLogger);
+        GeyserConfiguration.checkGeyserConfiguration(geyserConfig, geyserLogger);
         if (geyserConfig.getMetrics().getUniqueId().equals("generateduuid")) {
             getConfig().set("metrics.uuid", UUID.randomUUID().toString());
             saveConfig();

--- a/bootstrap/bukkit/src/main/java/org/geysermc/platform/bukkit/GeyserBukkitPlugin.java
+++ b/bootstrap/bukkit/src/main/java/org/geysermc/platform/bukkit/GeyserBukkitPlugin.java
@@ -28,6 +28,7 @@ package org.geysermc.platform.bukkit;
 import org.bukkit.Bukkit;
 import org.bukkit.plugin.java.JavaPlugin;
 import org.geysermc.common.PlatformType;
+import org.geysermc.connector.GeyserConfiguration;
 import org.geysermc.connector.GeyserConnector;
 import org.geysermc.connector.bootstrap.GeyserBootstrap;
 import org.geysermc.connector.command.CommandManager;
@@ -55,6 +56,7 @@ public class GeyserBukkitPlugin extends JavaPlugin implements GeyserBootstrap {
         saveDefaultConfig();
 
         this.geyserConfig = new GeyserBukkitConfiguration(getDataFolder(), getConfig());
+        GeyserConfiguration.CheckGeyserConfiguration(geyserConfig, geyserLogger);
         if (geyserConfig.getMetrics().getUniqueId().equals("generateduuid")) {
             getConfig().set("metrics.uuid", UUID.randomUUID().toString());
             saveConfig();

--- a/bootstrap/bungeecord/src/main/java/org/geysermc/platform/bungeecord/GeyserBungeeConfiguration.java
+++ b/bootstrap/bungeecord/src/main/java/org/geysermc/platform/bungeecord/GeyserBungeeConfiguration.java
@@ -86,6 +86,11 @@ public class GeyserBungeeConfiguration implements GeyserConfiguration {
     }
 
     @Override
+    public boolean isCommandSuggestions() {
+        return config.getBoolean("command-suggestions", true);
+    }
+
+    @Override
     public boolean isPingPassthrough() {
         return config.getBoolean("ping-passthrough", false);
     }
@@ -201,5 +206,10 @@ public class GeyserBungeeConfiguration implements GeyserConfiguration {
         public String getUniqueId() {
             return config.getString("metrics.uuid", "generateduuid");
         }
+    }
+
+    @Override
+    public int getConfigVersion() {
+        return config.getInt("config-version", 0);
     }
 }

--- a/bootstrap/bungeecord/src/main/java/org/geysermc/platform/bungeecord/GeyserBungeePlugin.java
+++ b/bootstrap/bungeecord/src/main/java/org/geysermc/platform/bungeecord/GeyserBungeePlugin.java
@@ -117,7 +117,7 @@ public class GeyserBungeePlugin extends Plugin implements GeyserBootstrap {
         }
 
         this.geyserLogger = new GeyserBungeeLogger(getLogger(), geyserConfig.isDebugMode());
-        GeyserConfiguration.CheckGeyserConfiguration(geyserConfig, geyserLogger);
+        GeyserConfiguration.checkGeyserConfiguration(geyserConfig, geyserLogger);
 
         geyserConfig.loadFloodgate(this);
 

--- a/bootstrap/bungeecord/src/main/java/org/geysermc/platform/bungeecord/GeyserBungeePlugin.java
+++ b/bootstrap/bungeecord/src/main/java/org/geysermc/platform/bungeecord/GeyserBungeePlugin.java
@@ -31,6 +31,7 @@ import net.md_5.bungee.config.Configuration;
 import net.md_5.bungee.config.ConfigurationProvider;
 import net.md_5.bungee.config.YamlConfiguration;
 import org.geysermc.common.PlatformType;
+import org.geysermc.connector.GeyserConfiguration;
 import org.geysermc.connector.GeyserConnector;
 import org.geysermc.connector.bootstrap.GeyserBootstrap;
 import org.geysermc.connector.command.CommandManager;
@@ -116,6 +117,7 @@ public class GeyserBungeePlugin extends Plugin implements GeyserBootstrap {
         }
 
         this.geyserLogger = new GeyserBungeeLogger(getLogger(), geyserConfig.isDebugMode());
+        GeyserConfiguration.CheckGeyserConfiguration(geyserConfig, geyserLogger);
 
         geyserConfig.loadFloodgate(this);
 

--- a/bootstrap/sponge/src/main/java/org/geysermc/platform/sponge/GeyserSpongeConfiguration.java
+++ b/bootstrap/sponge/src/main/java/org/geysermc/platform/sponge/GeyserSpongeConfiguration.java
@@ -80,6 +80,11 @@ public class GeyserSpongeConfiguration implements GeyserConfiguration {
     }
 
     @Override
+    public boolean isCommandSuggestions() {
+        return node.getNode("command-suggestions").getBoolean(true);
+    }
+
+    @Override
     public boolean isPingPassthrough() {
         return node.getNode("ping-passthrough").getBoolean(false);
     }
@@ -201,5 +206,10 @@ public class GeyserSpongeConfiguration implements GeyserConfiguration {
         public String getUniqueId() {
             return node.getNode("metrics").getNode("uuid").getString("generateduuid");
         }
+    }
+
+    @Override
+    public int getConfigVersion() {
+        return node.getNode("config-version").getInt(0);
     }
 }

--- a/bootstrap/sponge/src/main/java/org/geysermc/platform/sponge/GeyserSpongePlugin.java
+++ b/bootstrap/sponge/src/main/java/org/geysermc/platform/sponge/GeyserSpongePlugin.java
@@ -30,6 +30,7 @@ import ninja.leaping.configurate.ConfigurationNode;
 import ninja.leaping.configurate.loader.ConfigurationLoader;
 import ninja.leaping.configurate.yaml.YAMLConfigurationLoader;
 import org.geysermc.common.PlatformType;
+import org.geysermc.connector.GeyserConfiguration;
 import org.geysermc.connector.GeyserConnector;
 import org.geysermc.connector.bootstrap.GeyserBootstrap;
 import org.geysermc.connector.command.CommandManager;
@@ -105,6 +106,7 @@ public class GeyserSpongePlugin implements GeyserBootstrap {
         }
 
         this.geyserLogger = new GeyserSpongeLogger(logger, geyserConfig.isDebugMode());
+        GeyserConfiguration.CheckGeyserConfiguration(geyserConfig, geyserLogger);
         this.connector = GeyserConnector.start(PlatformType.SPONGE, this);
         this.geyserCommandManager = new GeyserSpongeCommandManager(Sponge.getCommandManager(), connector);
 

--- a/bootstrap/sponge/src/main/java/org/geysermc/platform/sponge/GeyserSpongePlugin.java
+++ b/bootstrap/sponge/src/main/java/org/geysermc/platform/sponge/GeyserSpongePlugin.java
@@ -106,7 +106,7 @@ public class GeyserSpongePlugin implements GeyserBootstrap {
         }
 
         this.geyserLogger = new GeyserSpongeLogger(logger, geyserConfig.isDebugMode());
-        GeyserConfiguration.CheckGeyserConfiguration(geyserConfig, geyserLogger);
+        GeyserConfiguration.checkGeyserConfiguration(geyserConfig, geyserLogger);
         this.connector = GeyserConnector.start(PlatformType.SPONGE, this);
         this.geyserCommandManager = new GeyserSpongeCommandManager(Sponge.getCommandManager(), connector);
 

--- a/bootstrap/standalone/src/main/java/org/geysermc/platform/standalone/GeyserStandaloneBootstrap.java
+++ b/bootstrap/standalone/src/main/java/org/geysermc/platform/standalone/GeyserStandaloneBootstrap.java
@@ -62,6 +62,7 @@ public class GeyserStandaloneBootstrap implements GeyserBootstrap {
             geyserLogger.severe("Failed to read/create config.yml! Make sure it's up to date and/or readable+writable!", ex);
             System.exit(0);
         }
+        GeyserConfiguration.CheckGeyserConfiguration(geyserConfig, geyserLogger);
 
         connector = GeyserConnector.start(PlatformType.STANDALONE, this);
         geyserCommandManager = new GeyserCommandManager(connector);

--- a/bootstrap/standalone/src/main/java/org/geysermc/platform/standalone/GeyserStandaloneBootstrap.java
+++ b/bootstrap/standalone/src/main/java/org/geysermc/platform/standalone/GeyserStandaloneBootstrap.java
@@ -62,7 +62,7 @@ public class GeyserStandaloneBootstrap implements GeyserBootstrap {
             geyserLogger.severe("Failed to read/create config.yml! Make sure it's up to date and/or readable+writable!", ex);
             System.exit(0);
         }
-        GeyserConfiguration.CheckGeyserConfiguration(geyserConfig, geyserLogger);
+        GeyserConfiguration.checkGeyserConfiguration(geyserConfig, geyserLogger);
 
         connector = GeyserConnector.start(PlatformType.STANDALONE, this);
         geyserCommandManager = new GeyserCommandManager(connector);

--- a/bootstrap/standalone/src/main/java/org/geysermc/platform/standalone/GeyserStandaloneConfiguration.java
+++ b/bootstrap/standalone/src/main/java/org/geysermc/platform/standalone/GeyserStandaloneConfiguration.java
@@ -47,6 +47,9 @@ public class GeyserStandaloneConfiguration implements GeyserConfiguration {
 
     private Map<String, UserAuthenticationInfo> userAuths;
 
+    @JsonProperty("command-suggestions")
+    private boolean isCommandSuggestions;
+
     @JsonProperty("ping-passthrough")
     private boolean pingPassthrough;
 
@@ -112,4 +115,7 @@ public class GeyserStandaloneConfiguration implements GeyserConfiguration {
         @JsonProperty("uuid")
         private String uniqueId;
     }
+
+    @JsonProperty("config-version")
+    private int configVersion;
 }

--- a/bootstrap/velocity/src/main/java/org/geysermc/platform/velocity/GeyserVelocityConfiguration.java
+++ b/bootstrap/velocity/src/main/java/org/geysermc/platform/velocity/GeyserVelocityConfiguration.java
@@ -52,6 +52,9 @@ public class GeyserVelocityConfiguration implements GeyserConfiguration {
 
     private Map<String, UserAuthenticationInfo> userAuths;
 
+    @JsonProperty("command-suggestions")
+    private boolean commandSuggestions;
+
     @JsonProperty("ping-passthrough")
     private boolean pingPassthrough;
 
@@ -127,4 +130,7 @@ public class GeyserVelocityConfiguration implements GeyserConfiguration {
         @JsonProperty("uuid")
         private String uniqueId;
     }
+
+    @JsonProperty("config-version")
+    private int configVersion;
 }

--- a/bootstrap/velocity/src/main/java/org/geysermc/platform/velocity/GeyserVelocityPlugin.java
+++ b/bootstrap/velocity/src/main/java/org/geysermc/platform/velocity/GeyserVelocityPlugin.java
@@ -91,7 +91,7 @@ public class GeyserVelocityPlugin implements GeyserBootstrap {
         geyserConfig.getRemote().setPort(javaAddr.getPort());
 
         this.geyserLogger = new GeyserVelocityLogger(logger, geyserConfig.isDebugMode());
-        GeyserConfiguration.CheckGeyserConfiguration(geyserConfig, geyserLogger);
+        GeyserConfiguration.checkGeyserConfiguration(geyserConfig, geyserLogger);
 
         geyserConfig.loadFloodgate(this, proxyServer, configDir);
 

--- a/bootstrap/velocity/src/main/java/org/geysermc/platform/velocity/GeyserVelocityPlugin.java
+++ b/bootstrap/velocity/src/main/java/org/geysermc/platform/velocity/GeyserVelocityPlugin.java
@@ -35,6 +35,7 @@ import com.velocitypowered.api.plugin.Plugin;
 
 import com.velocitypowered.api.proxy.ProxyServer;
 import org.geysermc.common.PlatformType;
+import org.geysermc.connector.GeyserConfiguration;
 import org.geysermc.connector.GeyserConnector;
 import org.geysermc.connector.bootstrap.GeyserBootstrap;
 import org.geysermc.connector.utils.FileUtils;
@@ -90,6 +91,7 @@ public class GeyserVelocityPlugin implements GeyserBootstrap {
         geyserConfig.getRemote().setPort(javaAddr.getPort());
 
         this.geyserLogger = new GeyserVelocityLogger(logger, geyserConfig.isDebugMode());
+        GeyserConfiguration.CheckGeyserConfiguration(geyserConfig, geyserLogger);
 
         geyserConfig.loadFloodgate(this, proxyServer, configDir);
 

--- a/connector/src/main/java/org/geysermc/connector/GeyserConfiguration.java
+++ b/connector/src/main/java/org/geysermc/connector/GeyserConfiguration.java
@@ -95,7 +95,7 @@ public interface GeyserConfiguration {
 
     int getConfigVersion();
 
-    static void CheckGeyserConfiguration(GeyserConfiguration geyserConfig, GeyserLogger geyserLogger) {
+    static void checkGeyserConfiguration(GeyserConfiguration geyserConfig, GeyserLogger geyserLogger) {
         if (geyserConfig.getConfigVersion() < CURRENT_CONFIG_VERSION) {
             geyserLogger.warning("Your Geyser config is out of date! Please regenerate your config when possible.");
         } else if (geyserConfig.getConfigVersion() > CURRENT_CONFIG_VERSION) {

--- a/connector/src/main/java/org/geysermc/connector/GeyserConfiguration.java
+++ b/connector/src/main/java/org/geysermc/connector/GeyserConfiguration.java
@@ -31,11 +31,16 @@ import java.util.Map;
 
 public interface GeyserConfiguration {
 
+    // Modify this when you update the config
+    int CURRENT_CONFIG_VERSION = 1;
+
     IBedrockConfiguration getBedrock();
 
     IRemoteConfiguration getRemote();
 
     Map<String, ? extends IUserAuthenticationInfo> getUserAuths();
+
+    boolean isCommandSuggestions();
 
     boolean isPingPassthrough();
 
@@ -86,5 +91,15 @@ public interface GeyserConfiguration {
         boolean isEnabled();
 
         String getUniqueId();
+    }
+
+    int getConfigVersion();
+
+    static void CheckGeyserConfiguration(GeyserConfiguration geyserConfig, GeyserLogger geyserLogger) {
+        if (geyserConfig.getConfigVersion() < CURRENT_CONFIG_VERSION) {
+            geyserLogger.warning("Your Geyser config is out of date! Please regenerate your config when possible.");
+        } else if (geyserConfig.getConfigVersion() > CURRENT_CONFIG_VERSION) {
+            geyserLogger.warning("Your Geyser config is too new! Errors may occur.");
+        }
     }
 }

--- a/connector/src/main/java/org/geysermc/connector/network/translators/java/JavaDeclareCommandsTranslator.java
+++ b/connector/src/main/java/org/geysermc/connector/network/translators/java/JavaDeclareCommandsTranslator.java
@@ -43,9 +43,14 @@ import org.geysermc.connector.network.translators.Translator;
 import java.util.*;
 
 @Translator(packet = ServerDeclareCommandsPacket.class)
-public class JavaServerDeclareCommandsTranslator extends PacketTranslator<ServerDeclareCommandsPacket> {
+public class JavaDeclareCommandsTranslator extends PacketTranslator<ServerDeclareCommandsPacket> {
     @Override
     public void translate(ServerDeclareCommandsPacket packet, GeyserSession session) {
+        // Don't send command suggestions if they are disabled
+        if (!session.getConnector().getConfig().isCommandSuggestions()) {
+            session.getConnector().getLogger().debug("Not sending command suggestions as they are disabled.");
+            return;
+        }
         List<CommandData> commandData = new ArrayList<>();
         Int2ObjectMap<String> commands = new Int2ObjectOpenHashMap<>();
         Int2ObjectMap<List<CommandNode>> commandArgs = new Int2ObjectOpenHashMap<>();

--- a/connector/src/main/resources/config.yml
+++ b/connector/src/main/resources/config.yml
@@ -41,6 +41,10 @@ floodgate-key-file: public-key.pem
 #    email: herpderp@derpherp.com
 #    password: dooooo
 
+# Bedrock clients can freeze when opening up the command prompt for the first time if given a lot of commands.
+# Disabling this will prevent command suggestions from being sent and solve freezing for Bedrock clients.
+command-suggestions: true
+
 # Relay the MOTD, player count and max players from the remote server
 ping-passthrough: false
 
@@ -78,3 +82,6 @@ metrics:
   enabled: true
   # UUID of server, don't change!
   uuid: generateduuid
+
+# DO NOT TOUCH!
+config-version: 1


### PR DESCRIPTION
This commit adds an option for disabling command suggestions. If enabled, command suggestions will not be sent to the server so as to remove command freezing. This commit also adds a config version variable so users are notified when to regenerate their configs.

Fixes #405.