### PR TITLE
GeyserSession: send command permission level OPERATOR if qualified

### DIFF
--- a/connector/src/main/java/org/geysermc/connector/network/session/GeyserSession.java
+++ b/connector/src/main/java/org/geysermc/connector/network/session/GeyserSession.java
@@ -710,7 +710,10 @@ public class GeyserSession implements CommandSender {
     public void sendAdventureSettings() {
         AdventureSettingsPacket adventureSettingsPacket = new AdventureSettingsPacket();
         adventureSettingsPacket.setUniqueEntityId(playerEntity.getGeyserId());
-        adventureSettingsPacket.setCommandPermission(CommandPermission.NORMAL);
+        // Set command permission if OP permission level is high enough
+        // This allows mobile players access to a GUI for doing commands. The commands there do not change above OPERATOR
+        // and all commands there are accessible with OP permission level 2
+        adventureSettingsPacket.setCommandPermission(opPermissionLevel >= 2 ? CommandPermission.OPERATOR : CommandPermission.NORMAL);
         adventureSettingsPacket.setPlayerPermission(PlayerPermission.MEMBER);
 
         Set<AdventureSetting> flags = new HashSet<>();


### PR DESCRIPTION
Mobile clients have a GUI for commands that shows if CommandPermission.OPERATOR or higher is sent. The commands present all require OP permission 2 or higher; therefore we set that command permission if the server tells us we have a OP permission level of 2 or higher.