### PR TITLE
Implement (hopefully) temporary dimension switching fix

### DIFF
--- a/connector/src/main/java/org/geysermc/connector/network/session/GeyserSession.java
+++ b/connector/src/main/java/org/geysermc/connector/network/session/GeyserSession.java
@@ -159,8 +159,6 @@ public class GeyserSession implements CommandSender {
     @Setter
     private Vector3i lastInteractionPosition;
 
-    @Setter
-    private boolean switchingDimension = false;
     private boolean manyDimPackets = false;
     private ServerRespawnPacket lastDimPacket = null;
 

--- a/connector/src/main/java/org/geysermc/connector/network/translators/java/world/JavaChunkDataTranslator.java
+++ b/connector/src/main/java/org/geysermc/connector/network/translators/java/world/JavaChunkDataTranslator.java
@@ -25,25 +25,22 @@
 
 package org.geysermc.connector.network.translators.java.world;
 
-import com.github.steveice10.mc.protocol.data.game.entity.metadata.Position;
 import com.github.steveice10.mc.protocol.packet.ingame.server.world.ServerChunkDataPacket;
 import com.nukkitx.nbt.NBTOutputStream;
 import com.nukkitx.nbt.NbtMap;
 import com.nukkitx.nbt.NbtUtils;
 import com.nukkitx.network.VarInts;
 import com.nukkitx.protocol.bedrock.packet.LevelChunkPacket;
-
 import io.netty.buffer.ByteBuf;
 import io.netty.buffer.ByteBufOutputStream;
 import io.netty.buffer.Unpooled;
-import it.unimi.dsi.fastutil.objects.Object2IntMap;
 import org.geysermc.connector.GeyserConnector;
 import org.geysermc.connector.network.session.GeyserSession;
 import org.geysermc.connector.network.translators.BiomeTranslator;
 import org.geysermc.connector.network.translators.PacketTranslator;
 import org.geysermc.connector.network.translators.Translator;
-import org.geysermc.connector.utils.ChunkUtils;
 import org.geysermc.connector.network.translators.world.chunk.ChunkSection;
+import org.geysermc.connector.utils.ChunkUtils;
 
 @Translator(packet = ServerChunkDataPacket.class)
 public class JavaChunkDataTranslator extends PacketTranslator<ServerChunkDataPacket> {
@@ -99,14 +96,6 @@ public class JavaChunkDataTranslator extends PacketTranslator<ServerChunkDataPac
                 levelChunkPacket.setData(payload);
                 session.sendUpstreamPacket(levelChunkPacket);
 
-                // Some block entities need to be loaded in later or else text doesn't show (signs) or they crash the game (end gateway blocks)
-                for (Object2IntMap.Entry<NbtMap> blockEntityEntry : chunkData.getLoadBlockEntitiesLater().object2IntEntrySet()) {
-                    int x = blockEntityEntry.getKey().getInt("x");
-                    int y = blockEntityEntry.getKey().getInt("y");
-                    int z = blockEntityEntry.getKey().getInt("z");
-                    ChunkUtils.updateBlock(session, blockEntityEntry.getIntValue(), new Position(x, y, z));
-                }
-                chunkData.getLoadBlockEntitiesLater().clear();
                 session.getChunkCache().addToCache(packet.getColumn());
             } catch (Exception ex) {
                 ex.printStackTrace();

--- a/connector/src/main/java/org/geysermc/connector/network/translators/java/world/JavaSpawnPositionTranslator.java
+++ b/connector/src/main/java/org/geysermc/connector/network/translators/java/world/JavaSpawnPositionTranslator.java
@@ -32,6 +32,7 @@ import org.geysermc.connector.network.translators.Translator;
 import com.github.steveice10.mc.protocol.packet.ingame.server.world.ServerSpawnPositionPacket;
 import com.nukkitx.math.vector.Vector3i;
 import com.nukkitx.protocol.bedrock.packet.SetSpawnPositionPacket;
+import org.geysermc.connector.utils.DimensionUtils;
 
 @Translator(packet = ServerSpawnPositionPacket.class)
 public class JavaSpawnPositionTranslator extends PacketTranslator<ServerSpawnPositionPacket> {
@@ -41,6 +42,7 @@ public class JavaSpawnPositionTranslator extends PacketTranslator<ServerSpawnPos
         SetSpawnPositionPacket spawnPositionPacket = new SetSpawnPositionPacket();
         spawnPositionPacket.setBlockPosition(Vector3i.from(packet.getPosition().getX(), packet.getPosition().getY(), packet.getPosition().getZ()));
         spawnPositionPacket.setSpawnForced(true);
+        spawnPositionPacket.setDimensionId(DimensionUtils.javaToBedrock(session.getPlayerEntity().getDimension()));
         spawnPositionPacket.setSpawnType(SetSpawnPositionPacket.Type.WORLD_SPAWN);
         session.sendUpstreamPacket(spawnPositionPacket);
     }

--- a/connector/src/main/java/org/geysermc/connector/utils/ChunkUtils.java
+++ b/connector/src/main/java/org/geysermc/connector/utils/ChunkUtils.java
@@ -271,7 +271,5 @@ public class ChunkUtils {
 
         @Getter
         private NbtMap[] blockEntities = new NbtMap[0];
-        @Getter
-        private Object2IntMap<NbtMap> loadBlockEntitiesLater = new Object2IntOpenHashMap<>();
     }
 }

--- a/connector/src/main/java/org/geysermc/connector/utils/DimensionUtils.java
+++ b/connector/src/main/java/org/geysermc/connector/utils/DimensionUtils.java
@@ -85,6 +85,10 @@ public class DimensionUtils {
         stopSoundPacket.setStoppingAllSound(true);
         stopSoundPacket.setSoundName("");
         session.sendUpstreamPacket(stopSoundPacket);
+
+        // TODO - fix this hack of a fix by sending the final dimension switching logic after chunks have been sent.
+        // The client wants chunks sent to it before it can successfully respawn.
+        ChunkUtils.sendEmptyChunks(session, player.getPosition().toInt(), 3, true);
     }
 
     /**


### PR DESCRIPTION
This fixes rare (?) instances where dimension switching doesn't finish loading on the client. Ideally a proper fix would send the finishing packets in the correct order but I didn't get far in this regard.

Fixes #1154 and #1072.

Other miscellaeous chunk-related fixes have also been included here.