### PR TITLE
EntityUtils: Properly map 1.14 entity status effects

### DIFF
--- a/connector/src/main/java/org/geysermc/connector/utils/EntityUtils.java
+++ b/connector/src/main/java/org/geysermc/connector/utils/EntityUtils.java
@@ -42,8 +42,7 @@ public class EntityUtils {
             case LUCK:
             case UNLUCK:
             case DOLPHINS_GRACE:
-            case BAD_OMEN:
-            case HERO_OF_THE_VILLAGE:
+                // All Java-exclusive effects as of 1.16.2
                 return 0;
             case LEVITATION:
                 return 24;
@@ -51,6 +50,10 @@ public class EntityUtils {
                 return 26;
             case SLOW_FALLING:
                 return 27;
+            case BAD_OMEN:
+                return 28;
+            case HERO_OF_THE_VILLAGE:
+                return 29;
             default:
                 return effect.ordinal() + 1;
         }


### PR DESCRIPTION
Previously, Hero of the Village and Bad Omen effects were mapped to 0. This commit updates them to their proper Bedrock values.

Fixes #1129