### PR TITLE
Remove 'geyser' from parameters when executing a command under Spigot, Bungeecord, Sponge, Velocity

### DIFF
--- a/bootstrap/bungeecord/src/main/java/org/geysermc/platform/bungeecord/command/GeyserBungeeCommandExecutor.java
+++ b/bootstrap/bungeecord/src/main/java/org/geysermc/platform/bungeecord/command/GeyserBungeeCommandExecutor.java
@@ -64,10 +64,10 @@ public class GeyserBungeeCommandExecutor extends Command implements TabExecutor 
                     sender.sendMessage(TextComponent.fromLegacyText(ChatColor.RED + message));
                     return;
                 }
-                getCommand(args[0]).execute(new BungeeCommandSender(sender), Arrays.copyOfRange(args, 1, args.length-1));
+                getCommand(args[0]).execute(new BungeeCommandSender(sender), args.length > 1 ? Arrays.copyOfRange(args, 1, args.length) : new String[0]);
             }
         } else {
-            getCommand("help").execute(new BungeeCommandSender(sender), Arrays.copyOfRange(args, 1, args.length-1));
+            getCommand("help").execute(new BungeeCommandSender(sender), new String[0]);
         }
     }
 

--- a/bootstrap/bungeecord/src/main/java/org/geysermc/platform/bungeecord/command/GeyserBungeeCommandExecutor.java
+++ b/bootstrap/bungeecord/src/main/java/org/geysermc/platform/bungeecord/command/GeyserBungeeCommandExecutor.java
@@ -64,10 +64,10 @@ public class GeyserBungeeCommandExecutor extends Command implements TabExecutor 
                     sender.sendMessage(TextComponent.fromLegacyText(ChatColor.RED + message));
                     return;
                 }
-                getCommand(args[0]).execute(new BungeeCommandSender(sender), args);
+                getCommand(args[0]).execute(new BungeeCommandSender(sender), Arrays.copyOfRange(args, 1, args.length-1));
             }
         } else {
-            getCommand("help").execute(new BungeeCommandSender(sender), args);
+            getCommand("help").execute(new BungeeCommandSender(sender), Arrays.copyOfRange(args, 1, args.length-1));
         }
     }
 

--- a/bootstrap/spigot/src/main/java/org/geysermc/platform/spigot/command/GeyserSpigotCommandExecutor.java
+++ b/bootstrap/spigot/src/main/java/org/geysermc/platform/spigot/command/GeyserSpigotCommandExecutor.java
@@ -59,11 +59,11 @@ public class GeyserSpigotCommandExecutor implements TabExecutor {
                     sender.sendMessage(ChatColor.RED + message);
                     return true;
                 }
-                getCommand(args[0]).execute(new SpigotCommandSender(sender), Arrays.copyOfRange(args, 1, args.length-1));
+                getCommand(args[0]).execute(new SpigotCommandSender(sender), args.length > 1 ? Arrays.copyOfRange(args, 1, args.length) : new String[0]);
                 return true;
             }
         } else {
-            getCommand("help").execute(new SpigotCommandSender(sender), Arrays.copyOfRange(args, 1, args.length-1));
+            getCommand("help").execute(new SpigotCommandSender(sender), new String[0]);
             return true;
         }
         return true;

--- a/bootstrap/spigot/src/main/java/org/geysermc/platform/spigot/command/GeyserSpigotCommandExecutor.java
+++ b/bootstrap/spigot/src/main/java/org/geysermc/platform/spigot/command/GeyserSpigotCommandExecutor.java
@@ -59,11 +59,11 @@ public class GeyserSpigotCommandExecutor implements TabExecutor {
                     sender.sendMessage(ChatColor.RED + message);
                     return true;
                 }
-                getCommand(args[0]).execute(new SpigotCommandSender(sender), args);
+                getCommand(args[0]).execute(new SpigotCommandSender(sender), Arrays.copyOfRange(args, 1, args.length-1));
                 return true;
             }
         } else {
-            getCommand("help").execute(new SpigotCommandSender(sender), args);
+            getCommand("help").execute(new SpigotCommandSender(sender), Arrays.copyOfRange(args, 1, args.length-1));
             return true;
         }
         return true;

--- a/bootstrap/sponge/src/main/java/org/geysermc/platform/sponge/command/GeyserSpongeCommandExecutor.java
+++ b/bootstrap/sponge/src/main/java/org/geysermc/platform/sponge/command/GeyserSpongeCommandExecutor.java
@@ -59,10 +59,10 @@ public class GeyserSpongeCommandExecutor implements CommandCallable {
                     source.sendMessage(Text.of(ChatColor.RED + LanguageUtils.getLocaleStringLog("geyser.bootstrap.command.permission_fail")));
                     return CommandResult.success();
                 }
