### PR TITLE
Reset color instead of turning color to white for standalone

### DIFF
--- a/bootstrap/standalone/src/main/java/org/geysermc/platform/standalone/GeyserStandaloneLogger.java
+++ b/bootstrap/standalone/src/main/java/org/geysermc/platform/standalone/GeyserStandaloneLogger.java
@@ -82,7 +82,7 @@ public class GeyserStandaloneLogger extends SimpleTerminalConsole implements org
 
     @Override
     public void info(String message) {
-        log.info(printConsole(ChatColor.WHITE + message, colored));
+        log.info(printConsole(ChatColor.RESET + ChatColor.BOLD + message, colored));
     }
 
     @Override


### PR DESCRIPTION
Allows non-black-back terminals to see the Geyser log.