### PR TITLE
Fix enchantment conversion

### DIFF
--- a/connector/src/main/java/org/geysermc/connector/network/translators/item/Enchantment.java
+++ b/connector/src/main/java/org/geysermc/connector/network/translators/item/Enchantment.java
@@ -76,7 +76,8 @@ public enum Enchantment {
 
     public static Enchantment getByJavaIdentifier(String javaIdentifier) {
         for (Enchantment enchantment : Enchantment.values()) {
-            if (enchantment.javaIdentifier.equals(javaIdentifier)) {
+            // Check for both the namespaced enchantment id and non namespaced
+            if (enchantment.javaIdentifier.equals(javaIdentifier) || enchantment.javaIdentifier.equals("minecraft:" + javaIdentifier)) {
                 return enchantment;
             }
         }

--- a/connector/src/main/java/org/geysermc/connector/network/translators/item/Enchantment.java
+++ b/connector/src/main/java/org/geysermc/connector/network/translators/item/Enchantment.java
@@ -66,7 +66,8 @@ public enum Enchantment {
     CHANNELING,
     MULTISHOT,
     PIERCING,
-    QUICK_CHARGE;
+    QUICK_CHARGE,
+    SOUL_SPEED;
 
     private final String javaIdentifier;
 

--- a/connector/src/main/java/org/geysermc/connector/network/translators/item/ItemTranslator.java
+++ b/connector/src/main/java/org/geysermc/connector/network/translators/item/ItemTranslator.java
@@ -134,10 +134,6 @@ public abstract class ItemTranslator {
             nbt.put(new IntTag("map", 0));
         }
 
-        if (bedrockItem.getBedrockId() == 313) {
-            GeyserConnector.getInstance().getLogger().debug("break");
-        }
-
         ItemStack itemStack = new ItemStack(stack.getId(), stack.getAmount(), nbt);
 
         if (nbt != null) {
@@ -308,7 +304,7 @@ public abstract class ItemTranslator {
         if (tag != null && !tag.isEmpty()) {
             for (String str : tag.keySet()) {
                 Object bedrockTag = tag.get(str);
-                com.github.steveice10.opennbt.tag.builtin.Tag translatedTag = translateToJavaNBT(name, bedrockTag);
+                com.github.steveice10.opennbt.tag.builtin.Tag translatedTag = translateToJavaNBT(str, bedrockTag);
                 if (translatedTag == null)
                     continue;
 
@@ -374,11 +370,7 @@ public abstract class ItemTranslator {
 
         if (object instanceof NbtMap) {
             NbtMap map = (NbtMap) object;
-            for (Map.Entry<String, Object> entry : map.entrySet()) {
-                if (entry.getValue().equals(map.get(name))) {
-                    return translateToJavaNBT(entry.getKey(), map.getCompound(name));
-                }
-            }
+            return translateToJavaNBT(name, map);
         }
 
         return null;

--- a/connector/src/main/java/org/geysermc/connector/network/translators/item/ItemTranslator.java
+++ b/connector/src/main/java/org/geysermc/connector/network/translators/item/ItemTranslator.java
@@ -141,6 +141,10 @@ public abstract class ItemTranslator {
             nbt.put(new IntTag("map", 0));
         }
 
+        if (bedrockItem.getBedrockId() == 313) {
+            GeyserConnector.getInstance().getLogger().debug("break");
+        }
+
         ItemStack itemStack = new ItemStack(stack.getId(), stack.getAmount(), nbt);
 
         if (nbt != null) {

--- a/connector/src/main/java/org/geysermc/connector/network/translators/item/translators/nbt/BasicItemTranslator.java
+++ b/connector/src/main/java/org/geysermc/connector/network/translators/item/translators/nbt/BasicItemTranslator.java
@@ -47,18 +47,6 @@ public class BasicItemTranslator extends NbtItemStackTranslator {
 
     @Override
     public void translateToBedrock(CompoundTag itemTag, ItemEntry itemEntry) {
-        // Check for a blank int tag and remove it\
-        for (Tag tag : itemTag.values()) {
-            if (tag instanceof IntTag) {
-                IntTag intTag = (IntTag) tag;
-                if (intTag.getValue() == 0 && intTag.getName().equals("")) {
-                    // Remove the blank tag
-                    itemTag.remove("");
-                    break;
-                }
-            }
-        }
-
         if (!itemTag.contains("display")) {
             return;
         }

--- a/connector/src/main/java/org/geysermc/connector/network/translators/item/translators/nbt/BasicItemTranslator.java
+++ b/connector/src/main/java/org/geysermc/connector/network/translators/item/translators/nbt/BasicItemTranslator.java
@@ -25,7 +25,6 @@
 
 package org.geysermc.connector.network.translators.item.translators.nbt;
 
-import com.github.steveice10.opennbt.tag.builtin.*;
 import com.github.steveice10.opennbt.tag.builtin.CompoundTag;
 import com.github.steveice10.opennbt.tag.builtin.ListTag;
 import com.github.steveice10.opennbt.tag.builtin.StringTag;

--- a/connector/src/main/java/org/geysermc/connector/network/translators/item/translators/nbt/BasicItemTranslator.java
+++ b/connector/src/main/java/org/geysermc/connector/network/translators/item/translators/nbt/BasicItemTranslator.java
@@ -25,17 +25,14 @@
 
 package org.geysermc.connector.network.translators.item.translators.nbt;
 
-import com.github.steveice10.opennbt.tag.builtin.CompoundTag;
-import com.github.steveice10.opennbt.tag.builtin.ListTag;
-import com.github.steveice10.opennbt.tag.builtin.StringTag;
-import com.github.steveice10.opennbt.tag.builtin.Tag;
+import com.github.steveice10.opennbt.tag.builtin.*;
 import net.kyori.text.Component;
 import net.kyori.text.TextComponent;
 import net.kyori.text.serializer.gson.GsonComponentSerializer;
 import net.kyori.text.serializer.legacy.LegacyComponentSerializer;
 import org.geysermc.connector.network.translators.ItemRemapper;
-import org.geysermc.connector.network.translators.item.NbtItemStackTranslator;
 import org.geysermc.connector.network.translators.item.ItemEntry;
+import org.geysermc.connector.network.translators.item.NbtItemStackTranslator;
 import org.geysermc.connector.utils.MessageUtils;
 
 import java.util.ArrayList;
@@ -46,6 +43,18 @@ public class BasicItemTranslator extends NbtItemStackTranslator {
 
     @Override
     public void translateToBedrock(CompoundTag itemTag, ItemEntry itemEntry) {
+        // Check for a blank int tag and remove it\
+        for (Tag tag : itemTag.values()) {
+            if (tag instanceof IntTag) {
+                IntTag intTag = (IntTag) tag;
+                if (intTag.getValue() == 0 && intTag.getName().equals("")) {
+                    // Remove the blank tag
+                    itemTag.remove("");
+                    break;
+                }
+            }
+        }
+
         if (!itemTag.contains("display")) {
             return;
         }


### PR DESCRIPTION
This fixes java to bedrock enchantment conversion, I believe currently its an issue in MCProtocolLib this is a non-ideal fix for it.
Its caused by an extra IntTag being on the nbt data and bedrock doesn't like this.

When enchantments are fixed it will close #649 and #783