### PR TITLE
Implement entity spectating

### DIFF
--- a/connector/src/main/java/org/geysermc/connector/entity/Entity.java
+++ b/connector/src/main/java/org/geysermc/connector/entity/Entity.java
@@ -56,16 +56,15 @@ import org.geysermc.connector.utils.AttributeUtils;
 import org.geysermc.connector.utils.ChunkUtils;
 import org.geysermc.connector.utils.MessageUtils;
 
-import java.util.ArrayList;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
+import java.util.*;
 
 @Getter
 @Setter
 public class Entity {
     protected long entityId;
     protected long geyserId;
+
+    protected UUID javaUuid;
 
     protected String dimension;
 

--- a/connector/src/main/java/org/geysermc/connector/network/session/GeyserSession.java
+++ b/connector/src/main/java/org/geysermc/connector/network/session/GeyserSession.java
@@ -47,13 +47,11 @@ import com.nukkitx.protocol.bedrock.BedrockPacket;
 import com.nukkitx.protocol.bedrock.BedrockServerSession;
 import com.nukkitx.protocol.bedrock.data.*;
 import com.nukkitx.protocol.bedrock.data.command.CommandPermission;
-import com.nukkitx.protocol.bedrock.data.entity.EntityData;
 import com.nukkitx.protocol.bedrock.data.entity.EntityLinkData;
 import com.nukkitx.protocol.bedrock.packet.*;
 import it.unimi.dsi.fastutil.longs.Long2ObjectMap;
 import it.unimi.dsi.fastutil.longs.Long2ObjectMaps;
 import it.unimi.dsi.fastutil.longs.Long2ObjectOpenHashMap;
-import it.unimi.dsi.fastutil.longs.LongOpenHashSet;
 import it.unimi.dsi.fastutil.objects.Object2LongMap;
 import it.unimi.dsi.fastutil.objects.Object2LongOpenHashMap;
 import lombok.Getter;
@@ -65,7 +63,6 @@ import org.geysermc.connector.command.CommandSender;
 import org.geysermc.connector.common.AuthType;
 import org.geysermc.connector.entity.Entity;
 import org.geysermc.connector.entity.PlayerEntity;
-import org.geysermc.connector.entity.type.EntityType;
 import org.geysermc.connector.inventory.PlayerInventory;
 import org.geysermc.connector.network.remote.RemoteServer;
 import org.geysermc.connector.network.session.auth.AuthData;
@@ -799,14 +796,5 @@ public class GeyserSession implements CommandSender {
         Vector3f rot = spectatingEntity.getRotation();
 
         playerEntity.updatePositionAndRotation(this, pos.getX(), pos.getY(), pos.getZ(), rot.getZ(), rot.getY(), spectatingEntity.isOnGround());
-
-        SetTitlePacket setTitlePacket = new SetTitlePacket();
-        setTitlePacket.setFadeOutTime(0);
-        setTitlePacket.setFadeInTime(0);
-        setTitlePacket.setStayTime(30);
-        setTitlePacket.setText("Sending position: " + pos.getX() + " " + pos.getY() + " " + pos.getZ());
-        setTitlePacket.setType(SetTitlePacket.Type.ACTIONBAR);
-
-        this.sendUpstreamPacket(setTitlePacket);
     }
 }

