### PR TITLE
connector/pom.xml: Move back to main MCProtocolLib repository

### DIFF
--- a/connector/pom.xml
+++ b/connector/pom.xml
@@ -109,9 +109,9 @@
             <scope>compile</scope>
         </dependency>
         <dependency>
-            <groupId>com.github.GeyserMC</groupId>
-            <artifactId>MCProtocolLib</artifactId>
-            <version>f37c98dc70</version>
+            <groupId>com.github.steveice10</groupId>
+            <artifactId>mcprotocollib</artifactId>
+            <version>b3cf3acbb3</version>
             <scope>compile</scope>
             <exclusions>
                 <exclusion>


### PR DESCRIPTION
Fixes a regression where ClientPlayerAbilitiesPacket was sending the incorrect flag.