### PR TITLE
Add visual support for signs colored with dye

### DIFF
--- a/connector/src/main/java/org/geysermc/connector/network/translators/world/block/entity/SignBlockEntityTranslator.java
+++ b/connector/src/main/java/org/geysermc/connector/network/translators/world/block/entity/SignBlockEntityTranslator.java
@@ -136,13 +136,10 @@ public class SignBlockEntityTranslator extends BlockEntityTranslator {
             case "black":
                 base += '0';
                 break;
+            default:
+                return "";
         }
-
-        if (base.length() > 1) {
-            return base;
-        } else {
-            return "";
-        }
+        return base;
     }
 
 }


### PR DESCRIPTION
This PR fixes #1179.

This PR does not add support for using dyes on signs in Bedrock Edition. It only adds support for signs that are dyed in Minecraft Java Edition.

The usage of the section sign (§) method in Bedrock Edition seems to be broken, maybe that should be looked in to.

Before:
![Picture showing colored signs in Java Edition but not in Bedrock Edition](https://i.ibb.co/vL26YV7/signcolors-before.png)

After:
![Picture showing colored signs in both versions](https://i.ibb.co/cxB3ss9/signcolor.png)
