### PR TITLE
Only send the client brand on game join

### DIFF
--- a/connector/src/main/java/org/geysermc/connector/network/translators/java/JavaJoinGameTranslator.java
+++ b/connector/src/main/java/org/geysermc/connector/network/translators/java/JavaJoinGameTranslator.java
@@ -28,6 +28,7 @@ package org.geysermc.connector.network.translators.java;
 import com.github.steveice10.mc.protocol.data.game.entity.player.HandPreference;
 import com.github.steveice10.mc.protocol.data.game.setting.ChatVisibility;
 import com.github.steveice10.mc.protocol.data.game.setting.SkinPart;
+import com.github.steveice10.mc.protocol.packet.ingame.client.ClientPluginMessagePacket;
 import com.github.steveice10.mc.protocol.packet.ingame.client.ClientSettingsPacket;
 import com.github.steveice10.mc.protocol.packet.ingame.server.ServerJoinGamePacket;
 import com.nukkitx.protocol.bedrock.data.GameRuleData;
@@ -38,6 +39,7 @@ import org.geysermc.connector.network.session.GeyserSession;
 import org.geysermc.connector.network.translators.PacketTranslator;
 import org.geysermc.connector.network.translators.Translator;
 import org.geysermc.connector.utils.DimensionUtils;
+import org.geysermc.connector.utils.PluginMessageUtils;
 
 import java.util.Arrays;
 import java.util.List;
@@ -91,6 +93,8 @@ public class JavaJoinGameTranslator extends PacketTranslator<ServerJoinGamePacke
         List<SkinPart> skinParts = Arrays.asList(SkinPart.values());
         ClientSettingsPacket clientSettingsPacket = new ClientSettingsPacket(locale, (byte) session.getRenderDistance(), ChatVisibility.FULL, true, skinParts, HandPreference.RIGHT_HAND);
         session.sendDownstreamPacket(clientSettingsPacket);
+
+        session.sendDownstreamPacket(new ClientPluginMessagePacket("minecraft:brand", PluginMessageUtils.getGeyserBrandData()));
 
         if (!newDimension.equals(entity.getDimension())) {
             DimensionUtils.switchDimension(session, newDimension);

--- a/connector/src/main/java/org/geysermc/connector/utils/PluginMessageUtils.java
+++ b/connector/src/main/java/org/geysermc/connector/utils/PluginMessageUtils.java
@@ -23,39 +23,29 @@
  * @link https://github.com/GeyserMC/Geyser
  */
 
-package org.geysermc.connector.network.translators.java;
+package org.geysermc.connector.utils;
 
 import org.geysermc.connector.GeyserConnector;
-import org.geysermc.connector.network.session.GeyserSession;
-import org.geysermc.connector.network.translators.PacketTranslator;
-import org.geysermc.connector.network.translators.Translator;
-
-import com.github.steveice10.mc.protocol.packet.ingame.client.ClientPluginMessagePacket;
-import com.github.steveice10.mc.protocol.packet.ingame.server.ServerPluginMessagePacket;
 
 import java.nio.charset.StandardCharsets;
 
-@Translator(packet = ServerPluginMessagePacket.class)
-public class JavaPluginMessageTranslator extends PacketTranslator<ServerPluginMessagePacket> {
+public class PluginMessageUtils {
 
-    private static byte[] brandData;
+    private static final byte[] BRAND_DATA;
 
     static {
         byte[] data = GeyserConnector.NAME.getBytes(StandardCharsets.UTF_8);
         byte[] varInt = writeVarInt(data.length);
-        brandData = new byte[varInt.length + data.length];
-        System.arraycopy(varInt, 0, brandData, 0, varInt.length);
-        System.arraycopy(data, 0, brandData, varInt.length, data.length);
+        BRAND_DATA = new byte[varInt.length + data.length];
+        System.arraycopy(varInt, 0, BRAND_DATA, 0, varInt.length);
+        System.arraycopy(data, 0, BRAND_DATA, varInt.length, data.length);
     }
 
-
-    @Override
-    public void translate(ServerPluginMessagePacket packet, GeyserSession session) {
-        if (packet.getChannel().equals("minecraft:brand")) {
-            session.sendDownstreamPacket(
-                    new ClientPluginMessagePacket(packet.getChannel(), brandData)
-            );
-        }
+    /**
+     * @return the brand information of the Geyser client
+     */
+    public static byte[] getGeyserBrandData() {
+        return BRAND_DATA;
     }
 
     private static byte[] writeVarInt(int value) {
@@ -85,4 +75,5 @@ public class JavaPluginMessageTranslator extends PacketTranslator<ServerPluginMe
         }
         return 5;
     }
+
 }

--- a/connector/src/main/java/org/geysermc/connector/utils/PluginMessageUtils.java
+++ b/connector/src/main/java/org/geysermc/connector/utils/PluginMessageUtils.java
@@ -42,6 +42,7 @@ public class PluginMessageUtils {
     }
 
     /**
+     * Get the prebuilt brand as a byte array
      * @return the brand information of the Geyser client
      */
     public static byte[] getGeyserBrandData() {
@@ -75,5 +76,4 @@ public class PluginMessageUtils {
         }
         return 5;
     }
-
 }


### PR DESCRIPTION
Matches vanilla behavior and prevents BungeeCord from throwing a fit at random.