### PR TITLE
Fix Spawn position not using offset.

### DIFF
--- a/connector/src/main/java/org/geysermc/connector/network/translators/java/entity/player/JavaPlayerPositionRotationTranslator.java
+++ b/connector/src/main/java/org/geysermc/connector/network/translators/java/entity/player/JavaPlayerPositionRotationTranslator.java
@@ -62,7 +62,7 @@ public class JavaPlayerPositionRotationTranslator extends PacketTranslator<Serve
 
             RespawnPacket respawnPacket = new RespawnPacket();
             respawnPacket.setRuntimeEntityId(entity.getGeyserId());
-            respawnPacket.setPosition(pos);
+            respawnPacket.setPosition(entity.getPosition());
             respawnPacket.setState(RespawnPacket.State.SERVER_READY);
             session.sendUpstreamPacket(respawnPacket);
 
@@ -79,7 +79,7 @@ public class JavaPlayerPositionRotationTranslator extends PacketTranslator<Serve
 
             MovePlayerPacket movePlayerPacket = new MovePlayerPacket();
             movePlayerPacket.setRuntimeEntityId(entity.getGeyserId());
-            movePlayerPacket.setPosition(pos);
+            movePlayerPacket.setPosition(entity.getPosition());
             movePlayerPacket.setRotation(Vector3f.from(packet.getPitch(), packet.getYaw(), 0));
             movePlayerPacket.setMode(MovePlayerPacket.Mode.RESPAWN); //TODO: PROBABLY RIGHT BUT STILL CHECK
 


### PR DESCRIPTION
Solves the player spawning too low. This is especially apparent on a oneblock server or simply creating 1 block far from other blocks setting the player spawn position on top and killing the player, but can be observed in normal gameplay when an open space is close enough underneath for the player to accidentally spawn too far down.