### PR TITLE
SRV resolving / Small Handshake rework

### DIFF
--- a/bootstrap/sponge/src/main/java/org/geysermc/platform/sponge/GeyserSpongeConfiguration.java
+++ b/bootstrap/sponge/src/main/java/org/geysermc/platform/sponge/GeyserSpongeConfiguration.java
@@ -196,8 +196,18 @@ public class GeyserSpongeConfiguration implements GeyserConfiguration {
         }
 
         @Override
+        public void setAddress(String address) {
+            node.getNode("address").setValue(address);
+        }
+
+        @Override
         public int getPort() {
             return node.getNode("port").getInt(25565);
+        }
+
+        @Override
+        public void setPort(int port) {
+            node.getNode("port").setValue(port);
         }
 
         @Override

--- a/connector/src/main/java/org/geysermc/connector/GeyserConnector.java
+++ b/connector/src/main/java/org/geysermc/connector/GeyserConnector.java
@@ -153,8 +153,8 @@ public class GeyserConnector {
                     String[] record = ((String) attr.get(0)).split(" ");
                     // Overwrites the existing address and port with that from the SRV record.
                     config.getRemote().setAddress(remoteAddress = record[3]);
-                    config.getRemote().setPort(Integer.parseInt(record[2]));
-                    logger.debug("Found SRV record \"" + remoteAddress + ":" + config.getRemote().getPort() + "\"");
+                    config.getRemote().setPort(remotePort = Integer.parseInt(record[2]));
+                    logger.debug("Found SRV record \"" + remoteAddress + ":" + remotePort + "\"");
                 }
             } catch (NamingException ex) {
                 ex.printStackTrace();

--- a/connector/src/main/java/org/geysermc/connector/configuration/GeyserConfiguration.java
+++ b/connector/src/main/java/org/geysermc/connector/configuration/GeyserConfiguration.java
@@ -92,6 +92,10 @@ public interface GeyserConfiguration {
         String getAddress();
 
         int getPort();
+        
+        void setAddress(String address);
+
+        void setPort(int port);
 
         String getAuthType();
     }

--- a/connector/src/main/java/org/geysermc/connector/ping/GeyserLegacyPingPassthrough.java
+++ b/connector/src/main/java/org/geysermc/connector/ping/GeyserLegacyPingPassthrough.java
@@ -79,15 +79,17 @@ public class GeyserLegacyPingPassthrough implements IGeyserPingPassthrough, Runn
     public void run() {
         try {
             Socket socket = new Socket();
-            socket.connect(new InetSocketAddress(connector.getConfig().getRemote().getAddress(), connector.getConfig().getRemote().getPort()), 5000);
+            String address = connector.getConfig().getRemote().getAddress();
+            int port = connector.getConfig().getRemote().getPort();
+            socket.connect(new InetSocketAddress(address, port), 5000);
 
             ByteArrayOutputStream byteArrayStream = new ByteArrayOutputStream();
             DataOutputStream handshake = new DataOutputStream(byteArrayStream);
             handshake.write(0x0);
             VarInts.writeUnsignedInt(handshake, MinecraftConstants.PROTOCOL_VERSION);
             VarInts.writeUnsignedInt(handshake, socket.getInetAddress().getHostAddress().length());
-            handshake.writeBytes(socket.getInetAddress().getHostAddress());
-            handshake.writeShort(socket.getPort());
+            handshake.writeBytes(address);
+            handshake.writeShort(port);
             VarInts.writeUnsignedInt(handshake, 1);
 
             DataOutputStream dataOutputStream = new DataOutputStream(socket.getOutputStream());

--- a/connector/src/main/java/org/geysermc/connector/ping/GeyserLegacyPingPassthrough.java
+++ b/connector/src/main/java/org/geysermc/connector/ping/GeyserLegacyPingPassthrough.java
@@ -87,7 +87,7 @@ public class GeyserLegacyPingPassthrough implements IGeyserPingPassthrough, Runn
             DataOutputStream handshake = new DataOutputStream(byteArrayStream);
             handshake.write(0x0);
             VarInts.writeUnsignedInt(handshake, MinecraftConstants.PROTOCOL_VERSION);
-            VarInts.writeUnsignedInt(handshake, socket.getInetAddress().getHostAddress().length());
+            VarInts.writeUnsignedInt(handshake, address.length());
             handshake.writeBytes(address);
             handshake.writeShort(port);
             VarInts.writeUnsignedInt(handshake, 1);


### PR DESCRIPTION
- Add SRV resolving for standalone / legacy ping passthrough
- Handshake now uses the server address directly from the config and no longer the IP from a domain (Some servers use the address that is given during the handshake)