### PR TITLE
Follows specified address/port in remote config for plugin versions: fix #1110

### DIFF
--- a/bootstrap/bungeecord/src/main/java/org/geysermc/platform/bungeecord/GeyserBungeePlugin.java
+++ b/bootstrap/bungeecord/src/main/java/org/geysermc/platform/bungeecord/GeyserBungeePlugin.java
@@ -83,15 +83,14 @@ public class GeyserBungeePlugin extends Plugin implements GeyserBootstrap {
 
             // Don't change the ip if its listening on all interfaces
             // By default this should be 127.0.0.1 but may need to be changed in some circumstances
-            if (!javaAddr.getHostString().equals("0.0.0.0") && !javaAddr.getHostString().equals("")) {
+            if (this.geyserConfig.getRemote().getAddress().equalsIgnoreCase("auto") && !javaAddr.getHostString().equals("0.0.0.0") && !javaAddr.getHostString().equals("")) {
                 this.geyserConfig.getRemote().setAddress(javaAddr.getHostString());
+                this.geyserConfig.getRemote().setPort(javaAddr.getPort());
             }
 
             if (geyserConfig.getBedrock().isCloneRemotePort()) {
                 geyserConfig.getBedrock().setPort(javaAddr.getPort());
             }
-
-            this.geyserConfig.getRemote().setPort(javaAddr.getPort());
         }
 
         this.geyserLogger = new GeyserBungeeLogger(getLogger(), geyserConfig.isDebugMode());

--- a/bootstrap/bungeecord/src/main/java/org/geysermc/platform/bungeecord/GeyserBungeePlugin.java
+++ b/bootstrap/bungeecord/src/main/java/org/geysermc/platform/bungeecord/GeyserBungeePlugin.java
@@ -81,10 +81,8 @@ public class GeyserBungeePlugin extends Plugin implements GeyserBootstrap {
 
             InetSocketAddress javaAddr = listener.getHost();
 
-            // Don't change the ip if its listening on all interfaces
-            // By default this should be 127.0.0.1 but may need to be changed in some circumstances
-            if (this.geyserConfig.getRemote().getAddress().equalsIgnoreCase("auto") && !javaAddr.getHostString().equals("0.0.0.0") && !javaAddr.getHostString().equals("")) {
-                this.geyserConfig.getRemote().setAddress(javaAddr.getHostString());
+            // By default this should be localhost but may need to be changed in some circumstances
+            if (this.geyserConfig.getRemote().getAddress().equalsIgnoreCase("auto")) {
                 this.geyserConfig.getRemote().setPort(javaAddr.getPort());
             }
 

--- a/bootstrap/spigot/src/main/java/org/geysermc/platform/spigot/GeyserSpigotPlugin.java
+++ b/bootstrap/spigot/src/main/java/org/geysermc/platform/spigot/GeyserSpigotPlugin.java
@@ -83,15 +83,14 @@ public class GeyserSpigotPlugin extends JavaPlugin implements GeyserBootstrap {
 
         // Don't change the ip if its listening on all interfaces
         // By default this should be 127.0.0.1 but may need to be changed in some circumstances
-        if (!Bukkit.getIp().equals("0.0.0.0") && !Bukkit.getIp().equals("")) {
+        if (this.geyserConfig.getRemote().getAddress().equalsIgnoreCase("auto") && !Bukkit.getIp().equals("0.0.0.0") && !Bukkit.getIp().equals("")) {
             geyserConfig.getRemote().setAddress(Bukkit.getIp());
+            geyserConfig.getRemote().setPort(Bukkit.getPort());
         }
 
         if (geyserConfig.getBedrock().isCloneRemotePort()) {
             geyserConfig.getBedrock().setPort(Bukkit.getPort());
         }
-
-        geyserConfig.getRemote().setPort(Bukkit.getPort());
 
         this.geyserLogger = new GeyserSpigotLogger(getLogger(), geyserConfig.isDebugMode());
         GeyserConfiguration.checkGeyserConfiguration(geyserConfig, geyserLogger);

--- a/bootstrap/spigot/src/main/java/org/geysermc/platform/spigot/GeyserSpigotPlugin.java
+++ b/bootstrap/spigot/src/main/java/org/geysermc/platform/spigot/GeyserSpigotPlugin.java
@@ -81,10 +81,8 @@ public class GeyserSpigotPlugin extends JavaPlugin implements GeyserBootstrap {
             ex.printStackTrace();
         }
 
-        // Don't change the ip if its listening on all interfaces
-        // By default this should be 127.0.0.1 but may need to be changed in some circumstances
-        if (this.geyserConfig.getRemote().getAddress().equalsIgnoreCase("auto") && !Bukkit.getIp().equals("0.0.0.0") && !Bukkit.getIp().equals("")) {
-            geyserConfig.getRemote().setAddress(Bukkit.getIp());
+        // By default this should be localhost but may need to be changed in some circumstances
+        if (this.geyserConfig.getRemote().getAddress().equalsIgnoreCase("auto")) {
             geyserConfig.getRemote().setPort(Bukkit.getPort());
         }
 

--- a/bootstrap/sponge/src/main/java/org/geysermc/platform/sponge/GeyserSpongePlugin.java
+++ b/bootstrap/sponge/src/main/java/org/geysermc/platform/sponge/GeyserSpongePlugin.java
@@ -104,11 +104,10 @@ public class GeyserSpongePlugin implements GeyserBootstrap {
 
             // Don't change the ip if its listening on all interfaces
             // By default this should be 127.0.0.1 but may need to be changed in some circumstances
-            if (!javaAddr.getHostString().equals("0.0.0.0") && !javaAddr.getHostString().equals("")) {
+            if (this.geyserConfig.getRemote().getAddress().equalsIgnoreCase("auto") && !javaAddr.getHostString().equals("0.0.0.0") && !javaAddr.getHostString().equals("")) {
                 serverIP.setValue("127.0.0.1");
+                serverPort.setValue(javaAddr.getPort());
             }
-
-            serverPort.setValue(javaAddr.getPort());
         }
 
         ConfigurationNode bedrockPort = config.getNode("bedrock").getNode("port");

--- a/bootstrap/sponge/src/main/java/org/geysermc/platform/sponge/GeyserSpongePlugin.java
+++ b/bootstrap/sponge/src/main/java/org/geysermc/platform/sponge/GeyserSpongePlugin.java
@@ -104,8 +104,7 @@ public class GeyserSpongePlugin implements GeyserBootstrap {
 
             // Don't change the ip if its listening on all interfaces
             // By default this should be 127.0.0.1 but may need to be changed in some circumstances
-            if (this.geyserConfig.getRemote().getAddress().equalsIgnoreCase("auto") && !javaAddr.getHostString().equals("0.0.0.0") && !javaAddr.getHostString().equals("")) {
-                serverIP.setValue("127.0.0.1");
+            if (this.geyserConfig.getRemote().getAddress().equalsIgnoreCase("auto")) {
                 serverPort.setValue(javaAddr.getPort());
             }
         }

--- a/bootstrap/standalone/src/main/java/org/geysermc/platform/standalone/GeyserStandaloneBootstrap.java
+++ b/bootstrap/standalone/src/main/java/org/geysermc/platform/standalone/GeyserStandaloneBootstrap.java
@@ -109,7 +109,7 @@ public class GeyserStandaloneBootstrap implements GeyserBootstrap {
             File configFile = FileUtils.fileOrCopiedFromResource("config.yml", (x) -> x.replaceAll("generateduuid", UUID.randomUUID().toString()));
             geyserConfig = FileUtils.loadConfig(configFile, GeyserStandaloneConfiguration.class);
             if (this.geyserConfig.getRemote().getAddress().equalsIgnoreCase("auto")) {
-            	geyserConfig.getRemote().setAddress("127.0.0.1");
+                geyserConfig.getRemote().setAddress("127.0.0.1");
             }
         } catch (IOException ex) {
             geyserLogger.severe(LanguageUtils.getLocaleStringLog("geyser.config.failed"), ex);

--- a/bootstrap/standalone/src/main/java/org/geysermc/platform/standalone/GeyserStandaloneBootstrap.java
+++ b/bootstrap/standalone/src/main/java/org/geysermc/platform/standalone/GeyserStandaloneBootstrap.java
@@ -108,6 +108,9 @@ public class GeyserStandaloneBootstrap implements GeyserBootstrap {
         try {
             File configFile = FileUtils.fileOrCopiedFromResource("config.yml", (x) -> x.replaceAll("generateduuid", UUID.randomUUID().toString()));
             geyserConfig = FileUtils.loadConfig(configFile, GeyserStandaloneConfiguration.class);
+            if (this.geyserConfig.getRemote().getAddress().equalsIgnoreCase("auto")) {
+            	geyserConfig.getRemote().setAddress("127.0.0.1");
+            }
         } catch (IOException ex) {
             geyserLogger.severe(LanguageUtils.getLocaleStringLog("geyser.config.failed"), ex);
             System.exit(0);

--- a/bootstrap/velocity/src/main/java/org/geysermc/platform/velocity/GeyserVelocityPlugin.java
+++ b/bootstrap/velocity/src/main/java/org/geysermc/platform/velocity/GeyserVelocityPlugin.java
@@ -94,15 +94,14 @@ public class GeyserVelocityPlugin implements GeyserBootstrap {
 
         // Don't change the ip if its listening on all interfaces
         // By default this should be 127.0.0.1 but may need to be changed in some circumstances
-        if (!javaAddr.getHostString().equals("0.0.0.0") && !javaAddr.getHostString().equals("")) {
+        if (this.geyserConfig.getRemote().getAddress().equalsIgnoreCase("auto") && !javaAddr.getHostString().equals("0.0.0.0") && !javaAddr.getHostString().equals("")) {
             geyserConfig.getRemote().setAddress(javaAddr.getHostString());
+            geyserConfig.getRemote().setPort(javaAddr.getPort());
         }
 
         if (geyserConfig.getBedrock().isCloneRemotePort()) {
             geyserConfig.getBedrock().setPort(javaAddr.getPort());
         }
-
-        geyserConfig.getRemote().setPort(javaAddr.getPort());
 
         this.geyserLogger = new GeyserVelocityLogger(logger, geyserConfig.isDebugMode());
         GeyserConfiguration.checkGeyserConfiguration(geyserConfig, geyserLogger);

--- a/bootstrap/velocity/src/main/java/org/geysermc/platform/velocity/GeyserVelocityPlugin.java
+++ b/bootstrap/velocity/src/main/java/org/geysermc/platform/velocity/GeyserVelocityPlugin.java
@@ -92,10 +92,8 @@ public class GeyserVelocityPlugin implements GeyserBootstrap {
 
         InetSocketAddress javaAddr = proxyServer.getBoundAddress();
 
-        // Don't change the ip if its listening on all interfaces
-        // By default this should be 127.0.0.1 but may need to be changed in some circumstances
-        if (this.geyserConfig.getRemote().getAddress().equalsIgnoreCase("auto") && !javaAddr.getHostString().equals("0.0.0.0") && !javaAddr.getHostString().equals("")) {
-            geyserConfig.getRemote().setAddress(javaAddr.getHostString());
+        // By default this should be localhost but may need to be changed in some circumstances
+        if (this.geyserConfig.getRemote().getAddress().equalsIgnoreCase("auto")) {
             geyserConfig.getRemote().setPort(javaAddr.getPort());
         }
 

--- a/connector/src/main/java/org/geysermc/connector/GeyserConnector.java
+++ b/connector/src/main/java/org/geysermc/connector/GeyserConnector.java
@@ -53,13 +53,14 @@ import org.geysermc.connector.network.translators.world.WorldManager;
 import org.geysermc.connector.network.translators.world.block.BlockTranslator;
 import org.geysermc.connector.network.translators.world.block.entity.BlockEntityTranslator;
 import org.geysermc.connector.utils.DimensionUtils;
-import org.geysermc.connector.utils.DockerCheck;
 import org.geysermc.connector.utils.LanguageUtils;
 import org.geysermc.connector.utils.LocaleUtils;
 
 import javax.naming.directory.Attribute;
 import javax.naming.directory.InitialDirContext;
+import java.net.InetAddress;
 import java.net.InetSocketAddress;
+import java.net.UnknownHostException;
 import java.text.DecimalFormat;
 import java.util.ArrayList;
 import java.util.List;
@@ -133,8 +134,16 @@ public class GeyserConnector {
         SoundRegistry.init();
         SoundHandlerRegistry.init();
 
-        if (platformType != PlatformType.STANDALONE) {
-            DockerCheck.check(bootstrap);
+        if (platformType != PlatformType.STANDALONE && config.getRemote().getAddress().equals("auto")) {
+            // Set the remote address to localhost since that is where we are always connecting
+            try {
+                config.getRemote().setAddress(InetAddress.getLocalHost().getHostAddress());
+            } catch (UnknownHostException ex) {
+                logger.debug("Unknown host when trying to find localhost.");
+                if (config.isDebugMode()) {
+                    ex.printStackTrace();
+                }
+            }
         }
         String remoteAddress = config.getRemote().getAddress();
         int remotePort = config.getRemote().getPort();

--- a/connector/src/main/java/org/geysermc/connector/utils/DockerCheck.java
+++ b/connector/src/main/java/org/geysermc/connector/utils/DockerCheck.java
@@ -25,36 +25,13 @@
 
 package org.geysermc.connector.utils;
 
-import org.geysermc.connector.bootstrap.GeyserBootstrap;
-
-import java.net.InetAddress;
 import java.nio.file.Files;
 import java.nio.file.Paths;
 
 public class DockerCheck {
-    public static void check(GeyserBootstrap bootstrap) {
-        try {
-            String OS = System.getProperty("os.name").toLowerCase();
-            String ipAddress = InetAddress.getLocalHost().getHostAddress();
 
-            // Check if the user is already using the recommended IP
-            if (ipAddress.equals(bootstrap.getGeyserConfig().getRemote().getAddress())) {
-                return;
-            }
-
-            if (OS.indexOf("nix") >= 0 || OS.indexOf("nux") >= 0 || OS.indexOf("aix") > 0) {
-                bootstrap.getGeyserLogger().debug("We are on a Unix system, checking for Docker...");
-
-                String output = new String(Files.readAllBytes(Paths.get("/proc/1/cgroup")));
-
-                if (output.contains("docker")) {
-                    bootstrap.getGeyserLogger().warning(LanguageUtils.getLocaleStringLog("geyser.bootstrap.docker_warn.line1"));
-                    bootstrap.getGeyserLogger().warning(LanguageUtils.getLocaleStringLog("geyser.bootstrap.docker_warn.line2", ipAddress));
-                }
-            }
-        } catch (Exception e) { } // Ignore any errors, inc ip failed to fetch, process could not run or access denied
-    }
-
+    // By default, Geyser now sets the IP to the local IP in all cases on plugin versions so we don't notify the user of anything
+    // However we still have this check for the potential future bug
     public static boolean checkBasic() {
         try {
             String OS = System.getProperty("os.name").toLowerCase();

--- a/connector/src/main/resources/config.yml
+++ b/connector/src/main/resources/config.yml
@@ -22,10 +22,11 @@ bedrock:
   motd2: "Another GeyserMC forced host."
 remote:
   # The IP address of the remote (Java Edition) server
-  # "auto" means let geyser to choose, in standalone version it will be 127.0.0.1, in plugin version it will de depending on server setting.
+  # If it is "auto", for standalone version the remote address will be set to 127.0.0.1,
+  # for plugins version the remote address will follow the server's listening address.
   address: auto
   # The port of the remote (Java Edition) server
-  # In plugin version, if address has been set to "auto", the port will also depending on server setting.
+  # For plugin versions, if address has been set to "auto", the port will also follow the server's listening port.
   port: 25565
   # Authentication type. Can be offline, online, or floodgate (see https://github.com/GeyserMC/Geyser/wiki/Floodgate).
   auth-type: online

--- a/connector/src/main/resources/config.yml
+++ b/connector/src/main/resources/config.yml
@@ -23,7 +23,7 @@ bedrock:
 remote:
   # The IP address of the remote (Java Edition) server
   # If it is "auto", for standalone version the remote address will be set to 127.0.0.1,
-  # for plugins version the remote address will follow the server's listening address.
+  # for plugin versions, Geyser will attempt to find the best address to connect to.
   address: auto
   # The port of the remote (Java Edition) server
   # For plugin versions, if address has been set to "auto", the port will also follow the server's listening port.

--- a/connector/src/main/resources/config.yml
+++ b/connector/src/main/resources/config.yml
@@ -22,8 +22,10 @@ bedrock:
   motd2: "Another GeyserMC forced host."
 remote:
   # The IP address of the remote (Java Edition) server
-  address: 127.0.0.1
+  # "auto" means let geyser to choose, in standalone version it will be 127.0.0.1, in plugin version it will de depending on server setting.
+  address: auto
   # The port of the remote (Java Edition) server
+  # In plugin version, if address has been set to "auto", the port will also depending on server setting.
   port: 25565
   # Authentication type. Can be offline, online, or floodgate (see https://github.com/GeyserMC/Geyser/wiki/Floodgate).
   auth-type: online


### PR DESCRIPTION
To deal with this problem #1110 , set default remote address setting to "auto". And if it is "auto", for standalone version the remote address will be set to 127.0.0.1, for plugin version the remote address will follow the server's listening address, the port will also follow the server's listening port.