### PR TITLE
JavaEntityMetadataTranslator: replace stack trace with concise warning

### DIFF
--- a/connector/src/main/java/org/geysermc/connector/network/translators/java/entity/JavaEntityMetadataTranslator.java
+++ b/connector/src/main/java/org/geysermc/connector/network/translators/java/entity/JavaEntityMetadataTranslator.java
@@ -32,6 +32,7 @@ import org.geysermc.connector.network.translators.Translator;
 
 import com.github.steveice10.mc.protocol.data.game.entity.metadata.EntityMetadata;
 import com.github.steveice10.mc.protocol.packet.ingame.server.entity.ServerEntityMetadataPacket;
+import org.geysermc.connector.utils.LanguageUtils;
 
 @Translator(packet = ServerEntityMetadataPacket.class)
 public class JavaEntityMetadataTranslator extends PacketTranslator<ServerEntityMetadataPacket> {
@@ -45,7 +46,18 @@ public class JavaEntityMetadataTranslator extends PacketTranslator<ServerEntityM
         if (entity == null) return;
 
         for (EntityMetadata metadata : packet.getMetadata()) {
-            entity.updateBedrockMetadata(metadata, session);
+            try {
+                entity.updateBedrockMetadata(metadata, session);
+            } catch (ClassCastException e) {
+                // Class cast exceptions are really the only ones we're going to get in normal gameplay
+                // Because some entity rewriters forget about some values
+                // Any other errors are actual bugs
+                session.getConnector().getLogger().warning(LanguageUtils.getLocaleStringLog("geyser.network.translator.metadata.failed", metadata, entity.getEntityType()));
+                session.getConnector().getLogger().debug("Entity Java ID: " + entity.getEntityId() + ", Geyser ID: " + entity.getGeyserId());
+                if (session.getConnector().getConfig().isDebugMode()) {
+                    e.printStackTrace();
+                }
+            }
         }
 
         entity.updateBedrockMetadata(session);


### PR DESCRIPTION
Removes the stack trace given when a ClassCastException occurs and replaces it with a friendlier message. Class cast errors will happen since some servers send incorrect values, and apparently it is default Minecraft behavior to ignore them.