### PR TITLE
Add Server Name config option

### DIFF
--- a/bootstrap/sponge/src/main/java/org/geysermc/platform/sponge/GeyserSpongeConfiguration.java
+++ b/bootstrap/sponge/src/main/java/org/geysermc/platform/sponge/GeyserSpongeConfiguration.java
@@ -198,6 +198,11 @@ public class GeyserSpongeConfiguration implements GeyserConfiguration {
         public String getMotd2() {
             return node.getNode("motd2").getString("GeyserMC");
         }
+
+        @Override
+        public String getServerName() {
+            return node.getNode("server-name").getString("Geyser");
+        }
     }
 
     @AllArgsConstructor

--- a/connector/src/main/java/org/geysermc/connector/configuration/GeyserConfiguration.java
+++ b/connector/src/main/java/org/geysermc/connector/configuration/GeyserConfiguration.java
@@ -95,6 +95,8 @@ public interface GeyserConfiguration {
         String getMotd1();
 
         String getMotd2();
+
+        String getServerName();
     }
 
     interface IRemoteConfiguration {

--- a/connector/src/main/java/org/geysermc/connector/configuration/GeyserJacksonConfiguration.java
+++ b/connector/src/main/java/org/geysermc/connector/configuration/GeyserJacksonConfiguration.java
@@ -29,7 +29,6 @@ import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import lombok.Getter;
 import lombok.Setter;
-
 import org.geysermc.connector.GeyserConnector;
 import org.geysermc.connector.common.serializer.AsteriskSerializer;
 

--- a/connector/src/main/java/org/geysermc/connector/configuration/GeyserJacksonConfiguration.java
+++ b/connector/src/main/java/org/geysermc/connector/configuration/GeyserJacksonConfiguration.java
@@ -29,6 +29,8 @@ import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import lombok.Getter;
 import lombok.Setter;
+
+import org.geysermc.connector.GeyserConnector;
 import org.geysermc.connector.common.serializer.AsteriskSerializer;
 
 import java.nio.file.Path;
@@ -112,6 +114,9 @@ public abstract class GeyserJacksonConfiguration implements GeyserConfiguration 
 
         private String motd1;
         private String motd2;
+
+        @JsonProperty("server-name")
+        private String serverName = GeyserConnector.NAME;
     }
 
     @Getter

--- a/connector/src/main/java/org/geysermc/connector/network/session/GeyserSession.java
+++ b/connector/src/main/java/org/geysermc/connector/network/session/GeyserSession.java
@@ -586,8 +586,10 @@ public class GeyserSession implements CommandSender {
         startGamePacket.setFromWorldTemplate(false);
         startGamePacket.setWorldTemplateOptionLocked(false);
 
-        startGamePacket.setLevelId("world");
-        startGamePacket.setLevelName("world");
+        String serverName = connector.getConfig().getBedrock().getServerName();
+        startGamePacket.setLevelId(serverName);
+        startGamePacket.setLevelName(serverName);
+
         startGamePacket.setPremiumWorldTemplateId("00000000-0000-0000-0000-000000000000");
         // startGamePacket.setCurrentTick(0);
         startGamePacket.setEnchantmentSeed(0);

--- a/connector/src/main/resources/config.yml
+++ b/connector/src/main/resources/config.yml
@@ -20,6 +20,8 @@ bedrock:
   # The MOTD that will be broadcasted to Minecraft: Bedrock Edition clients. Irrelevant if "passthrough-motd" is set to true
   motd1: "GeyserMC"
   motd2: "Another GeyserMC forced host."
+  # The Server Name that will be sent fo Minecraft: Bedrock Edition clients. Visible in both the pause menu and the settings menu.
+  server-name: "Geyser"
 remote:
   # The IP address of the remote (Java Edition) server
   # If it is "auto", for standalone version the remote address will be set to 127.0.0.1,

--- a/connector/src/main/resources/config.yml
+++ b/connector/src/main/resources/config.yml
@@ -20,7 +20,7 @@ bedrock:
   # The MOTD that will be broadcasted to Minecraft: Bedrock Edition clients. Irrelevant if "passthrough-motd" is set to true
   motd1: "GeyserMC"
   motd2: "Another GeyserMC forced host."
-  # The Server Name that will be sent fo Minecraft: Bedrock Edition clients. Visible in both the pause menu and the settings menu.
+  # The Server Name that will be sent to Minecraft: Bedrock Edition clients. Visible in both the pause menu and the settings menu.
   server-name: "Geyser"
 remote:
   # The IP address of the remote (Java Edition) server


### PR DESCRIPTION
Shows up both in the pause menu and in the options menu.

Unfortunately this can only be set once for the duration of the session (bedrock protocol limitation) but after #656 we could potentially add an option for using the world-name from the java server.