### PR TITLE
clone-remote-port option

### DIFF
--- a/bootstrap/bukkit/src/main/java/org/geysermc/platform/bukkit/GeyserBukkitPlugin.java
+++ b/bootstrap/bukkit/src/main/java/org/geysermc/platform/bukkit/GeyserBukkitPlugin.java
@@ -78,6 +78,10 @@ public class GeyserBukkitPlugin extends JavaPlugin implements GeyserBootstrap {
             geyserConfig.getRemote().setAddress(Bukkit.getIp());
         }
 
+        if (geyserConfig.getBedrock().isCloneRemotePort()) {
+            geyserConfig.getBedrock().setPort(Bukkit.getPort());
+        }
+
         geyserConfig.getRemote().setPort(Bukkit.getPort());
 
         this.geyserLogger = new GeyserBukkitLogger(getLogger(), geyserConfig.isDebugMode());

--- a/bootstrap/bungeecord/src/main/java/org/geysermc/platform/bungeecord/GeyserBungeePlugin.java
+++ b/bootstrap/bungeecord/src/main/java/org/geysermc/platform/bungeecord/GeyserBungeePlugin.java
@@ -85,6 +85,10 @@ public class GeyserBungeePlugin extends Plugin implements GeyserBootstrap {
                 this.geyserConfig.getRemote().setAddress(javaAddr.getHostString());
             }
 
+            if (geyserConfig.getBedrock().isCloneRemotePort()) {
+                geyserConfig.getBedrock().setPort(javaAddr.getPort());
+            }
+
             this.geyserConfig.getRemote().setPort(javaAddr.getPort());
         }
 

--- a/bootstrap/sponge/src/main/java/org/geysermc/platform/sponge/GeyserSpongeConfiguration.java
+++ b/bootstrap/sponge/src/main/java/org/geysermc/platform/sponge/GeyserSpongeConfiguration.java
@@ -175,6 +175,11 @@ public class GeyserSpongeConfiguration implements GeyserConfiguration {
         }
 
         @Override
+        public boolean isCloneRemotePort() {
+            return node.getNode("clone-remote-port").getBoolean(false);
+        }
+
+        @Override
         public String getMotd1() {
             return node.getNode("motd1").getString("GeyserMC");
         }

--- a/bootstrap/sponge/src/main/java/org/geysermc/platform/sponge/GeyserSpongePlugin.java
+++ b/bootstrap/sponge/src/main/java/org/geysermc/platform/sponge/GeyserSpongePlugin.java
@@ -109,8 +109,9 @@ public class GeyserSpongePlugin implements GeyserBootstrap {
             serverPort.setValue(javaAddr.getPort());
         }
 
