### PR TITLE
Use static commit of MCProtocolLib

### DIFF
--- a/connector/pom.xml
+++ b/connector/pom.xml
@@ -99,7 +99,7 @@
         <dependency>
             <groupId>com.github.steveice10</groupId>
             <artifactId>mcprotocollib</artifactId>
-            <version>1.15.2-1-SNAPSHOT</version>
+            <version>4c315aa206</version>
             <scope>compile</scope>
             <exclusions>
                 <exclusion>

--- a/pom.xml
+++ b/pom.xml
@@ -38,14 +38,8 @@
 
     <repositories>
         <repository>
-            <id>CodeMC-repo</id>
-            <url>https://repo.codemc.org/repository/maven-public</url>
-            <releases>
-                <enabled>true</enabled>
-            </releases>
-            <snapshots>
-                <enabled>true</enabled>
-            </snapshots>
+            <id>jitpack.io</id>
+            <url>https://jitpack.io</url>
         </repository>
         <repository>
             <id>nukkitx-release-repo</id>


### PR DESCRIPTION
This prevents changes upstream from immediately affecting Geyser workflow. This also removes the CodeMC repository in favor of Jitpack (which can use the commit hash as a version).