### PR TITLE
Implement translator for AdventureSettingsPacket

### DIFF
--- a/connector/src/main/java/org/geysermc/connector/network/translators/bedrock/BedrockAdventureSettingsTranslator.java
+++ b/connector/src/main/java/org/geysermc/connector/network/translators/bedrock/BedrockAdventureSettingsTranslator.java
@@ -38,7 +38,6 @@ public class BedrockAdventureSettingsTranslator extends PacketTranslator<Adventu
 
     @Override
     public void translate(AdventureSettingsPacket packet, GeyserSession session) {
-        System.out.println(packet.toString());
         // Only canFly and flying are used by the server
         // https://wiki.vg/Protocol#Player_Abilities_.28serverbound.29
         boolean canFly = packet.getFlags().contains(AdventureSettingsPacket.Flag.MAY_FLY);

--- a/connector/src/main/java/org/geysermc/connector/network/translators/bedrock/BedrockAdventureSettingsTranslator.java
+++ b/connector/src/main/java/org/geysermc/connector/network/translators/bedrock/BedrockAdventureSettingsTranslator.java
@@ -1,0 +1,52 @@
+/*
+ * Copyright (c) 2019-2020 GeyserMC. http://geysermc.org
+ *
+ *  Permission is hereby granted, free of charge, to any person obtaining a copy
+ *  of this software and associated documentation files (the "Software"), to deal
+ *  in the Software without restriction, including without limitation the rights
+ *  to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ *  copies of the Software, and to permit persons to whom the Software is
+ *  furnished to do so, subject to the following conditions:
+ *
+ *  The above copyright notice and this permission notice shall be included in
+ *  all copies or substantial portions of the Software.
+ *
+ *  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ *  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ *  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ *  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ *  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ *  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ *  THE SOFTWARE.
+ *
+ *  @author GeyserMC
+ *  @link https://github.com/GeyserMC/Geyser
+ *
+ */
+
+package org.geysermc.connector.network.translators.bedrock;
+
+import com.github.steveice10.mc.protocol.data.game.entity.player.GameMode;
+import com.github.steveice10.mc.protocol.packet.ingame.client.player.ClientPlayerAbilitiesPacket;
+import com.nukkitx.protocol.bedrock.packet.AdventureSettingsPacket;
+import org.geysermc.connector.network.session.GeyserSession;
+import org.geysermc.connector.network.translators.PacketTranslator;
+import org.geysermc.connector.network.translators.Translator;
+
+@Translator(packet = AdventureSettingsPacket.class)
+public class BedrockAdventureSettingsTranslator extends PacketTranslator<AdventureSettingsPacket> {
+
+    @Override
+    public void translate(AdventureSettingsPacket packet, GeyserSession session) {
+        System.out.println(packet.toString());
+        // Only canFly and flying are used by the server
+        // https://wiki.vg/Protocol#Player_Abilities_.28serverbound.29
+        boolean canFly = packet.getFlags().contains(AdventureSettingsPacket.Flag.MAY_FLY);
+        boolean flying = packet.getFlags().contains(AdventureSettingsPacket.Flag.FLYING);
+        boolean creative = session.getGameMode() == GameMode.CREATIVE;
+        ClientPlayerAbilitiesPacket abilitiesPacket = new ClientPlayerAbilitiesPacket(
+                false, canFly, flying, creative, 0.05f, 0.1f
+        );
+        session.sendDownstreamPacket(abilitiesPacket);
+    }
+}


### PR DESCRIPTION
The AdventureSettingsPacket is translated into ClientSettingsPacket so the MAY_FLY and FLYING flags are sent to the server. This fixes double-jumping on some servers that rely on the client sending their flying information through this packet.