### PR TITLE
Faster chunk conversion

### DIFF
--- a/connector/src/main/java/org/geysermc/connector/network/session/cache/ChunkCache.java
+++ b/connector/src/main/java/org/geysermc/connector/network/session/cache/ChunkCache.java
@@ -48,22 +48,26 @@ public class ChunkCache {
         }
     }
 
-    public void addToCache(Column chunk) {
+    public Column addToCache(Column chunk) {
         if (!cache) {
-            return;
+            return chunk;
         }
 
         long chunkPosition = ChunkPosition.toLong(chunk.getX(), chunk.getZ());
         Column existingChunk;
-        if (chunk.getBiomeData() != null // Only consider merging columns if the new chunk isn't a full chunk
+        if (chunk.getBiomeData() == null // Only consider merging columns if the new chunk isn't a full chunk
             && (existingChunk = chunks.getOrDefault(chunkPosition, null)) != null) { // Column is already present in cache, we can merge with existing
+            boolean changed = false;
             for (int i = 0; i < chunk.getChunks().length; i++) { // The chunks member is final, so chunk.getChunks() will probably be inlined and then completely optimized away
                 if (chunk.getChunks()[i] != null) {
                     existingChunk.getChunks()[i] = chunk.getChunks()[i];
+                    changed = true;
                 }
             }
+            return changed ? existingChunk : null;
         } else {
             chunks.put(chunkPosition, chunk);
+            return chunk;
         }
     }
 

--- a/connector/src/main/java/org/geysermc/connector/network/translators/java/world/JavaChunkDataTranslator.java
+++ b/connector/src/main/java/org/geysermc/connector/network/translators/java/world/JavaChunkDataTranslator.java
@@ -95,12 +95,6 @@ public class JavaChunkDataTranslator extends PacketTranslator<ServerChunkDataPac
                 }
 
                 byte[] bedrockBiome = BiomeTranslator.toBedrockBiome(mergedColumn.getBiomeData());
-                /*byte[] bedrockBiome;
-                if (packet.getColumn().getBiomeData() == null) {
-                    bedrockBiome = BiomeTranslator.toBedrockBiome(session.getConnector().getWorldManager().getBiomeDataAt(session, packet.getColumn().getX(), packet.getColumn().getZ()));
-                } else {
-                    bedrockBiome = BiomeTranslator.toBedrockBiome(packet.getColumn().getBiomeData());
-                }*/
 
                 byteBuf.writeBytes(bedrockBiome); // Biomes - 256 bytes
                 byteBuf.writeByte(0); // Border blocks - Edu edition only

--- a/connector/src/main/java/org/geysermc/connector/network/translators/world/chunk/BlockStorage.java
+++ b/connector/src/main/java/org/geysermc/connector/network/translators/world/chunk/BlockStorage.java
@@ -64,16 +64,16 @@ public class BlockStorage {
         return BitArrayVersion.get(header >> 1, true);
     }
 
-    public synchronized int getFullBlock(int index) {
+    public int getFullBlock(int index) {
         return this.palette.getInt(this.bitArray.get(index));
     }
 
-    public synchronized void setFullBlock(int index, int runtimeId) {
+    public void setFullBlock(int index, int runtimeId) {
         int idx = this.idFor(runtimeId);
         this.bitArray.set(index, idx);
     }
 
-    public synchronized void writeToNetwork(ByteBuf buffer) {
+    public void writeToNetwork(ByteBuf buffer) {
         buffer.writeByte(getPaletteHeader(bitArray.getVersion(), true));
 
         for (int word : bitArray.getWords()) {

--- a/connector/src/main/java/org/geysermc/connector/network/translators/world/chunk/BlockStorage.java
+++ b/connector/src/main/java/org/geysermc/connector/network/translators/world/chunk/BlockStorage.java
@@ -29,14 +29,16 @@ import com.nukkitx.network.VarInts;
 import io.netty.buffer.ByteBuf;
 import it.unimi.dsi.fastutil.ints.IntArrayList;
 import it.unimi.dsi.fastutil.ints.IntList;
+import lombok.Getter;
 import org.geysermc.connector.network.translators.world.chunk.bitarray.BitArray;
 import org.geysermc.connector.network.translators.world.chunk.bitarray.BitArrayVersion;
 
 import java.util.function.IntConsumer;
 
+@Getter
 public class BlockStorage {
 
-    private static final int SIZE = 4096;
+    public static final int SIZE = 4096;
 
     private final IntList palette;
     private BitArray bitArray;
@@ -51,7 +53,7 @@ public class BlockStorage {
         this.palette.add(0); // Air is at the start of every palette.
     }
 
-    private BlockStorage(BitArray bitArray, IntArrayList palette) {
+    public BlockStorage(BitArray bitArray, IntList palette) {
         this.palette = palette;
         this.bitArray = bitArray;
     }

--- a/connector/src/main/java/org/geysermc/connector/network/translators/world/chunk/ChunkSection.java
+++ b/connector/src/main/java/org/geysermc/connector/network/translators/world/chunk/ChunkSection.java
@@ -35,34 +35,13 @@ public class ChunkSection {
     public static final int SIZE = 4096;
 
     private final BlockStorage[] storage;
-    private final NibbleArray blockLight;
-    private final NibbleArray skyLight;
 
     public ChunkSection() {
-        this(new BlockStorage[]{new BlockStorage(), new BlockStorage()}, new NibbleArray(SIZE),
-                new NibbleArray(SIZE));
+        this(new BlockStorage[]{new BlockStorage(), new BlockStorage()});
     }
 
-    public ChunkSection(BlockStorage[] blockStorage) {
-        this(blockStorage, new NibbleArray(SIZE), new NibbleArray(SIZE));
-    }
-
-    public ChunkSection(BlockStorage[] storage, byte[] blockLight, byte[] skyLight) {
-        Preconditions.checkNotNull(storage, "storage");
-        Preconditions.checkArgument(storage.length > 1, "Block storage length must be at least 2");
-        for (BlockStorage blockStorage : storage) {
-            Preconditions.checkNotNull(blockStorage, "storage");
-        }
-
+    public ChunkSection(BlockStorage[] storage) {
         this.storage = storage;
-        this.blockLight = new NibbleArray(blockLight);
-        this.skyLight = new NibbleArray(skyLight);
-    }
-
-    private ChunkSection(BlockStorage[] storage, NibbleArray blockLight, NibbleArray skyLight) {
-        this.storage = storage;
-        this.blockLight = blockLight;
-        this.skyLight = skyLight;
     }
 
     public int getFullBlock(int x, int y, int z, int layer) {
@@ -77,44 +56,12 @@ public class ChunkSection {
         this.storage[layer].setFullBlock(blockPosition(x, y, z), fullBlock);
     }
 
-    @Synchronized("skyLight")
-    public byte getSkyLight(int x, int y, int z) {
-        checkBounds(x, y, z);
-        return this.skyLight.get(blockPosition(x, y, z));
-    }
-
-    @Synchronized("skyLight")
-    public void setSkyLight(int x, int y, int z, byte val) {
-        checkBounds(x, y, z);
-        this.skyLight.set(blockPosition(x, y, z), val);
-    }
-
-    @Synchronized("blockLight")
-    public byte getBlockLight(int x, int y, int z) {
-        checkBounds(x, y, z);
-        return this.blockLight.get(blockPosition(x, y, z));
-    }
-
-    @Synchronized("blockLight")
-    public void setBlockLight(int x, int y, int z, byte val) {
-        checkBounds(x, y, z);
-        this.blockLight.set(blockPosition(x, y, z), val);
-    }
-
     public void writeToNetwork(ByteBuf buffer) {
         buffer.writeByte(CHUNK_SECTION_VERSION);
         buffer.writeByte(this.storage.length);
         for (BlockStorage blockStorage : this.storage) {
             blockStorage.writeToNetwork(buffer);
         }
-    }
-
-    public NibbleArray getSkyLightArray() {
-        return skyLight;
-    }
-
-    public NibbleArray getBlockLightArray() {
-        return blockLight;
     }
 
     public BlockStorage[] getBlockStorageArray() {
@@ -135,7 +82,7 @@ public class ChunkSection {
         for (int i = 0; i < storage.length; i++) {
             storage[i] = this.storage[i].copy();
         }
-        return new ChunkSection(storage, skyLight.copy(), blockLight.copy());
+        return new ChunkSection(storage);
     }
 
     public static int blockPosition(int x, int y, int z) {

--- a/connector/src/main/java/org/geysermc/connector/network/translators/world/chunk/bitarray/BitArrayVersion.java
+++ b/connector/src/main/java/org/geysermc/connector/network/translators/world/chunk/bitarray/BitArrayVersion.java
@@ -37,6 +37,8 @@ public enum BitArrayVersion {
     V2(2, 16, V3),
     V1(1, 32, V2);
 
+    private static final BitArrayVersion[] VALUES = values();
+
     final byte bits;
     final byte entriesPerWord;
     final int maxEntryValue;
@@ -56,6 +58,25 @@ public enum BitArrayVersion {
             }
         }
         throw new IllegalArgumentException("Invalid palette version: " + version);
+    }
+
+    public static BitArrayVersion forBitsExact(int bits) {
+        for (BitArrayVersion version : VALUES)  {
+            if (version.bits == bits)   {
+                return version;
+            }
+        }
+        return null;
+    }
+
+    public static BitArrayVersion forBitsCeil(int bits) {
+        for (int i = VALUES.length - 1; i >= 0; i--)  {
+            BitArrayVersion version = VALUES[i];
+            if (version.bits >= bits)   {
+                return version;
+            }
+        }
+        return null;
     }
 
     public BitArray createPalette(int size) {

--- a/connector/src/main/java/org/geysermc/connector/network/translators/world/chunk/bitarray/BitArrayVersion.java
+++ b/connector/src/main/java/org/geysermc/connector/network/translators/world/chunk/bitarray/BitArrayVersion.java
@@ -60,15 +60,6 @@ public enum BitArrayVersion {
         throw new IllegalArgumentException("Invalid palette version: " + version);
     }
 
-    public static BitArrayVersion forBitsExact(int bits) {
-        for (BitArrayVersion version : VALUES)  {
-            if (version.bits == bits)   {
-                return version;
-            }
-        }
-        return null;
-    }
-
     public static BitArrayVersion forBitsCeil(int bits) {
         for (int i = VALUES.length - 1; i >= 0; i--)  {
             BitArrayVersion version = VALUES[i];


### PR DESCRIPTION
This PR optimizes the process of translating and encoding chunks for transmission to the Bedrock client.

Profiling and some basic benchmarks suggest a performance boost in the order of 10-20 *times* faster than the current chunk code.

This is nearly done, the only major thing that remains is making partial chunk updates work correctly on Spigot servers (as they don't need a chunk cache, but can serve the block data directly from memory).