### PR TITLE
Fix block entities on older versions

### DIFF
--- a/connector/src/main/java/org/geysermc/connector/network/translators/world/block/entity/BlockEntityTranslator.java
+++ b/connector/src/main/java/org/geysermc/connector/network/translators/world/block/entity/BlockEntityTranslator.java
@@ -46,6 +46,19 @@ public abstract class BlockEntityTranslator {
     public static final Map<String, BlockEntityTranslator> BLOCK_ENTITY_TRANSLATORS = new HashMap<>();
     public static ObjectArrayList<RequiresBlockState> REQUIRES_BLOCK_STATE_LIST = new ObjectArrayList<>();
 
+    /**
+     * Contains a list of irregular block entity name translations that can't be fit into the regex
+     */
+    public static final Map<String, String> BLOCK_ENTITY_TRANSLATIONS = new HashMap<String, String>() {
+        {
+            // Bedrock/Java differences
+            put("minecraft:enchanting_table", "EnchantTable");
+            put("minecraft:piston_head", "PistonArm");
+            put("minecraft:trapped_chest", "Chest");
+            // There are some legacy IDs sent but as far as I can tell they are not needed for things to work properly
+        }
+    };
+
     protected BlockEntityTranslator() {
     }
 

--- a/connector/src/main/java/org/geysermc/connector/utils/BlockEntityUtils.java
+++ b/connector/src/main/java/org/geysermc/connector/utils/BlockEntityUtils.java
@@ -6,27 +6,14 @@ import com.nukkitx.protocol.bedrock.packet.BlockEntityDataPacket;
 import org.geysermc.connector.network.session.GeyserSession;
 import org.geysermc.connector.network.translators.world.block.entity.BlockEntityTranslator;
 
-import java.util.HashMap;
-import java.util.Map;
-
 public class BlockEntityUtils {
 
     private static final BlockEntityTranslator EMPTY_TRANSLATOR = BlockEntityTranslator.BLOCK_ENTITY_TRANSLATORS.get("Empty");
 
-    private static final Map<String, String> BLOCK_ENTITY_TRANSLATIONS = new HashMap<String, String>() {
-        {
-            // Bedrock/Java differences
-            put("minecraft:enchanting_table", "EnchantTable");
-            put("minecraft:piston_head", "PistonArm");
-            put("minecraft:trapped_chest", "Chest");
-            // There are some legacy IDs sent but as far as I can tell they are not needed for things to work properly
-        }
-    };
-
     public static String getBedrockBlockEntityId(String id) {
         // These are the only exceptions when it comes to block entity ids
-        if (BLOCK_ENTITY_TRANSLATIONS.containsKey(id)) {
-            return BLOCK_ENTITY_TRANSLATIONS.get(id);
+        if (BlockEntityTranslator.BLOCK_ENTITY_TRANSLATIONS.containsKey(id)) {
+            return BlockEntityTranslator.BLOCK_ENTITY_TRANSLATIONS.get(id);
         }
 
         id = id.replace("minecraft:", "")

--- a/connector/src/main/java/org/geysermc/connector/utils/ChunkUtils.java
+++ b/connector/src/main/java/org/geysermc/connector/utils/ChunkUtils.java
@@ -30,6 +30,8 @@ import com.github.steveice10.mc.protocol.data.game.chunk.Column;
 import com.github.steveice10.mc.protocol.data.game.entity.metadata.Position;
 import com.github.steveice10.mc.protocol.data.game.world.block.BlockState;
 import com.github.steveice10.opennbt.tag.builtin.CompoundTag;
+import com.github.steveice10.opennbt.tag.builtin.StringTag;
+import com.github.steveice10.opennbt.tag.builtin.Tag;
 import com.nukkitx.math.vector.Vector2i;
 import com.nukkitx.math.vector.Vector3i;
 import com.nukkitx.nbt.CompoundTagBuilder;
@@ -137,11 +139,23 @@ public class ChunkUtils {
         while (i < blockEntities.length) {
             CompoundTag tag = blockEntities[i];
             String tagName;
-            if (!tag.contains("id")) {
-                GeyserConnector.getInstance().getLogger().debug("Got tag with no id: " + tag.getValue());
-                tagName = "Empty";
-            } else {
+            if (tag.contains("id")) {
                 tagName = (String) tag.get("id").getValue();
+            } else {
+                tagName = "Empty";
+                // Sometimes legacy tags have their ID be a StringTag with empty value
+                for (Tag subTag : tag) {
+                    if (subTag instanceof StringTag) {
+                        StringTag stringTag = (StringTag) subTag;
+                        if (stringTag.getValue().equals("")) {
+                            tagName = stringTag.getName();
+                            break;
+                        }
+                    }
+                }
+                if (tagName.equals("Empty")) {
+                    GeyserConnector.getInstance().getLogger().debug("Got tag with no id: " + tag.getValue());
+                }
             }
 
             String id = BlockEntityUtils.getBedrockBlockEntityId(tagName);


### PR DESCRIPTION
This commit solves two problems related to block entities on older versions:

- Occasionally, tags would contain the ID under a StringTag with an empty value, and not the ID tag.
- The block entity regex did not account for block entity tags that were already in a Bedrock-compatible format (BlockEntity)