### PR TITLE
Adding option to use different config file for standalone

### DIFF
--- a/bootstrap/standalone/src/main/java/org/geysermc/platform/standalone/GeyserStandaloneBootstrap.java
+++ b/bootstrap/standalone/src/main/java/org/geysermc/platform/standalone/GeyserStandaloneBootstrap.java
@@ -143,7 +143,7 @@ public class GeyserStandaloneBootstrap implements GeyserBootstrap {
         LoopbackUtil.checkLoopback(geyserLogger);
         
         try {
-            File configFile = FileUtils.fileOrCopiedFromResource(configFilename, (x) -> x.replaceAll("generateduuid", UUID.randomUUID().toString()));
+            File configFile = FileUtils.fileOrCopiedFromResource(new File(configFilename), "config.yml", (x) -> x.replaceAll("generateduuid", UUID.randomUUID().toString()));
             geyserConfig = FileUtils.loadConfig(configFile, GeyserStandaloneConfiguration.class);
         } catch (IOException ex) {
             geyserLogger.severe(LanguageUtils.getLocaleStringLog("geyser.config.failed"), ex);

--- a/bootstrap/standalone/src/main/java/org/geysermc/platform/standalone/GeyserStandaloneBootstrap.java
+++ b/bootstrap/standalone/src/main/java/org/geysermc/platform/standalone/GeyserStandaloneBootstrap.java
@@ -62,22 +62,55 @@ public class GeyserStandaloneBootstrap implements GeyserBootstrap {
 
     @Getter
     private boolean useGui = System.console() == null && !isHeadless();
+    private String configFilename = "config.yml";
 
     private GeyserConnector connector;
 
+
     public static void main(String[] args) {
-        for (String arg : args) {
+        GeyserStandaloneBootstrap bootstrap = new GeyserStandaloneBootstrap();
+        // set defaults
+        boolean useGuiOpts = bootstrap.useGui;
+        String configFilenameOpt = bootstrap.configFilename;
+        for (int i = 0; i < args.length; i++) {
+        //for (String arg : args) {
             // By default, standalone Geyser will check if it should open the GUI based on if the GUI is null
             // Optionally, you can force the use of a GUI or no GUI by specifying args
-            if (arg.equals("gui")) {
-                new GeyserStandaloneBootstrap().onEnable(true);
-                return;
-            } else if (arg.equals("nogui")) {
-                new GeyserStandaloneBootstrap().onEnable(false);
-                return;
+            String arg = args[i];
+            switch (arg) {
+                case "gui":
+                    useGuiOpts = true;
+                    break;
+                case "nogui":
+                    useGuiOpts = false;
+                    break;
+                case "--config":
+                case "-c":
+                    if (i >= args.length - 1) {
+                        System.err.println("Please specify config file");
+                        return;
+                    }
+                    configFilenameOpt = args[i+1]; i++;
+                    break;
+                case "--help":
+                case "-h":
+                    System.out.println("Usage: [java -jar] Geyser.jar [opts] [gui/nogui]");
+                    System.out.println("  Options:");
+                    System.out.println("    -c, --config [file]    use file for config");
+                    System.out.println("    -h, --help             show this help message");
+                    return;
+                default:
+                    System.err.println("Unrecognised argument " + arg);
+                    return;
             }
         }
-        new GeyserStandaloneBootstrap().onEnable();
+        bootstrap.onEnable(useGuiOpts, configFilenameOpt);
+    }
+
+    public void onEnable(boolean useGui, String configFilename) {
+        this.configFilename = configFilename;
+        this.useGui = useGui;
+        this.onEnable();
     }
 
     public void onEnable(boolean useGui) {
@@ -106,7 +139,7 @@ public class GeyserStandaloneBootstrap implements GeyserBootstrap {
         LoopbackUtil.checkLoopback(geyserLogger);
         
         try {
-            File configFile = FileUtils.fileOrCopiedFromResource("config.yml", (x) -> x.replaceAll("generateduuid", UUID.randomUUID().toString()));
+            File configFile = FileUtils.fileOrCopiedFromResource(configFilename, (x) -> x.replaceAll("generateduuid", UUID.randomUUID().toString()));
             geyserConfig = FileUtils.loadConfig(configFile, GeyserStandaloneConfiguration.class);
         } catch (IOException ex) {
             geyserLogger.severe(LanguageUtils.getLocaleStringLog("geyser.config.failed"), ex);

--- a/bootstrap/standalone/src/main/java/org/geysermc/platform/standalone/GeyserStandaloneBootstrap.java
+++ b/bootstrap/standalone/src/main/java/org/geysermc/platform/standalone/GeyserStandaloneBootstrap.java
@@ -76,11 +76,14 @@ public class GeyserStandaloneBootstrap implements GeyserBootstrap {
         for (int i = 0; i < args.length; i++) {
             // By default, standalone Geyser will check if it should open the GUI based on if the GUI is null
             // Optionally, you can force the use of a GUI or no GUI by specifying args
+            // Allows gui and nogui without options, for backwards compatibility
             String arg = args[i];
             switch (arg) {
+                case "--gui":
                 case "gui":
                     useGuiOpts = true;
                     break;
+                case "--nogui":
                 case "nogui":
                     useGuiOpts = false;
                     break;
@@ -94,10 +97,11 @@ public class GeyserStandaloneBootstrap implements GeyserBootstrap {
                     break;
                 case "--help":
                 case "-h":
-                    System.out.println("Usage: [java -jar] Geyser.jar [opts] [gui/nogui]");
+                    System.out.println("Usage: [java -jar] Geyser.jar [opts]");
                     System.out.println("  Options:");
                     System.out.println("    -c, --config [file]    use file for config");
                     System.out.println("    -h, --help             show this help message");
+                    System.out.println("    --gui, --nogui         enable/disable gui");
                     return;
                 default:
                     System.err.println("Unrecognised argument " + arg);

--- a/bootstrap/standalone/src/main/java/org/geysermc/platform/standalone/GeyserStandaloneBootstrap.java
+++ b/bootstrap/standalone/src/main/java/org/geysermc/platform/standalone/GeyserStandaloneBootstrap.java
@@ -49,6 +49,7 @@ import java.io.IOException;
 import java.lang.reflect.Method;
 import java.nio.file.Path;
 import java.nio.file.Paths;
+import java.text.MessageFormat;
 import java.util.UUID;
 
 public class GeyserStandaloneBootstrap implements GeyserBootstrap {
@@ -90,21 +91,18 @@ public class GeyserStandaloneBootstrap implements GeyserBootstrap {
                 case "--config":
                 case "-c":
                     if (i >= args.length - 1) {
-                        System.err.println("Please specify config file");
+                        System.err.println(LanguageUtils.getLocaleStringLog("geyser.bootstrap.args.confignotspecified"));
                         return;
                     }
                     configFilenameOpt = args[i+1]; i++;
                     break;
                 case "--help":
                 case "-h":
-                    System.out.println("Usage: [java -jar] Geyser.jar [opts]");
-                    System.out.println("  Options:");
-                    System.out.println("    -c, --config [file]    use file for config");
-                    System.out.println("    -h, --help             show this help message");
-                    System.out.println("    --gui, --nogui         enable/disable gui");
+                    System.out.println(LanguageUtils.getLocaleStringLog("geyser.bootstrap.args.usage"));
                     return;
                 default:
-                    System.err.println("Unrecognised argument " + arg);
+                    String badArgMsg = LanguageUtils.getLocaleStringLog("geyser.bootstrap.args.unrecognised");
+                    System.err.println(MessageFormat.format(badArgMsg, arg));
                     return;
             }
         }

--- a/bootstrap/standalone/src/main/java/org/geysermc/platform/standalone/GeyserStandaloneBootstrap.java
+++ b/bootstrap/standalone/src/main/java/org/geysermc/platform/standalone/GeyserStandaloneBootstrap.java
@@ -91,7 +91,7 @@ public class GeyserStandaloneBootstrap implements GeyserBootstrap {
                 case "--config":
                 case "-c":
                     if (i >= args.length - 1) {
-                        System.err.println(LanguageUtils.getLocaleStringLog("geyser.bootstrap.args.confignotspecified"));
+                        System.err.println(MessageFormat.format(LanguageUtils.getLocaleStringLog("geyser.bootstrap.args.confignotspecified"), "-c"));
                         return;
                     }
                     configFilenameOpt = args[i+1]; i++;

--- a/bootstrap/standalone/src/main/java/org/geysermc/platform/standalone/GeyserStandaloneBootstrap.java
+++ b/bootstrap/standalone/src/main/java/org/geysermc/platform/standalone/GeyserStandaloneBootstrap.java
@@ -69,11 +69,11 @@ public class GeyserStandaloneBootstrap implements GeyserBootstrap {
 
     public static void main(String[] args) {
         GeyserStandaloneBootstrap bootstrap = new GeyserStandaloneBootstrap();
-        // set defaults
+        // Set defaults
         boolean useGuiOpts = bootstrap.useGui;
         String configFilenameOpt = bootstrap.configFilename;
+
         for (int i = 0; i < args.length; i++) {
-        //for (String arg : args) {
             // By default, standalone Geyser will check if it should open the GUI based on if the GUI is null
             // Optionally, you can force the use of a GUI or no GUI by specifying args
             String arg = args[i];

--- a/bootstrap/standalone/src/main/java/org/geysermc/platform/standalone/GeyserStandaloneBootstrap.java
+++ b/bootstrap/standalone/src/main/java/org/geysermc/platform/standalone/GeyserStandaloneBootstrap.java
@@ -95,10 +95,15 @@ public class GeyserStandaloneBootstrap implements GeyserBootstrap {
                         return;
                     }
                     configFilenameOpt = args[i+1]; i++;
+                    System.out.println(MessageFormat.format(LanguageUtils.getLocaleStringLog("geyser.bootstrap.args.configspecified"), configFilenameOpt));
                     break;
                 case "--help":
                 case "-h":
-                    System.out.println(LanguageUtils.getLocaleStringLog("geyser.bootstrap.args.usage"));
+                    System.out.println(MessageFormat.format(LanguageUtils.getLocaleStringLog("geyser.bootstrap.args.usage"), "[java -jar] Geyser.jar [opts]"));
+                    System.out.println("  " + LanguageUtils.getLocaleStringLog("geyser.bootstrap.args.options"));
+                    System.out.println("    -c, --config [file]    " + LanguageUtils.getLocaleStringLog("geyser.bootstrap.args.config"));
+                    System.out.println("    -h, --help             " + LanguageUtils.getLocaleStringLog("geyser.bootstrap.args.help"));
+                    System.out.println("    --gui, --nogui         " + LanguageUtils.getLocaleStringLog("geyser.bootstrap.args.gui"));
                     return;
                 default:
                     String badArgMsg = LanguageUtils.getLocaleStringLog("geyser.bootstrap.args.unrecognised");


### PR DESCRIPTION
Sort of a quick edit, perhaps could be cleaner. If you have any comments I'd be glad to edit this more.

I think it could be a useful feature, and this isn't the worst way to do command line arguments if you want to take more arguments in the future -- although maybe it's worth looking at something like Argparse. I didn't use that since I didn't want to add an unnecessary dependency.

Tests:
- [x] Compiles, runs with defaults as expected
- [x] `-h`, `--help` work as expected (print message and exit)
- [x] `-c`, `--config` both work as expected
 - [x] `-c` doesn't crash the program if no config specified
 - [x] `gui` and `nogui` still work as expected.

TODO: Look at locale and put strings in there rather than being hardcoded