--- a/connector/src/main/java/org/geysermc/connector/network/translators/bedrock/BedrockInventoryTransactionTranslator.java
+++ b/connector/src/main/java/org/geysermc/connector/network/translators/bedrock/BedrockInventoryTransactionTranslator.java
@@ -246,7 +246,7 @@ public class BedrockInventoryTransactionTranslator extends PacketTranslator<Inve
                     case 0: //Interact
                         if (session.getGameMode() == GameMode.SPECTATOR) {
                             if (entity.getJavaUuid() == null) {
-                                GeyserConnector.getInstance().getLogger().warning("DEBUG: Tried to spectate entity with no Java UUID");
+                                GeyserConnector.getInstance().getLogger().debug("Tried to spectate entity with no Java UUID");
                                 return;
                             }
                             session.sendDownstreamPacket(new ClientSpectatePacket(entity.getJavaUuid()));

--- a/connector/src/main/java/org/geysermc/connector/network/translators/bedrock/BedrockInventoryTransactionTranslator.java
+++ b/connector/src/main/java/org/geysermc/connector/network/translators/bedrock/BedrockInventoryTransactionTranslator.java
@@ -36,6 +36,7 @@ import com.github.steveice10.mc.protocol.packet.ingame.client.player.ClientPlaye
 import com.github.steveice10.mc.protocol.packet.ingame.client.player.ClientPlayerInteractEntityPacket;
 import com.github.steveice10.mc.protocol.packet.ingame.client.player.ClientPlayerPlaceBlockPacket;
 import com.github.steveice10.mc.protocol.packet.ingame.client.player.ClientPlayerUseItemPacket;
+import com.github.steveice10.mc.protocol.packet.ingame.client.world.ClientSpectatePacket;
 import com.nukkitx.math.vector.Vector3f;
 import com.nukkitx.math.vector.Vector3i;
 import com.nukkitx.protocol.bedrock.data.LevelEventType;
@@ -45,6 +46,7 @@ import com.nukkitx.protocol.bedrock.packet.ContainerOpenPacket;
 import com.nukkitx.protocol.bedrock.packet.InventorySlotPacket;
 import com.nukkitx.protocol.bedrock.packet.InventoryTransactionPacket;
 import com.nukkitx.protocol.bedrock.packet.LevelEventPacket;
+import org.geysermc.connector.GeyserConnector;
 import org.geysermc.connector.entity.CommandBlockMinecartEntity;
 import org.geysermc.connector.entity.Entity;
 import org.geysermc.connector.entity.ItemFrameEntity;
@@ -242,6 +244,15 @@ public class BedrockInventoryTransactionTranslator extends PacketTranslator<Inve
                 //https://wiki.vg/Protocol#Interact_Entity
                 switch (packet.getActionType()) {
                     case 0: //Interact
+                        if (session.getGameMode() == GameMode.SPECTATOR) {
+                            if (entity.getJavaUuid() == null) {
+                                GeyserConnector.getInstance().getLogger().warning("DEBUG: Tried to spectate entity with no Java UUID");
+                                return;
+                            }
+                            session.sendDownstreamPacket(new ClientSpectatePacket(entity.getJavaUuid()));
+                            return;
+                        }
+
                         if (entity instanceof CommandBlockMinecartEntity) {
                             // The UI is handled client-side on Java Edition
                             // Ensure OP permission level and gamemode is appropriate

--- a/connector/src/main/java/org/geysermc/connector/network/translators/bedrock/entity/player/BedrockInteractTranslator.java
+++ b/connector/src/main/java/org/geysermc/connector/network/translators/bedrock/entity/player/BedrockInteractTranslator.java
@@ -77,10 +77,6 @@ public class BedrockInteractTranslator extends PacketTranslator<InteractPacket> 
                 ClientPlayerStatePacket sneakPacket = new ClientPlayerStatePacket((int) entity.getEntityId(), PlayerState.START_SNEAKING);
                 session.sendDownstreamPacket(sneakPacket);
                 session.setRidingVehicleEntity(null);
-
-                if (session.getGameMode() == GameMode.SPECTATOR && session.getSpectatingEntity() != null) {
-                    //session.stopSpectatingEntity();
-                }
                 break;
             case MOUSEOVER:
                 // Handle the buttons for mobile - "Mount", etc; and the suggestions for console - "ZL: Mount", etc

--- a/connector/src/main/java/org/geysermc/connector/network/translators/bedrock/entity/player/BedrockInteractTranslator.java
+++ b/connector/src/main/java/org/geysermc/connector/network/translators/bedrock/entity/player/BedrockInteractTranslator.java
@@ -25,6 +25,7 @@
 
 package org.geysermc.connector.network.translators.bedrock.entity.player;
 
+import com.github.steveice10.mc.protocol.data.game.entity.player.GameMode;
 import com.nukkitx.protocol.bedrock.data.entity.EntityData;
 import com.nukkitx.protocol.bedrock.data.entity.EntityDataMap;
 import com.nukkitx.protocol.bedrock.data.entity.EntityFlag;
@@ -76,6 +77,10 @@ public class BedrockInteractTranslator extends PacketTranslator<InteractPacket> 
                 ClientPlayerStatePacket sneakPacket = new ClientPlayerStatePacket((int) entity.getEntityId(), PlayerState.START_SNEAKING);
                 session.sendDownstreamPacket(sneakPacket);
                 session.setRidingVehicleEntity(null);
+
+                if (session.getGameMode() == GameMode.SPECTATOR && session.getSpectatingEntity() != null) {
+                    //session.stopSpectatingEntity();
+                }
                 break;
             case MOUSEOVER:
                 // Handle the buttons for mobile - "Mount", etc; and the suggestions for console - "ZL: Mount", etc

--- a/connector/src/main/java/org/geysermc/connector/network/translators/java/entity/JavaEntityPositionRotationTranslator.java
+++ b/connector/src/main/java/org/geysermc/connector/network/translators/java/entity/JavaEntityPositionRotationTranslator.java
@@ -43,5 +43,9 @@ public class JavaEntityPositionRotationTranslator extends PacketTranslator<Serve
         if (entity == null) return;
 
         entity.updatePositionAndRotation(session, packet.getMoveX(), packet.getMoveY(), packet.getMoveZ(), packet.getYaw(), packet.getPitch(), packet.isOnGround());
+
+        if (session.getSpectatingEntity() != null && session.getSpectatingEntity().getGeyserId() == entity.getGeyserId()) {
+            session.sendSpectateLocation();
+        }
     }
 }

--- a/connector/src/main/java/org/geysermc/connector/network/translators/java/entity/JavaEntityPositionTranslator.java
+++ b/connector/src/main/java/org/geysermc/connector/network/translators/java/entity/JavaEntityPositionTranslator.java
@@ -44,5 +44,9 @@ public class JavaEntityPositionTranslator extends PacketTranslator<ServerEntityP
         if (entity == null) return;
 
         entity.moveRelative(session, packet.getMoveX(), packet.getMoveY(), packet.getMoveZ(), entity.getRotation(), packet.isOnGround());
+
+        if (session.getSpectatingEntity() != null && session.getSpectatingEntity().getGeyserId() == entity.getGeyserId()) {
+            session.sendSpectateLocation();
+        }
     }
 }