-        if (geyserConfig.getBedrock().isCloneRemotePort()) {
-            serverPort.setValue(geyserConfig.getBedrock().getPort());
+        ConfigurationNode bedrockPort = config.getNode("bedrock").getNode("port");
+        if (geyserConfig.getBedrock().isCloneRemotePort()){
+            bedrockPort.setValue(serverPort.getValue());
         }
 
         this.geyserLogger = new GeyserSpongeLogger(logger, geyserConfig.isDebugMode());

--- a/bootstrap/sponge/src/main/java/org/geysermc/platform/sponge/GeyserSpongePlugin.java
+++ b/bootstrap/sponge/src/main/java/org/geysermc/platform/sponge/GeyserSpongePlugin.java
@@ -109,6 +109,10 @@ public class GeyserSpongePlugin implements GeyserBootstrap {
             serverPort.setValue(javaAddr.getPort());
         }
 
+        if (geyserConfig.getBedrock().isCloneRemotePort()) {
+            serverPort.setValue(geyserConfig.getBedrock().getPort());
+        }
+
         this.geyserLogger = new GeyserSpongeLogger(logger, geyserConfig.isDebugMode());
         GeyserConfiguration.checkGeyserConfiguration(geyserConfig, geyserLogger);
         this.connector = GeyserConnector.start(PlatformType.SPONGE, this);

--- a/bootstrap/velocity/src/main/java/org/geysermc/platform/velocity/GeyserVelocityPlugin.java
+++ b/bootstrap/velocity/src/main/java/org/geysermc/platform/velocity/GeyserVelocityPlugin.java
@@ -96,6 +96,10 @@ public class GeyserVelocityPlugin implements GeyserBootstrap {
             geyserConfig.getRemote().setAddress(javaAddr.getHostString());
         }
 
+        if (geyserConfig.getBedrock().isCloneRemotePort()) {
+            geyserConfig.getBedrock().setPort(javaAddr.getPort());
+        }
+
         geyserConfig.getRemote().setPort(javaAddr.getPort());
 
         this.geyserLogger = new GeyserVelocityLogger(logger, geyserConfig.isDebugMode());

--- a/connector/src/main/java/org/geysermc/connector/configuration/GeyserConfiguration.java
+++ b/connector/src/main/java/org/geysermc/connector/configuration/GeyserConfiguration.java
@@ -80,6 +80,8 @@ public interface GeyserConfiguration {
 
         int getPort();
 
+        boolean isCloneRemotePort();
+
         String getMotd1();
 
         String getMotd2();

--- a/connector/src/main/java/org/geysermc/connector/configuration/GeyserJacksonConfiguration.java
+++ b/connector/src/main/java/org/geysermc/connector/configuration/GeyserJacksonConfiguration.java
@@ -96,7 +96,9 @@ public abstract class GeyserJacksonConfiguration implements GeyserConfiguration 
     public static class BedrockConfiguration implements IBedrockConfiguration {
 
         private String address;
+        @Setter
         private int port;
+        private boolean isCloneRemotePort;
 
         private String motd1;
         private String motd2;

--- a/connector/src/main/resources/config.yml
+++ b/connector/src/main/resources/config.yml
@@ -13,6 +13,9 @@ bedrock:
   address: 0.0.0.0
   # The port that will listen for connections
   port: 19132
+  # Clone remote server port number
+  # Geyser will try to set bedrock port to the same as java's server port if it is run as a plugin
+  clone-remote-port: false
   # The MOTD that will be broadcasted to Minecraft: Bedrock Edition clients. Irrelevant if "passthrough-motd" is set to true
   motd1: "GeyserMC"
   motd2: "Another GeyserMC forced host."

--- a/connector/src/main/resources/config.yml
+++ b/connector/src/main/resources/config.yml
@@ -13,8 +13,8 @@ bedrock:
   address: 0.0.0.0
   # The port that will listen for connections
   port: 19132
-  # Clone remote server port number
-  # Geyser will try to set bedrock port to the same as java's server port if it is run as a plugin
+  # Use Java server port
+  # This option ignores the above port and uses the Java server's port as Bedrock's port. Only available for plugin versions.
   clone-remote-port: false
   # The MOTD that will be broadcasted to Minecraft: Bedrock Edition clients. Irrelevant if "passthrough-motd" is set to true
   motd1: "GeyserMC"

--- a/connector/src/main/resources/config.yml
+++ b/connector/src/main/resources/config.yml
@@ -13,8 +13,9 @@ bedrock:
   address: 0.0.0.0
   # The port that will listen for connections
   port: 19132
-  # Use Java server port
-  # This option ignores the above port and uses the Java server's port as Bedrock's port. Only available for plugin versions.
+  # Some hosting services change your Java port everytime you open the server, sometimes these hosts can't open UDP ports for you
+  # This option makes the bedrock port the same as the Java port everytime you start the server
+  # This option is for the plugin version only
   clone-remote-port: false
   # The MOTD that will be broadcasted to Minecraft: Bedrock Edition clients. Irrelevant if "passthrough-motd" is set to true
   motd1: "GeyserMC"


### PR DESCRIPTION
Added a clone-remote-port option which makes the bedrock's port the same as the java's port if geyser is running as a plugin