### PR TITLE
Translate scoreboard nametag visibility

### DIFF
--- a/connector/src/main/java/org/geysermc/connector/entity/PlayerEntity.java
+++ b/connector/src/main/java/org/geysermc/connector/entity/PlayerEntity.java
@@ -27,6 +27,7 @@ package org.geysermc.connector.entity;
 
 import com.github.steveice10.mc.auth.data.GameProfile;
 import com.github.steveice10.mc.protocol.data.game.entity.metadata.EntityMetadata;
+import com.github.steveice10.mc.protocol.data.game.scoreboard.NameTagVisibility;
 import com.github.steveice10.mc.protocol.data.message.TextMessage;
 import com.github.steveice10.opennbt.tag.builtin.CompoundTag;
 import com.nukkitx.math.vector.Vector3f;
@@ -221,7 +222,18 @@ public class PlayerEntity extends LivingEntity {
             }
             Team team = session.getWorldCache().getScoreboard().getTeamFor(username);
             if (team != null) {
-                metadata.put(EntityData.NAMETAG, team.getPrefix() + MessageUtils.toChatColor(team.getColor()) + username + team.getSuffix());
+                // Cover different visibility settings
+                if (team.getNameTagVisibility() == NameTagVisibility.NEVER) {
+                    metadata.put(EntityData.NAMETAG, "");
+                } else if (team.getNameTagVisibility() == NameTagVisibility.HIDE_FOR_OTHER_TEAMS &&
+                        !team.getEntities().contains(session.getPlayerEntity().getUsername())) {
+                    metadata.put(EntityData.NAMETAG, "");
+                } else if (team.getNameTagVisibility() == NameTagVisibility.HIDE_FOR_OWN_TEAM &&
+                        team.getEntities().contains(session.getPlayerEntity().getUsername())) {
+                    metadata.put(EntityData.NAMETAG, "");
+                } else {
+                    metadata.put(EntityData.NAMETAG, team.getPrefix() + MessageUtils.toChatColor(team.getColor()) + username + team.getSuffix());
+                }
             }
         }
 

--- a/connector/src/main/java/org/geysermc/connector/network/translators/java/scoreboard/JavaTeamTranslator.java
+++ b/connector/src/main/java/org/geysermc/connector/network/translators/java/scoreboard/JavaTeamTranslator.java
@@ -61,6 +61,7 @@ public class JavaTeamTranslator extends PacketTranslator<ServerTeamPacket> {
                 scoreboard.registerNewTeam(packet.getTeamName(), toPlayerSet(packet.getPlayers()))
                         .setName(MessageUtils.getBedrockMessage(packet.getDisplayName()))
                         .setColor(packet.getColor())
+                        .setNameTagVisibility(packet.getNameTagVisibility())
                         .setPrefix(MessageUtils.getTranslatedBedrockMessage(packet.getPrefix(), session.getClientData().getLanguageCode()))
                         .setSuffix(MessageUtils.getTranslatedBedrockMessage(packet.getSuffix(), session.getClientData().getLanguageCode()));
                 break;
@@ -75,6 +76,7 @@ public class JavaTeamTranslator extends PacketTranslator<ServerTeamPacket> {
 
                 team.setName(MessageUtils.getBedrockMessage(packet.getDisplayName()))
                         .setColor(packet.getColor())
+                        .setNameTagVisibility(packet.getNameTagVisibility())
                         .setPrefix(MessageUtils.getTranslatedBedrockMessage(packet.getPrefix(), session.getClientData().getLanguageCode()))
                         .setSuffix(MessageUtils.getTranslatedBedrockMessage(packet.getSuffix(), session.getClientData().getLanguageCode()))
                         .setUpdateType(UpdateType.UPDATE);

--- a/connector/src/main/java/org/geysermc/connector/scoreboard/Team.java
+++ b/connector/src/main/java/org/geysermc/connector/scoreboard/Team.java
@@ -25,6 +25,7 @@
 
 package org.geysermc.connector.scoreboard;
 
+import com.github.steveice10.mc.protocol.data.game.scoreboard.NameTagVisibility;
 import com.github.steveice10.mc.protocol.data.game.scoreboard.TeamColor;
 import it.unimi.dsi.fastutil.objects.ObjectOpenHashSet;
 import lombok.Getter;
@@ -44,6 +45,7 @@ public class Team {
     private UpdateType updateType = UpdateType.ADD;
     private String name;
 
+    private NameTagVisibility nameTagVisibility;
     private String prefix;
     private TeamColor color;
     private String suffix;


### PR DESCRIPTION
This commit adds support for name tag visibility in teams. If a player is set to hide their nametag, it will be hidden from the Bedrock client. Notably, this fixes most NPC nametag hiding, including Citizens. This does not fix some NPC nametag hiding - there are several NPCs in Hypixel that still have a nametag show up, and they are not a part of any team.