### PR TITLE
Fix inconsistencies with players and the player list

### DIFF
--- a/connector/src/main/java/org/geysermc/connector/entity/PlayerEntity.java
+++ b/connector/src/main/java/org/geysermc/connector/entity/PlayerEntity.java
@@ -118,7 +118,7 @@ public class PlayerEntity extends LivingEntity {
     }
 
     public void sendPlayer(GeyserSession session) {
-        if(session.getEntityCache().getPlayerEntity(uuid) == null)
+        if (session.getEntityCache().getPlayerEntity(uuid) == null)
             return;
 
         if (session.getUpstream().isInitialized() && session.getEntityCache().getEntityByGeyserId(geyserId) == null) {

--- a/connector/src/main/java/org/geysermc/connector/network/session/cache/EntityCache.java
+++ b/connector/src/main/java/org/geysermc/connector/network/session/cache/EntityCache.java
@@ -76,9 +76,6 @@ public class EntityCache {
         if (entity != null && entity.isValid() && (force || entity.despawnEntity(session))) {
             long geyserId = entityIdTranslations.remove(entity.getEntityId());
             entities.remove(geyserId);
-            if (entity.is(PlayerEntity.class)) {
-                playerEntities.remove(entity.as(PlayerEntity.class).getUuid());
-            }
             return true;
         }
         return false;

--- a/connector/src/main/java/org/geysermc/connector/network/translators/java/entity/player/JavaPlayerListEntryTranslator.java
+++ b/connector/src/main/java/org/geysermc/connector/network/translators/java/entity/player/JavaPlayerListEntryTranslator.java
@@ -90,10 +90,10 @@ public class JavaPlayerListEntryTranslator extends PacketTranslator<ServerPlayer
                     PlayerEntity entity = session.getEntityCache().getPlayerEntity(entry.getProfile().getId());
                     if (entity != null) {
                         // Just remove the entity's player list status
-                        // Don't despawn the entity - the server will also take care of that.
+                        // Don't despawn the entity - the Java server will also take care of that.
                         entity.setPlayerList(false);
                     }
-                    // just remove it from caching
+                    // As the player entity is no longer present, we can remove the entry
                     session.getEntityCache().removePlayerEntity(entry.getProfile().getId());
                     if (entity == session.getPlayerEntity()) {
                         // If removing ourself we use our AuthData UUID

--- a/connector/src/main/java/org/geysermc/connector/network/translators/java/entity/player/JavaPlayerListEntryTranslator.java
+++ b/connector/src/main/java/org/geysermc/connector/network/translators/java/entity/player/JavaPlayerListEntryTranslator.java
@@ -88,18 +88,13 @@ public class JavaPlayerListEntryTranslator extends PacketTranslator<ServerPlayer
                     break;
                 case REMOVE_PLAYER:
                     PlayerEntity entity = session.getEntityCache().getPlayerEntity(entry.getProfile().getId());
-                    if (entity != null && entity.isValid()) {
-                        // remove from tablist but player entity is still there
+                    if (entity != null) {
+                        // Just remove the entity's player list status
+                        // Don't despawn the entity - the server will also take care of that.
                         entity.setPlayerList(false);
-                    } else {
-                        if (entity == null) {
-                            // just remove it from caching
-                            session.getEntityCache().removePlayerEntity(entry.getProfile().getId());
-                        } else {
-                            entity.setPlayerList(false);
-                            session.getEntityCache().removeEntity(entity, false);
-                        }
                     }
+                    // just remove it from caching
+                    session.getEntityCache().removePlayerEntity(entry.getProfile().getId());
                     if (entity == session.getPlayerEntity()) {
                         // If removing ourself we use our AuthData UUID
                         translate.getEntries().add(new PlayerListPacket.Entry(session.getAuthData().getUUID()));


### PR DESCRIPTION
This commit makes the player list entry packet control the player cache, fixing inconsistencies that appeared when removing the override on despawning the player.