### PR TITLE
Auto-set the remote configuration on plugin versions where possible

### DIFF
--- a/bootstrap/bungeecord/src/main/java/org/geysermc/platform/bungeecord/GeyserBungeePlugin.java
+++ b/bootstrap/bungeecord/src/main/java/org/geysermc/platform/bungeecord/GeyserBungeePlugin.java
@@ -81,10 +81,10 @@ public class GeyserBungeePlugin extends Plugin implements GeyserBootstrap {
 
             InetSocketAddress javaAddr = listener.getHost();
 
-            // Don't change the ip if its listening on all interfaces
-            // By default this should be 127.0.0.1 but may need to be changed in some circumstances
-            if (!javaAddr.getHostString().equals("0.0.0.0") && !javaAddr.getHostString().equals("")) {
-                this.geyserConfig.getRemote().setAddress(javaAddr.getHostString());
+            if (javaAddr.getHostString().equals("")) {
+                this.geyserConfig.getBedrock().setAddress("0.0.0.0");
+            } else {
+                this.geyserConfig.getBedrock().setAddress(javaAddr.getHostString());
             }
 
             this.geyserConfig.getRemote().setPort(javaAddr.getPort());
@@ -96,6 +96,10 @@ public class GeyserBungeePlugin extends Plugin implements GeyserBootstrap {
         if (geyserConfig.getRemote().getAuthType().equals("floodgate") && getProxy().getPluginManager().getPlugin("floodgate-bungee") == null) {
             geyserLogger.severe(LanguageUtils.getLocaleStringLog("geyser.bootstrap.floodgate.not_installed") + " " + LanguageUtils.getLocaleStringLog("geyser.bootstrap.floodgate.disabling"));
             return;
+        } else if (getProxy().getPluginManager().getPlugin("floodgate-bungee") != null) {
+            // Floodgate installed means that the user wants Floodgate authentication
+            geyserLogger.debug("Auto-setting to Floodgate authentication.");
+            geyserConfig.getRemote().setAuthType("floodgate");
         }
 
         geyserConfig.loadFloodgate(this, configuration);

--- a/bootstrap/spigot/src/main/java/org/geysermc/platform/spigot/GeyserSpigotPlugin.java
+++ b/bootstrap/spigot/src/main/java/org/geysermc/platform/spigot/GeyserSpigotPlugin.java
@@ -27,10 +27,10 @@ package org.geysermc.platform.spigot;
 
 import org.bukkit.Bukkit;
 import org.bukkit.plugin.java.JavaPlugin;
-import org.geysermc.connector.common.PlatformType;
 import org.geysermc.connector.GeyserConnector;
 import org.geysermc.connector.bootstrap.GeyserBootstrap;
 import org.geysermc.connector.command.CommandManager;
+import org.geysermc.connector.common.PlatformType;
 import org.geysermc.connector.configuration.GeyserConfiguration;
 import org.geysermc.connector.dump.BootstrapDumpInfo;
 import org.geysermc.connector.network.translators.world.WorldManager;
@@ -81,10 +81,10 @@ public class GeyserSpigotPlugin extends JavaPlugin implements GeyserBootstrap {
             ex.printStackTrace();
         }
 
-        // Don't change the ip if its listening on all interfaces
-        // By default this should be 127.0.0.1 but may need to be changed in some circumstances
-        if (!Bukkit.getIp().equals("0.0.0.0") && !Bukkit.getIp().equals("")) {
-            geyserConfig.getRemote().setAddress(Bukkit.getIp());
+        if (Bukkit.getIp().equals("")) {
+            geyserConfig.getBedrock().setAddress("0.0.0.0");
+        } else {
+            geyserConfig.getBedrock().setAddress(Bukkit.getIp());
         }
 
         geyserConfig.getRemote().setPort(Bukkit.getPort());
@@ -96,6 +96,10 @@ public class GeyserSpigotPlugin extends JavaPlugin implements GeyserBootstrap {
             geyserLogger.severe(LanguageUtils.getLocaleStringLog("geyser.bootstrap.floodgate.not_installed") + " " + LanguageUtils.getLocaleStringLog("geyser.bootstrap.floodgate.disabling"));
             this.getPluginLoader().disablePlugin(this);
             return;
+        } else if (Bukkit.getPluginManager().getPlugin("floodgate-bukkit") != null) {
+            // Floodgate installed means that the user wants Floodgate authentication
+            geyserLogger.debug("Auto-setting to Floodgate authentication.");
+            geyserConfig.getRemote().setAuthType("floodgate");
         }
 
         geyserConfig.loadFloodgate(this);

--- a/bootstrap/sponge/src/main/java/org/geysermc/platform/sponge/GeyserSpongeConfiguration.java
+++ b/bootstrap/sponge/src/main/java/org/geysermc/platform/sponge/GeyserSpongeConfiguration.java
@@ -169,6 +169,10 @@ public class GeyserSpongeConfiguration implements GeyserConfiguration {
             return node.getNode("address").getString("0.0.0.0");
         }
 
+        public void setAddress(String address) {
+            node.getNode("address").setValue(address);
+        }
+
         @Override
         public int getPort() {
             return node.getNode("port").getInt(19132);
@@ -193,6 +197,11 @@ public class GeyserSpongeConfiguration implements GeyserConfiguration {
         @Override
         public String getAddress() {
             return node.getNode("address").getString("127.0.0.1");
+        }
+
+        @Override
+        public void setAddress(String address) {
+            node.getNode("address").setValue(address);
         }
 
         @Override

--- a/bootstrap/sponge/src/main/java/org/geysermc/platform/sponge/GeyserSpongePlugin.java
+++ b/bootstrap/sponge/src/main/java/org/geysermc/platform/sponge/GeyserSpongePlugin.java
@@ -96,16 +96,15 @@ public class GeyserSpongePlugin implements GeyserBootstrap {
             return;
         }
 
-        ConfigurationNode serverIP = config.getNode("remote").getNode("address");
         ConfigurationNode serverPort = config.getNode("remote").getNode("port");
 
         if (Sponge.getServer().getBoundAddress().isPresent()) {
             InetSocketAddress javaAddr = Sponge.getServer().getBoundAddress().get();
 
-            // Don't change the ip if its listening on all interfaces
-            // By default this should be 127.0.0.1 but may need to be changed in some circumstances
-            if (!javaAddr.getHostString().equals("0.0.0.0") && !javaAddr.getHostString().equals("")) {
-                serverIP.setValue("127.0.0.1");
+            if (javaAddr.getHostString().equals("")) {
+                geyserConfig.getBedrock().setAddress("0.0.0.0");
+            } else {
+                geyserConfig.getBedrock().setAddress(javaAddr.getHostString());
             }
 
             serverPort.setValue(javaAddr.getPort());

--- a/bootstrap/velocity/src/main/java/org/geysermc/platform/velocity/GeyserVelocityPlugin.java
+++ b/bootstrap/velocity/src/main/java/org/geysermc/platform/velocity/GeyserVelocityPlugin.java
@@ -92,10 +92,10 @@ public class GeyserVelocityPlugin implements GeyserBootstrap {
 
         InetSocketAddress javaAddr = proxyServer.getBoundAddress();
 
-        // Don't change the ip if its listening on all interfaces
-        // By default this should be 127.0.0.1 but may need to be changed in some circumstances
-        if (!javaAddr.getHostString().equals("0.0.0.0") && !javaAddr.getHostString().equals("")) {
-            geyserConfig.getRemote().setAddress(javaAddr.getHostString());
+        if (javaAddr.getHostString().equals("")) {
+            this.geyserConfig.getBedrock().setAddress("0.0.0.0");
+        } else {
+            this.geyserConfig.getBedrock().setAddress(javaAddr.getHostString());
         }
 
         geyserConfig.getRemote().setPort(javaAddr.getPort());
@@ -106,6 +106,10 @@ public class GeyserVelocityPlugin implements GeyserBootstrap {
         if (geyserConfig.getRemote().getAuthType().equals("floodgate") && !proxyServer.getPluginManager().getPlugin("floodgate").isPresent()) {
             geyserLogger.severe(LanguageUtils.getLocaleStringLog("geyser.bootstrap.floodgate.not_installed") + " " + LanguageUtils.getLocaleStringLog("geyser.bootstrap.floodgate.disabling"));
             return;
+        } else if (proxyServer.getPluginManager().getPlugin("floodgate").isPresent()) {
+            // Floodgate installed means that the user wants Floodgate authentication
+            geyserLogger.debug("Auto-setting to Floodgate authentication.");
+            geyserConfig.getRemote().setAuthType("floodgate");
         }
 
         geyserConfig.loadFloodgate(this, proxyServer, configFolder.toFile());

--- a/connector/src/main/java/org/geysermc/connector/GeyserConnector.java
+++ b/connector/src/main/java/org/geysermc/connector/GeyserConnector.java
@@ -137,8 +137,11 @@ public class GeyserConnector {
             // Set the remote address to localhost since that is where we are always connecting
             try {
                 config.getRemote().setAddress(InetAddress.getLocalHost().getHostAddress());
-            } catch (UnknownHostException ignored) {
+            } catch (UnknownHostException ex) {
                 logger.debug("Unknown host when trying to find localhost.");
+                if (config.isDebugMode()) {
+                    ex.printStackTrace();
+                }
             }
         }
 

--- a/connector/src/main/java/org/geysermc/connector/GeyserConnector.java
+++ b/connector/src/main/java/org/geysermc/connector/GeyserConnector.java
@@ -32,10 +32,10 @@ import com.nukkitx.protocol.bedrock.BedrockServer;
 import com.nukkitx.protocol.bedrock.v407.Bedrock_v407;
 import lombok.Getter;
 import lombok.Setter;
-import org.geysermc.connector.common.AuthType;
-import org.geysermc.connector.common.PlatformType;
 import org.geysermc.connector.bootstrap.GeyserBootstrap;
 import org.geysermc.connector.command.CommandManager;
+import org.geysermc.connector.common.AuthType;
+import org.geysermc.connector.common.PlatformType;
 import org.geysermc.connector.configuration.GeyserConfiguration;
 import org.geysermc.connector.metrics.Metrics;
 import org.geysermc.connector.network.ConnectorServerEventHandler;
@@ -51,17 +51,17 @@ import org.geysermc.connector.network.translators.item.PotionMixRegistry;
 import org.geysermc.connector.network.translators.sound.SoundHandlerRegistry;
 import org.geysermc.connector.network.translators.sound.SoundRegistry;
 import org.geysermc.connector.network.translators.world.WorldManager;
-import org.geysermc.connector.utils.LanguageUtils;
 import org.geysermc.connector.network.translators.world.block.BlockTranslator;
 import org.geysermc.connector.network.translators.world.block.entity.BlockEntityTranslator;
 import org.geysermc.connector.utils.DimensionUtils;
-import org.geysermc.connector.utils.DockerCheck;
+import org.geysermc.connector.utils.LanguageUtils;
 import org.geysermc.connector.utils.LocaleUtils;
 
+import java.net.InetAddress;
 import java.net.InetSocketAddress;
+import java.net.UnknownHostException;
 import java.text.DecimalFormat;
 import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.List;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.Executors;
@@ -134,7 +134,12 @@ public class GeyserConnector {
         SoundHandlerRegistry.init();
 
         if (platformType != PlatformType.STANDALONE) {
-            DockerCheck.check(bootstrap);
+            // Set the remote address to localhost since that is where we are always connecting
+            try {
+                config.getRemote().setAddress(InetAddress.getLocalHost().getHostAddress());
+            } catch (UnknownHostException ignored) {
+                logger.debug("Unknown host when trying to find localhost.");
+            }
         }
 
         remoteServer = new RemoteServer(config.getRemote().getAddress(), config.getRemote().getPort());

--- a/connector/src/main/java/org/geysermc/connector/configuration/GeyserConfiguration.java
+++ b/connector/src/main/java/org/geysermc/connector/configuration/GeyserConfiguration.java
@@ -91,6 +91,8 @@ public interface GeyserConfiguration {
 
         String getAddress();
 
+        void setAddress(String hostAddress);
+
         int getPort();
 
         String getAuthType();

--- a/connector/src/main/java/org/geysermc/connector/configuration/GeyserJacksonConfiguration.java
+++ b/connector/src/main/java/org/geysermc/connector/configuration/GeyserJacksonConfiguration.java
@@ -96,6 +96,7 @@ public abstract class GeyserJacksonConfiguration implements GeyserConfiguration 
     @Getter
     public static class BedrockConfiguration implements IBedrockConfiguration {
 
+        @Setter
         private String address;
         private int port;
 
@@ -112,6 +113,7 @@ public abstract class GeyserJacksonConfiguration implements GeyserConfiguration 
         @Setter
         private int port;
 
+        @Setter
         @JsonProperty("auth-type")
         private String authType;
     }

--- a/connector/src/main/java/org/geysermc/connector/utils/DockerCheck.java
+++ b/connector/src/main/java/org/geysermc/connector/utils/DockerCheck.java
@@ -26,36 +26,13 @@
 
 package org.geysermc.connector.utils;
 
-import org.geysermc.connector.bootstrap.GeyserBootstrap;
-
-import java.net.InetAddress;
 import java.nio.file.Files;
 import java.nio.file.Paths;
 
 public class DockerCheck {
-    public static void check(GeyserBootstrap bootstrap) {
-        try {
-            String OS = System.getProperty("os.name").toLowerCase();
-            String ipAddress = InetAddress.getLocalHost().getHostAddress();
 
-            // Check if the user is already using the recommended IP
-            if (ipAddress.equals(bootstrap.getGeyserConfig().getRemote().getAddress())) {
-                return;
-            }
-
-            if (OS.indexOf("nix") >= 0 || OS.indexOf("nux") >= 0 || OS.indexOf("aix") > 0) {
-                bootstrap.getGeyserLogger().debug("We are on a Unix system, checking for Docker...");
-
-                String output = new String(Files.readAllBytes(Paths.get("/proc/1/cgroup")));
-
-                if (output.contains("docker")) {
-                    bootstrap.getGeyserLogger().warning(LanguageUtils.getLocaleStringLog("geyser.bootstrap.docker_warn.line1"));
-                    bootstrap.getGeyserLogger().warning(LanguageUtils.getLocaleStringLog("geyser.bootstrap.docker_warn.line2", ipAddress));
-                }
-            }
-        } catch (Exception e) { } // Ignore any errors, inc ip failed to fetch, process could not run or access denied
-    }
-
+    // Geyser now sets the IP to the local IP in all cases on plugin versions so we don't notify the user of anything
+    // However we still have this check for the potential future bug
     public static boolean checkBasic() {
         try {
             String OS = System.getProperty("os.name").toLowerCase();

--- a/connector/src/main/resources/config.yml
+++ b/connector/src/main/resources/config.yml
@@ -17,6 +17,7 @@ bedrock:
   motd1: "GeyserMC"
   motd2: "Another GeyserMC forced host."
 remote:
+  # The following two values are ignored for plugin versions
   # The IP address of the remote (Java Edition) server
   address: 127.0.0.1
   # The port of the remote (Java Edition) server


### PR DESCRIPTION
- The Bedrock listening IP is set to the server listening IP
- The Java server IP is auto-set to localhost
- If Floodgate is installed, auth-type is automatically set to Floodgate