### PR TITLE
Fix some book translation failures

### DIFF
--- a/connector/src/main/java/org/geysermc/connector/network/translators/item/translators/nbt/BookPagesTranslator.java
+++ b/connector/src/main/java/org/geysermc/connector/network/translators/item/translators/nbt/BookPagesTranslator.java
@@ -55,7 +55,7 @@ public class BookPagesTranslator extends NbtItemStackTranslator {
 
             CompoundTag pageTag = new CompoundTag("");
             pageTag.put(new StringTag("photoname", ""));
-            pageTag.put(new StringTag("text", MessageUtils.getBedrockMessage(textTag.getValue())));
+            pageTag.put(new StringTag("text", MessageUtils.getBedrockMessageLenient(textTag.getValue())));
             pages.add(pageTag);
         }
 

--- a/connector/src/main/java/org/geysermc/connector/utils/MessageUtils.java
+++ b/connector/src/main/java/org/geysermc/connector/utils/MessageUtils.java
@@ -145,9 +145,9 @@ public class MessageUtils {
      * @return Bedrock formatted message
      */
     public static String getBedrockMessageLenient(String message) {
-        if(isMessage(message)){
+        if (isMessage(message)) {
             return getBedrockMessage(message);
-        }else{
+        } else {
             final JsonObject obj = new JsonObject();
             obj.addProperty("text", message);
             return getBedrockMessage(obj.toString());

--- a/connector/src/main/java/org/geysermc/connector/utils/MessageUtils.java
+++ b/connector/src/main/java/org/geysermc/connector/utils/MessageUtils.java
@@ -137,6 +137,10 @@ public class MessageUtils {
         }
     }
 
+    /**
+     * Verifies the message is valid JSON in case it's plaintext. Works around GsonComponentSeraializer not using lenient mode.
+     * See https://wiki.vg/Chat for messages sent in lenient mode, and for a description on leniency.
+     */
     public static String getBedrockMessageLenient(String message) {
         if(isMessage(message)){
             return getBedrockMessage(message);

--- a/connector/src/main/java/org/geysermc/connector/utils/MessageUtils.java
+++ b/connector/src/main/java/org/geysermc/connector/utils/MessageUtils.java
@@ -137,6 +137,16 @@ public class MessageUtils {
         }
     }
 
+    public static String getBedrockMessageLenient(String message) {
+        if(isMessage(message)){
+            return getBedrockMessage(message);
+        }else{
+            final JsonObject obj = new JsonObject();
+            obj.addProperty("text", message);
+            return getBedrockMessage(obj.toString());
+        }
+    }
+
     public static String getBedrockMessage(String message) {
         Component component = phraseJavaMessage(message);
         return LegacyComponentSerializer.legacy().serialize(component);

--- a/connector/src/main/java/org/geysermc/connector/utils/MessageUtils.java
+++ b/connector/src/main/java/org/geysermc/connector/utils/MessageUtils.java
@@ -140,6 +140,9 @@ public class MessageUtils {
     /**
      * Verifies the message is valid JSON in case it's plaintext. Works around GsonComponentSeraializer not using lenient mode.
      * See https://wiki.vg/Chat for messages sent in lenient mode, and for a description on leniency.
+     *
+     * @param message Potentially lenient JSON message
+     * @return Bedrock formatted message
      */
     public static String getBedrockMessageLenient(String message) {
         if(isMessage(message)){


### PR DESCRIPTION
Fixes #642 

Book pages can be sent as plain text rather than JSON. The text library doesn't use lenient parsing, so this fails, and the book isn't visible in the inventory.

This will convert the text into JSON if it's not already, before feeding it to the text library. 

This may be a 'hack fix' and there may be a better way.