### PR TITLE
Update MCProtocolLib dependency

### DIFF
--- a/common/src/main/java/org/geysermc/common/window/component/ToggleComponent.java
+++ b/common/src/main/java/org/geysermc/common/window/component/ToggleComponent.java
@@ -25,9 +25,17 @@
 
 package org.geysermc.common.window.component;
 
+import lombok.Getter;
+import lombok.Setter;
+
 public class ToggleComponent extends FormComponent {
 
+    @Getter
+    @Setter
     private String text;
+
+    @Getter
+    @Setter
     private boolean defaultValue;
 
     public ToggleComponent(String text) {

--- a/connector/pom.xml
+++ b/connector/pom.xml
@@ -68,6 +68,12 @@
         </dependency>
         <dependency>
             <groupId>com.nukkitx.fastutil</groupId>
+            <artifactId>fastutil-int-byte-maps</artifactId>
+            <version>8.3.1</version>
+            <scope>compile</scope>
+        </dependency>
+        <dependency>
+            <groupId>com.nukkitx.fastutil</groupId>
             <artifactId>fastutil-int-double-maps</artifactId>
             <version>8.3.1</version>
             <scope>compile</scope>
@@ -99,7 +105,7 @@
         <dependency>
             <groupId>com.github.steveice10</groupId>
             <artifactId>mcprotocollib</artifactId>
-            <version>4c315aa206</version>
+            <version>013e8e6dc4</version>
             <scope>compile</scope>
             <exclusions>
                 <exclusion>

--- a/connector/src/main/java/org/geysermc/connector/entity/Entity.java
+++ b/connector/src/main/java/org/geysermc/connector/entity/Entity.java
@@ -32,7 +32,6 @@ import com.github.steveice10.mc.protocol.data.game.entity.metadata.Position;
 import com.github.steveice10.mc.protocol.data.game.entity.player.Hand;
 import com.github.steveice10.mc.protocol.data.game.entity.player.PlayerAction;
 import com.github.steveice10.mc.protocol.data.game.world.block.BlockFace;
-import com.github.steveice10.mc.protocol.data.game.world.block.BlockState;
 import com.github.steveice10.mc.protocol.data.message.TextMessage;
 import com.github.steveice10.mc.protocol.data.message.TranslationMessage;
 import com.github.steveice10.mc.protocol.packet.ingame.client.player.ClientPlayerActionPacket;
@@ -335,7 +334,7 @@ public class Entity {
                         Vector3i lastInteractionPos = session.getLastInteractionPosition();
                         metadata.put(EntityData.BED_RESPAWN_POS, lastInteractionPos);
                         if (session.getConnector().getConfig().isCacheChunks()) {
-                            BlockState bed = session.getConnector().getWorldManager().getBlockAt(session, lastInteractionPos.getX(),
+                            int bed = session.getConnector().getWorldManager().getBlockAt(session, lastInteractionPos.getX(),
                                     lastInteractionPos.getY(), lastInteractionPos.getZ());
                             // Bed has to be updated, or else player is floating in the air
                             ChunkUtils.updateBlock(session, bed, lastInteractionPos);

--- a/connector/src/main/java/org/geysermc/connector/entity/living/monster/EndermanEntity.java
+++ b/connector/src/main/java/org/geysermc/connector/entity/living/monster/EndermanEntity.java
@@ -26,7 +26,6 @@
 package org.geysermc.connector.entity.living.monster;
 
 import com.github.steveice10.mc.protocol.data.game.entity.metadata.EntityMetadata;
-import com.github.steveice10.mc.protocol.data.game.world.block.BlockState;
 import com.nukkitx.math.vector.Vector3f;
 import com.nukkitx.protocol.bedrock.data.EntityData;
 import com.nukkitx.protocol.bedrock.data.EntityFlag;
@@ -44,7 +43,7 @@ public class EndermanEntity extends MonsterEntity {
     public void updateBedrockMetadata(EntityMetadata entityMetadata, GeyserSession session) {
         // Held block
         if (entityMetadata.getId() == 15) {
-            metadata.put(EntityData.ENDERMAN_HELD_ITEM_ID, BlockTranslator.getBedrockBlockId((BlockState) entityMetadata.getValue()));
+            metadata.put(EntityData.ENDERMAN_HELD_ITEM_ID, BlockTranslator.getBedrockBlockId((int) entityMetadata.getValue()));
         }
         // 'Angry' - mouth open
         if (entityMetadata.getId() == 16) {

--- a/connector/src/main/java/org/geysermc/connector/network/ConnectorServerEventHandler.java
+++ b/connector/src/main/java/org/geysermc/connector/network/ConnectorServerEventHandler.java
@@ -25,15 +25,17 @@
 
 package org.geysermc.connector.network;
 
-import com.github.steveice10.mc.protocol.data.message.Message;
-import com.nukkitx.protocol.bedrock.*;
+import com.github.steveice10.mc.protocol.data.message.MessageSerializer;
+import com.nukkitx.protocol.bedrock.BedrockPong;
+import com.nukkitx.protocol.bedrock.BedrockServerEventHandler;
+import com.nukkitx.protocol.bedrock.BedrockServerSession;
 import io.netty.channel.ChannelHandlerContext;
 import io.netty.channel.socket.DatagramPacket;
 import org.geysermc.common.ping.GeyserPingInfo;
-import org.geysermc.connector.ping.IGeyserPingPassthrough;
-import org.geysermc.connector.configuration.GeyserConfiguration;
 import org.geysermc.connector.GeyserConnector;
+import org.geysermc.connector.configuration.GeyserConfiguration;
 import org.geysermc.connector.network.session.GeyserSession;
+import org.geysermc.connector.ping.IGeyserPingPassthrough;
 import org.geysermc.connector.utils.MessageUtils;
 
 import java.net.InetSocketAddress;
@@ -73,7 +75,7 @@ public class ConnectorServerEventHandler implements BedrockServerEventHandler {
         pong.setIpv4Port(config.getBedrock().getPort());
 
         if (config.isPassthroughMotd() && pingInfo != null && pingInfo.motd != null) {
-            String[] motd = MessageUtils.getBedrockMessage(Message.fromString(pingInfo.motd)).split("\n");
+            String[] motd = MessageUtils.getBedrockMessage(MessageSerializer.fromString(pingInfo.motd)).split("\n");
             String mainMotd = motd[0]; // First line of the motd.
             String subMotd = (motd.length != 1) ? motd[1] : ""; // Second line of the motd if present, otherwise blank.
 

--- a/connector/src/main/java/org/geysermc/connector/network/QueryPacketHandler.java
+++ b/connector/src/main/java/org/geysermc/connector/network/QueryPacketHandler.java
@@ -26,7 +26,7 @@
 
 package org.geysermc.connector.network;
 
-import com.github.steveice10.mc.protocol.data.message.Message;
+import com.github.steveice10.mc.protocol.data.message.MessageSerializer;
 import io.netty.buffer.ByteBuf;
 import io.netty.buffer.ByteBufAllocator;
 import org.geysermc.common.ping.GeyserPingInfo;
@@ -148,7 +148,7 @@ public class QueryPacketHandler {
         }
 
         if (connector.getConfig().isPassthroughMotd() && pingInfo != null) {
-            String[] javaMotd = MessageUtils.getBedrockMessage(Message.fromString(pingInfo.motd)).split("\n");
+            String[] javaMotd = MessageUtils.getBedrockMessage(MessageSerializer.fromString(pingInfo.motd)).split("\n");
             motd = javaMotd[0].trim(); // First line of the motd.
         } else {
             motd = connector.getConfig().getBedrock().getMotd1();

--- a/connector/src/main/java/org/geysermc/connector/network/session/GeyserSession.java
+++ b/connector/src/main/java/org/geysermc/connector/network/session/GeyserSession.java
@@ -32,7 +32,6 @@ import com.github.steveice10.mc.protocol.MinecraftProtocol;
 import com.github.steveice10.mc.protocol.data.SubProtocol;
 import com.github.steveice10.mc.protocol.data.game.entity.player.GameMode;
 import com.github.steveice10.mc.protocol.data.game.window.VillagerTrade;
-import com.github.steveice10.mc.protocol.data.game.world.block.BlockState;
 import com.github.steveice10.mc.protocol.packet.handshake.client.HandshakePacket;
 import com.github.steveice10.mc.protocol.packet.ingame.client.world.ClientTeleportConfirmPacket;
 import com.github.steveice10.mc.protocol.packet.ingame.server.ServerRespawnPacket;
@@ -146,7 +145,7 @@ public class GeyserSession implements CommandSender {
     private boolean jumping;
 
     @Setter
-    private BlockState breakingBlock;
+    private int breakingBlock;
 
     @Setter
     private Vector3i lastBlockPlacePosition;

--- a/connector/src/main/java/org/geysermc/connector/network/session/cache/ChunkCache.java
+++ b/connector/src/main/java/org/geysermc/connector/network/session/cache/ChunkCache.java
@@ -28,7 +28,6 @@ package org.geysermc.connector.network.session.cache;
 import com.github.steveice10.mc.protocol.data.game.chunk.Chunk;
 import com.github.steveice10.mc.protocol.data.game.chunk.Column;
 import com.github.steveice10.mc.protocol.data.game.entity.metadata.Position;
-import com.github.steveice10.mc.protocol.data.game.world.block.BlockState;
 import lombok.Getter;
 import org.geysermc.connector.network.session.GeyserSession;
 import org.geysermc.connector.network.translators.world.block.BlockTranslator;
@@ -58,7 +57,7 @@ public class ChunkCache {
         chunks.put(position, chunk);
     }
 
-    public void updateBlock(Position position, BlockState block) {
+    public void updateBlock(Position position, int block) {
         if (!cache) {
             return;
         }
@@ -74,7 +73,7 @@ public class ChunkCache {
         }
     }
 
-    public BlockState getBlockAt(Position position) {
+    public int getBlockAt(Position position) {
         if (!cache) {
             return BlockTranslator.AIR;
         }

--- a/connector/src/main/java/org/geysermc/connector/network/translators/bedrock/BedrockActionTranslator.java
+++ b/connector/src/main/java/org/geysermc/connector/network/translators/bedrock/BedrockActionTranslator.java
@@ -114,7 +114,7 @@ public class BedrockActionTranslator extends PacketTranslator<PlayerActionPacket
             case CONTINUE_BREAK:
                 LevelEventPacket continueBreakPacket = new LevelEventPacket();
                 continueBreakPacket.setType(LevelEventType.PUNCH_BLOCK);
-                continueBreakPacket.setData(BlockTranslator.getBedrockBlockId(session.getBreakingBlock() == null ? BlockTranslator.AIR : session.getBreakingBlock()));
+                continueBreakPacket.setData(BlockTranslator.getBedrockBlockId(session.getBreakingBlock()));
                 continueBreakPacket.setPosition(packet.getBlockPosition().toFloat());
                 session.sendUpstreamPacket(continueBreakPacket);
                 break;

--- a/connector/src/main/java/org/geysermc/connector/network/translators/bedrock/BedrockBlockPickRequestPacketTranslator.java
+++ b/connector/src/main/java/org/geysermc/connector/network/translators/bedrock/BedrockBlockPickRequestPacketTranslator.java
@@ -26,7 +26,6 @@
 
 package org.geysermc.connector.network.translators.bedrock;
 
-import com.github.steveice10.mc.protocol.data.game.world.block.BlockState;
 import com.github.steveice10.mc.protocol.packet.ingame.client.window.ClientMoveItemToHotbarPacket;
 import com.nukkitx.math.vector.Vector3i;
 import com.nukkitx.protocol.bedrock.packet.BlockPickRequestPacket;
@@ -45,10 +44,10 @@ public class BedrockBlockPickRequestPacketTranslator extends PacketTranslator<Bl
     @Override
     public void translate(BlockPickRequestPacket packet, GeyserSession session) {
         Vector3i vector = packet.getBlockPosition();
-        BlockState blockToPick = session.getConnector().getWorldManager().getBlockAt(session, vector.getX(), vector.getY(), vector.getZ());
+        int blockToPick = session.getConnector().getWorldManager().getBlockAt(session, vector.getX(), vector.getY(), vector.getZ());
         
         // Block is air - chunk caching is probably off
-        if (blockToPick.getId() == 0) {
+        if (blockToPick == 0) {
             return;
         }
 

--- a/connector/src/main/java/org/geysermc/connector/network/translators/bedrock/BedrockInventoryTransactionTranslator.java
+++ b/connector/src/main/java/org/geysermc/connector/network/translators/bedrock/BedrockInventoryTransactionTranslator.java
@@ -36,7 +36,6 @@ import com.github.steveice10.mc.protocol.packet.ingame.client.player.ClientPlaye
 import com.github.steveice10.mc.protocol.packet.ingame.client.player.ClientPlayerInteractEntityPacket;
 import com.github.steveice10.mc.protocol.packet.ingame.client.player.ClientPlayerPlaceBlockPacket;
 import com.github.steveice10.mc.protocol.packet.ingame.client.player.ClientPlayerUseItemPacket;
-import com.github.steveice10.mc.protocol.data.game.world.block.BlockState;
 import com.nukkitx.math.vector.Vector3i;
 import com.nukkitx.math.vector.Vector3f;
 import com.nukkitx.protocol.bedrock.data.LevelEventType;
@@ -146,8 +145,8 @@ public class BedrockInventoryTransactionTranslator extends PacketTranslator<Inve
                         session.setLastInteractionPosition(packet.getBlockPosition());
                         break;
                     case 2:
-                        BlockState blockState = session.getConnector().getWorldManager().getBlockAt(session, packet.getBlockPosition().getX(), packet.getBlockPosition().getY(), packet.getBlockPosition().getZ());
-                        double blockHardness = BlockTranslator.JAVA_RUNTIME_ID_TO_HARDNESS.get(blockState.getId());
+                        int blockState = session.getConnector().getWorldManager().getBlockAt(session, packet.getBlockPosition().getX(), packet.getBlockPosition().getY(), packet.getBlockPosition().getZ());
+                        double blockHardness = BlockTranslator.JAVA_RUNTIME_ID_TO_HARDNESS.get(blockState);
                         if (session.getGameMode() == GameMode.CREATIVE || (session.getConnector().getConfig().isCacheChunks() && blockHardness == 0)) {
                             session.setLastBlockPlacedId(null);
                             session.setLastBlockPlacePosition(null);

--- a/connector/src/main/java/org/geysermc/connector/network/translators/inventory/AnvilInventoryTranslator.java
+++ b/connector/src/main/java/org/geysermc/connector/network/translators/inventory/AnvilInventoryTranslator.java
@@ -27,6 +27,7 @@ package org.geysermc.connector.network.translators.inventory;
 
 import com.github.steveice10.mc.protocol.data.game.entity.metadata.ItemStack;
 import com.github.steveice10.mc.protocol.data.message.Message;
+import com.github.steveice10.mc.protocol.data.message.MessageSerializer;
 import com.github.steveice10.mc.protocol.packet.ingame.client.window.ClientRenameItemPacket;
 import com.github.steveice10.opennbt.tag.builtin.CompoundTag;
 import com.nukkitx.protocol.bedrock.data.ContainerId;
@@ -129,8 +130,8 @@ public class AnvilInventoryTranslator extends BlockInventoryTranslator {
                     CompoundTag displayTag = tag.get("display");
                     if (displayTag != null) {
                         String itemName = displayTag.get("Name").getValue().toString();
-                        Message message = Message.fromString(itemName);
-                        rename = message.getText();
+                        Message message = MessageSerializer.fromString(itemName);
+                        rename = message.toString();
                     } else {
                         rename = "";
                     }

--- a/connector/src/main/java/org/geysermc/connector/network/translators/inventory/AnvilInventoryTranslator.java
+++ b/connector/src/main/java/org/geysermc/connector/network/translators/inventory/AnvilInventoryTranslator.java
@@ -26,8 +26,8 @@
 package org.geysermc.connector.network.translators.inventory;
 
 import com.github.steveice10.mc.protocol.data.game.entity.metadata.ItemStack;
-import com.github.steveice10.mc.protocol.data.message.Message;
 import com.github.steveice10.mc.protocol.data.message.MessageSerializer;
+import com.github.steveice10.mc.protocol.data.message.TextMessage;
 import com.github.steveice10.mc.protocol.packet.ingame.client.window.ClientRenameItemPacket;
 import com.github.steveice10.opennbt.tag.builtin.CompoundTag;
 import com.nukkitx.protocol.bedrock.data.ContainerId;
@@ -130,8 +130,8 @@ public class AnvilInventoryTranslator extends BlockInventoryTranslator {
                     CompoundTag displayTag = tag.get("display");
                     if (displayTag != null) {
                         String itemName = displayTag.get("Name").getValue().toString();
-                        Message message = MessageSerializer.fromString(itemName);
-                        rename = message.toString();
+                        TextMessage message = (TextMessage) MessageSerializer.fromString(itemName);
+                        rename = message.getText();
                     } else {
                         rename = "";
                     }

--- a/connector/src/main/java/org/geysermc/connector/network/translators/inventory/BlockInventoryTranslator.java
+++ b/connector/src/main/java/org/geysermc/connector/network/translators/inventory/BlockInventoryTranslator.java
@@ -25,7 +25,6 @@
 
 package org.geysermc.connector.network.translators.inventory;
 
-import com.github.steveice10.mc.protocol.data.game.world.block.BlockState;
 import com.nukkitx.protocol.bedrock.data.ContainerType;
 import org.geysermc.connector.inventory.Inventory;
 import org.geysermc.connector.network.session.GeyserSession;
@@ -40,7 +39,7 @@ public class BlockInventoryTranslator extends BaseInventoryTranslator {
 
     public BlockInventoryTranslator(int size, String javaBlockIdentifier, ContainerType containerType, InventoryUpdater updater) {
         super(size);
-        BlockState javaBlockState = BlockTranslator.getJavaBlockState(javaBlockIdentifier);
+        int javaBlockState = BlockTranslator.getJavaBlockState(javaBlockIdentifier);
         int blockId = BlockTranslator.getBedrockBlockId(javaBlockState);
         this.holder = new BlockInventoryHolder(blockId, containerType);
         this.updater = updater;

--- a/connector/src/main/java/org/geysermc/connector/network/translators/inventory/DoubleChestInventoryTranslator.java
+++ b/connector/src/main/java/org/geysermc/connector/network/translators/inventory/DoubleChestInventoryTranslator.java
@@ -26,7 +26,6 @@
 package org.geysermc.connector.network.translators.inventory;
 
 import com.github.steveice10.mc.protocol.data.game.entity.metadata.Position;
-import com.github.steveice10.mc.protocol.data.game.world.block.BlockState;
 import com.nukkitx.math.vector.Vector3i;
 import com.nukkitx.nbt.tag.CompoundTag;
 import com.nukkitx.protocol.bedrock.data.ContainerType;
@@ -36,15 +35,13 @@ import com.nukkitx.protocol.bedrock.packet.UpdateBlockPacket;
 import org.geysermc.connector.inventory.Inventory;
 import org.geysermc.connector.network.session.GeyserSession;
 import org.geysermc.connector.network.translators.world.block.BlockTranslator;
-import org.geysermc.connector.network.translators.inventory.updater.ChestInventoryUpdater;
-import org.geysermc.connector.network.translators.inventory.updater.InventoryUpdater;
 
 public class DoubleChestInventoryTranslator extends ChestInventoryTranslator {
     private final int blockId;
 
     public DoubleChestInventoryTranslator(int size) {
         super(size, 54);
-        BlockState javaBlockState = BlockTranslator.getJavaBlockState("minecraft:chest[facing=north,type=single,waterlogged=false]");
+        int javaBlockState = BlockTranslator.getJavaBlockState("minecraft:chest[facing=north,type=single,waterlogged=false]");
         this.blockId = BlockTranslator.getBedrockBlockId(javaBlockState);
     }
 
@@ -110,7 +107,7 @@ public class DoubleChestInventoryTranslator extends ChestInventoryTranslator {
     public void closeInventory(GeyserSession session, Inventory inventory) {
         Vector3i holderPos = inventory.getHolderPosition();
         Position pos = new Position(holderPos.getX(), holderPos.getY(), holderPos.getZ());
-        BlockState realBlock = session.getConnector().getWorldManager().getBlockAt(session, pos.getX(), pos.getY(), pos.getZ());
+        int realBlock = session.getConnector().getWorldManager().getBlockAt(session, pos.getX(), pos.getY(), pos.getZ());
         UpdateBlockPacket blockPacket = new UpdateBlockPacket();
         blockPacket.setDataLayer(0);
         blockPacket.setBlockPosition(holderPos);

--- a/connector/src/main/java/org/geysermc/connector/network/translators/inventory/SingleChestInventoryTranslator.java
+++ b/connector/src/main/java/org/geysermc/connector/network/translators/inventory/SingleChestInventoryTranslator.java
@@ -25,7 +25,6 @@
 
 package org.geysermc.connector.network.translators.inventory;
 
-import com.github.steveice10.mc.protocol.data.game.world.block.BlockState;
 import com.nukkitx.protocol.bedrock.data.ContainerType;
 import org.geysermc.connector.inventory.Inventory;
 import org.geysermc.connector.network.session.GeyserSession;
@@ -38,7 +37,7 @@ public class SingleChestInventoryTranslator extends ChestInventoryTranslator {
 
     public SingleChestInventoryTranslator(int size) {
         super(size, 27);
-        BlockState javaBlockState = BlockTranslator.getJavaBlockState("minecraft:chest[facing=north,type=single,waterlogged=false]");
+        int javaBlockState = BlockTranslator.getJavaBlockState("minecraft:chest[facing=north,type=single,waterlogged=false]");
         this.holder = new BlockInventoryHolder(BlockTranslator.getBedrockBlockId(javaBlockState), ContainerType.CONTAINER);
     }
 

--- a/connector/src/main/java/org/geysermc/connector/network/translators/inventory/holder/BlockInventoryHolder.java
+++ b/connector/src/main/java/org/geysermc/connector/network/translators/inventory/holder/BlockInventoryHolder.java
@@ -26,7 +26,6 @@
 package org.geysermc.connector.network.translators.inventory.holder;
 
 import com.github.steveice10.mc.protocol.data.game.entity.metadata.Position;
-import com.github.steveice10.mc.protocol.data.game.world.block.BlockState;
 import com.nukkitx.math.vector.Vector3i;
 import com.nukkitx.nbt.tag.CompoundTag;
 import com.nukkitx.protocol.bedrock.data.ContainerType;
@@ -82,7 +81,7 @@ public class BlockInventoryHolder extends InventoryHolder {
     public void closeInventory(InventoryTranslator translator, GeyserSession session, Inventory inventory) {
         Vector3i holderPos = inventory.getHolderPosition();
         Position pos = new Position(holderPos.getX(), holderPos.getY(), holderPos.getZ());
-        BlockState realBlock = session.getConnector().getWorldManager().getBlockAt(session, pos.getX(), pos.getY(), pos.getZ());
+        int realBlock = session.getConnector().getWorldManager().getBlockAt(session, pos.getX(), pos.getY(), pos.getZ());
         UpdateBlockPacket blockPacket = new UpdateBlockPacket();
         blockPacket.setDataLayer(0);
         blockPacket.setBlockPosition(holderPos);

--- a/connector/src/main/java/org/geysermc/connector/network/translators/item/ItemTranslator.java
+++ b/connector/src/main/java/org/geysermc/connector/network/translators/item/ItemTranslator.java
@@ -27,7 +27,7 @@
 package org.geysermc.connector.network.translators.item;
 
 import com.github.steveice10.mc.protocol.data.game.entity.metadata.ItemStack;
-import com.github.steveice10.mc.protocol.data.message.Message;
+import com.github.steveice10.mc.protocol.data.message.MessageSerializer;
 import com.github.steveice10.opennbt.tag.builtin.*;
 import com.nukkitx.nbt.CompoundTagBuilder;
 import com.nukkitx.nbt.tag.CompoundTag;
@@ -159,7 +159,7 @@ public abstract class ItemTranslator {
                 // Check if its a message to translate
                 if (MessageUtils.isMessage(name)) {
                     // Get the translated name
-                    name = MessageUtils.getTranslatedBedrockMessage(Message.fromString(name), session.getClientData().getLanguageCode());
+                    name = MessageUtils.getTranslatedBedrockMessage(MessageSerializer.fromString(name), session.getClientData().getLanguageCode());
 
                     // Build the new display tag
                     CompoundTagBuilder displayBuilder = display.toBuilder();

--- a/connector/src/main/java/org/geysermc/connector/network/translators/java/JavaChatTranslator.java
+++ b/connector/src/main/java/org/geysermc/connector/network/translators/java/JavaChatTranslator.java
@@ -66,7 +66,7 @@ public class JavaChatTranslator extends PacketTranslator<ServerChatPacket> {
             textPacket.setType(TextPacket.Type.TRANSLATION);
             textPacket.setNeedsTranslation(true);
 
-            List<String> paramsTranslated = MessageUtils.getTranslationParams(((TranslationMessage) packet.getMessage()).getTranslationParams(), locale);
+            List<String> paramsTranslated = MessageUtils.getTranslationParams(((TranslationMessage) packet.getMessage()).getWith(), locale);
             textPacket.setParameters(paramsTranslated);
 
             textPacket.setMessage(MessageUtils.insertParams(MessageUtils.getTranslatedBedrockMessage(packet.getMessage(), locale, true), paramsTranslated));

--- a/connector/src/main/java/org/geysermc/connector/network/translators/java/entity/player/JavaPlayerActionAckTranslator.java
+++ b/connector/src/main/java/org/geysermc/connector/network/translators/java/entity/player/JavaPlayerActionAckTranslator.java
@@ -50,13 +50,13 @@ public class JavaPlayerActionAckTranslator extends PacketTranslator<ServerPlayer
         LevelEventPacket levelEvent = new LevelEventPacket();
         switch (packet.getAction()) {
             case FINISH_DIGGING:
-                double blockHardness = BlockTranslator.JAVA_RUNTIME_ID_TO_HARDNESS.get(session.getBreakingBlock() == null ? 0 : session.getBreakingBlock().getId());
+                double blockHardness = BlockTranslator.JAVA_RUNTIME_ID_TO_HARDNESS.get(session.getBreakingBlock());
                 if (session.getGameMode() != GameMode.CREATIVE && blockHardness != 0) {
                     levelEvent.setType(LevelEventType.DESTROY);
                     levelEvent.setPosition(Vector3f.from(packet.getPosition().getX(), packet.getPosition().getY(), packet.getPosition().getZ()));
                     levelEvent.setData(BlockTranslator.getBedrockBlockId(session.getBreakingBlock()));
                     session.sendUpstreamPacket(levelEvent);
-                    session.setBreakingBlock(null);
+                    session.setBreakingBlock(0);
                 }
                 ChunkUtils.updateBlock(session, packet.getNewState(), packet.getPosition());
                 break;
@@ -64,7 +64,7 @@ public class JavaPlayerActionAckTranslator extends PacketTranslator<ServerPlayer
                 if (session.getGameMode() == GameMode.CREATIVE) {
                     break;
                 }
-                blockHardness = BlockTranslator.JAVA_RUNTIME_ID_TO_HARDNESS.get(packet.getNewState().getId());
+                blockHardness = BlockTranslator.JAVA_RUNTIME_ID_TO_HARDNESS.get(packet.getNewState());
                 levelEvent.setType(LevelEventType.BLOCK_START_BREAK);
                 levelEvent.setPosition(Vector3f.from(
                         packet.getPosition().getX(),
@@ -79,7 +79,7 @@ public class JavaPlayerActionAckTranslator extends PacketTranslator<ServerPlayer
                     itemEntry = ItemRegistry.getItem(item);
                     nbtData = item.getNbt();
                 }
-                double breakTime = Math.ceil(BlockUtils.getBreakTime(blockHardness, packet.getNewState().getId(), itemEntry, nbtData, session) * 20);
+                double breakTime = Math.ceil(BlockUtils.getBreakTime(blockHardness, packet.getNewState(), itemEntry, nbtData, session) * 20);
                 levelEvent.setData((int) (65535 / breakTime));
                 session.setBreakingBlock(packet.getNewState());
                 session.sendUpstreamPacket(levelEvent);
@@ -92,7 +92,7 @@ public class JavaPlayerActionAckTranslator extends PacketTranslator<ServerPlayer
                         packet.getPosition().getZ()
                 ));
                 levelEvent.setData(0);
-                session.setBreakingBlock(null);
+                session.setBreakingBlock(0);
                 session.sendUpstreamPacket(levelEvent);
                 break;
         }

--- a/connector/src/main/java/org/geysermc/connector/network/translators/java/world/JavaBlockBreakAnimTranslator.java
+++ b/connector/src/main/java/org/geysermc/connector/network/translators/java/world/JavaBlockBreakAnimTranslator.java
@@ -26,7 +26,6 @@
 
 package org.geysermc.connector.network.translators.java.world;
 
-import com.github.steveice10.mc.protocol.data.game.world.block.BlockState;
 import com.github.steveice10.mc.protocol.packet.ingame.server.world.ServerBlockBreakAnimPacket;
 import com.github.steveice10.opennbt.tag.builtin.CompoundTag;
 import com.nukkitx.math.vector.Vector3f;
@@ -44,8 +43,8 @@ public class JavaBlockBreakAnimTranslator extends PacketTranslator<ServerBlockBr
 
     @Override
     public void translate(ServerBlockBreakAnimPacket packet, GeyserSession session) {
-        BlockState state = session.getConnector().getWorldManager().getBlockAt(session, packet.getPosition().getX(), packet.getPosition().getY(), packet.getPosition().getZ());
-        int breakTime = (int) (65535 / Math.ceil(BlockUtils.getBreakTime(BlockTranslator.JAVA_RUNTIME_ID_TO_HARDNESS.get(state.getId()), state.getId(), ItemEntry.AIR, new CompoundTag(""), null) * 20));
+        int state = session.getConnector().getWorldManager().getBlockAt(session, packet.getPosition().getX(), packet.getPosition().getY(), packet.getPosition().getZ());
+        int breakTime = (int) (65535 / Math.ceil(BlockUtils.getBreakTime(BlockTranslator.JAVA_RUNTIME_ID_TO_HARDNESS.get(state), state, ItemEntry.AIR, new CompoundTag(""), null) * 20));
         LevelEventPacket levelEventPacket = new LevelEventPacket();
         levelEventPacket.setPosition(Vector3f.from(
                 packet.getPosition().getX(),

--- a/connector/src/main/java/org/geysermc/connector/network/translators/java/world/JavaBlockChangeTranslator.java
+++ b/connector/src/main/java/org/geysermc/connector/network/translators/java/world/JavaBlockChangeTranslator.java
@@ -45,7 +45,7 @@ public class JavaBlockChangeTranslator extends PacketTranslator<ServerBlockChang
     @Override
     public void translate(ServerBlockChangePacket packet, GeyserSession session) {
         Position pos = packet.getRecord().getPosition();
-        boolean updatePlacement = !(session.getConnector().getConfig().isCacheChunks() && session.getConnector().getWorldManager().getBlockAt(session, pos.getX(), pos.getY(), pos.getZ()).getId() == packet.getRecord().getBlock().getId());
+        boolean updatePlacement = !(session.getConnector().getConfig().isCacheChunks() && session.getConnector().getWorldManager().getBlockAt(session, pos.getX(), pos.getY(), pos.getZ()) == packet.getRecord().getBlock());
         ChunkUtils.updateBlock(session, packet.getRecord().getBlock(), packet.getRecord().getPosition());
         if (updatePlacement && session.getConnector().getPlatformType() != PlatformType.BUKKIT) {
             this.checkPlace(session, packet);

--- a/connector/src/main/java/org/geysermc/connector/network/translators/java/world/JavaChunkDataTranslator.java
+++ b/connector/src/main/java/org/geysermc/connector/network/translators/java/world/JavaChunkDataTranslator.java
@@ -25,7 +25,6 @@
 
 package org.geysermc.connector.network.translators.java.world;
 
-import com.github.steveice10.mc.protocol.data.game.world.block.BlockState;
 import com.github.steveice10.mc.protocol.data.game.entity.metadata.Position;
 import com.github.steveice10.mc.protocol.packet.ingame.server.world.ServerChunkDataPacket;
 import com.nukkitx.nbt.NbtUtils;
@@ -105,7 +104,7 @@ public class JavaChunkDataTranslator extends PacketTranslator<ServerChunkDataPac
                     int x = blockEntityEntry.getKey().getInt("x");
                     int y = blockEntityEntry.getKey().getInt("y");
                     int z = blockEntityEntry.getKey().getInt("z");
-                    ChunkUtils.updateBlock(session, new BlockState(blockEntityEntry.getIntValue()), new Position(x, y, z));
+                    ChunkUtils.updateBlock(session, blockEntityEntry.getIntValue(), new Position(x, y, z));
                 }
                 chunkData.getLoadBlockEntitiesLater().clear();
                 session.getChunkCache().addToCache(packet.getColumn());

--- a/connector/src/main/java/org/geysermc/connector/network/translators/java/world/JavaUpdateTileEntityTranslator.java
+++ b/connector/src/main/java/org/geysermc/connector/network/translators/java/world/JavaUpdateTileEntityTranslator.java
@@ -47,7 +47,7 @@ public class JavaUpdateTileEntityTranslator extends PacketTranslator<ServerUpdat
                     ChunkUtils.CACHED_BLOCK_ENTITIES.get(packet.getPosition())), packet.getPosition());
             ChunkUtils.CACHED_BLOCK_ENTITIES.remove(packet.getPosition());
         } else {
-            BlockEntityUtils.updateBlockEntity(session, translator.getBlockEntityTag(id, packet.getNbt(), null), packet.getPosition());
+            BlockEntityUtils.updateBlockEntity(session, translator.getBlockEntityTag(id, packet.getNbt(), 0), packet.getPosition());
         }
     }
 }

--- a/connector/src/main/java/org/geysermc/connector/network/translators/world/CachedChunkManager.java
+++ b/connector/src/main/java/org/geysermc/connector/network/translators/world/CachedChunkManager.java
@@ -27,13 +27,12 @@
 package org.geysermc.connector.network.translators.world;
 
 import com.github.steveice10.mc.protocol.data.game.entity.metadata.Position;
-import com.github.steveice10.mc.protocol.data.game.world.block.BlockState;
 import org.geysermc.connector.network.session.GeyserSession;
 
 public class CachedChunkManager extends WorldManager {
 
     @Override
-    public BlockState getBlockAt(GeyserSession session, int x, int y, int z) {
+    public int getBlockAt(GeyserSession session, int x, int y, int z) {
         return session.getChunkCache().getBlockAt(new Position(x, y, z));
     }
 }

--- a/connector/src/main/java/org/geysermc/connector/network/translators/world/WorldManager.java
+++ b/connector/src/main/java/org/geysermc/connector/network/translators/world/WorldManager.java
@@ -27,8 +27,6 @@
 package org.geysermc.connector.network.translators.world;
 
 import com.github.steveice10.mc.protocol.data.game.entity.metadata.Position;
-import com.github.steveice10.mc.protocol.data.game.world.block.BlockState;
-
 import com.nukkitx.math.vector.Vector3i;
 import org.geysermc.connector.network.session.GeyserSession;
 
@@ -42,29 +40,29 @@ import org.geysermc.connector.network.session.GeyserSession;
 public abstract class WorldManager {
 
     /**
-     * Gets the {@link BlockState} at the specified location
+     * Gets the block state at the specified location
      *
      * @param session the session
      * @param position the position
      * @return the block state at the specified location
      */
-    public BlockState getBlockAt(GeyserSession session, Position position) {
+    public int getBlockAt(GeyserSession session, Position position) {
         return this.getBlockAt(session, position.getX(), position.getY(), position.getZ());
     }
 
     /**
-     * Gets the {@link BlockState} at the specified location
+     * Gets the block state at the specified location
      *
      * @param session the session
      * @param vector the position
      * @return the block state at the specified location
      */
-    public BlockState getBlockAt(GeyserSession session, Vector3i vector) {
+    public int getBlockAt(GeyserSession session, Vector3i vector) {
         return this.getBlockAt(session, vector.getX(), vector.getY(), vector.getZ());
     }
 
     /**
-     * Gets the {@link BlockState} at the specified location
+     * Gets the block state at the specified location
      *
      * @param session the session
      * @param x the x coordinate to get the block at
@@ -72,5 +70,5 @@ public abstract class WorldManager {
      * @param z the z coordinate to get the block at
      * @return the block state at the specified location
      */
-    public abstract BlockState getBlockAt(GeyserSession session, int x, int y, int z);
+    public abstract int getBlockAt(GeyserSession session, int x, int y, int z);
 }

--- a/connector/src/main/java/org/geysermc/connector/network/translators/world/block/BlockStateValues.java
+++ b/connector/src/main/java/org/geysermc/connector/network/translators/world/block/BlockStateValues.java
@@ -26,16 +26,8 @@
 package org.geysermc.connector.network.translators.world.block;
 
 import com.fasterxml.jackson.databind.JsonNode;
-import com.github.steveice10.mc.protocol.data.game.world.block.BlockState;
 import com.nukkitx.nbt.tag.CompoundTag;
-import it.unimi.dsi.fastutil.ints.Int2BooleanMap;
-import it.unimi.dsi.fastutil.ints.Int2BooleanOpenHashMap;
-import it.unimi.dsi.fastutil.ints.Int2ObjectMap;
-import it.unimi.dsi.fastutil.ints.Int2ObjectOpenHashMap;
-import it.unimi.dsi.fastutil.objects.Object2ByteMap;
-import it.unimi.dsi.fastutil.objects.Object2ByteOpenHashMap;
-import it.unimi.dsi.fastutil.objects.Object2IntMap;
-import it.unimi.dsi.fastutil.objects.Object2IntOpenHashMap;
+import it.unimi.dsi.fastutil.ints.*;
 
 import java.util.HashMap;
 import java.util.Map;
@@ -45,24 +37,24 @@ import java.util.Map;
  */
 public class BlockStateValues {
 
-    private static final Object2IntMap<BlockState> BANNER_COLORS = new Object2IntOpenHashMap<>();
-    private static final Object2ByteMap<BlockState> BED_COLORS = new Object2ByteOpenHashMap<>();
+    private static final Int2IntMap BANNER_COLORS = new Int2IntOpenHashMap();
+    private static final Int2ByteMap BED_COLORS = new Int2ByteOpenHashMap();
     private static final Int2ObjectMap<DoubleChestValue> DOUBLE_CHEST_VALUES = new Int2ObjectOpenHashMap<>();
     private static final Int2ObjectMap<String> FLOWER_POT_VALUES = new Int2ObjectOpenHashMap<>();
     private static final Map<String, CompoundTag> FLOWER_POT_BLOCKS = new HashMap<>();
-    private static final Object2IntMap<BlockState> NOTEBLOCK_PITCHES = new Object2IntOpenHashMap<>();
+    private static final Int2IntMap NOTEBLOCK_PITCHES = new Int2IntOpenHashMap();
     private static final Int2BooleanMap IS_STICKY_PISTON = new Int2BooleanOpenHashMap();
     private static final Int2BooleanMap PISTON_VALUES = new Int2BooleanOpenHashMap();
-    private static final Object2ByteMap<BlockState> SKULL_VARIANTS = new Object2ByteOpenHashMap<>();
-    private static final Object2ByteMap<BlockState> SKULL_ROTATIONS = new Object2ByteOpenHashMap<>();
-    private static final Object2ByteMap<BlockState> SHULKERBOX_DIRECTIONS = new Object2ByteOpenHashMap<>();
+    private static final Int2ByteMap SKULL_VARIANTS = new Int2ByteOpenHashMap();
+    private static final Int2ByteMap SKULL_ROTATIONS = new Int2ByteOpenHashMap();
+    private static final Int2ByteMap SHULKERBOX_DIRECTIONS = new Int2ByteOpenHashMap();
 
     /**
      * Determines if the block state contains Bedrock block information
      * @param entry The String to JsonNode map used in BlockTranslator
      * @param javaBlockState the Java Block State of the block
      */
-    public static void storeBlockStateValues(Map.Entry<String, JsonNode> entry, BlockState javaBlockState) {
+    public static void storeBlockStateValues(Map.Entry<String, JsonNode> entry, int javaBlockState) {
         JsonNode bannerColor = entry.getValue().get("banner_color");
         if (bannerColor != null) {
             BANNER_COLORS.put(javaBlockState, (byte) bannerColor.intValue());
@@ -80,12 +72,12 @@ public class BlockStateValues {
             boolean isDirectionPositive = ((entry.getValue().get("x") != null && entry.getValue().get("x").asBoolean()) ||
                     (entry.getValue().get("z") != null && entry.getValue().get("z").asBoolean()));
             boolean isLeft = (entry.getValue().get("double_chest_position").asText().contains("left"));
-            DOUBLE_CHEST_VALUES.put(javaBlockState.getId(), new DoubleChestValue(isX, isDirectionPositive, isLeft));
+            DOUBLE_CHEST_VALUES.put(javaBlockState, new DoubleChestValue(isX, isDirectionPositive, isLeft));
             return;
         }
 
         if (entry.getKey().contains("potted_")) {
-            FLOWER_POT_VALUES.put(javaBlockState.getId(), entry.getKey().replace("potted_", ""));
+            FLOWER_POT_VALUES.put(javaBlockState, entry.getKey().replace("potted_", ""));
             return;
         }
 
@@ -97,8 +89,8 @@ public class BlockStateValues {
 
         if (entry.getKey().contains("piston")) {
             // True if extended, false if not
-            PISTON_VALUES.put(javaBlockState.getId(), entry.getKey().contains("extended=true"));
-            IS_STICKY_PISTON.put(javaBlockState.getId(), entry.getKey().contains("sticky"));
+            PISTON_VALUES.put(javaBlockState, entry.getKey().contains("extended=true"));
+            IS_STICKY_PISTON.put(javaBlockState, entry.getKey().contains("sticky"));
             return;
         }
 
@@ -125,9 +117,9 @@ public class BlockStateValues {
      * @param state BlockState of the block
      * @return Banner color integer or -1 if no color
      */
-    public static int getBannerColor(BlockState state) {
+    public static int getBannerColor(int state) {
         if (BANNER_COLORS.containsKey(state)) {
-            return BANNER_COLORS.getInt(state);
+            return BANNER_COLORS.get(state);
         }
         return -1;
     }
@@ -139,9 +131,9 @@ public class BlockStateValues {
      * @param state BlockState of the block
      * @return Bed color byte or -1 if no color
      */
-    public static byte getBedColor(BlockState state) {
+    public static byte getBedColor(int state) {
         if (BED_COLORS.containsKey(state)) {
-            return BED_COLORS.getByte(state);
+            return BED_COLORS.get(state);
         }
         return -1;
     }
@@ -177,9 +169,9 @@ public class BlockStateValues {
      * @param state BlockState of the block
      * @return note block note integer or -1 if not present
      */
-    public static int getNoteblockPitch(BlockState state) {
+    public static int getNoteblockPitch(int state) {
         if (NOTEBLOCK_PITCHES.containsKey(state)) {
-            return NOTEBLOCK_PITCHES.getInt(state);
+            return NOTEBLOCK_PITCHES.get(state);
         }
         return -1;
     }
@@ -192,8 +184,8 @@ public class BlockStateValues {
         return PISTON_VALUES;
     }
 
-    public static boolean isStickyPiston(BlockState blockState) {
-        return IS_STICKY_PISTON.get(blockState.getId());
+    public static boolean isStickyPiston(int blockState) {
+        return IS_STICKY_PISTON.get(blockState);
     }
 
     /**
@@ -203,9 +195,9 @@ public class BlockStateValues {
      * @param state BlockState of the block
      * @return Skull variant byte or -1 if no variant
      */
-    public static byte getSkullVariant(BlockState state) {
+    public static byte getSkullVariant(int state) {
         if (SKULL_VARIANTS.containsKey(state)) {
-            return SKULL_VARIANTS.getByte(state);
+            return SKULL_VARIANTS.get(state);
         }
         return -1;
     }
@@ -217,9 +209,9 @@ public class BlockStateValues {
      * @param state BlockState of the block
      * @return Skull rotation value or -1 if no value
      */
-    public static byte getSkullRotation(BlockState state) {
+    public static byte getSkullRotation(int state) {
         if (SKULL_ROTATIONS.containsKey(state)) {
-            return SKULL_ROTATIONS.getByte(state);
+            return SKULL_ROTATIONS.get(state);
         }
         return -1;
     }
@@ -232,9 +224,9 @@ public class BlockStateValues {
      * @param state BlockState of the block
      * @return Shulker direction value or -1 if no value
      */
-    public static byte getShulkerBoxDirection(BlockState state) {
+    public static byte getShulkerBoxDirection(int state) {
         if (SHULKERBOX_DIRECTIONS.containsKey(state)) {
-            return SHULKERBOX_DIRECTIONS.getByte(state);
+            return SHULKERBOX_DIRECTIONS.get(state);
         }
         return -1;
     }

--- a/connector/src/main/java/org/geysermc/connector/network/translators/world/block/BlockTranslator.java
+++ b/connector/src/main/java/org/geysermc/connector/network/translators/world/block/BlockTranslator.java
@@ -26,7 +26,6 @@
 package org.geysermc.connector.network.translators.world.block;
 
 import com.fasterxml.jackson.databind.JsonNode;
-import com.github.steveice10.mc.protocol.data.game.world.block.BlockState;
 import com.google.common.collect.BiMap;
 import com.google.common.collect.HashBiMap;
 import com.nukkitx.nbt.CompoundTagBuilder;
@@ -47,19 +46,19 @@ import java.util.*;
 
 public class BlockTranslator {
     public static final ListTag<CompoundTag> BLOCKS;
-    public static final BlockState AIR = new BlockState(0);
+    public static final int AIR = 0;
     public static final int BEDROCK_WATER_ID;
 
     private static final Int2IntMap JAVA_TO_BEDROCK_BLOCK_MAP = new Int2IntOpenHashMap();
-    private static final Int2ObjectMap<BlockState> BEDROCK_TO_JAVA_BLOCK_MAP = new Int2ObjectOpenHashMap<>();
-    private static final BiMap<String, BlockState> JAVA_ID_BLOCK_MAP = HashBiMap.create();
+    private static final Int2IntMap BEDROCK_TO_JAVA_BLOCK_MAP = new Int2IntOpenHashMap();
+    private static final BiMap<String, Integer> JAVA_ID_BLOCK_MAP = HashBiMap.create();
     private static final IntSet WATERLOGGED = new IntOpenHashSet();
     private static final Object2IntMap<CompoundTag> ITEM_FRAMES = new Object2IntOpenHashMap<>();
 
     // Bedrock carpet ID, used in LlamaEntity.java for decoration
     public static final int CARPET = 171;
 
-    private static final Map<BlockState, String> JAVA_ID_TO_BLOCK_ENTITY_MAP = new HashMap<>();
+    private static final Int2ObjectMap<String> JAVA_ID_TO_BLOCK_ENTITY_MAP = new Int2ObjectOpenHashMap<>();
 
     public static final Int2DoubleMap JAVA_RUNTIME_ID_TO_HARDNESS = new Int2DoubleOpenHashMap();
     public static final Int2BooleanMap JAVA_RUNTIME_ID_TO_CAN_HARVEST_WITH_HAND = new Int2BooleanOpenHashMap();
@@ -121,7 +120,6 @@ public class BlockTranslator {
             javaRuntimeId++;
             Map.Entry<String, JsonNode> entry = blocksIterator.next();
             String javaId = entry.getKey();
-            BlockState javaBlockState = new BlockState(javaRuntimeId);
             CompoundTag blockTag = buildBedrockState(entry.getValue());
 
             // TODO fix this, (no block should have a null hardness)
@@ -145,7 +143,7 @@ public class BlockTranslator {
                 cobwebRuntimeId = javaRuntimeId;
             }
 
-            JAVA_ID_BLOCK_MAP.put(javaId, javaBlockState);
+            JAVA_ID_BLOCK_MAP.put(javaId, javaRuntimeId);
 
             // Used for adding all "special" Java block states to block state map
             String identifier;
@@ -154,12 +152,12 @@ public class BlockTranslator {
                 identifier = clazz.getAnnotation(BlockEntity.class).regex();
                 // Endswith, or else the block bedrock gets picked up for bed
                 if (bedrock_identifer.endsWith(identifier) && !identifier.equals("")) {
-                    JAVA_ID_TO_BLOCK_ENTITY_MAP.put(javaBlockState, clazz.getAnnotation(BlockEntity.class).name());
+                    JAVA_ID_TO_BLOCK_ENTITY_MAP.put(javaRuntimeId, clazz.getAnnotation(BlockEntity.class).name());
                     break;
                 }
             }
 
-            BlockStateValues.storeBlockStateValues(entry, javaBlockState);
+            BlockStateValues.storeBlockStateValues(entry, javaRuntimeId);
 
             // Get the tag needed for non-empty flower pots
             if (entry.getValue().get("pottable") != null) {
@@ -173,10 +171,10 @@ public class BlockTranslator {
                     || javaId.contains("minecraft:bubble_column") || javaId.contains("minecraft:kelp") || javaId.contains("seagrass");
 
             if (waterlogged) {
-                BEDROCK_TO_JAVA_BLOCK_MAP.putIfAbsent(bedrockRuntimeId | 1 << 31, javaBlockState);
+                BEDROCK_TO_JAVA_BLOCK_MAP.putIfAbsent(bedrockRuntimeId | 1 << 31, javaRuntimeId);
                 WATERLOGGED.add(javaRuntimeId);
             } else {
-                BEDROCK_TO_JAVA_BLOCK_MAP.putIfAbsent(bedrockRuntimeId, javaBlockState);
+                BEDROCK_TO_JAVA_BLOCK_MAP.putIfAbsent(bedrockRuntimeId, javaRuntimeId);
             }
 
             CompoundTag runtimeTag = blockStateMap.remove(blockTag);
@@ -285,15 +283,11 @@ public class BlockTranslator {
         return tagBuilder.tag(statesBuilder.build("states")).build("block");
     }
 
-    public static int getBedrockBlockId(BlockState state) {
-        return JAVA_TO_BEDROCK_BLOCK_MAP.get(state.getId());
+    public static int getBedrockBlockId(int state) {
+        return JAVA_TO_BEDROCK_BLOCK_MAP.get(state);
     }
 
-    public static int getBedrockBlockId(int javaId) {
-        return JAVA_TO_BEDROCK_BLOCK_MAP.get(javaId);
-    }
-
-    public static BlockState getJavaBlockState(int bedrockId) {
+    public static int getJavaBlockState(int bedrockId) {
         return BEDROCK_TO_JAVA_BLOCK_MAP.get(bedrockId);
     }
 
@@ -309,23 +303,23 @@ public class BlockTranslator {
         return BLOCK_STATE_VERSION;
     }
 
-    public static BlockState getJavaBlockState(String javaId) {
+    public static int getJavaBlockState(String javaId) {
         return JAVA_ID_BLOCK_MAP.get(javaId);
     }
 
-    public static String getBlockEntityString(BlockState javaId) {
+    public static String getBlockEntityString(int javaId) {
         return JAVA_ID_TO_BLOCK_ENTITY_MAP.get(javaId);
     }
 
-    public static boolean isWaterlogged(BlockState state) {
-        return WATERLOGGED.contains(state.getId());
+    public static boolean isWaterlogged(int state) {
+        return WATERLOGGED.contains(state);
     }
 
-    public static BiMap<String, BlockState> getJavaIdBlockMap() {
+    public static BiMap<String, Integer> getJavaIdBlockMap() {
         return JAVA_ID_BLOCK_MAP;
     }
 
-    public static BlockState getJavaWaterloggedState(int bedrockId) {
+    public static int getJavaWaterloggedState(int bedrockId) {
         return BEDROCK_TO_JAVA_BLOCK_MAP.get(1 << 31 | bedrockId);
     }
 }

--- a/connector/src/main/java/org/geysermc/connector/network/translators/world/block/entity/BannerBlockEntityTranslator.java
+++ b/connector/src/main/java/org/geysermc/connector/network/translators/world/block/entity/BannerBlockEntityTranslator.java
@@ -25,7 +25,6 @@
 
 package org.geysermc.connector.network.translators.world.block.entity;
 
-import com.github.steveice10.mc.protocol.data.game.world.block.BlockState;
 import com.github.steveice10.opennbt.tag.builtin.CompoundTag;
 import com.github.steveice10.opennbt.tag.builtin.ListTag;
 import com.nukkitx.nbt.CompoundTagBuilder;
@@ -42,12 +41,12 @@ import java.util.List;
 public class BannerBlockEntityTranslator extends BlockEntityTranslator implements RequiresBlockState {
 
     @Override
-    public boolean isBlock(BlockState blockState) {
+    public boolean isBlock(int blockState) {
         return BlockStateValues.getBannerColor(blockState) != -1;
     }
 
     @Override
-    public List<Tag<?>> translateTag(CompoundTag tag, BlockState blockState) {
+    public List<Tag<?>> translateTag(CompoundTag tag, int blockState) {
         List<Tag<?>> tags = new ArrayList<>();
 
         int bannerColor = BlockStateValues.getBannerColor(blockState);

--- a/connector/src/main/java/org/geysermc/connector/network/translators/world/block/entity/BedBlockEntityTranslator.java
+++ b/connector/src/main/java/org/geysermc/connector/network/translators/world/block/entity/BedBlockEntityTranslator.java
@@ -25,7 +25,6 @@
 
 package org.geysermc.connector.network.translators.world.block.entity;
 
-import com.github.steveice10.mc.protocol.data.game.world.block.BlockState;
 import com.github.steveice10.opennbt.tag.builtin.CompoundTag;
 import com.nukkitx.nbt.CompoundTagBuilder;
 import com.nukkitx.nbt.tag.ByteTag;
@@ -39,12 +38,12 @@ import java.util.List;
 public class BedBlockEntityTranslator extends BlockEntityTranslator implements RequiresBlockState {
 
     @Override
-    public boolean isBlock(BlockState blockState) {
+    public boolean isBlock(int blockState) {
         return BlockStateValues.getBedColor(blockState) != -1;
     }
 
     @Override
-    public List<Tag<?>> translateTag(CompoundTag tag, BlockState blockState) {
+    public List<Tag<?>> translateTag(CompoundTag tag, int blockState) {
         List<Tag<?>> tags = new ArrayList<>();
         byte bedcolor = BlockStateValues.getBedColor(blockState);
         // Just in case...

--- a/connector/src/main/java/org/geysermc/connector/network/translators/world/block/entity/BedrockOnlyBlockEntity.java
+++ b/connector/src/main/java/org/geysermc/connector/network/translators/world/block/entity/BedrockOnlyBlockEntity.java
@@ -26,7 +26,6 @@
 
 package org.geysermc.connector.network.translators.world.block.entity;
 
-import com.github.steveice10.mc.protocol.data.game.world.block.BlockState;
 import com.nukkitx.math.vector.Vector3i;
 import com.nukkitx.nbt.tag.CompoundTag;
 import org.geysermc.connector.network.session.GeyserSession;
@@ -42,7 +41,7 @@ public interface BedrockOnlyBlockEntity {
      * @param blockState The Java block state.
      * @param position The Bedrock block position.
      */
-    void updateBlock(GeyserSession session, BlockState blockState, Vector3i position);
+    void updateBlock(GeyserSession session, int blockState, Vector3i position);
 
     /**
      * Get the tag of the Bedrock-only block entity
@@ -50,7 +49,7 @@ public interface BedrockOnlyBlockEntity {
      * @param blockState Java BlockState of block.
      * @return Bedrock tag, or null if not a Bedrock-only Block Entity
      */
-    static CompoundTag getTag(Vector3i position, BlockState blockState) {
+    static CompoundTag getTag(Vector3i position, int blockState) {
         if (new FlowerPotBlockEntityTranslator().isBlock(blockState)) {
             return FlowerPotBlockEntityTranslator.getTag(blockState, position);
         } else if (PistonBlockEntityTranslator.isBlock(blockState)) {

--- a/connector/src/main/java/org/geysermc/connector/network/translators/world/block/entity/BlockEntityTranslator.java
+++ b/connector/src/main/java/org/geysermc/connector/network/translators/world/block/entity/BlockEntityTranslator.java
@@ -25,7 +25,6 @@
 
 package org.geysermc.connector.network.translators.world.block.entity;
 
-import com.github.steveice10.mc.protocol.data.game.world.block.BlockState;
 import com.github.steveice10.opennbt.tag.builtin.CompoundTag;
 import com.github.steveice10.opennbt.tag.builtin.IntTag;
 import com.github.steveice10.opennbt.tag.builtin.StringTag;
@@ -88,13 +87,13 @@ public abstract class BlockEntityTranslator {
         }
     }
 
-    public abstract List<Tag<?>> translateTag(CompoundTag tag, BlockState blockState);
+    public abstract List<Tag<?>> translateTag(CompoundTag tag, int blockState);
 
     public abstract CompoundTag getDefaultJavaTag(String javaId, int x, int y, int z);
 
     public abstract com.nukkitx.nbt.tag.CompoundTag getDefaultBedrockTag(String bedrockId, int x, int y, int z);
 
-    public com.nukkitx.nbt.tag.CompoundTag getBlockEntityTag(String id, CompoundTag tag, BlockState blockState) {
+    public com.nukkitx.nbt.tag.CompoundTag getBlockEntityTag(String id, CompoundTag tag, int blockState) {
         int x = Integer.parseInt(String.valueOf(tag.getValue().get("x").getValue()));
         int y = Integer.parseInt(String.valueOf(tag.getValue().get("y").getValue()));
         int z = Integer.parseInt(String.valueOf(tag.getValue().get("z").getValue()));

--- a/connector/src/main/java/org/geysermc/connector/network/translators/world/block/entity/CampfireBlockEntityTranslator.java
+++ b/connector/src/main/java/org/geysermc/connector/network/translators/world/block/entity/CampfireBlockEntityTranslator.java
@@ -25,7 +25,6 @@
 
 package org.geysermc.connector.network.translators.world.block.entity;
 
-import com.github.steveice10.mc.protocol.data.game.world.block.BlockState;
 import com.github.steveice10.opennbt.tag.builtin.CompoundTag;
 import com.github.steveice10.opennbt.tag.builtin.ListTag;
 import com.nukkitx.nbt.CompoundTagBuilder;
@@ -41,7 +40,7 @@ import java.util.List;
 public class CampfireBlockEntityTranslator extends BlockEntityTranslator {
 
     @Override
-    public List<Tag<?>> translateTag(CompoundTag tag, BlockState blockState) {
+    public List<Tag<?>> translateTag(CompoundTag tag, int blockState) {
         List<Tag<?>> tags = new ArrayList<>();
         ListTag items = tag.get("Items");
         int i = 1;

--- a/connector/src/main/java/org/geysermc/connector/network/translators/world/block/entity/DoubleChestBlockEntityTranslator.java
+++ b/connector/src/main/java/org/geysermc/connector/network/translators/world/block/entity/DoubleChestBlockEntityTranslator.java
@@ -26,7 +26,6 @@
 
 package org.geysermc.connector.network.translators.world.block.entity;
 
-import com.github.steveice10.mc.protocol.data.game.world.block.BlockState;
 import com.github.steveice10.opennbt.tag.builtin.CompoundTag;
 import com.nukkitx.math.vector.Vector3i;
 import com.nukkitx.nbt.CompoundTagBuilder;
@@ -48,12 +47,12 @@ import java.util.List;
 public class DoubleChestBlockEntityTranslator extends BlockEntityTranslator implements BedrockOnlyBlockEntity, RequiresBlockState {
 
     @Override
-    public boolean isBlock(BlockState blockState) {
-        return BlockStateValues.getDoubleChestValues().containsKey(blockState.getId());
+    public boolean isBlock(int blockState) {
+        return BlockStateValues.getDoubleChestValues().containsKey(blockState);
     }
 
     @Override
-    public void updateBlock(GeyserSession session, BlockState blockState, Vector3i position) {
+    public void updateBlock(GeyserSession session, int blockState, Vector3i position) {
         CompoundTag javaTag = getConstantJavaTag("chest", position.getX(), position.getY(), position.getZ());
         CompoundTagBuilder tagBuilder = getConstantBedrockTag(BlockEntityUtils.getBedrockBlockEntityId("chest"), position.getX(), position.getY(), position.getZ()).toBuilder();
         translateTag(javaTag, blockState).forEach(tagBuilder::tag);
@@ -61,10 +60,10 @@ public class DoubleChestBlockEntityTranslator extends BlockEntityTranslator impl
     }
 
     @Override
-    public List<Tag<?>> translateTag(CompoundTag tag, BlockState blockState) {
+    public List<Tag<?>> translateTag(CompoundTag tag, int blockState) {
         List<Tag<?>> tags = new ArrayList<>();
-        if (blockState != null && BlockStateValues.getDoubleChestValues().containsKey(blockState.getId())) {
-            DoubleChestValue chestValues = BlockStateValues.getDoubleChestValues().get(blockState.getId());
+        if (BlockStateValues.getDoubleChestValues().containsKey(blockState)) {
+            DoubleChestValue chestValues = BlockStateValues.getDoubleChestValues().get(blockState);
             if (chestValues != null) {
                 int x = (int) tag.getValue().get("x").getValue();
                 int z = (int) tag.getValue().get("z").getValue();

--- a/connector/src/main/java/org/geysermc/connector/network/translators/world/block/entity/EmptyBlockEntityTranslator.java
+++ b/connector/src/main/java/org/geysermc/connector/network/translators/world/block/entity/EmptyBlockEntityTranslator.java
@@ -25,7 +25,6 @@
 
 package org.geysermc.connector.network.translators.world.block.entity;
 
-import com.github.steveice10.mc.protocol.data.game.world.block.BlockState;
 import com.github.steveice10.opennbt.tag.builtin.CompoundTag;
 import com.nukkitx.nbt.tag.Tag;
 
@@ -36,7 +35,7 @@ import java.util.List;
 public class EmptyBlockEntityTranslator extends BlockEntityTranslator {
 
     @Override
-    public List<Tag<?>> translateTag(CompoundTag tag, BlockState blockState) {
+    public List<Tag<?>> translateTag(CompoundTag tag, int blockState) {
         return new ArrayList<>();
     }
 

--- a/connector/src/main/java/org/geysermc/connector/network/translators/world/block/entity/EndGatewayBlockEntityTranslator.java
+++ b/connector/src/main/java/org/geysermc/connector/network/translators/world/block/entity/EndGatewayBlockEntityTranslator.java
@@ -25,7 +25,6 @@
 
 package org.geysermc.connector.network.translators.world.block.entity;
 
-import com.github.steveice10.mc.protocol.data.game.world.block.BlockState;
 import com.github.steveice10.opennbt.tag.builtin.CompoundTag;
 import com.github.steveice10.opennbt.tag.builtin.LongTag;
 import com.nukkitx.nbt.CompoundTagBuilder;
@@ -40,7 +39,7 @@ import java.util.List;
 public class EndGatewayBlockEntityTranslator extends BlockEntityTranslator {
 
     @Override
-    public List<Tag<?>> translateTag(CompoundTag tag, BlockState blockState) {
+    public List<Tag<?>> translateTag(CompoundTag tag, int blockState) {
         List<Tag<?>> tags = new ArrayList<>();
         tags.add(new IntTag("Age", (int) (long) tag.get("Age").getValue()));
         // Java sometimes does not provide this tag, but Bedrock crashes if it doesn't exist

--- a/connector/src/main/java/org/geysermc/connector/network/translators/world/block/entity/FlowerPotBlockEntityTranslator.java
+++ b/connector/src/main/java/org/geysermc/connector/network/translators/world/block/entity/FlowerPotBlockEntityTranslator.java
@@ -26,7 +26,6 @@
 
 package org.geysermc.connector.network.translators.world.block.entity;
 
-import com.github.steveice10.mc.protocol.data.game.world.block.BlockState;
 import com.nukkitx.math.vector.Vector3i;
 import com.nukkitx.nbt.CompoundTagBuilder;
 import com.nukkitx.nbt.tag.CompoundTag;
@@ -39,12 +38,12 @@ import org.geysermc.connector.utils.BlockEntityUtils;
 public class FlowerPotBlockEntityTranslator implements BedrockOnlyBlockEntity, RequiresBlockState {
 
     @Override
-    public boolean isBlock(BlockState blockState) {
-        return (BlockStateValues.getFlowerPotValues().containsKey(blockState.getId()));
+    public boolean isBlock(int blockState) {
+        return (BlockStateValues.getFlowerPotValues().containsKey(blockState));
     }
 
     @Override
-    public void updateBlock(GeyserSession session, BlockState blockState, Vector3i position) {
+    public void updateBlock(GeyserSession session, int blockState, Vector3i position) {
         BlockEntityUtils.updateBlockEntity(session, getTag(blockState, position), position);
         UpdateBlockPacket updateBlockPacket = new UpdateBlockPacket();
         updateBlockPacket.setDataLayer(0);
@@ -58,11 +57,11 @@ public class FlowerPotBlockEntityTranslator implements BedrockOnlyBlockEntity, R
 
     /**
      * Get the Nukkit CompoundTag of the flower pot.
-     * @param blockState Java BlockState of flower pot.
+     * @param blockState Java block state of flower pot.
      * @param position Bedrock position of flower pot.
      * @return Bedrock tag of flower pot.
      */
-    public static CompoundTag getTag(BlockState blockState, Vector3i position) {
+    public static CompoundTag getTag(int blockState, Vector3i position) {
         CompoundTagBuilder tagBuilder = CompoundTagBuilder.builder()
                 .intTag("x", position.getX())
                 .intTag("y", position.getY())
@@ -70,7 +69,7 @@ public class FlowerPotBlockEntityTranslator implements BedrockOnlyBlockEntity, R
                 .byteTag("isMovable", (byte) 1)
                 .stringTag("id", "FlowerPot");
         // Get the Java name of the plant inside. e.g. minecraft:oak_sapling
-        String name = BlockStateValues.getFlowerPotValues().get(blockState.getId());
+        String name = BlockStateValues.getFlowerPotValues().get(blockState);
         if (name != null) {
             // Get the Bedrock CompoundTag of the block.
             // This is where we need to store the *Java* name because Bedrock has six minecraft:sapling blocks with different block states.

--- a/connector/src/main/java/org/geysermc/connector/network/translators/world/block/entity/NoteblockBlockEntityTranslator.java
+++ b/connector/src/main/java/org/geysermc/connector/network/translators/world/block/entity/NoteblockBlockEntityTranslator.java
@@ -27,7 +27,6 @@
 package org.geysermc.connector.network.translators.world.block.entity;
 
 import com.github.steveice10.mc.protocol.data.game.entity.metadata.Position;
-import com.github.steveice10.mc.protocol.data.game.world.block.BlockState;
 import com.nukkitx.math.vector.Vector3i;
 import com.nukkitx.protocol.bedrock.packet.BlockEventPacket;
 import org.geysermc.connector.network.session.GeyserSession;
@@ -40,12 +39,12 @@ import org.geysermc.connector.utils.ChunkUtils;
 public class NoteblockBlockEntityTranslator implements RequiresBlockState {
 
     @Override
-    public boolean isBlock(BlockState blockState) {
+    public boolean isBlock(int blockState) {
         return BlockStateValues.getNoteblockPitch(blockState) != -1;
     }
 
     public static void translate(GeyserSession session, Position position) {
-        BlockState blockState = ChunkUtils.CACHED_BLOCK_ENTITIES.get(position);
+        int blockState = ChunkUtils.CACHED_BLOCK_ENTITIES.getOrDefault(position, 0);
         BlockEventPacket blockEventPacket = new BlockEventPacket();
         blockEventPacket.setBlockPosition(Vector3i.from(position.getX(), position.getY(), position.getZ()));
         blockEventPacket.setEventType(0);

--- a/connector/src/main/java/org/geysermc/connector/network/translators/world/block/entity/PistonBlockEntityTranslator.java
+++ b/connector/src/main/java/org/geysermc/connector/network/translators/world/block/entity/PistonBlockEntityTranslator.java
@@ -26,7 +26,6 @@
 
 package org.geysermc.connector.network.translators.world.block.entity;
 
-import com.github.steveice10.mc.protocol.data.game.world.block.BlockState;
 import com.nukkitx.math.vector.Vector3i;
 import com.nukkitx.nbt.CompoundTagBuilder;
 import com.nukkitx.nbt.tag.CompoundTag;
@@ -42,25 +41,25 @@ public class PistonBlockEntityTranslator {
      * @param blockState Java BlockState of block.
      * @return if block is a piston or not.
      */
-    public static boolean isBlock(BlockState blockState) {
-        return BlockStateValues.getPistonValues().containsKey(blockState.getId());
+    public static boolean isBlock(int blockState) {
+        return BlockStateValues.getPistonValues().containsKey(blockState);
     }
 
     /**
      * Calculates the Nukkit CompoundTag to send to the client on chunk
-     * @param blockState Java BlockState of block.
+     * @param blockState Java block state of block.
      * @param position Bedrock position of piston.
      * @return Bedrock tag of piston.
      */
-    public static CompoundTag getTag(BlockState blockState, Vector3i position) {
+    public static CompoundTag getTag(int blockState, Vector3i position) {
         CompoundTagBuilder tagBuilder = CompoundTagBuilder.builder()
                 .intTag("x", position.getX())
                 .intTag("y", position.getY())
                 .intTag("z", position.getZ())
                 .byteTag("isMovable", (byte) 1)
                 .stringTag("id", "PistonArm");
-        if (BlockStateValues.getPistonValues().containsKey(blockState.getId())) {
-            boolean extended = BlockStateValues.getPistonValues().get(blockState.getId());
+        if (BlockStateValues.getPistonValues().containsKey(blockState)) {
+            boolean extended = BlockStateValues.getPistonValues().get(blockState);
             // 1f if extended, otherwise 0f
             tagBuilder.floatTag("Progress", (extended) ? 1.0f : 0.0f);
             // 1 if sticky, 0 if not

--- a/connector/src/main/java/org/geysermc/connector/network/translators/world/block/entity/RequiresBlockState.java
+++ b/connector/src/main/java/org/geysermc/connector/network/translators/world/block/entity/RequiresBlockState.java
@@ -25,8 +25,6 @@
 
 package org.geysermc.connector.network.translators.world.block.entity;
 
-import com.github.steveice10.mc.protocol.data.game.world.block.BlockState;
-
 /**
  * Implemented in block entities if their Java block state is required for additional values in Bedrock
  */
@@ -37,6 +35,6 @@ public interface RequiresBlockState {
      * @param blockState BlockState to be compared
      * @return true if part of the class
      */
-    boolean isBlock(BlockState blockState);
+    boolean isBlock(int blockState);
 
 }

--- a/connector/src/main/java/org/geysermc/connector/network/translators/world/block/entity/ShulkerBoxBlockEntityTranslator.java
+++ b/connector/src/main/java/org/geysermc/connector/network/translators/world/block/entity/ShulkerBoxBlockEntityTranslator.java
@@ -26,7 +26,6 @@
 
 package org.geysermc.connector.network.translators.world.block.entity;
 
-import com.github.steveice10.mc.protocol.data.game.world.block.BlockState;
 import com.github.steveice10.opennbt.tag.builtin.CompoundTag;
 import com.nukkitx.nbt.CompoundTagBuilder;
 import com.nukkitx.nbt.tag.ByteTag;
@@ -40,7 +39,7 @@ import java.util.List;
 public class ShulkerBoxBlockEntityTranslator extends BlockEntityTranslator {
 
     @Override
-    public List<Tag<?>> translateTag(CompoundTag tag, BlockState blockState) {
+    public List<Tag<?>> translateTag(CompoundTag tag, int blockState) {
         List<Tag<?>> tags = new ArrayList<>();
 
         byte direction = BlockStateValues.getShulkerBoxDirection(blockState);

--- a/connector/src/main/java/org/geysermc/connector/network/translators/world/block/entity/SignBlockEntityTranslator.java
+++ b/connector/src/main/java/org/geysermc/connector/network/translators/world/block/entity/SignBlockEntityTranslator.java
@@ -25,12 +25,11 @@
 
 package org.geysermc.connector.network.translators.world.block.entity;
 
-import com.github.steveice10.mc.protocol.data.message.Message;
+import com.github.steveice10.mc.protocol.data.message.MessageSerializer;
 import com.github.steveice10.opennbt.tag.builtin.CompoundTag;
 import com.nukkitx.nbt.CompoundTagBuilder;
 import com.nukkitx.nbt.tag.StringTag;
 import com.nukkitx.nbt.tag.Tag;
-import io.netty.util.internal.StringUtil;
 import org.geysermc.connector.utils.MessageUtils;
 
 import java.util.ArrayList;
@@ -47,7 +46,7 @@ public class SignBlockEntityTranslator extends BlockEntityTranslator {
         for(int i = 0; i < 4; i++) {
             int currentLine = i+1;
             String signLine = getOrDefault(tag.getValue().get("Text" + currentLine), "");
-            signLine = MessageUtils.getBedrockMessage(Message.fromString(signLine));
+            signLine = MessageUtils.getBedrockMessage(MessageSerializer.fromString(signLine));
 
             //Java allows up to 16+ characters on certain symbols. 
             if(signLine.length() >= 15 && (signLine.contains("-") || signLine.contains("="))) {
@@ -58,7 +57,7 @@ public class SignBlockEntityTranslator extends BlockEntityTranslator {
             signText.append("\n");
         }
 
-        tags.add(new StringTag("Text", MessageUtils.getBedrockMessage(Message.fromString(signText.toString()))));
+        tags.add(new StringTag("Text", MessageUtils.getBedrockMessage(MessageSerializer.fromString(signText.toString()))));
         return tags;
     }
 

--- a/connector/src/main/java/org/geysermc/connector/network/translators/world/block/entity/SignBlockEntityTranslator.java
+++ b/connector/src/main/java/org/geysermc/connector/network/translators/world/block/entity/SignBlockEntityTranslator.java
@@ -25,7 +25,6 @@
 
 package org.geysermc.connector.network.translators.world.block.entity;
 
-import com.github.steveice10.mc.protocol.data.game.world.block.BlockState;
 import com.github.steveice10.mc.protocol.data.message.Message;
 import com.github.steveice10.opennbt.tag.builtin.CompoundTag;
 import com.nukkitx.nbt.CompoundTagBuilder;
@@ -41,7 +40,7 @@ import java.util.List;
 public class SignBlockEntityTranslator extends BlockEntityTranslator {
 
     @Override
-    public List<Tag<?>> translateTag(CompoundTag tag, BlockState blockState) {
+    public List<Tag<?>> translateTag(CompoundTag tag, int blockState) {
         List<Tag<?>> tags = new ArrayList<>();
 
         StringBuilder signText = new StringBuilder();

--- a/connector/src/main/java/org/geysermc/connector/network/translators/world/block/entity/SkullBlockEntityTranslator.java
+++ b/connector/src/main/java/org/geysermc/connector/network/translators/world/block/entity/SkullBlockEntityTranslator.java
@@ -25,7 +25,6 @@
 
 package org.geysermc.connector.network.translators.world.block.entity;
 
-import com.github.steveice10.mc.protocol.data.game.world.block.BlockState;
 import com.nukkitx.nbt.CompoundTagBuilder;
 import com.nukkitx.nbt.tag.ByteTag;
 import com.nukkitx.nbt.tag.CompoundTag;
@@ -40,12 +39,12 @@ import java.util.List;
 public class SkullBlockEntityTranslator extends BlockEntityTranslator implements RequiresBlockState {
 
     @Override
-    public boolean isBlock(BlockState blockState) {
+    public boolean isBlock(int blockState) {
         return BlockStateValues.getSkullVariant(blockState) != -1;
     }
 
     @Override
-    public List<Tag<?>> translateTag(com.github.steveice10.opennbt.tag.builtin.CompoundTag tag, BlockState blockState) {
+    public List<Tag<?>> translateTag(com.github.steveice10.opennbt.tag.builtin.CompoundTag tag, int blockState) {
         List<Tag<?>> tags = new ArrayList<>();
         byte skullVariant = BlockStateValues.getSkullVariant(blockState);
         float rotation = BlockStateValues.getSkullRotation(blockState) * 22.5f;

--- a/connector/src/main/java/org/geysermc/connector/network/translators/world/block/entity/SpawnerBlockEntityTranslator.java
+++ b/connector/src/main/java/org/geysermc/connector/network/translators/world/block/entity/SpawnerBlockEntityTranslator.java
@@ -26,7 +26,6 @@
 
 package org.geysermc.connector.network.translators.world.block.entity;
 
-import com.github.steveice10.mc.protocol.data.game.world.block.BlockState;
 import com.github.steveice10.opennbt.tag.builtin.CompoundTag;
 import com.nukkitx.nbt.CompoundTagBuilder;
 import com.nukkitx.nbt.tag.*;
@@ -39,7 +38,7 @@ import java.util.List;
 public class SpawnerBlockEntityTranslator extends BlockEntityTranslator {
 
     @Override
-    public List<Tag<?>> translateTag(CompoundTag tag, BlockState blockState) {
+    public List<Tag<?>> translateTag(CompoundTag tag, int blockState) {
         List<Tag<?>> tags = new ArrayList<>();
 
         if (tag.get("MaxNearbyEntities") != null) {

--- a/connector/src/main/java/org/geysermc/connector/ping/GeyserLegacyPingPassthrough.java
+++ b/connector/src/main/java/org/geysermc/connector/ping/GeyserLegacyPingPassthrough.java
@@ -77,7 +77,7 @@ public class GeyserLegacyPingPassthrough implements IGeyserPingPassthrough, Runn
         try {
             this.client = new Client(connector.getConfig().getRemote().getAddress(), connector.getConfig().getRemote().getPort(), new MinecraftProtocol(SubProtocol.STATUS), new TcpSessionFactory());
             this.client.getSession().setFlag(MinecraftConstants.SERVER_INFO_HANDLER_KEY, (ServerInfoHandler) (session, info) -> {
-                this.pingInfo = new GeyserPingInfo(info.getDescription().getFullText(), info.getPlayerInfo().getOnlinePlayers(), info.getPlayerInfo().getMaxPlayers());
+                this.pingInfo = new GeyserPingInfo(info.getDescription().toString(), info.getPlayerInfo().getOnlinePlayers(), info.getPlayerInfo().getMaxPlayers());
                 this.client.getSession().disconnect(null);
             });
 

--- a/connector/src/main/java/org/geysermc/connector/ping/GeyserLegacyPingPassthrough.java
+++ b/connector/src/main/java/org/geysermc/connector/ping/GeyserLegacyPingPassthrough.java
@@ -29,6 +29,7 @@ package org.geysermc.connector.ping;
 import com.github.steveice10.mc.protocol.MinecraftConstants;
 import com.github.steveice10.mc.protocol.MinecraftProtocol;
 import com.github.steveice10.mc.protocol.data.SubProtocol;
+import com.github.steveice10.mc.protocol.data.message.TextMessage;
 import com.github.steveice10.mc.protocol.data.status.handler.ServerInfoHandler;
 import com.github.steveice10.packetlib.Client;
 import com.github.steveice10.packetlib.tcp.TcpSessionFactory;
@@ -77,7 +78,7 @@ public class GeyserLegacyPingPassthrough implements IGeyserPingPassthrough, Runn
         try {
             this.client = new Client(connector.getConfig().getRemote().getAddress(), connector.getConfig().getRemote().getPort(), new MinecraftProtocol(SubProtocol.STATUS), new TcpSessionFactory());
             this.client.getSession().setFlag(MinecraftConstants.SERVER_INFO_HANDLER_KEY, (ServerInfoHandler) (session, info) -> {
-                this.pingInfo = new GeyserPingInfo(info.getDescription().toString(), info.getPlayerInfo().getOnlinePlayers(), info.getPlayerInfo().getMaxPlayers());
+                this.pingInfo = new GeyserPingInfo(((TextMessage) info.getDescription()).getText(), info.getPlayerInfo().getOnlinePlayers(), info.getPlayerInfo().getMaxPlayers());
                 this.client.getSession().disconnect(null);
             });
 

--- a/connector/src/main/java/org/geysermc/connector/utils/ChunkUtils.java
+++ b/connector/src/main/java/org/geysermc/connector/utils/ChunkUtils.java
@@ -28,7 +28,6 @@ package org.geysermc.connector.utils;
 import com.github.steveice10.mc.protocol.data.game.chunk.Chunk;
 import com.github.steveice10.mc.protocol.data.game.chunk.Column;
 import com.github.steveice10.mc.protocol.data.game.entity.metadata.Position;
-import com.github.steveice10.mc.protocol.data.game.world.block.BlockState;
 import com.github.steveice10.opennbt.tag.builtin.CompoundTag;
 import com.github.steveice10.opennbt.tag.builtin.StringTag;
 import com.github.steveice10.opennbt.tag.builtin.Tag;
@@ -54,8 +53,6 @@ import org.geysermc.connector.network.translators.world.chunk.ChunkSection;
 
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
-import java.util.HashMap;
-import java.util.Map;
 
 import static org.geysermc.connector.network.translators.world.block.BlockTranslator.AIR;
 import static org.geysermc.connector.network.translators.world.block.BlockTranslator.BEDROCK_WATER_ID;
@@ -65,7 +62,7 @@ public class ChunkUtils {
     /**
      * Temporarily stores positions of BlockState values that are needed for certain block entities actively
      */
-    public static final Map<Position, BlockState> CACHED_BLOCK_ENTITIES = new HashMap<>();
+    public static final Object2IntMap<Position> CACHED_BLOCK_ENTITIES = new Object2IntOpenHashMap<>();
 
     private static final com.nukkitx.nbt.tag.CompoundTag EMPTY_TAG = CompoundTagBuilder.builder().buildRootTag();
     public static final byte[] EMPTY_LEVEL_CHUNK_DATA;
@@ -91,7 +88,7 @@ public class ChunkUtils {
 
         CompoundTag[] blockEntities = column.getTileEntities();
         // Temporarily stores positions of BlockState values per chunk load
-        Map<Position, BlockState> blockEntityPositions = new HashMap<>();
+        Object2IntMap<Position> blockEntityPositions = new Object2IntOpenHashMap<>();
 
         // Temporarily stores compound tags of Bedrock-only block entities
         ObjectArrayList<com.nukkitx.nbt.tag.CompoundTag> bedrockOnlyBlockEntities = new ObjectArrayList<>();
@@ -107,7 +104,7 @@ public class ChunkUtils {
             for (int x = 0; x < 16; x++) {
                 for (int y = 0; y < 16; y++) {
                     for (int z = 0; z < 16; z++) {
-                        BlockState blockState = chunk.get(x, y, z);
+                        int blockState = chunk.get(x, y, z);
                         int id = BlockTranslator.getBedrockBlockId(blockState);
 
                         // Check to see if the name is in BlockTranslator.getBlockEntityString, and therefore must be handled differently
@@ -119,8 +116,8 @@ public class ChunkUtils {
                         section.getBlockStorageArray()[0].setFullBlock(ChunkSection.blockPosition(x, y, z), id);
 
                         // Check if block is piston or flower - only block entities in Bedrock
-                        if (BlockStateValues.getFlowerPotValues().containsKey(blockState.getId()) ||
-                                BlockStateValues.getPistonValues().containsKey(blockState.getId())) {
+                        if (BlockStateValues.getFlowerPotValues().containsKey(blockState) ||
+                                BlockStateValues.getPistonValues().containsKey(blockState)) {
                             Position pos = new ChunkPosition(column.getX(), column.getZ()).getBlock(x, (chunkY << 4) + y, z);
                             bedrockOnlyBlockEntities.add(BedrockOnlyBlockEntity.getTag(Vector3i.from(pos.getX(), pos.getY(), pos.getZ()), blockState));
                         }
@@ -161,7 +158,7 @@ public class ChunkUtils {
             String id = BlockEntityUtils.getBedrockBlockEntityId(tagName);
             BlockEntityTranslator blockEntityTranslator = BlockEntityUtils.getBlockEntityTranslator(id);
             Position pos = new Position((int) tag.get("x").getValue(), (int) tag.get("y").getValue(), (int) tag.get("z").getValue());
-            BlockState blockState = blockEntityPositions.get(pos);
+            int blockState = blockEntityPositions.getOrDefault(pos, 0);
             bedrockBlockEntities[i] = blockEntityTranslator.getBlockEntityTag(tagName, tag, blockState);
             i++;
         }
@@ -188,14 +185,14 @@ public class ChunkUtils {
         }
     }
 
-    public static void updateBlock(GeyserSession session, BlockState blockState, Position position) {
+    public static void updateBlock(GeyserSession session, int blockState, Position position) {
         Vector3i pos = Vector3i.from(position.getX(), position.getY(), position.getZ());
         updateBlock(session, blockState, pos);
     }
 
-    public static void updateBlock(GeyserSession session, BlockState blockState, Vector3i position) {
+    public static void updateBlock(GeyserSession session, int blockState, Vector3i position) {
         // Checks for item frames so they aren't tripped up and removed
-        if (ItemFrameEntity.positionContainsItemFrame(session, position) && blockState.equals(AIR)) {
+        if (ItemFrameEntity.positionContainsItemFrame(session, position) && blockState == AIR) {
             ((ItemFrameEntity) session.getEntityCache().getEntityByJavaId(ItemFrameEntity.getItemFrameEntityId(session, position))).updateBlock(session);
             return;
         } else if (ItemFrameEntity.positionContainsItemFrame(session, position)) {

--- a/connector/src/main/java/org/geysermc/connector/utils/MessageUtils.java
+++ b/connector/src/main/java/org/geysermc/connector/utils/MessageUtils.java
@@ -28,6 +28,7 @@ package org.geysermc.connector.utils;
 import com.github.steveice10.mc.protocol.data.game.scoreboard.TeamColor;
 import com.github.steveice10.mc.protocol.data.message.Message;
 import com.github.steveice10.mc.protocol.data.message.MessageSerializer;
+import com.github.steveice10.mc.protocol.data.message.TextMessage;
 import com.github.steveice10.mc.protocol.data.message.TranslationMessage;
 import com.github.steveice10.mc.protocol.data.message.style.ChatColor;
 import com.github.steveice10.mc.protocol.data.message.style.ChatFormat;
@@ -98,7 +99,7 @@ public class MessageUtils {
             message = MessageSerializer.fromJson(formatJson(object));
         }
 
-        String messageText = message.toString();
+        String messageText = (message instanceof TranslationMessage) ? ((TranslationMessage) message).getKey() : ((TextMessage) message).getText();
         if (locale != null && shouldTranslate) {
             messageText = LocaleUtils.getLocaleString(messageText, locale);
         }
@@ -135,8 +136,8 @@ public class MessageUtils {
     }
 
     public static String getBedrockMessage(Message message) {
-        if (isMessage(message.toString())) {
-            return getBedrockMessage(message.toString());
+        if (isMessage(((TextMessage) message).getText())) {
+            return getBedrockMessage(((TextMessage) message).getText());
         } else {
             return getBedrockMessage(MessageSerializer.toJsonString(message));
         }
@@ -276,7 +277,7 @@ public class MessageUtils {
                 base += "f";
                 break;
             case RESET:
-            case NONE:
+            //case NONE:
                 base += "r";
                 break;
             default:


### PR DESCRIPTION
Removes the BlockState class. Needs testing! This may just become the base for our 1.16 implementation. Thanks to @rtm516 for handling message upgrades.