### PR TITLE
DumpInfo: Mark internal IP as sensitive

### DIFF
--- a/connector/src/main/java/org/geysermc/connector/dump/DumpInfo.java
+++ b/connector/src/main/java/org/geysermc/connector/dump/DumpInfo.java
@@ -31,6 +31,7 @@ import it.unimi.dsi.fastutil.objects.Object2IntMap;
 import it.unimi.dsi.fastutil.objects.Object2IntOpenHashMap;
 import lombok.Getter;
 import org.geysermc.connector.GeyserConnector;
+import org.geysermc.connector.common.serializer.AsteriskSerializer;
 import org.geysermc.connector.configuration.GeyserConfiguration;
 import org.geysermc.connector.network.BedrockProtocol;
 import org.geysermc.connector.network.session.GeyserSession;
@@ -112,16 +113,21 @@ public class DumpInfo {
         private final boolean dockerCheck;
 
         NetworkInfo() {
-            try {
-                // This is the most reliable for getting the main local IP
-                Socket socket = new Socket();
-                socket.connect(new InetSocketAddress("geysermc.org", 80));
-                this.internalIP = socket.getLocalAddress().getHostAddress();
-            } catch (IOException e1) {
+            if (AsteriskSerializer.showSensitive) {
                 try {
-                    // Fallback to the normal way of getting the local IP
-                    this.internalIP = InetAddress.getLocalHost().getHostAddress();
-                } catch (UnknownHostException ignored) { }
+                    // This is the most reliable for getting the main local IP
+                    Socket socket = new Socket();
+                    socket.connect(new InetSocketAddress("geysermc.org", 80));
+                    this.internalIP = socket.getLocalAddress().getHostAddress();
+                } catch (IOException e1) {
+                    try {
+                        // Fallback to the normal way of getting the local IP
+                        this.internalIP = InetAddress.getLocalHost().getHostAddress();
+                    } catch (UnknownHostException ignored) { }
+                }
+            } else {
+                // Sometimes the internal IP is the external IP...
+                this.internalIP = "***";
             }
 
             this.dockerCheck = DockerCheck.checkBasic();


### PR DESCRIPTION
Sometimes the internal IP is the external IP of the server.