-                getCommand(args[0]).execute(new SpongeCommandSender(source), Arrays.copyOfRange(args, 1, args.length-1));
+                getCommand(args[0]).execute(new SpongeCommandSender(source), args.length > 1 ? Arrays.copyOfRange(args, 1, args.length) : new String[0]);
             }
         } else {
-            getCommand("help").execute(new SpongeCommandSender(source), Arrays.copyOfRange(args, 1, args.length-1));
+            getCommand("help").execute(new SpongeCommandSender(source), new String[0]);
         }
         return CommandResult.success();
     }

--- a/bootstrap/sponge/src/main/java/org/geysermc/platform/sponge/command/GeyserSpongeCommandExecutor.java
+++ b/bootstrap/sponge/src/main/java/org/geysermc/platform/sponge/command/GeyserSpongeCommandExecutor.java
@@ -59,10 +59,10 @@ public class GeyserSpongeCommandExecutor implements CommandCallable {
                     source.sendMessage(Text.of(ChatColor.RED + LanguageUtils.getLocaleStringLog("geyser.bootstrap.command.permission_fail")));
                     return CommandResult.success();
                 }
-                getCommand(args[0]).execute(new SpongeCommandSender(source), args);
+                getCommand(args[0]).execute(new SpongeCommandSender(source), Arrays.copyOfRange(args, 1, args.length-1));
             }
         } else {
-            getCommand("help").execute(new SpongeCommandSender(source), args);
+            getCommand("help").execute(new SpongeCommandSender(source), Arrays.copyOfRange(args, 1, args.length-1));
         }
         return CommandResult.success();
     }

--- a/bootstrap/velocity/src/main/java/org/geysermc/platform/velocity/command/GeyserVelocityCommandExecutor.java
+++ b/bootstrap/velocity/src/main/java/org/geysermc/platform/velocity/command/GeyserVelocityCommandExecutor.java
@@ -53,10 +53,10 @@ public class GeyserVelocityCommandExecutor implements Command {
                     source.sendMessage(TextComponent.of(ChatColor.RED + LanguageUtils.getLocaleStringLog("geyser.bootstrap.command.permission_fail")));
                     return;
                 }
-                getCommand(args[0]).execute(new VelocityCommandSender(source), Arrays.copyOfRange(args, 1, args.length-1));
+                getCommand(args[0]).execute(new VelocityCommandSender(source), args.length > 1 ? Arrays.copyOfRange(args, 1, args.length) : new String[0]);
             }
         } else {
-            getCommand("help").execute(new VelocityCommandSender(source), Arrays.copyOfRange(args, 1, args.length-1));
+            getCommand("help").execute(new VelocityCommandSender(source), new String[0]);
         }
     }
 

--- a/bootstrap/velocity/src/main/java/org/geysermc/platform/velocity/command/GeyserVelocityCommandExecutor.java
+++ b/bootstrap/velocity/src/main/java/org/geysermc/platform/velocity/command/GeyserVelocityCommandExecutor.java
@@ -37,6 +37,8 @@ import org.geysermc.connector.GeyserConnector;
 import org.geysermc.connector.command.GeyserCommand;
 import org.geysermc.connector.utils.LanguageUtils;
 
+import java.util.Arrays;
+
 @AllArgsConstructor
 public class GeyserVelocityCommandExecutor implements Command {
 
@@ -51,10 +53,10 @@ public class GeyserVelocityCommandExecutor implements Command {
                     source.sendMessage(TextComponent.of(ChatColor.RED + LanguageUtils.getLocaleStringLog("geyser.bootstrap.command.permission_fail")));
                     return;
                 }
-                getCommand(args[0]).execute(new VelocityCommandSender(source), args);
+                getCommand(args[0]).execute(new VelocityCommandSender(source), Arrays.copyOfRange(args, 1, args.length-1));
             }
         } else {
-            getCommand("help").execute(new VelocityCommandSender(source), args);
+            getCommand("help").execute(new VelocityCommandSender(source), Arrays.copyOfRange(args, 1, args.length-1));
         }
     }
 


### PR DESCRIPTION
Geyser removes the first argument when run standalone but retains it when run as a plugin.
This brings everything into a consistent manner.


## Todo
* [x] Test it with a custom command (I'll do this once GeyserReversion updates)

## Resolves
Fixes https://github.com/bundabrg/GeyserReversion/issues/8