--- a/connector/src/main/java/org/geysermc/connector/network/translators/java/entity/spawn/JavaSpawnEntityTranslator.java
+++ b/connector/src/main/java/org/geysermc/connector/network/translators/java/entity/spawn/JavaSpawnEntityTranslator.java
@@ -83,6 +83,7 @@ public class JavaSpawnEntityTranslator extends PacketTranslator<ServerSpawnEntit
                         type, position, motion, rotation
                 );
             }
+            entity.setJavaUuid(packet.getUuid());
             session.getEntityCache().spawnEntity(entity);
         } catch (NoSuchMethodException | InstantiationException | IllegalAccessException | InvocationTargetException ex) {
             ex.printStackTrace();

--- a/connector/src/main/java/org/geysermc/connector/network/translators/java/entity/spawn/JavaSpawnLivingEntityTranslator.java
+++ b/connector/src/main/java/org/geysermc/connector/network/translators/java/entity/spawn/JavaSpawnLivingEntityTranslator.java
@@ -61,6 +61,7 @@ public class JavaSpawnLivingEntityTranslator extends PacketTranslator<ServerSpaw
             Entity entity = entityConstructor.newInstance(packet.getEntityId(), session.getEntityCache().getNextEntityId().incrementAndGet(),
                     type, position, motion, rotation
             );
+            entity.setJavaUuid(packet.getUuid());
             session.getEntityCache().spawnEntity(entity);
         } catch (NoSuchMethodException | InstantiationException | IllegalAccessException | InvocationTargetException ex) {
             ex.printStackTrace();

--- a/connector/src/main/java/org/geysermc/connector/network/translators/java/entity/spawn/JavaSpawnPlayerTranslator.java
+++ b/connector/src/main/java/org/geysermc/connector/network/translators/java/entity/spawn/JavaSpawnPlayerTranslator.java
@@ -50,6 +50,7 @@ public class JavaSpawnPlayerTranslator extends PacketTranslator<ServerSpawnPlaye
         }
 
         entity.setEntityId(packet.getEntityId());
+        entity.setJavaUuid(packet.getUuid());
         entity.setPosition(position);
         entity.setRotation(rotation);
         session.getEntityCache().cacheEntity(entity);


### PR DESCRIPTION
### Introduction
This PR implements #1334. It is not the best way by a long shot, but it's all we have until bedrock implements it.

At the time of writing, this PR \*works\*. There is a few debug messages in there and the teleporting is extremely glitchy (i heard short range teleports aren't great?), but it works.

### TODO
- [ ] Fix the glitchy teleports
- [ ] Only forward move packets every 10 ticks / 1 second?
- [ ] Change the position slightly so you aren't inside the entity you're spectating
- [ ] Make the player invisible to itself