### PR TITLE
Fix NPE if block data string isn't in mappings

### DIFF
--- a/bootstrap/spigot/src/main/java/org/geysermc/platform/spigot/world/GeyserSpigotBlockPlaceListener.java
+++ b/bootstrap/spigot/src/main/java/org/geysermc/platform/spigot/world/GeyserSpigotBlockPlaceListener.java
@@ -59,7 +59,7 @@ public class GeyserSpigotBlockPlaceListener implements Listener {
                 } else {
                     javaBlockId = event.getBlockPlaced().getBlockData().getAsString();
                 }
-                placeBlockSoundPacket.setExtraData(BlockTranslator.getBedrockBlockId(BlockTranslator.getJavaIdBlockMap().get(javaBlockId)));
+                placeBlockSoundPacket.setExtraData(BlockTranslator.getBedrockBlockId(BlockTranslator.getJavaIdBlockMap().getOrDefault(javaBlockId, 0)));
                 placeBlockSoundPacket.setIdentifier(":");
                 session.sendUpstreamPacket(placeBlockSoundPacket);
                 session.setLastBlockPlacePosition(null);

--- a/bootstrap/spigot/src/main/java/org/geysermc/platform/spigot/world/GeyserSpigotWorldManager.java
+++ b/bootstrap/spigot/src/main/java/org/geysermc/platform/spigot/world/GeyserSpigotWorldManager.java
@@ -25,7 +25,6 @@
 
 package org.geysermc.platform.spigot.world;
 
-import com.github.steveice10.mc.protocol.data.game.entity.player.GameMode;
 import lombok.AllArgsConstructor;
 import org.bukkit.Bukkit;
 import org.bukkit.block.Block;
@@ -49,10 +48,14 @@ public class GeyserSpigotWorldManager extends GeyserWorldManager {
         if (session.getPlayerEntity() == null) {
             return BlockTranslator.AIR;
         }
+        if (Bukkit.getPlayer(session.getPlayerEntity().getUsername()) == null) {
+            return BlockTranslator.AIR;
+        }
         if (isLegacy) {
             return getLegacyBlock(session, x, y, z, isViaVersion);
         }
-        return BlockTranslator.getJavaIdBlockMap().get(Bukkit.getPlayer(session.getPlayerEntity().getUsername()).getWorld().getBlockAt(x, y, z).getBlockData().getAsString());
+        //TODO possibly: detect server version for all versions and use ViaVersion for block state mappings like below
+        return BlockTranslator.getJavaIdBlockMap().getOrDefault(Bukkit.getPlayer(session.getPlayerEntity().getUsername()).getWorld().getBlockAt(x, y, z).getBlockData().getAsString(), 0);
     }
 
     @SuppressWarnings("deprecation")


### PR DESCRIPTION
This happens when the server version is below the current version and the block state changed. A better solution would be to use ViaVersion to translate the block state strings but this would require getting the server version and figuring out mappings from there.

Fixes #997.