### PR TITLE
Fix version checking on older Java versions

### DIFF
--- a/connector/src/main/java/org/geysermc/connector/command/defaults/VersionCommand.java
+++ b/connector/src/main/java/org/geysermc/connector/command/defaults/VersionCommand.java
@@ -29,6 +29,7 @@ import com.github.steveice10.mc.protocol.MinecraftConstants;
 import org.geysermc.connector.GeyserConnector;
 import org.geysermc.connector.command.CommandSender;
 import org.geysermc.connector.command.GeyserCommand;
+import org.geysermc.connector.common.ChatColor;
 import org.geysermc.connector.utils.FileUtils;
 import org.geysermc.connector.utils.LanguageUtils;
 import org.geysermc.connector.utils.WebUtils;
@@ -63,7 +64,7 @@ public class VersionCommand extends GeyserCommand {
                 if (buildXML.startsWith("<buildNumber>")) {
                     int latestBuildNum = Integer.parseInt(buildXML.replaceAll("<(\\\\)?(/)?buildNumber>", "").trim());
                     int buildNum = Integer.parseInt(gitProp.getProperty("git.build.number"));
-                    if (latestBuildNum != buildNum) {
+                    if (latestBuildNum == buildNum) {
                         sender.sendMessage(LanguageUtils.getLocaleStringLog("geyser.commands.version.no_updates"));
                     } else {
                         sender.sendMessage(LanguageUtils.getLocaleStringLog("geyser.commands.version.outdated", (latestBuildNum - buildNum), "http://ci.geysermc.org/"));
@@ -73,7 +74,7 @@ public class VersionCommand extends GeyserCommand {
                 }
             } catch (IOException | AssertionError | NumberFormatException e) {
                 GeyserConnector.getInstance().getLogger().error(LanguageUtils.getLocaleStringLog("geyser.commands.version.failed"), e);
-                sender.sendMessage(LanguageUtils.getLocaleStringLog("geyser.commands.version.failed"));
+                sender.sendMessage(ChatColor.RED + LanguageUtils.getLocaleStringLog("geyser.commands.version.failed"));
             }
         }
     }

--- a/connector/src/main/java/org/geysermc/connector/utils/WebUtils.java
+++ b/connector/src/main/java/org/geysermc/connector/utils/WebUtils.java
@@ -49,7 +49,7 @@ public class WebUtils {
             url = new URL(reqURL);
             HttpURLConnection con = (HttpURLConnection) url.openConnection();
             con.setRequestMethod("GET");
-            con.setRequestProperty("User-Agent", "Geyser-" + GeyserConnector.getInstance().getPlatformType().toString() + "/" + GeyserConnector.VERSION);
+            con.setRequestProperty("User-Agent", "Geyser-" + GeyserConnector.getInstance().getPlatformType().toString() + "/" + GeyserConnector.VERSION); // Otherwise Java 8 fails on checking updates
 
             BufferedReader in = new BufferedReader(new InputStreamReader(con.getInputStream()));
             String inputLine;

--- a/connector/src/main/java/org/geysermc/connector/utils/WebUtils.java
+++ b/connector/src/main/java/org/geysermc/connector/utils/WebUtils.java
@@ -25,6 +25,8 @@
 
 package org.geysermc.connector.utils;
 
+import org.geysermc.connector.GeyserConnector;
+
 import java.io.*;
 import java.net.HttpURLConnection;
 import java.net.URL;
@@ -47,6 +49,7 @@ public class WebUtils {
             url = new URL(reqURL);
             HttpURLConnection con = (HttpURLConnection) url.openConnection();
             con.setRequestMethod("GET");
+            con.setRequestProperty("User-Agent", "Geyser-" + GeyserConnector.getInstance().getPlatformType().toString() + "/" + GeyserConnector.VERSION);
 
             BufferedReader in = new BufferedReader(new InputStreamReader(con.getInputStream()));
             String inputLine;


### PR DESCRIPTION
We add a useragent header to stop cloudflare blocking the default Java useragent