### PR TITLE
Ignore all downstream packet errors

### DIFF
--- a/connector/pom.xml
+++ b/connector/pom.xml
@@ -105,7 +105,7 @@
         <dependency>
             <groupId>com.github.steveice10</groupId>
             <artifactId>packetlib</artifactId>
-            <version>1.5-SNAPSHOT</version>
+            <version>1.6-SNAPSHOT</version>
             <scope>compile</scope>
             <exclusions>
                 <exclusion>

--- a/connector/src/main/java/org/geysermc/connector/network/session/GeyserSession.java
+++ b/connector/src/main/java/org/geysermc/connector/network/session/GeyserSession.java
@@ -366,6 +366,12 @@ public class GeyserSession implements CommandSender {
                             PacketTranslatorRegistry.JAVA_TRANSLATOR.translate(event.getPacket().getClass(), event.getPacket(), GeyserSession.this);
                         }
                     }
+
+                    @Override
+                    public void packetError(PacketErrorEvent event) {
+                        connector.getLogger().warning("Downstream packet error! " + event.getCause().getMessage());
+                        event.setSuppress(true);
+                    }
                 });
 
                 downstream.getSession().connect();

--- a/connector/src/main/java/org/geysermc/connector/network/session/GeyserSession.java
+++ b/connector/src/main/java/org/geysermc/connector/network/session/GeyserSession.java
@@ -370,6 +370,8 @@ public class GeyserSession implements CommandSender {
                     @Override
                     public void packetError(PacketErrorEvent event) {
                         connector.getLogger().warning("Downstream packet error! " + event.getCause().getMessage());
+                        if (connector.getConfig().isDebugMode())
+                            event.getCause().printStackTrace();
                         event.setSuppress(true);
                     }
                 });


### PR DESCRIPTION
Instead of kicking the client off because of an error, we simply display a logger warning and suppress the error.