### PR TITLE
Don't manually grab MCProtocolLib's dependencies

### DIFF
--- a/connector/pom.xml
+++ b/connector/pom.xml
@@ -101,6 +101,18 @@
             <artifactId>mcprotocollib</artifactId>
             <version>1.15.2-1-SNAPSHOT</version>
             <scope>compile</scope>
+            <exclusions>
+                <exclusion>
+                    <groupId>io.netty</groupId>
+                    <artifactId>netty-all</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
+        <dependency>
+            <groupId>io.netty</groupId>
+            <artifactId>netty-resolver-dns</artifactId>
+            <version>4.1.43.Final</version>
+            <scope>compile</scope>
         </dependency>
         <dependency>
             <groupId>org.reflections</groupId>

--- a/connector/pom.xml
+++ b/connector/pom.xml
@@ -98,47 +98,9 @@
         </dependency>
         <dependency>
             <groupId>com.github.steveice10</groupId>
-            <artifactId>opennbt</artifactId>
-            <version>1.4-SNAPSHOT</version>
-            <scope>compile</scope>
-        </dependency>
-        <dependency>
-            <groupId>com.github.steveice10</groupId>
-            <artifactId>packetlib</artifactId>
-            <version>1.6-SNAPSHOT</version>
-            <scope>compile</scope>
-            <exclusions>
-                <exclusion>
-                    <groupId>io.netty</groupId>
-                    <artifactId>netty-all</artifactId>
-                </exclusion>
-            </exclusions>
-        </dependency>
-        <dependency>
-            <groupId>com.github.steveice10</groupId>
-            <artifactId>mcauthlib</artifactId>
-            <version>1.3-SNAPSHOT</version>
-            <scope>compile</scope>
-        </dependency>
-        <dependency>
-            <groupId>com.github.steveice10</groupId>
             <artifactId>mcprotocollib</artifactId>
             <version>1.15.2-1-SNAPSHOT</version>
             <scope>compile</scope>
-            <exclusions>
-                <exclusion>
-                    <groupId>com.github.steveice10</groupId>
-                    <artifactId>opennbt</artifactId>
-                </exclusion>
-                <exclusion>
-                    <groupId>com.github.steveice10</groupId>
-                    <artifactId>packetlib</artifactId>
-                </exclusion>
-                <exclusion>
-                    <groupId>com.github.steveice10</groupId>
-                    <artifactId>mcauthlib</artifactId>
-                </exclusion>
-            </exclusions>
         </dependency>
         <dependency>
             <groupId>org.reflections</groupId>


### PR DESCRIPTION
~~Seems to increase jar size by 2MB because `netty-all` is not excluded anymore.
Re-adding the exclusion will cause an exception when connecting to the java server:~~
Fixed by 1dafb77
```
Exception in thread "Thread-1" java.lang.NoClassDefFoundError: io/netty/handler/codec/dns/DnsQuestion
        at com.github.steveice10.packetlib.tcp.TcpSessionFactory.createClientSession(TcpSessionFactory.java:25)
        at com.github.steveice10.packetlib.Client.<init>(Client.java:18)
        at org.geysermc.connector.network.session.GeyserSession.lambda$authenticate$0(GeyserSession.java:279)
        at java.lang.Thread.run(Thread.java:748)
```