### PR TITLE
Relocate Google Common

### DIFF
--- a/bootstrap/bungeecord/pom.xml
+++ b/bootstrap/bungeecord/pom.xml
@@ -74,8 +74,12 @@
                                     <shadedPattern>org.geysermc.platform.bungeecord.shaded.reflections</shadedPattern>
                                 </relocation>
                                 <relocation>
+                                    <pattern>com.google.common</pattern>
+                                    <shadedPattern>org.geysermc.platform.bungeecord.shaded.google.common</shadedPattern>
+                                </relocation>
+                                <relocation>
                                     <pattern>com.google.guava</pattern>
-                                    <shadedPattern>org.geysermc.platform.bungeecord.shaded.guava</shadedPattern>
+                                    <shadedPattern>org.geysermc.platform.bungeecord.shaded.google.guava</shadedPattern>
                                 </relocation>
                                 <relocation>
                                     <pattern>org.dom4j</pattern>

--- a/bootstrap/spigot/pom.xml
+++ b/bootstrap/spigot/pom.xml
@@ -80,8 +80,12 @@
                                     <shadedPattern>org.geysermc.platform.spigot.shaded.reflections</shadedPattern>
                                 </relocation>
                                 <relocation>
+                                    <pattern>com.google.common</pattern>
+                                    <shadedPattern>org.geysermc.platform.spigot.shaded.google.common</shadedPattern>
+                                </relocation>
+                                <relocation>
                                     <pattern>com.google.guava</pattern>
-                                    <shadedPattern>org.geysermc.platform.spigot.shaded.guava</shadedPattern>
+                                    <shadedPattern>org.geysermc.platform.spigot.shaded.google.guava</shadedPattern>
                                 </relocation>
                                 <relocation>
                                     <pattern>org.dom4j</pattern>

--- a/bootstrap/sponge/pom.xml
+++ b/bootstrap/sponge/pom.xml
@@ -74,8 +74,12 @@
                                     <shadedPattern>org.geysermc.platform.sponge.shaded.reflections</shadedPattern>
                                 </relocation>
                                 <relocation>
+                                    <pattern>com.google.common</pattern>
+                                    <shadedPattern>org.geysermc.platform.sponge.shaded.google.common</shadedPattern>
+                                </relocation>
+                                <relocation>
                                     <pattern>com.google.guava</pattern>
-                                    <shadedPattern>org.geysermc.platform.sponge.shaded.guava</shadedPattern>
+                                    <shadedPattern>org.geysermc.platform.sponge.shaded.google.guava</shadedPattern>
                                 </relocation>
                                 <relocation>
                                     <pattern>org.dom4j</pattern>

--- a/bootstrap/velocity/pom.xml
+++ b/bootstrap/velocity/pom.xml
@@ -70,8 +70,12 @@
                                     <shadedPattern>org.geysermc.platform.velocity.shaded.reflections</shadedPattern>
                                 </relocation>
                                 <relocation>
+                                    <pattern>com.google.common</pattern>
+                                    <shadedPattern>org.geysermc.platform.velocity.shaded.google.common</shadedPattern>
+                                </relocation>
+                                <relocation>
                                     <pattern>com.google.guava</pattern>
-                                    <shadedPattern>org.geysermc.platform.velocity.shaded.guava</shadedPattern>
+                                    <shadedPattern>org.geysermc.platform.velocity.shaded.google.guava</shadedPattern>
                                 </relocation>
                                 <relocation>
                                     <pattern>org.dom4j</pattern>


### PR DESCRIPTION
Fixes NoSuchMethodErrors from occuring on certain Spigot servers.