### PR TITLE
GeyserSession: Always set Keep Inventory to true

### DIFF
--- a/connector/src/main/java/org/geysermc/connector/network/session/GeyserSession.java
+++ b/connector/src/main/java/org/geysermc/connector/network/session/GeyserSession.java
@@ -305,7 +305,7 @@ public class GeyserSession implements CommandSender {
         // Only allow the server to send health information
         // Setting this to false allows natural regeneration to work false but doesn't break it being true
         gamerulePacket.getGameRules().add(new GameRuleData<>("naturalregeneration", false));
-        // Set Keep Inventory to "true" so the client doesn't try to remove items upon death should Keep Inventory be true
+        // Set Keep Inventory to "true" so the client doesn't try to remove items upon death should Keep Inventory be false
         gamerulePacket.getGameRules().add(new GameRuleData<>("keepinventory", true));
         upstream.sendPacket(gamerulePacket);
     }

--- a/connector/src/main/java/org/geysermc/connector/network/session/GeyserSession.java
+++ b/connector/src/main/java/org/geysermc/connector/network/session/GeyserSession.java
@@ -305,7 +305,8 @@ public class GeyserSession implements CommandSender {
         // Only allow the server to send health information
         // Setting this to false allows natural regeneration to work false but doesn't break it being true
         gamerulePacket.getGameRules().add(new GameRuleData<>("naturalregeneration", false));
-        // Set Keep Inventory to "true" so the client doesn't try to remove items upon death should Keep Inventory be false
+        // Don't let the client modify the inventory on death
+        // Setting this to true allows keep inventory to work if enabled but doesn't break functionality being false
         gamerulePacket.getGameRules().add(new GameRuleData<>("keepinventory", true));
         upstream.sendPacket(gamerulePacket);
     }

--- a/connector/src/main/java/org/geysermc/connector/network/session/GeyserSession.java
+++ b/connector/src/main/java/org/geysermc/connector/network/session/GeyserSession.java
@@ -301,10 +301,12 @@ public class GeyserSession implements CommandSender {
         attributesPacket.setAttributes(attributes);
         upstream.sendPacket(attributesPacket);
 
+        GameRulesChangedPacket gamerulePacket = new GameRulesChangedPacket();
         // Only allow the server to send health information
         // Setting this to false allows natural regeneration to work false but doesn't break it being true
-        GameRulesChangedPacket gamerulePacket = new GameRulesChangedPacket();
         gamerulePacket.getGameRules().add(new GameRuleData<>("naturalregeneration", false));
+        // Set Keep Inventory to "true" so the client doesn't try to remove items upon death should Keep Inventory be true
+        gamerulePacket.getGameRules().add(new GameRuleData<>("keepinventory", true));
         upstream.sendPacket(gamerulePacket);
     }
 


### PR DESCRIPTION
This prevents the client from removing items on death in creative mode if Keep Inventory is true, but doesn't break existing behavior. Essentially, this assures full server-side behavior of the inventory during death.