### PR TITLE
Remove Y pos workaround in BedrockItemFrameDropItemTranslator

### DIFF
--- a/connector/src/main/java/org/geysermc/connector/network/translators/bedrock/BedrockItemFrameDropItemTranslator.java
+++ b/connector/src/main/java/org/geysermc/connector/network/translators/bedrock/BedrockItemFrameDropItemTranslator.java
@@ -40,15 +40,7 @@ public class BedrockItemFrameDropItemTranslator extends PacketTranslator<ItemFra
 
     @Override
     public void translate(ItemFrameDropItemPacket packet, GeyserSession session) {
-        // I hope that, when we die, God (or whoever is waiting for us) tells us exactly why this code exists
-        // The packet sends the Y coordinate (and just the Y coordinate) divided by two, and it's negative if it needs to be subtracted by one
-        int y;
-        if (packet.getBlockPosition().getY() > 0) {
-            y = packet.getBlockPosition().getY() * 2;
-        } else {
-            y = (packet.getBlockPosition().getY() * -2) - 1;
-        }
-        Vector3i position = Vector3i.from(packet.getBlockPosition().getX(), y, packet.getBlockPosition().getZ());
+        Vector3i position = Vector3i.from(packet.getBlockPosition().getX(), packet.getBlockPosition().getY(), packet.getBlockPosition().getZ());
         ClientPlayerInteractEntityPacket interactPacket = new ClientPlayerInteractEntityPacket((int) ItemFrameEntity.getItemFrameEntityId(session, position),
                 InteractAction.ATTACK, Hand.MAIN_HAND, session.isSneaking());
         session.sendDownstreamPacket(interactPacket);


### PR DESCRIPTION
This should only be merged once the fix for the underlying problem is merged in CloudburstMC/Protocol#68