### PR TITLE
Relocate the rest of our dependencies

### DIFF
--- a/bootstrap/bungeecord/pom.xml
+++ b/bootstrap/bungeecord/pom.xml
@@ -62,12 +62,28 @@
                                     <shadedPattern>org.geysermc.platform.bungeecord.shaded.jni</shadedPattern>
                                 </relocation>
                                 <relocation>
+                                    <pattern>com.fasterxml.jackson</pattern>
+                                    <shadedPattern>org.geysermc.platform.bungeecord.shaded.jackson</shadedPattern>
+                                </relocation>
+                                <relocation>
                                     <pattern>io.netty</pattern>
                                     <shadedPattern>org.geysermc.platform.bungeecord.shaded.netty</shadedPattern>
                                 </relocation>
                                 <relocation>
                                     <pattern>org.reflections</pattern>
                                     <shadedPattern>org.geysermc.platform.bungeecord.shaded.reflections</shadedPattern>
+                                </relocation>
+                                <relocation>
+                                    <pattern>com.google.guava</pattern>
+                                    <shadedPattern>org.geysermc.platform.bungeecord.shaded.guava</shadedPattern>
+                                </relocation>
+                                <relocation>
+                                    <pattern>org.dom4j</pattern>
+                                    <shadedPattern>org.geysermc.platform.bungeecord.shaded.dom4j</shadedPattern>
+                                </relocation>
+                                <relocation>
+                                    <pattern>net.kyori.adventure</pattern>
+                                    <shadedPattern>org.geysermc.platform.bungeecord.shaded.adventure</shadedPattern>
                                 </relocation>
                             </relocations>
                         </configuration>

--- a/bootstrap/spigot/pom.xml
+++ b/bootstrap/spigot/pom.xml
@@ -79,6 +79,18 @@
                                     <pattern>org.reflections</pattern>
                                     <shadedPattern>org.geysermc.platform.spigot.shaded.reflections</shadedPattern>
                                 </relocation>
+                                <relocation>
+                                    <pattern>com.google.guava</pattern>
+                                    <shadedPattern>org.geysermc.platform.spigot.shaded.guava</shadedPattern>
+                                </relocation>
+                                <relocation>
+                                    <pattern>org.dom4j</pattern>
+                                    <shadedPattern>org.geysermc.platform.spigot.shaded.dom4j</shadedPattern>
+                                </relocation>
+                                <relocation>
+                                    <pattern>net.kyori.adventure</pattern>
+                                    <shadedPattern>org.geysermc.platform.spigot.shaded.adventure</shadedPattern>
+                                </relocation>
                             </relocations>
                         </configuration>
                     </execution>

--- a/bootstrap/sponge/pom.xml
+++ b/bootstrap/sponge/pom.xml
@@ -73,6 +73,18 @@
                                     <pattern>org.reflections</pattern>
                                     <shadedPattern>org.geysermc.platform.sponge.shaded.reflections</shadedPattern>
                                 </relocation>
+                                <relocation>
+                                    <pattern>com.google.guava</pattern>
+                                    <shadedPattern>org.geysermc.platform.sponge.shaded.guava</shadedPattern>
+                                </relocation>
+                                <relocation>
+                                    <pattern>org.dom4j</pattern>
+                                    <shadedPattern>org.geysermc.platform.sponge.shaded.dom4j</shadedPattern>
+                                </relocation>
+                                <relocation>
+                                    <pattern>net.kyori.adventure</pattern>
+                                    <shadedPattern>org.geysermc.platform.sponge.shaded.adventure</shadedPattern>
+                                </relocation>
                             </relocations>
                         </configuration>
                     </execution>

--- a/bootstrap/velocity/pom.xml
+++ b/bootstrap/velocity/pom.xml
@@ -58,12 +58,28 @@
                         <configuration>
                             <relocations>
                                 <relocation>
+                                    <pattern>com.fasterxml.jackson</pattern>
+                                    <shadedPattern>org.geysermc.platform.velocity.shaded.jackson</shadedPattern>
+                                </relocation>
+                                <relocation>
                                     <pattern>it.unimi.dsi.fastutil</pattern>
                                     <shadedPattern>org.geysermc.platform.velocity.shaded.fastutil</shadedPattern>
                                 </relocation>
                                 <relocation>
                                     <pattern>org.reflections</pattern>
                                     <shadedPattern>org.geysermc.platform.velocity.shaded.reflections</shadedPattern>
+                                </relocation>
+                                <relocation>
+                                    <pattern>com.google.guava</pattern>
+                                    <shadedPattern>org.geysermc.platform.velocity.shaded.guava</shadedPattern>
+                                </relocation>
+                                <relocation>
+                                    <pattern>org.dom4j</pattern>
+                                    <shadedPattern>org.geysermc.platform.velocity.shaded.dom4j</shadedPattern>
+                                </relocation>
+                                <relocation>
+                                    <pattern>net.kyori.adventure</pattern>
+                                    <shadedPattern>org.geysermc.platform.velocity.shaded.adventure</shadedPattern>
                                 </relocation>
                             </relocations>
                         </configuration>

--- a/connector/pom.xml
+++ b/connector/pom.xml
@@ -137,21 +137,21 @@
             <version>2.1.3</version>
         </dependency>
         <dependency>
-            <groupId>net.kyori</groupId>
+            <groupId>com.github.kyoripowered.adventure</groupId>
             <artifactId>adventure-api</artifactId>
-            <version>4.0.0-SNAPSHOT</version>
+            <version>557865caef</version>
             <scope>compile</scope>
         </dependency>
         <dependency>
-            <groupId>net.kyori</groupId>
+            <groupId>com.github.kyoripowered.adventure</groupId>
             <artifactId>adventure-text-serializer-gson</artifactId>
-            <version>4.0.0-SNAPSHOT</version>
+            <version>557865caef</version>
             <scope>compile</scope>
         </dependency>
         <dependency>
-            <groupId>net.kyori</groupId>
+            <groupId>com.github.kyoripowered.adventure</groupId>
             <artifactId>adventure-text-serializer-legacy</artifactId>
-            <version>4.0.0-SNAPSHOT</version>
+            <version>557865caef</version>
             <scope>compile</scope>
         </dependency>
     </dependencies>


### PR DESCRIPTION
- Relocate all of our dependencies. This does not include MCProtocolLib and Nukkit dependencies at this time as there are no other known plugins that use these dependencies.
- Switch to a static commit for Adventure dependencies.

Tested working on all versions.