### PR TITLE
Add 1.9+ PvP 'Cooldown'

### DIFF
--- a/bootstrap/sponge/src/main/java/org/geysermc/platform/sponge/GeyserSpongeConfiguration.java
+++ b/bootstrap/sponge/src/main/java/org/geysermc/platform/sponge/GeyserSpongeConfiguration.java
@@ -130,6 +130,11 @@ public class GeyserSpongeConfiguration implements GeyserConfiguration {
     }
 
     @Override
+    public boolean isShowCooldown() {
+        return node.getNode("show-cooldown").getBoolean(true);
+    }
+
+    @Override
     public String getDefaultLocale() {
         return node.getNode("default-locale").getString("en_us");
     }

--- a/connector/src/main/java/org/geysermc/connector/configuration/GeyserConfiguration.java
+++ b/connector/src/main/java/org/geysermc/connector/configuration/GeyserConfiguration.java
@@ -34,7 +34,7 @@ import java.util.Map;
 public interface GeyserConfiguration {
 
     // Modify this when you update the config
-    int CURRENT_CONFIG_VERSION = 4;
+    int CURRENT_CONFIG_VERSION = 3;
 
     IBedrockConfiguration getBedrock();
 

--- a/connector/src/main/java/org/geysermc/connector/configuration/GeyserConfiguration.java
+++ b/connector/src/main/java/org/geysermc/connector/configuration/GeyserConfiguration.java
@@ -34,7 +34,7 @@ import java.util.Map;
 public interface GeyserConfiguration {
 
     // Modify this when you update the config
-    int CURRENT_CONFIG_VERSION = 3;
+    int CURRENT_CONFIG_VERSION = 4;
 
     IBedrockConfiguration getBedrock();
 
@@ -61,6 +61,8 @@ public interface GeyserConfiguration {
     boolean isAllowThirdPartyCapes();
 
     boolean isAllowThirdPartyEars();
+
+    boolean isShowCooldown();
 
     String getDefaultLocale();
 

--- a/connector/src/main/java/org/geysermc/connector/configuration/GeyserJacksonConfiguration.java
+++ b/connector/src/main/java/org/geysermc/connector/configuration/GeyserJacksonConfiguration.java
@@ -75,6 +75,9 @@ public abstract class GeyserJacksonConfiguration implements GeyserConfiguration 
     @JsonProperty("allow-third-party-capes")
     private boolean allowThirdPartyCapes;
 
+    @JsonProperty("show-cooldown")
+    private boolean showCooldown;
+
     @JsonProperty("allow-third-party-ears")
     private boolean allowThirdPartyEars;
 

--- a/connector/src/main/java/org/geysermc/connector/configuration/GeyserJacksonConfiguration.java
+++ b/connector/src/main/java/org/geysermc/connector/configuration/GeyserJacksonConfiguration.java
@@ -76,7 +76,7 @@ public abstract class GeyserJacksonConfiguration implements GeyserConfiguration 
     private boolean allowThirdPartyCapes;
 
     @JsonProperty("show-cooldown")
-    private boolean showCooldown;
+    private boolean showCooldown = true;
 
     @JsonProperty("allow-third-party-ears")
     private boolean allowThirdPartyEars;

--- a/connector/src/main/java/org/geysermc/connector/network/session/GeyserSession.java
+++ b/connector/src/main/java/org/geysermc/connector/network/session/GeyserSession.java
@@ -180,6 +180,12 @@ public class GeyserSession implements CommandSender {
      */
     @Setter
     private double attackSpeed;
+    /**
+     * The time of the last hit. Used to gauge how long the cooldown is taking.
+     * This is a session variable in order to minimize visual glitches.
+     */
+    @Setter
+    private long lastHitTime;
 
     private MinecraftProtocol protocol;
 

--- a/connector/src/main/java/org/geysermc/connector/network/session/GeyserSession.java
+++ b/connector/src/main/java/org/geysermc/connector/network/session/GeyserSession.java
@@ -175,6 +175,12 @@ public class GeyserSession implements CommandSender {
     @Setter
     private long lastInteractedVillagerEid;
 
+    /**
+     * The current attack speed of the player. Used for sending proper cooldown timings.
+     */
+    @Setter
+    private double attackSpeed;
+
     private MinecraftProtocol protocol;
 
     public GeyserSession(GeyserConnector connector, BedrockServerSession bedrockServerSession) {

--- a/connector/src/main/java/org/geysermc/connector/network/session/GeyserSession.java
+++ b/connector/src/main/java/org/geysermc/connector/network/session/GeyserSession.java
@@ -182,7 +182,7 @@ public class GeyserSession implements CommandSender {
     private double attackSpeed;
     /**
      * The time of the last hit. Used to gauge how long the cooldown is taking.
-     * This is a session variable in order to minimize visual glitches.
+     * This is a session variable in order to prevent more scheduled threads than necessary.
      */
     @Setter
     private long lastHitTime;

--- a/connector/src/main/java/org/geysermc/connector/network/translators/bedrock/BedrockLevelSoundEventTranslator.java
+++ b/connector/src/main/java/org/geysermc/connector/network/translators/bedrock/BedrockLevelSoundEventTranslator.java
@@ -25,10 +25,12 @@
 
 package org.geysermc.connector.network.translators.bedrock;
 
+import com.nukkitx.protocol.bedrock.data.SoundEvent;
 import com.nukkitx.protocol.bedrock.packet.LevelSoundEventPacket;
 import org.geysermc.connector.network.session.GeyserSession;
 import org.geysermc.connector.network.translators.PacketTranslator;
 import org.geysermc.connector.network.translators.Translator;
+import org.geysermc.connector.utils.CooldownUtils;
 
 @Translator(packet = LevelSoundEventPacket.class)
 public class BedrockLevelSoundEventTranslator extends PacketTranslator<LevelSoundEventPacket> {
@@ -37,5 +39,12 @@ public class BedrockLevelSoundEventTranslator extends PacketTranslator<LevelSoun
     public void translate(LevelSoundEventPacket packet, GeyserSession session) {
         // lol what even :thinking:
         session.sendUpstreamPacket(packet);
+
+        // Yes, what even, but thankfully we can hijack this packet to send the cooldown
+        if (packet.getSound() == SoundEvent.ATTACK_NODAMAGE || packet.getSound() == SoundEvent.ATTACK || packet.getSound() == SoundEvent.ATTACK_STRONG) {
+            // Send a faux cooldown since Bedrock has no cooldown support
+            // Sent here because Java still sends a cooldown if the player doesn't hit anything but Bedrock always sends a sound
+            CooldownUtils.sendCooldown(session);
+        }
     }
 }

--- a/connector/src/main/java/org/geysermc/connector/network/translators/bedrock/BedrockMobEquipmentTranslator.java
+++ b/connector/src/main/java/org/geysermc/connector/network/translators/bedrock/BedrockMobEquipmentTranslator.java
@@ -32,6 +32,7 @@ import org.geysermc.connector.network.translators.Translator;
 import com.github.steveice10.mc.protocol.packet.ingame.client.player.ClientPlayerChangeHeldItemPacket;
 import com.nukkitx.protocol.bedrock.data.ContainerId;
 import com.nukkitx.protocol.bedrock.packet.MobEquipmentPacket;
+import org.geysermc.connector.utils.CooldownUtils;
 
 @Translator(packet = MobEquipmentPacket.class)
 public class BedrockMobEquipmentTranslator extends PacketTranslator<MobEquipmentPacket> {
@@ -47,5 +48,8 @@ public class BedrockMobEquipmentTranslator extends PacketTranslator<MobEquipment
 
         ClientPlayerChangeHeldItemPacket changeHeldItemPacket = new ClientPlayerChangeHeldItemPacket(packet.getHotbarSlot());
         session.sendDownstreamPacket(changeHeldItemPacket);
+
+        // Java sends a cooldown indicator whenever you switch an item
+        CooldownUtils.sendCooldown(session);
     }
 }

--- a/connector/src/main/java/org/geysermc/connector/network/translators/java/entity/JavaEntityPropertiesTranslator.java
+++ b/connector/src/main/java/org/geysermc/connector/network/translators/java/entity/JavaEntityPropertiesTranslator.java
@@ -62,14 +62,8 @@ public class JavaEntityPropertiesTranslator extends PacketTranslator<ServerEntit
                     break;
                 case GENERIC_ATTACK_SPEED:
                     if (isSessionPlayer) {
-                        // Compute attack speed value for use in sending the faux cooldown
-                        double attackSpeed = attribute.getValue();
-                        // To match vanilla behavior
-                        // Realistically only the add modifier is sent in survival gameplay,
-                        // but if multiple modifiers are included they are strictly applied in the following order
-                        attackSpeed = applyModifier(attribute.getModifiers(), attackSpeed, ModifierOperation.ADD);
-                        attackSpeed = applyModifier(attribute.getModifiers(), attackSpeed, ModifierOperation.ADD_MULTIPLIED);
-                        attackSpeed = applyModifier(attribute.getModifiers(), attackSpeed, ModifierOperation.MULTIPLY);
+                        // Get attack speed value for use in sending the faux cooldown
+                        double attackSpeed = AttributeUtils.calculateValue(attribute);
                         session.setAttackSpeed(attackSpeed);
                     }
                     break;
@@ -93,33 +87,5 @@ public class JavaEntityPropertiesTranslator extends PacketTranslator<ServerEntit
         }
 
         entity.updateBedrockAttributes(session);
-    }
-
-    /**
-     * Apply attribute modifiers to the current attack speed.
-     * @param modifiers The list of all attack speed modifiers.
-     * @param attackSpeed The current attack speed.
-     * @param operation The type of modifier operation to check for.
-     * @return The new attack speed. May be the same number.
-     */
-    private double applyModifier(List<AttributeModifier> modifiers, double attackSpeed, ModifierOperation operation) {
-        for (AttributeModifier modifier : modifiers) {
-            if (modifier.getType().isPresent() && modifier.getType().get() == ModifierType.ATTACK_SPEED_MODIFIER) {
-                if (operation == modifier.getOperation()) {
-                    switch (modifier.getOperation()) {
-                        case ADD:
-                            attackSpeed += modifier.getAmount();
-                            break;
-                        case ADD_MULTIPLIED: // Multiply current number by percentage
-                            attackSpeed += (attackSpeed * modifier.getAmount());
-                            break;
-                        case MULTIPLY:
-                            attackSpeed *= modifier.getAmount();
-                            break;
-                    }
-                }
-            }
-        }
-        return attackSpeed;
     }
 }

--- a/connector/src/main/java/org/geysermc/connector/network/translators/java/entity/JavaEntityPropertiesTranslator.java
+++ b/connector/src/main/java/org/geysermc/connector/network/translators/java/entity/JavaEntityPropertiesTranslator.java
@@ -26,9 +26,6 @@
 package org.geysermc.connector.network.translators.java.entity;
 
 import com.github.steveice10.mc.protocol.data.game.entity.attribute.Attribute;
-import com.github.steveice10.mc.protocol.data.game.entity.attribute.AttributeModifier;
-import com.github.steveice10.mc.protocol.data.game.entity.attribute.ModifierOperation;
-import com.github.steveice10.mc.protocol.data.game.entity.attribute.ModifierType;
 import com.github.steveice10.mc.protocol.packet.ingame.server.entity.ServerEntityPropertiesPacket;
 import org.geysermc.connector.entity.Entity;
 import org.geysermc.connector.entity.attribute.AttributeType;
@@ -36,8 +33,6 @@ import org.geysermc.connector.network.session.GeyserSession;
 import org.geysermc.connector.network.translators.PacketTranslator;
 import org.geysermc.connector.network.translators.Translator;
 import org.geysermc.connector.utils.AttributeUtils;
-
-import java.util.List;
 
 @Translator(packet = ServerEntityPropertiesPacket.class)
 public class JavaEntityPropertiesTranslator extends PacketTranslator<ServerEntityPropertiesPacket> {

--- a/connector/src/main/java/org/geysermc/connector/utils/AttributeUtils.java
+++ b/connector/src/main/java/org/geysermc/connector/utils/AttributeUtils.java
@@ -70,7 +70,12 @@ public class AttributeUtils {
         return new com.nukkitx.protocol.bedrock.data.Attribute(type.getBedrockIdentifier(), attribute.getMinimum(), attribute.getMaximum(), attribute.getValue(), attribute.getDefaultValue());
     }
 
-    //https://minecraft.gamepedia.com/Attribute#Modifiers
+    /**
+     * Retrieve the base attribute value with all modifiers applied.
+     * https://minecraft.gamepedia.com/Attribute#Modifiers
+     * @param attribute The attribute to calculate the total value.
+     * @return The finished attribute with all modifiers applied.
+     */
     public static double calculateValue(com.github.steveice10.mc.protocol.data.game.entity.attribute.Attribute attribute) {
         double base = attribute.getValue();
         for (AttributeModifier modifier : attribute.getModifiers()) {

--- a/connector/src/main/java/org/geysermc/connector/utils/CooldownUtils.java
+++ b/connector/src/main/java/org/geysermc/connector/utils/CooldownUtils.java
@@ -1,0 +1,119 @@
+/*
+ * Copyright (c) 2019-2020 GeyserMC. http://geysermc.org
+ *
+ *  Permission is hereby granted, free of charge, to any person obtaining a copy
+ *  of this software and associated documentation files (the "Software"), to deal
+ *  in the Software without restriction, including without limitation the rights
+ *  to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ *  copies of the Software, and to permit persons to whom the Software is
+ *  furnished to do so, subject to the following conditions:
+ *
+ *  The above copyright notice and this permission notice shall be included in
+ *  all copies or substantial portions of the Software.
+ *
+ *  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ *  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ *  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ *  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ *  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ *  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ *  THE SOFTWARE.
+ *
+ *  @author GeyserMC
+ *  @link https://github.com/GeyserMC/Geyser
+ *
+ */
+
+package org.geysermc.connector.utils;
+
+import com.nukkitx.protocol.bedrock.packet.SetTitlePacket;
+import org.geysermc.connector.GeyserConnector;
+import org.geysermc.connector.network.session.GeyserSession;
+
+import java.util.concurrent.TimeUnit;
+
+/**
+ * Manages the sending of a cooldown indicator to the Bedrock player as there is no cooldown indicator in Bedrock.
+ * Much of the work here is from the wonderful folks from ViaRewind: https://github.com/ViaVersion/ViaRewind
+ */
+public class CooldownUtils {
+
+    private final static boolean SHOW_COOLDOWN;
+
+    static {
+        SHOW_COOLDOWN = GeyserConnector.getInstance().getConfig().isShowCooldown();
+    }
+
+    /**
+     * Starts sending the fake cooldown to the Bedrock client.
+     * @param session GeyserSession
+     */
+    public static void sendCooldown(GeyserSession session) {
+        if (!SHOW_COOLDOWN) return;
+        if (session.getAttackSpeed() == 0.0 || session.getAttackSpeed() > 20) return; // 0.0 usually happens on login and causes issues with visuals; anything above 20 means a plugin OldCombatMechanics is being used
+        // Needs to be sent or no subtitle packet is recognized by the client
+        SetTitlePacket titlePacket = new SetTitlePacket();
+        titlePacket.setType(SetTitlePacket.Type.SET_TITLE);
+        titlePacket.setText(" ");
+        session.sendUpstreamPacket(titlePacket);
+        long lastHitTime = System.currentTimeMillis();
+        computeCooldown(session, lastHitTime);
+    }
+
+    /**
+     * Keeps updating the cooldown until the bar is complete.
+     * @param session GeyserSession
+     * @param lastHitTime The time of the last hit. Used to gauge how long the cooldown is taking.
+     */
+    private static void computeCooldown(GeyserSession session, long lastHitTime) {
+        if (session.isClosed()) return; // Don't run scheduled tasks if the client left
+        SetTitlePacket titlePacket = new SetTitlePacket();
+        titlePacket.setType(SetTitlePacket.Type.SET_SUBTITLE);
+        titlePacket.setText(getTitle(session, lastHitTime));
+        titlePacket.setFadeInTime(0);
+        titlePacket.setFadeOutTime(5);
+        titlePacket.setStayTime(2);
+        session.sendUpstreamPacket(titlePacket);
+        if (hasCooldown(session, lastHitTime)) {
+            session.getConnector().getGeneralThreadPool().schedule(() -> computeCooldown(session, lastHitTime), 50, TimeUnit.MILLISECONDS); // Updated per tick. 1000 divided by 20 ticks equals 50
+        } else {
+            SetTitlePacket removeTitlePacket = new SetTitlePacket();
+            removeTitlePacket.setType(SetTitlePacket.Type.SET_SUBTITLE);
+            removeTitlePacket.setText(" ");
+            session.sendUpstreamPacket(removeTitlePacket);
+        }
+    }
+
+    private static boolean hasCooldown(GeyserSession session, long lastHitTime) {
+        long time = System.currentTimeMillis() - lastHitTime;
+        double cooldown = restrain(((double) time) * session.getAttackSpeed() / 1000d, 1.5);
+        return cooldown < 1.1;
+    }
+
+
+    private static double restrain(double x, double max) {
+        if (x < 0d)
+            return 0d;
+        return Math.min(x, max);
+    }
+
+    private static String getTitle(GeyserSession session, long lastHitTime) {
+        long time = System.currentTimeMillis() - lastHitTime;
+        double cooldown = restrain(((double) time) * session.getAttackSpeed() / 1000d, 1);
+
+        int darkGrey = (int) Math.floor(((double) 10) * cooldown);
+        int grey = 10 - darkGrey;
+        StringBuilder builder = new StringBuilder("§8");
+        while (darkGrey > 0) {
+            builder.append("˙");
+            darkGrey--;
+        }
+        builder.append("§7");
+        while (grey > 0) {
+            builder.append("˙");
+            grey--;
+        }
+        return builder.toString();
+    }
+
+}

--- a/connector/src/main/java/org/geysermc/connector/utils/CooldownUtils.java
+++ b/connector/src/main/java/org/geysermc/connector/utils/CooldownUtils.java
@@ -101,7 +101,7 @@ public class CooldownUtils {
         long time = System.currentTimeMillis() - lastHitTime;
         double cooldown = restrain(((double) time) * session.getAttackSpeed() / 1000d, 1);
 
-        int darkGrey = (int) Math.floor(((double) 10) * cooldown);
+        int darkGrey = (int) Math.floor(10d * cooldown);
         int grey = 10 - darkGrey;
         StringBuilder builder = new StringBuilder("§8");
         while (darkGrey > 0) {

--- a/connector/src/main/resources/config.yml
+++ b/connector/src/main/resources/config.yml
@@ -106,4 +106,4 @@ metrics:
   uuid: generateduuid
 
 # DO NOT TOUCH!
-config-version: 4
+config-version: 3

--- a/connector/src/main/resources/config.yml
+++ b/connector/src/main/resources/config.yml
@@ -74,6 +74,9 @@ allow-third-party-capes: true
 # MinecraftCapes
 allow-third-party-ears: false
 
+# Allow a fake cooldown indicator to be sent. Bedrock players do not see a cooldown as they still use 1.8 combat
+show-cooldown: true
+
 # The default locale if we dont have the one the client requested
 default-locale: en_us
 
@@ -103,4 +106,4 @@ metrics:
   uuid: generateduuid
 
 # DO NOT TOUCH!
-config-version: 3
+config-version: 4


### PR DESCRIPTION
This commit adds a subtitle that acts as the Java cooldown. This is an optional feature disabled in the config with `show-cooldown`. This does not appear on plugins that use OldCombatMechanics.

A lot of this work could not be done were it not for the folks at ViaRewind, and for that I thank them.