### PR TITLE
Add support for sensitive data in dumps

### DIFF
--- a/bootstrap/bungeecord/src/main/java/org/geysermc/platform/bungeecord/GeyserBungeeDumpInfo.java
+++ b/bootstrap/bungeecord/src/main/java/org/geysermc/platform/bungeecord/GeyserBungeeDumpInfo.java
@@ -28,6 +28,7 @@ package org.geysermc.platform.bungeecord;
 import lombok.Getter;
 import net.md_5.bungee.api.ProxyServer;
 import net.md_5.bungee.api.plugin.Plugin;
+import org.geysermc.connector.common.serializer.AsteriskSerializer;
 import org.geysermc.connector.dump.BootstrapDumpInfo;
 
 import java.util.ArrayList;
@@ -52,7 +53,13 @@ public class GeyserBungeeDumpInfo extends BootstrapDumpInfo {
         this.plugins = new ArrayList<>();
 
         for (net.md_5.bungee.api.config.ListenerInfo listener : proxy.getConfig().getListeners()) {
-            this.listeners.add(new ListenerInfo(listener.getHost().getHostString(), listener.getHost().getPort()));
+            String hostname;
+            if (AsteriskSerializer.showSensitive || (listener.getHost().getHostString().equals("") || listener.getHost().getHostString().equals("0.0.0.0"))) {
+                hostname = listener.getHost().getHostString();
+            } else {
+                hostname = "***";
+            }
+            this.listeners.add(new ListenerInfo(hostname, listener.getHost().getPort()));
         }
 
         for (Plugin plugin : proxy.getPluginManager().getPlugins()) {

--- a/bootstrap/spigot/src/main/java/org/geysermc/platform/spigot/GeyserSpigotDumpInfo.java
+++ b/bootstrap/spigot/src/main/java/org/geysermc/platform/spigot/GeyserSpigotDumpInfo.java
@@ -28,6 +28,7 @@ package org.geysermc.platform.spigot;
 import lombok.Getter;
 import org.bukkit.Bukkit;
 import org.bukkit.plugin.Plugin;
+import org.geysermc.connector.common.serializer.AsteriskSerializer;
 import org.geysermc.connector.dump.BootstrapDumpInfo;
 
 import java.util.ArrayList;
@@ -50,7 +51,11 @@ public class GeyserSpigotDumpInfo extends BootstrapDumpInfo {
         this.platformVersion = Bukkit.getVersion();
         this.platformAPIVersion = Bukkit.getBukkitVersion();
         this.onlineMode = Bukkit.getOnlineMode();
-        this.serverIP = Bukkit.getIp();
+        if (AsteriskSerializer.showSensitive || (Bukkit.getIp().equals("") || Bukkit.getIp().equals("0.0.0.0"))) {
+            this.serverIP = Bukkit.getIp();
+        } else {
+            this.serverIP = "***";
+        }
         this.serverPort = Bukkit.getPort();
         this.plugins = new ArrayList<>();
 

--- a/bootstrap/velocity/src/main/java/org/geysermc/platform/velocity/GeyserVelocityDumpInfo.java
+++ b/bootstrap/velocity/src/main/java/org/geysermc/platform/velocity/GeyserVelocityDumpInfo.java
@@ -28,6 +28,7 @@ package org.geysermc.platform.velocity;
 import com.velocitypowered.api.plugin.PluginContainer;
 import com.velocitypowered.api.proxy.ProxyServer;
 import lombok.Getter;
+import org.geysermc.connector.common.serializer.AsteriskSerializer;
 import org.geysermc.connector.dump.BootstrapDumpInfo;
 
 import java.util.ArrayList;
@@ -50,7 +51,11 @@ public class GeyserVelocityDumpInfo extends BootstrapDumpInfo {
         this.platformVersion = proxy.getVersion().getVersion();
         this.platformVendor = proxy.getVersion().getVendor();
         this.onlineMode = proxy.getConfiguration().isOnlineMode();
-        this.serverIP = proxy.getBoundAddress().getHostString();
+        if (AsteriskSerializer.showSensitive || (proxy.getBoundAddress().getHostString().equals("") || proxy.getBoundAddress().getHostString().equals("0.0.0.0"))) {
+            this.serverIP = proxy.getBoundAddress().getHostString();
+        } else {
+            this.serverIP = "***";
+        }
         this.serverPort = proxy.getBoundAddress().getPort();
         this.plugins = new ArrayList<>();
 

--- a/connector/pom.xml
+++ b/connector/pom.xml
@@ -111,7 +111,7 @@
         <dependency>
             <groupId>com.github.GeyserMC</groupId>
             <artifactId>MCProtocolLib</artifactId>
-            <version>82c20c954c</version>
+            <version>f37c98dc70</version>
             <scope>compile</scope>
             <exclusions>
                 <exclusion>

--- a/connector/src/main/java/org/geysermc/connector/command/defaults/DumpCommand.java
+++ b/connector/src/main/java/org/geysermc/connector/command/defaults/DumpCommand.java
@@ -33,6 +33,7 @@ import org.geysermc.connector.common.ChatColor;
 import org.geysermc.connector.GeyserConnector;
 import org.geysermc.connector.command.CommandSender;
 import org.geysermc.connector.command.GeyserCommand;
+import org.geysermc.connector.common.serializer.AsteriskSerializer;
 import org.geysermc.connector.dump.DumpInfo;
 import org.geysermc.connector.utils.LanguageUtils;
 import org.geysermc.connector.utils.WebUtils;
@@ -49,15 +50,17 @@ public class DumpCommand extends GeyserCommand {
         super(name, description, permission);
 
         this.connector = connector;
-
-        final SimpleFilterProvider filter = new SimpleFilterProvider();
-        filter.addFilter("dump_user_auth", SimpleBeanPropertyFilter.serializeAllExcept(new String[] {"password"}));
-
-        MAPPER.setFilterProvider(filter);
     }
 
     @Override
     public void execute(CommandSender sender, String[] args) {
+        if (args.length >= 1 && "full".equals(args[0])) {
+            AsteriskSerializer.showSensitive = true;
+        } else {
+            AsteriskSerializer.showSensitive = false;
+        }
+
+
         sender.sendMessage(LanguageUtils.getLocaleStringLog("geyser.commands.dump.collecting"));
         String dumpData = "";
         try {

--- a/connector/src/main/java/org/geysermc/connector/command/defaults/DumpCommand.java
+++ b/connector/src/main/java/org/geysermc/connector/command/defaults/DumpCommand.java
@@ -38,6 +38,7 @@ import org.geysermc.connector.dump.DumpInfo;
 import org.geysermc.connector.utils.LanguageUtils;
 import org.geysermc.connector.utils.WebUtils;
 
+import java.io.FileOutputStream;
 import java.io.IOException;
 
 public class DumpCommand extends GeyserCommand {
@@ -54,41 +55,76 @@ public class DumpCommand extends GeyserCommand {
 
     @Override
     public void execute(CommandSender sender, String[] args) {
-        if (args.length >= 1 && "full".equals(args[0])) {
-            AsteriskSerializer.showSensitive = true;
-        } else {
-            AsteriskSerializer.showSensitive = false;
+        boolean showSensitive = false;
+        boolean offlineDump = false;
+        if (args.length >= 1) {
+            for (String arg : args) {
+                switch (arg) {
+                    case "full":
+                        showSensitive = true;
+                        break;
+                    case "offline":
+                        offlineDump = true;
+                        break;
+
+                }
+            }
         }
 
+        AsteriskSerializer.showSensitive = showSensitive;
 
         sender.sendMessage(LanguageUtils.getLocaleStringLog("geyser.commands.dump.collecting"));
         String dumpData = "";
         try {
-            dumpData = MAPPER.writeValueAsString(new DumpInfo());
+            if (offlineDump) {
+                dumpData = MAPPER.writerWithDefaultPrettyPrinter().writeValueAsString(new DumpInfo());
+            } else {
+                dumpData = MAPPER.writeValueAsString(new DumpInfo());
+            }
         } catch (IOException e) {
             sender.sendMessage(ChatColor.RED + LanguageUtils.getLocaleStringLog("geyser.commands.dump.collect_error"));
             connector.getLogger().error(LanguageUtils.getLocaleStringLog("geyser.commands.dump.collect_error_short"), e);
             return;
         }
 
-        sender.sendMessage(LanguageUtils.getLocaleStringLog("geyser.commands.dump.uploading"));
-        String response;
-        JsonNode responseNode;
-        try {
-            response = WebUtils.post(DUMP_URL + "documents", dumpData);
-            responseNode = MAPPER.readTree(response);
-        } catch (IOException e) {
-            sender.sendMessage(ChatColor.RED + LanguageUtils.getLocaleStringLog("geyser.commands.dump.upload_error"));
-            connector.getLogger().error(LanguageUtils.getLocaleStringLog("geyser.commands.dump.upload_error_short"), e);
-            return;
+        String uploadedDumpUrl = "";
+
+        if (offlineDump) {
+            sender.sendMessage(LanguageUtils.getLocaleStringLog("geyser.commands.dump.writing"));
+
+            try {
+                FileOutputStream outputStream = new FileOutputStream(GeyserConnector.getInstance().getBootstrap().getConfigFolder().resolve("dump.json").toFile());
+                outputStream.write(dumpData.getBytes());
+                outputStream.close();
+            } catch (IOException e) {
+                sender.sendMessage(ChatColor.RED + LanguageUtils.getLocaleStringLog("geyser.commands.dump.write_error"));
+                connector.getLogger().error(LanguageUtils.getLocaleStringLog("geyser.commands.dump.write_error_short"), e);
+                return;
+            }
+
+            uploadedDumpUrl = "dump.json";
+        } else {
+            sender.sendMessage(LanguageUtils.getLocaleStringLog("geyser.commands.dump.uploading"));
+
+            String response;
+            JsonNode responseNode;
+            try {
+                response = WebUtils.post(DUMP_URL + "documents", dumpData);
+                responseNode = MAPPER.readTree(response);
+            } catch (IOException e) {
+                sender.sendMessage(ChatColor.RED + LanguageUtils.getLocaleStringLog("geyser.commands.dump.upload_error"));
+                connector.getLogger().error(LanguageUtils.getLocaleStringLog("geyser.commands.dump.upload_error_short"), e);
+                return;
+            }
+
+            if (!responseNode.has("key")) {
+                sender.sendMessage(ChatColor.RED + LanguageUtils.getLocaleStringLog("geyser.commands.dump.upload_error_short") + ": " + (responseNode.has("message") ? responseNode.get("message").asText() : response));
+                return;
+            }
+
+            uploadedDumpUrl = DUMP_URL + responseNode.get("key").asText();
         }
 
-        if (!responseNode.has("key")) {
-            sender.sendMessage(ChatColor.RED + LanguageUtils.getLocaleStringLog("geyser.commands.dump.upload_error_short") + ": " + (responseNode.has("message") ? responseNode.get("message").asText() : response));
-            return;
-        }
-
-        String uploadedDumpUrl = DUMP_URL + responseNode.get("key").asText();
         sender.sendMessage(LanguageUtils.getLocaleStringLog("geyser.commands.dump.message") + " " + ChatColor.DARK_AQUA + uploadedDumpUrl);
         if (!sender.isConsole()) {
             connector.getLogger().info(LanguageUtils.getLocaleStringLog("geyser.commands.dump.created", sender.getName(), uploadedDumpUrl));

--- a/connector/src/main/java/org/geysermc/connector/configuration/GeyserJacksonConfiguration.java
+++ b/connector/src/main/java/org/geysermc/connector/configuration/GeyserJacksonConfiguration.java
@@ -114,6 +114,7 @@ public abstract class GeyserJacksonConfiguration implements GeyserConfiguration 
     public static class RemoteConfiguration implements IRemoteConfiguration {
 
         @Setter
+        @AsteriskSerializer.Asterisk(sensitive = true)
         private String address;
 
         @Setter

--- a/connector/src/main/java/org/geysermc/connector/configuration/GeyserJacksonConfiguration.java
+++ b/connector/src/main/java/org/geysermc/connector/configuration/GeyserJacksonConfiguration.java
@@ -98,6 +98,7 @@ public abstract class GeyserJacksonConfiguration implements GeyserConfiguration 
     @Getter
     public static class BedrockConfiguration implements IBedrockConfiguration {
 
+        @AsteriskSerializer.Asterisk(sensitive = true)
         private String address;
 
         @Setter


### PR DESCRIPTION
Adds optional arguments to the dump command.

- `full` shows sensitive field values in the dump
- `offline` save the dump to a `dump.json` file