### PR TITLE
Clarify Bedrock remote address change

### DIFF
--- a/connector/src/main/resources/config.yml
+++ b/connector/src/main/resources/config.yml
@@ -8,7 +8,8 @@
 # --------------------------------
 
 bedrock:
-  # The IP address that will listen for connections
+  # The IP address that will listen for connections.
+  # There is no reason to change this unless you want to limit what IPs can connect to your server.
   address: 0.0.0.0
   # The port that will listen for connections
   port: 19132


### PR DESCRIPTION
There's no reason for most users to try changing this.