### PR TITLE
Fix Ender Crystal collision and explosion effects

### DIFF
--- a/connector/src/main/java/org/geysermc/connector/entity/type/EntityType.java
+++ b/connector/src/main/java/org/geysermc/connector/entity/type/EntityType.java
@@ -105,7 +105,7 @@ public enum EntityType {
     THROWN_EXP_BOTTLE(ThrowableEntity.class, 68, 0.25f, 0.25f, 0f, 0f, "minecraft:xp_bottle"),
     EXPERIENCE_ORB(ExpOrbEntity.class, 69, 0f, 0f, 0f, 0f, "minecraft:xp_orb"),
     EYE_OF_ENDER(Entity.class, 70, 0.25f, 0.25f, 0f, 0f, "minecraft:eye_of_ender_signal"),
-    END_CRYSTAL(EnderCrystalEntity.class, 71, 0f, 0f, 0f, 0f, "minecraft:ender_crystal"),
+    END_CRYSTAL(EnderCrystalEntity.class, 71, 2.0f, 2.0f, 2.0f, 0f, "minecraft:ender_crystal"),
     FIREWORK_ROCKET(FireworkEntity.class, 72, 0.25f, 0.25f, 0.25f, 0f, "minecraft:fireworks_rocket"),
     TRIDENT(TridentEntity.class, 73, 0f, 0f, 0f, 0f, "minecraft:thrown_trident"),
     TURTLE(AnimalEntity.class, 74, 0.4f, 1.2f),

--- a/connector/src/main/java/org/geysermc/connector/network/translators/java/world/JavaExplosionTranslator.java
+++ b/connector/src/main/java/org/geysermc/connector/network/translators/java/world/JavaExplosionTranslator.java
@@ -46,14 +46,17 @@ public class JavaExplosionTranslator extends PacketTranslator<ServerExplosionPac
     public void translate(ServerExplosionPacket packet, GeyserSession session) {
         for (ExplodedBlockRecord record : packet.getExploded()) {
             Vector3f pos = Vector3f.from(packet.getX() + record.getX(), packet.getY() + record.getY(), packet.getZ() + record.getZ());
-            // Since bedrock does not play an explosion sound and particles sound, we have to manually do so
-            LevelEventPacket levelEventPacket = new LevelEventPacket();
-            levelEventPacket.setType(LevelEventType.PARTICLE_LARGE_EXPLOSION);
-            levelEventPacket.setData(0);
-            levelEventPacket.setPosition(pos.toFloat());
-            session.sendUpstreamPacket(levelEventPacket);
             ChunkUtils.updateBlock(session, BlockTranslator.AIR, pos.toInt());
         }
+
+        Vector3f pos = Vector3f.from(packet.getX(), packet.getY(), packet.getZ());
+        // Since bedrock does not play an explosion sound and particles sound, we have to manually do so
+        LevelEventPacket levelEventPacket = new LevelEventPacket();
+        levelEventPacket.setType(packet.getRadius() >= 2.0f ? LevelEventType.PARTICLE_HUGE_EXPLODE : LevelEventType.PARTICLE_LARGE_EXPLOSION);
+        levelEventPacket.setData(0);
+        levelEventPacket.setPosition(pos.toFloat());
+        session.sendUpstreamPacket(levelEventPacket);
+
         LevelSoundEventPacket levelSoundEventPacket = new LevelSoundEventPacket();
         levelSoundEventPacket.setRelativeVolumeDisabled(false);
         levelSoundEventPacket.setBabySound(false);


### PR DESCRIPTION
Fixed the collision box being non-existent for ender crystals and fixed explosion effects not being displayed properly


Fixes: https://github.com/GeyserMC/Geyser/issues/668