### PR TITLE
Add 'passthrough-protocol-name' config option

### DIFF
--- a/bootstrap/sponge/src/main/java/org/geysermc/platform/sponge/GeyserSpongeConfiguration.java
+++ b/bootstrap/sponge/src/main/java/org/geysermc/platform/sponge/GeyserSpongeConfiguration.java
@@ -90,6 +90,11 @@ public class GeyserSpongeConfiguration implements GeyserConfiguration {
     }
 
     @Override
+    public boolean isPassthroughProtocolName() {
+        return node.getNode("passthrough-protocol-name").getBoolean(false);
+    }
+
+    @Override
     public boolean isPassthroughPlayerCounts() {
         return node.getNode("passthrough-player-counts").getBoolean(false);
     }

--- a/connector/src/main/java/org/geysermc/connector/configuration/GeyserConfiguration.java
+++ b/connector/src/main/java/org/geysermc/connector/configuration/GeyserConfiguration.java
@@ -36,7 +36,7 @@ import java.util.Map;
 public interface GeyserConfiguration {
 
     // Modify this when you update the config
-    int CURRENT_CONFIG_VERSION = 3;
+    int CURRENT_CONFIG_VERSION = 4;
 
     IBedrockConfiguration getBedrock();
 
@@ -48,6 +48,9 @@ public interface GeyserConfiguration {
 
     @JsonIgnore
     boolean isPassthroughMotd();
+
+    @JsonIgnore
+    boolean isPassthroughProtocolName();
 
     @JsonIgnore
     boolean isPassthroughPlayerCounts();
@@ -99,7 +102,7 @@ public interface GeyserConfiguration {
         String getAddress();
 
         int getPort();
-        
+
         void setAddress(String address);
 
         void setPort(int port);

--- a/connector/src/main/java/org/geysermc/connector/configuration/GeyserConfiguration.java
+++ b/connector/src/main/java/org/geysermc/connector/configuration/GeyserConfiguration.java
@@ -102,7 +102,7 @@ public interface GeyserConfiguration {
         String getAddress();
 
         int getPort();
-
+        
         void setAddress(String address);
 
         void setPort(int port);

--- a/connector/src/main/java/org/geysermc/connector/configuration/GeyserConfiguration.java
+++ b/connector/src/main/java/org/geysermc/connector/configuration/GeyserConfiguration.java
@@ -36,7 +36,7 @@ import java.util.Map;
 public interface GeyserConfiguration {
 
     // Modify this when you update the config
-    int CURRENT_CONFIG_VERSION = 4;
+    int CURRENT_CONFIG_VERSION = 3;
 
     IBedrockConfiguration getBedrock();
 

--- a/connector/src/main/java/org/geysermc/connector/configuration/GeyserJacksonConfiguration.java
+++ b/connector/src/main/java/org/geysermc/connector/configuration/GeyserJacksonConfiguration.java
@@ -57,6 +57,9 @@ public abstract class GeyserJacksonConfiguration implements GeyserConfiguration 
     @JsonProperty("passthrough-player-counts")
     private boolean isPassthroughPlayerCounts;
 
+    @JsonProperty("passthrough-protocol-name")
+    private boolean isPassthroughProtocolName;
+
     @JsonProperty("legacy-ping-passthrough")
     private boolean isLegacyPingPassthrough;
 

--- a/connector/src/main/java/org/geysermc/connector/network/QueryPacketHandler.java
+++ b/connector/src/main/java/org/geysermc/connector/network/QueryPacketHandler.java
@@ -141,6 +141,7 @@ public class QueryPacketHandler {
         String motd;
         String currentPlayerCount;
         String maxPlayerCount;
+        String map;
 
         if (connector.getConfig().isPassthroughMotd() || connector.getConfig().isPassthroughPlayerCounts()) {
             pingInfo = connector.getBootstrap().getGeyserPingPassthrough().getPingInformation();
@@ -162,6 +163,13 @@ public class QueryPacketHandler {
             maxPlayerCount = String.valueOf(connector.getConfig().getMaxPlayers());
         }
 
+        // If passthrough protocol name is enabled let's get the protocol name from the ping response.
+        if (connector.getConfig().isPassthroughProtocolName() && pingInfo != null) {
+            map = String.valueOf((pingInfo.getVersion().getName()));
+        } else {
+            map = GeyserConnector.NAME;
+        }
+
         // Create a hashmap of all game data needed in the query
         Map<String, String> gameData = new HashMap<String, String>();
         gameData.put("hostname", motd);
@@ -169,7 +177,7 @@ public class QueryPacketHandler {
         gameData.put("game_id", "MINECRAFT");
         gameData.put("version", GeyserConnector.BEDROCK_PACKET_CODEC.getMinecraftVersion());
         gameData.put("plugins", "");
-        gameData.put("map", GeyserConnector.NAME);
+        gameData.put("map", map);
         gameData.put("numplayers", currentPlayerCount);
         gameData.put("maxplayers", maxPlayerCount);
         gameData.put("hostport", String.valueOf(connector.getConfig().getBedrock().getPort()));

--- a/connector/src/main/resources/config.yml
+++ b/connector/src/main/resources/config.yml
@@ -50,9 +50,11 @@ floodgate-key-file: public-key.pem
 # Disabling this will prevent command suggestions from being sent and solve freezing for Bedrock clients.
 command-suggestions: true
 
-# The following two options enable "ping passthrough" - the MOTD and/or player count gets retrieved from the Java server.
+# The following three options enable "ping passthrough" - the MOTD and/or player count and/or protocol name gets retrieved from the Java server.
 # Relay the MOTD from the remote server to Bedrock players.
 passthrough-motd: false
+# Relay the protocol name (e.g. BungeeCord [X.X], Paper 1.X) - only really useful when using a custom protocol name!
+passthrough-protocol-name: false
 # Relay the player count and max players from the remote server to Bedrock players.
 passthrough-player-counts: false
 # Enable LEGACY ping passthrough. There is no need to enable this unless your MOTD or player count does not appear properly.
@@ -114,9 +116,9 @@ metrics:
   # UUID of server, don't change!
   uuid: generateduuid
 
-# ADVANCED OPTIONS - DO NOT TOUCH UNLESS YOU KNOW WHAT YOU ARE DOING! 
+# ADVANCED OPTIONS - DO NOT TOUCH UNLESS YOU KNOW WHAT YOU ARE DOING!
 # The internet supports a maximum MTU of 1492 but could cause issues with packet fragmentation.
 # 1400 is the default.
 # mtu: 1400
 
-config-version: 3
+config-version: 4

--- a/connector/src/main/resources/config.yml
+++ b/connector/src/main/resources/config.yml
@@ -121,4 +121,4 @@ metrics:
 # 1400 is the default.
 # mtu: 1400
 
-config-version: 4
+config-version: 3

--- a/connector/src/main/resources/config.yml
+++ b/connector/src/main/resources/config.yml
@@ -54,7 +54,7 @@ command-suggestions: true
 # Relay the MOTD from the remote server to Bedrock players.
 passthrough-motd: false
 # Relay the protocol name (e.g. BungeeCord [X.X], Paper 1.X) - only really useful when using a custom protocol name!
-# This will also show up on sites like MCSrvStatus <mcsrvstat.us>
+# This will also show up on sites like MCSrvStatus. <mcsrvstat.us>
 passthrough-protocol-name: false
 # Relay the player count and max players from the remote server to Bedrock players.
 passthrough-player-counts: false

--- a/connector/src/main/resources/config.yml
+++ b/connector/src/main/resources/config.yml
@@ -50,10 +50,11 @@ floodgate-key-file: public-key.pem
 # Disabling this will prevent command suggestions from being sent and solve freezing for Bedrock clients.
 command-suggestions: true
 
-# The following three options enable "ping passthrough" - the MOTD and/or player count and/or protocol name gets retrieved from the Java server.
+# The following three options enable "ping passthrough" -the MOTD, player count and/or protocol name gets retrieved from the Java server.
 # Relay the MOTD from the remote server to Bedrock players.
 passthrough-motd: false
 # Relay the protocol name (e.g. BungeeCord [X.X], Paper 1.X) - only really useful when using a custom protocol name!
+# This will also show up on sites like MCSrvStatus <mcsrvstat.us>
 passthrough-protocol-name: false
 # Relay the player count and max players from the remote server to Bedrock players.
 passthrough-player-counts: false
@@ -116,7 +117,7 @@ metrics:
   # UUID of server, don't change!
   uuid: generateduuid
 
-# ADVANCED OPTIONS - DO NOT TOUCH UNLESS YOU KNOW WHAT YOU ARE DOING!
+# ADVANCED OPTIONS - DO NOT TOUCH UNLESS YOU KNOW WHAT YOU ARE DOING! 
 # The internet supports a maximum MTU of 1492 but could cause issues with packet fragmentation.
 # 1400 is the default.
 # mtu: 1400


### PR DESCRIPTION
Adds a `passthrough-protocol-name` config option, ~~also bumps the `config-version` to 4.~~ *not needed*

I set it to use the map option as it seems to me that it is not possible to change the actual protocol version - came up to me as `1.16.0 (Vanilla)`?

Not entirely sure if this is something that would be accepted (although I will be using it at least) but worth a shot! As said in the `config.yml` comment, this is only really useful for java servers that show a custom protocol. (popular real-world example: The Hive using `BeeCord`)

Let me know if you need anything!