### PR TITLE
Introduce CommandSender.getLocale()

### DIFF
--- a/bootstrap/bungeecord/src/main/java/org/geysermc/platform/bungeecord/command/BungeeCommandSender.java
+++ b/bootstrap/bungeecord/src/main/java/org/geysermc/platform/bungeecord/command/BungeeCommandSender.java
@@ -25,17 +25,20 @@
 
 package org.geysermc.platform.bungeecord.command;
 
-import lombok.AllArgsConstructor;
-
 import net.md_5.bungee.api.chat.TextComponent;
 import net.md_5.bungee.api.connection.ProxiedPlayer;
-
 import org.geysermc.connector.command.CommandSender;
+import org.geysermc.connector.utils.LanguageUtils;
 
-@AllArgsConstructor
 public class BungeeCommandSender implements CommandSender {
 
-    private net.md_5.bungee.api.CommandSender handle;
+    private final net.md_5.bungee.api.CommandSender handle;
+
+    public BungeeCommandSender(net.md_5.bungee.api.CommandSender handle) {
+        this.handle = handle;
+        // Ensure even Java players' languages are loaded
+        LanguageUtils.loadGeyserLocale(getLocale());
+    }
 
     @Override
     public String getName() {
@@ -50,5 +53,15 @@ public class BungeeCommandSender implements CommandSender {
     @Override
     public boolean isConsole() {
         return !(handle instanceof ProxiedPlayer);
+    }
+
+    @Override
+    public String getLocale() {
+        if (handle instanceof ProxiedPlayer) {
+            ProxiedPlayer player = (ProxiedPlayer) handle;
+            String locale = player.getLocale().getLanguage() + "_" + player.getLocale().getCountry();
+            return LanguageUtils.formatLocale(locale);
+        }
+        return LanguageUtils.getDefaultLocale();
     }
 }

--- a/bootstrap/bungeecord/src/main/java/org/geysermc/platform/bungeecord/command/GeyserBungeeCommandExecutor.java
+++ b/bootstrap/bungeecord/src/main/java/org/geysermc/platform/bungeecord/command/GeyserBungeeCommandExecutor.java
@@ -27,13 +27,10 @@ package org.geysermc.platform.bungeecord.command;
 
 import net.md_5.bungee.api.ChatColor;
 import net.md_5.bungee.api.CommandSender;
-import net.md_5.bungee.api.chat.TextComponent;
 import net.md_5.bungee.api.plugin.Command;
 import net.md_5.bungee.api.plugin.TabExecutor;
-
 import org.geysermc.connector.GeyserConnector;
 import org.geysermc.connector.command.GeyserCommand;
-import org.geysermc.connector.network.session.GeyserSession;
 import org.geysermc.connector.utils.LanguageUtils;
 
 import java.util.ArrayList;
@@ -41,7 +38,7 @@ import java.util.Arrays;
 
 public class GeyserBungeeCommandExecutor extends Command implements TabExecutor {
 
-    private GeyserConnector connector;
+    private final GeyserConnector connector;
 
     public GeyserBungeeCommandExecutor(GeyserConnector connector) {
         super("geyser");
@@ -54,14 +51,10 @@ public class GeyserBungeeCommandExecutor extends Command implements TabExecutor 
         if (args.length > 0) {
             if (getCommand(args[0]) != null) {
                 if (!sender.hasPermission(getCommand(args[0]).getPermission())) {
-                    String message = "";
-                    if (sender instanceof GeyserSession) {
-                        message = LanguageUtils.getPlayerLocaleString("geyser.bootstrap.command.permission_fail", ((GeyserSession) sender).getClientData().getLanguageCode());
-                    } else {
-                        message = LanguageUtils.getLocaleStringLog("geyser.bootstrap.command.permission_fail");
-                    }
+                    BungeeCommandSender commandSender = new BungeeCommandSender(sender);
+                    String message = LanguageUtils.getPlayerLocaleString("geyser.bootstrap.command.permission_fail", commandSender.getLocale());
 
-                    sender.sendMessage(TextComponent.fromLegacyText(ChatColor.RED + message));
+                    commandSender.sendMessage(ChatColor.RED + message);
                     return;
                 }
                 getCommand(args[0]).execute(new BungeeCommandSender(sender), args.length > 1 ? Arrays.copyOfRange(args, 1, args.length) : new String[0]);

--- a/bootstrap/spigot/src/main/java/org/geysermc/platform/spigot/GeyserSpigotPlugin.java
+++ b/bootstrap/spigot/src/main/java/org/geysermc/platform/spigot/GeyserSpigotPlugin.java
@@ -40,6 +40,7 @@ import org.geysermc.connector.utils.FileUtils;
 import org.geysermc.connector.utils.LanguageUtils;
 import org.geysermc.platform.spigot.command.GeyserSpigotCommandExecutor;
 import org.geysermc.platform.spigot.command.GeyserSpigotCommandManager;
+import org.geysermc.platform.spigot.command.SpigotCommandSender;
 import org.geysermc.platform.spigot.world.GeyserSpigotBlockPlaceListener;
 import org.geysermc.platform.spigot.world.GeyserSpigotWorldManager;
 
@@ -129,6 +130,9 @@ public class GeyserSpigotPlugin extends JavaPlugin implements GeyserBootstrap {
         if (!use3dBiomes) {
             geyserLogger.debug("Legacy version of Minecraft (1.15.2 or older) detected; not using 3D biomes.");
         }
+
+        // Set if we need to use a different method for getting a player's locale
+        SpigotCommandSender.setUseLegacyLocaleMethod(!isCompatible(Bukkit.getServer().getVersion(), "1.12.0"));
 
         this.geyserWorldManager = new GeyserSpigotWorldManager(isLegacy, use3dBiomes, isViaVersion);
         GeyserSpigotBlockPlaceListener blockPlaceListener = new GeyserSpigotBlockPlaceListener(connector, isLegacy, isViaVersion);

--- a/bootstrap/spigot/src/main/java/org/geysermc/platform/spigot/command/GeyserSpigotCommandExecutor.java
+++ b/bootstrap/spigot/src/main/java/org/geysermc/platform/spigot/command/GeyserSpigotCommandExecutor.java
@@ -32,7 +32,6 @@ import org.bukkit.command.CommandSender;
 import org.bukkit.command.TabExecutor;
 import org.geysermc.connector.GeyserConnector;
 import org.geysermc.connector.command.GeyserCommand;
-import org.geysermc.connector.network.session.GeyserSession;
 import org.geysermc.connector.utils.LanguageUtils;
 
 import java.util.ArrayList;
@@ -42,21 +41,17 @@ import java.util.List;
 @AllArgsConstructor
 public class GeyserSpigotCommandExecutor implements TabExecutor {
 
-    private GeyserConnector connector;
+    private final GeyserConnector connector;
 
     @Override
     public boolean onCommand(CommandSender sender, Command command, String label, String[] args) {
         if (args.length > 0) {
             if (getCommand(args[0]) != null) {
                 if (!sender.hasPermission(getCommand(args[0]).getPermission())) {
-                    String message = "";
-                    if (sender instanceof GeyserSession) {
-                        message = LanguageUtils.getPlayerLocaleString("geyser.bootstrap.command.permission_fail", ((GeyserSession) sender).getClientData().getLanguageCode());
-                    } else {
-                        message = LanguageUtils.getLocaleStringLog("geyser.bootstrap.command.permission_fail");
-                    }
+                    SpigotCommandSender commandSender = new SpigotCommandSender(sender);
+                    String message = LanguageUtils.getPlayerLocaleString("geyser.bootstrap.command.permission_fail", commandSender.getLocale());;
 
-                    sender.sendMessage(ChatColor.RED + message);
+                    commandSender.sendMessage(ChatColor.RED + message);
                     return true;
                 }
                 getCommand(args[0]).execute(new SpigotCommandSender(sender), args.length > 1 ? Arrays.copyOfRange(args, 1, args.length) : new String[0]);

--- a/bootstrap/spigot/src/main/java/org/geysermc/platform/spigot/command/SpigotCommandSender.java
+++ b/bootstrap/spigot/src/main/java/org/geysermc/platform/spigot/command/SpigotCommandSender.java
@@ -25,15 +25,33 @@
 
 package org.geysermc.platform.spigot.command;
 
-import lombok.AllArgsConstructor;
-
 import org.bukkit.command.ConsoleCommandSender;
+import org.bukkit.entity.Player;
+import org.geysermc.connector.GeyserConnector;
 import org.geysermc.connector.command.CommandSender;
+import org.geysermc.connector.utils.LanguageUtils;
 
-@AllArgsConstructor
+import java.lang.reflect.InvocationTargetException;
+import java.lang.reflect.Method;
+
 public class SpigotCommandSender implements CommandSender {
 
-    private org.bukkit.command.CommandSender handle;
+    /**
+     * Whether to use {@code Player.getLocale()} or {@code Player.spigot().getLocale()}, depending on version.
+     * 1.12 or greater should not use the legacy method.
+     */
+    private static boolean USE_LEGACY_METHOD = false;
+    private static Method LOCALE_METHOD;
+
+    private final org.bukkit.command.CommandSender handle;
+    private final String locale;
+
+    public SpigotCommandSender(org.bukkit.command.CommandSender handle) {
+        this.handle = handle;
+        this.locale = getSpigotLocale();
+        // Ensure even Java players' languages are loaded
+        LanguageUtils.loadGeyserLocale(locale);
+    }
 
     @Override
     public String getName() {
@@ -48,5 +66,48 @@ public class SpigotCommandSender implements CommandSender {
     @Override
     public boolean isConsole() {
         return handle instanceof ConsoleCommandSender;
+    }
+
+    @Override
+    public String getLocale() {
+        return locale;
+    }
+
+    /**
+     * Set if we are on pre-1.12, and therefore {@code player.getLocale()} doesn't exist and we have to get
+     * {@code player.spigot().getLocale()}.
+     * @param useLegacyMethod if we are running pre-1.12 and therefore need to use reflection to get the player locale
+     */
+    public static void setUseLegacyLocaleMethod(boolean useLegacyMethod) {
+        USE_LEGACY_METHOD = useLegacyMethod;
+        if (USE_LEGACY_METHOD) {
+            try {
+                //noinspection JavaReflectionMemberAccess - of course it doesn't exist; that's why we're doing it
+                LOCALE_METHOD = Player.Spigot.class.getMethod("getLocale");
+            } catch (NoSuchMethodException e) {
+                GeyserConnector.getInstance().getLogger().debug("Player.Spigot.getLocale() doesn't exist? Not a big deal but if you're seeing this please report it to the developers!");
+            }
+        }
+    }
+
+    /**
+     * So we only have to do nasty reflection stuff once per command
+     * @return the locale of the Spigot player
+     */
+    private String getSpigotLocale() {
+        if (handle instanceof Player) {
+            Player player = (Player) handle;
+            if (USE_LEGACY_METHOD) {
+                try {
+                    // sigh
+                    // This was the only option on older Spigot instances and now it's gone
+                    return (String) LOCALE_METHOD.invoke(player.spigot());
+                } catch (IllegalAccessException | InvocationTargetException ignored) {
+                }
+            } else {
+                return player.getLocale();
+            }
+        }
+        return LanguageUtils.getDefaultLocale();
     }
 }

--- a/bootstrap/velocity/src/main/java/org/geysermc/platform/velocity/command/GeyserVelocityCommandExecutor.java
+++ b/bootstrap/velocity/src/main/java/org/geysermc/platform/velocity/command/GeyserVelocityCommandExecutor.java
@@ -27,14 +27,11 @@ package org.geysermc.platform.velocity.command;
 
 import com.velocitypowered.api.command.Command;
 import com.velocitypowered.api.command.CommandSource;
-
 import lombok.AllArgsConstructor;
-
-import net.kyori.text.TextComponent;
-
-import org.geysermc.connector.common.ChatColor;
 import org.geysermc.connector.GeyserConnector;
+import org.geysermc.connector.command.CommandSender;
 import org.geysermc.connector.command.GeyserCommand;
+import org.geysermc.connector.common.ChatColor;
 import org.geysermc.connector.utils.LanguageUtils;
 
 import java.util.Arrays;
@@ -42,15 +39,15 @@ import java.util.Arrays;
 @AllArgsConstructor
 public class GeyserVelocityCommandExecutor implements Command {
 
-    private GeyserConnector connector;
+    private final GeyserConnector connector;
 
     @Override
     public void execute(CommandSource source, String[] args) {
         if (args.length > 0) {
             if (getCommand(args[0]) != null) {
                 if (!source.hasPermission(getCommand(args[0]).getPermission())) {
-                    // Not ideal to use log here but we dont get a session
-                    source.sendMessage(TextComponent.of(ChatColor.RED + LanguageUtils.getLocaleStringLog("geyser.bootstrap.command.permission_fail")));
+                    CommandSender sender = new VelocityCommandSender(source);
+                    sender.sendMessage(ChatColor.RED + LanguageUtils.getPlayerLocaleString("geyser.bootstrap.command.permission_fail", sender.getLocale()));
                     return;
                 }
                 getCommand(args[0]).execute(new VelocityCommandSender(source), args.length > 1 ? Arrays.copyOfRange(args, 1, args.length) : new String[0]);

--- a/bootstrap/velocity/src/main/java/org/geysermc/platform/velocity/command/VelocityCommandSender.java
+++ b/bootstrap/velocity/src/main/java/org/geysermc/platform/velocity/command/VelocityCommandSender.java
@@ -28,17 +28,21 @@ package org.geysermc.platform.velocity.command;
 import com.velocitypowered.api.command.CommandSource;
 import com.velocitypowered.api.proxy.ConsoleCommandSource;
 import com.velocitypowered.api.proxy.Player;
-
-import lombok.AllArgsConstructor;
-
 import net.kyori.text.TextComponent;
-
 import org.geysermc.connector.command.CommandSender;
+import org.geysermc.connector.utils.LanguageUtils;
 
-@AllArgsConstructor
+import java.util.Locale;
+
 public class VelocityCommandSender implements CommandSender {
 
-    private CommandSource handle;
+    private final CommandSource handle;
+
+    public VelocityCommandSender(CommandSource handle) {
+        this.handle = handle;
+        // Ensure even Java players' languages are loaded
+        LanguageUtils.loadGeyserLocale(getLocale());
+    }
 
     @Override
     public String getName() {
@@ -58,5 +62,14 @@ public class VelocityCommandSender implements CommandSender {
     @Override
     public boolean isConsole() {
         return handle instanceof ConsoleCommandSource;
+    }
+
+    @Override
+    public String getLocale() {
+        if (handle instanceof Player) {
+            Locale locale = ((Player) handle).getPlayerSettings().getLocale();
+            return LanguageUtils.formatLocale(locale.getLanguage() + "_" + locale.getCountry());
+        }
+        return LanguageUtils.getDefaultLocale();
     }
 }

--- a/connector/src/main/java/org/geysermc/connector/GeyserConnector.java
+++ b/connector/src/main/java/org/geysermc/connector/GeyserConnector.java
@@ -271,7 +271,7 @@ public class GeyserConnector {
             // Make a copy to prevent ConcurrentModificationException
             final List<GeyserSession> tmpPlayers = new ArrayList<>(players);
             for (GeyserSession playerSession : tmpPlayers) {
-                playerSession.disconnect(LanguageUtils.getPlayerLocaleString("geyser.core.shutdown.kick.message", playerSession.getClientData().getLanguageCode()));
+                playerSession.disconnect(LanguageUtils.getPlayerLocaleString("geyser.core.shutdown.kick.message", playerSession.getLocale()));
             }
 
             CompletableFuture<Void> future = CompletableFuture.runAsync(new Runnable() {

--- a/connector/src/main/java/org/geysermc/connector/command/CommandManager.java
+++ b/connector/src/main/java/org/geysermc/connector/command/CommandManager.java
@@ -40,7 +40,7 @@ public abstract class CommandManager {
     @Getter
     private final Map<String, GeyserCommand> commands = Collections.synchronizedMap(new HashMap<>());
 
-    private GeyserConnector connector;
+    private final GeyserConnector connector;
 
     public CommandManager(GeyserConnector connector) {
         this.connector = connector;

--- a/connector/src/main/java/org/geysermc/connector/command/CommandManager.java
+++ b/connector/src/main/java/org/geysermc/connector/command/CommandManager.java
@@ -45,13 +45,13 @@ public abstract class CommandManager {
     public CommandManager(GeyserConnector connector) {
         this.connector = connector;
 
-        registerCommand(new HelpCommand(connector, "help", LanguageUtils.getLocaleStringLog("geyser.commands.help.desc"), "geyser.command.help"));
-        registerCommand(new ListCommand(connector, "list", LanguageUtils.getLocaleStringLog("geyser.commands.list.desc"), "geyser.command.list"));
-        registerCommand(new ReloadCommand(connector, "reload", LanguageUtils.getLocaleStringLog("geyser.commands.reload.desc"), "geyser.command.reload"));
-        registerCommand(new StopCommand(connector, "stop", LanguageUtils.getLocaleStringLog("geyser.commands.stop.desc"), "geyser.command.stop"));
-        registerCommand(new OffhandCommand(connector, "offhand", LanguageUtils.getLocaleStringLog("geyser.commands.offhand.desc"), "geyser.command.offhand"));
-        registerCommand(new DumpCommand(connector, "dump", LanguageUtils.getLocaleStringLog("geyser.commands.dump.desc"), "geyser.command.dump"));
-        registerCommand(new VersionCommand(connector, "version", LanguageUtils.getLocaleStringLog("geyser.commands.version.desc"), "geyser.command.version"));
+        registerCommand(new HelpCommand(connector, "help", "geyser.commands.help.desc", "geyser.command.help"));
+        registerCommand(new ListCommand(connector, "list", "geyser.commands.list.desc", "geyser.command.list"));
+        registerCommand(new ReloadCommand(connector, "reload", "geyser.commands.reload.desc", "geyser.command.reload"));
+        registerCommand(new StopCommand(connector, "stop", "geyser.commands.stop.desc", "geyser.command.stop"));
+        registerCommand(new OffhandCommand(connector, "offhand", "geyser.commands.offhand.desc", "geyser.command.offhand"));
+        registerCommand(new DumpCommand(connector, "dump", "geyser.commands.dump.desc", "geyser.command.dump"));
+        registerCommand(new VersionCommand(connector, "version", "geyser.commands.version.desc", "geyser.command.version"));
     }
 
     public void registerCommand(GeyserCommand command) {

--- a/connector/src/main/java/org/geysermc/connector/command/CommandSender.java
+++ b/connector/src/main/java/org/geysermc/connector/command/CommandSender.java
@@ -25,6 +25,12 @@
 
 package org.geysermc.connector.command;
 
+import org.geysermc.connector.utils.LanguageUtils;
+
+/**
+ * Implemented on top of any class that can send a command.
+ * For example, it wraps around Spigot's CommandSender class.
+ */
 public interface CommandSender {
 
     String getName();
@@ -37,5 +43,16 @@ public interface CommandSender {
 
     void sendMessage(String message);
 
+    /**
+     * @return true if the specified sender is from the console.
+     */
     boolean isConsole();
+
+    /**
+     * Returns the locale of the command sender. Defaults to the default locale at {@link LanguageUtils#getDefaultLocale()}.
+     * @return the locale of the command sender.
+     */
+    default String getLocale() {
+        return LanguageUtils.getDefaultLocale();
+    }
 }

--- a/connector/src/main/java/org/geysermc/connector/command/CommandSender.java
+++ b/connector/src/main/java/org/geysermc/connector/command/CommandSender.java
@@ -50,6 +50,7 @@ public interface CommandSender {
 
     /**
      * Returns the locale of the command sender. Defaults to the default locale at {@link LanguageUtils#getDefaultLocale()}.
+     * 
      * @return the locale of the command sender.
      */
     default String getLocale() {

--- a/connector/src/main/java/org/geysermc/connector/command/GeyserCommand.java
+++ b/connector/src/main/java/org/geysermc/connector/command/GeyserCommand.java
@@ -37,6 +37,9 @@ import java.util.List;
 public abstract class GeyserCommand {
 
     protected final String name;
+    /**
+     * The description of the command - will attempt to be translated.
+     */
     protected final String description;
     protected final String permission;
 

--- a/connector/src/main/java/org/geysermc/connector/command/defaults/DumpCommand.java
+++ b/connector/src/main/java/org/geysermc/connector/command/defaults/DumpCommand.java
@@ -27,12 +27,10 @@ package org.geysermc.connector.command.defaults;
 
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
-import com.fasterxml.jackson.databind.ser.impl.SimpleBeanPropertyFilter;
-import com.fasterxml.jackson.databind.ser.impl.SimpleFilterProvider;
-import org.geysermc.connector.common.ChatColor;
 import org.geysermc.connector.GeyserConnector;
 import org.geysermc.connector.command.CommandSender;
 import org.geysermc.connector.command.GeyserCommand;
+import org.geysermc.connector.common.ChatColor;
 import org.geysermc.connector.common.serializer.AsteriskSerializer;
 import org.geysermc.connector.dump.DumpInfo;
 import org.geysermc.connector.utils.LanguageUtils;
@@ -73,7 +71,7 @@ public class DumpCommand extends GeyserCommand {
 
         AsteriskSerializer.showSensitive = showSensitive;
 
-        sender.sendMessage(LanguageUtils.getLocaleStringLog("geyser.commands.dump.collecting"));
+        sender.sendMessage(LanguageUtils.getPlayerLocaleString("geyser.commands.dump.collecting", sender.getLocale()));
         String dumpData = "";
         try {
             if (offlineDump) {
@@ -82,7 +80,7 @@ public class DumpCommand extends GeyserCommand {
                 dumpData = MAPPER.writeValueAsString(new DumpInfo());
             }
         } catch (IOException e) {
-            sender.sendMessage(ChatColor.RED + LanguageUtils.getLocaleStringLog("geyser.commands.dump.collect_error"));
+            sender.sendMessage(ChatColor.RED + LanguageUtils.getPlayerLocaleString("geyser.commands.dump.collect_error", sender.getLocale()));
             connector.getLogger().error(LanguageUtils.getLocaleStringLog("geyser.commands.dump.collect_error_short"), e);
             return;
         }
@@ -90,21 +88,21 @@ public class DumpCommand extends GeyserCommand {
         String uploadedDumpUrl = "";
 
         if (offlineDump) {
-            sender.sendMessage(LanguageUtils.getLocaleStringLog("geyser.commands.dump.writing"));
+            sender.sendMessage(LanguageUtils.getPlayerLocaleString("geyser.commands.dump.writing", sender.getLocale()));
 
             try {
                 FileOutputStream outputStream = new FileOutputStream(GeyserConnector.getInstance().getBootstrap().getConfigFolder().resolve("dump.json").toFile());
                 outputStream.write(dumpData.getBytes());
                 outputStream.close();
             } catch (IOException e) {
-                sender.sendMessage(ChatColor.RED + LanguageUtils.getLocaleStringLog("geyser.commands.dump.write_error"));
+                sender.sendMessage(ChatColor.RED + LanguageUtils.getPlayerLocaleString("geyser.commands.dump.write_error", sender.getLocale()));
                 connector.getLogger().error(LanguageUtils.getLocaleStringLog("geyser.commands.dump.write_error_short"), e);
                 return;
             }
 
             uploadedDumpUrl = "dump.json";
         } else {
-            sender.sendMessage(LanguageUtils.getLocaleStringLog("geyser.commands.dump.uploading"));
+            sender.sendMessage(LanguageUtils.getPlayerLocaleString("geyser.commands.dump.uploading", sender.getLocale()));
 
             String response;
             JsonNode responseNode;
@@ -112,20 +110,20 @@ public class DumpCommand extends GeyserCommand {
                 response = WebUtils.post(DUMP_URL + "documents", dumpData);
                 responseNode = MAPPER.readTree(response);
             } catch (IOException e) {
-                sender.sendMessage(ChatColor.RED + LanguageUtils.getLocaleStringLog("geyser.commands.dump.upload_error"));
+                sender.sendMessage(ChatColor.RED + LanguageUtils.getPlayerLocaleString("geyser.commands.dump.upload_error", sender.getLocale()));
                 connector.getLogger().error(LanguageUtils.getLocaleStringLog("geyser.commands.dump.upload_error_short"), e);
                 return;
             }
 
             if (!responseNode.has("key")) {
-                sender.sendMessage(ChatColor.RED + LanguageUtils.getLocaleStringLog("geyser.commands.dump.upload_error_short") + ": " + (responseNode.has("message") ? responseNode.get("message").asText() : response));
+                sender.sendMessage(ChatColor.RED + LanguageUtils.getPlayerLocaleString("geyser.commands.dump.upload_error_short", sender.getLocale()) + ": " + (responseNode.has("message") ? responseNode.get("message").asText() : response));
                 return;
             }
 
             uploadedDumpUrl = DUMP_URL + responseNode.get("key").asText();
         }
 
-        sender.sendMessage(LanguageUtils.getLocaleStringLog("geyser.commands.dump.message") + " " + ChatColor.DARK_AQUA + uploadedDumpUrl);
+        sender.sendMessage(LanguageUtils.getPlayerLocaleString("geyser.commands.dump.message", sender.getLocale()) + " " + ChatColor.DARK_AQUA + uploadedDumpUrl);
         if (!sender.isConsole()) {
             connector.getLogger().info(LanguageUtils.getLocaleStringLog("geyser.commands.dump.created", sender.getName(), uploadedDumpUrl));
         }

--- a/connector/src/main/java/org/geysermc/connector/command/defaults/HelpCommand.java
+++ b/connector/src/main/java/org/geysermc/connector/command/defaults/HelpCommand.java
@@ -25,11 +25,10 @@
 
 package org.geysermc.connector.command.defaults;
 
-import org.geysermc.connector.common.ChatColor;
 import org.geysermc.connector.GeyserConnector;
 import org.geysermc.connector.command.CommandSender;
 import org.geysermc.connector.command.GeyserCommand;
-import org.geysermc.connector.network.session.GeyserSession;
+import org.geysermc.connector.common.ChatColor;
 import org.geysermc.connector.utils.LanguageUtils;
 
 import java.util.Collections;
@@ -52,17 +51,12 @@ public class HelpCommand extends GeyserCommand {
     public void execute(CommandSender sender, String[] args) {
         int page = 1;
         int maxPage = 1;
-        String header = "";
-
-        if (sender instanceof GeyserSession) {
-            header = LanguageUtils.getPlayerLocaleString("geyser.commands.help.header", ((GeyserSession) sender).getClientData().getLanguageCode(), page, maxPage);
-        } else {
-            header = LanguageUtils.getLocaleStringLog("geyser.commands.help.header", page, maxPage);
-        }
+        String header = LanguageUtils.getPlayerLocaleString("geyser.commands.help.header", sender.getLocale(), page, maxPage);
 
         sender.sendMessage(header);
         Map<String, GeyserCommand> cmds = connector.getCommandManager().getCommands();
         List<String> commands = connector.getCommandManager().getCommands().keySet().stream().sorted().collect(Collectors.toList());
-        commands.forEach(cmd -> sender.sendMessage(ChatColor.YELLOW + "/geyser " + cmd + ChatColor.WHITE + ": " + cmds.get(cmd).getDescription()));
+        commands.forEach(cmd -> sender.sendMessage(ChatColor.YELLOW + "/geyser " + cmd + ChatColor.WHITE + ": " +
+                LanguageUtils.getPlayerLocaleString(cmds.get(cmd).getDescription(), sender.getLocale())));
     }
 }

--- a/connector/src/main/java/org/geysermc/connector/command/defaults/ListCommand.java
+++ b/connector/src/main/java/org/geysermc/connector/command/defaults/ListCommand.java
@@ -35,7 +35,7 @@ import java.util.stream.Collectors;
 
 public class ListCommand extends GeyserCommand {
 
-    private GeyserConnector connector;
+    private final GeyserConnector connector;
 
     public ListCommand(GeyserConnector connector, String name, String description, String permission) {
         super(name, description, permission);
@@ -46,11 +46,9 @@ public class ListCommand extends GeyserCommand {
     @Override
     public void execute(CommandSender sender, String[] args) {
         String message = "";
-        if (sender instanceof GeyserSession) {
-            message = LanguageUtils.getPlayerLocaleString("geyser.commands.list.message", ((GeyserSession) sender).getClientData().getLanguageCode(), connector.getPlayers().size(), connector.getPlayers().stream().map(GeyserSession::getName).collect(Collectors.joining(" ")));
-        } else {
-            message = LanguageUtils.getLocaleStringLog("geyser.commands.list.message", connector.getPlayers().size(), connector.getPlayers().stream().map(GeyserSession::getName).collect(Collectors.joining(" ")));
-        }
+        message = LanguageUtils.getPlayerLocaleString("geyser.commands.list.message", sender.getLocale(),
+                connector.getPlayers().size(),
+                connector.getPlayers().stream().map(GeyserSession::getName).collect(Collectors.joining(" ")));
 
         sender.sendMessage(message);
     }

--- a/connector/src/main/java/org/geysermc/connector/command/defaults/OffhandCommand.java
+++ b/connector/src/main/java/org/geysermc/connector/command/defaults/OffhandCommand.java
@@ -36,7 +36,7 @@ import org.geysermc.connector.network.session.GeyserSession;
 
 public class OffhandCommand extends GeyserCommand {
 
-    private GeyserConnector connector;
+    private final GeyserConnector connector;
 
     public OffhandCommand(GeyserConnector connector, String name, String description, String permission) {
         super(name, description, permission);
@@ -58,7 +58,7 @@ public class OffhandCommand extends GeyserCommand {
             session.sendDownstreamPacket(releaseItemPacket);
             return;
         }
-        // Needed for Bukkit - sender is not an instance of GeyserSession
+        // Needed for Spigot - sender is not an instance of GeyserSession
         for (GeyserSession session : connector.getPlayers()) {
             if (sender.getName().equals(session.getPlayerEntity().getUsername())) {
                 ClientPlayerActionPacket releaseItemPacket = new ClientPlayerActionPacket(PlayerAction.SWAP_HANDS, new Position(0,0,0),

--- a/connector/src/main/java/org/geysermc/connector/command/defaults/ReloadCommand.java
+++ b/connector/src/main/java/org/geysermc/connector/command/defaults/ReloadCommand.java
@@ -47,12 +47,7 @@ public class ReloadCommand extends GeyserCommand {
             return;
         }
 
-        String message = "";
-        if (sender instanceof GeyserSession) {
-            message = LanguageUtils.getPlayerLocaleString("geyser.commands.reload.message", ((GeyserSession) sender).getLocale());
-        } else {
-            message = LanguageUtils.getLocaleStringLog("geyser.commands.reload.message");
-        }
+        String message = LanguageUtils.getPlayerLocaleString("geyser.commands.reload.message", sender.getLocale());
 
         sender.sendMessage(message);
 

--- a/connector/src/main/java/org/geysermc/connector/command/defaults/ReloadCommand.java
+++ b/connector/src/main/java/org/geysermc/connector/command/defaults/ReloadCommand.java
@@ -49,7 +49,7 @@ public class ReloadCommand extends GeyserCommand {
 
         String message = "";
         if (sender instanceof GeyserSession) {
-            message = LanguageUtils.getPlayerLocaleString("geyser.commands.reload.message", ((GeyserSession) sender).getClientData().getLanguageCode());
+            message = LanguageUtils.getPlayerLocaleString("geyser.commands.reload.message", ((GeyserSession) sender).getLocale());
         } else {
             message = LanguageUtils.getLocaleStringLog("geyser.commands.reload.message");
         }
@@ -57,7 +57,7 @@ public class ReloadCommand extends GeyserCommand {
         sender.sendMessage(message);
 
         for (GeyserSession session : connector.getPlayers()) {
-            session.disconnect(LanguageUtils.getPlayerLocaleString("geyser.commands.reload.kick", session.getClientData().getLanguageCode()));
+            session.disconnect(LanguageUtils.getPlayerLocaleString("geyser.commands.reload.kick", session.getLocale()));
         }
         connector.reload();
     }

--- a/connector/src/main/java/org/geysermc/connector/command/defaults/VersionCommand.java
+++ b/connector/src/main/java/org/geysermc/connector/command/defaults/VersionCommand.java
@@ -61,12 +61,12 @@ public class VersionCommand extends GeyserCommand {
             bedrockVersions = BedrockProtocol.DEFAULT_BEDROCK_CODEC.getMinecraftVersion();
         }
 
-        sender.sendMessage(LanguageUtils.getLocaleStringLog("geyser.commands.version.version", GeyserConnector.NAME, GeyserConnector.VERSION, MinecraftConstants.GAME_VERSION, bedrockVersions));
+        sender.sendMessage(LanguageUtils.getPlayerLocaleString("geyser.commands.version.version", sender.getLocale(), GeyserConnector.NAME, GeyserConnector.VERSION, MinecraftConstants.GAME_VERSION, bedrockVersions));
 
         // Disable update checking in dev mode
         //noinspection ConstantConditions - changes in production
         if (!GeyserConnector.VERSION.equals("DEV")) {
-            sender.sendMessage(LanguageUtils.getLocaleStringLog("geyser.commands.version.checking"));
+            sender.sendMessage(LanguageUtils.getPlayerLocaleString("geyser.commands.version.checking", sender.getLocale()));
             try {
                 Properties gitProp = new Properties();
                 gitProp.load(FileUtils.getResource("git.properties"));
@@ -76,16 +76,16 @@ public class VersionCommand extends GeyserCommand {
                     int latestBuildNum = Integer.parseInt(buildXML.replaceAll("<(\\\\)?(/)?buildNumber>", "").trim());
                     int buildNum = Integer.parseInt(gitProp.getProperty("git.build.number"));
                     if (latestBuildNum == buildNum) {
-                        sender.sendMessage(LanguageUtils.getLocaleStringLog("geyser.commands.version.no_updates"));
+                        sender.sendMessage(LanguageUtils.getPlayerLocaleString("geyser.commands.version.no_updates", sender.getLocale()));
                     } else {
-                        sender.sendMessage(LanguageUtils.getLocaleStringLog("geyser.commands.version.outdated", (latestBuildNum - buildNum), "http://ci.geysermc.org/"));
+                        sender.sendMessage(LanguageUtils.getPlayerLocaleString("geyser.commands.version.outdated", sender.getLocale(), (latestBuildNum - buildNum), "http://ci.geysermc.org/"));
                     }
                 } else {
                     throw new AssertionError("buildNumber missing");
                 }
             } catch (IOException | AssertionError | NumberFormatException e) {
                 GeyserConnector.getInstance().getLogger().error(LanguageUtils.getLocaleStringLog("geyser.commands.version.failed"), e);
-                sender.sendMessage(ChatColor.RED + LanguageUtils.getLocaleStringLog("geyser.commands.version.failed"));
+                sender.sendMessage(ChatColor.RED + LanguageUtils.getPlayerLocaleString("geyser.commands.version.failed", sender.getLocale()));
             }
         }
     }

--- a/connector/src/main/java/org/geysermc/connector/command/defaults/VersionCommand.java
+++ b/connector/src/main/java/org/geysermc/connector/command/defaults/VersionCommand.java
@@ -78,7 +78,7 @@ public class VersionCommand extends GeyserCommand {
                     if (latestBuildNum == buildNum) {
                         sender.sendMessage(LanguageUtils.getPlayerLocaleString("geyser.commands.version.no_updates", sender.getLocale()));
                     } else {
-                        sender.sendMessage(LanguageUtils.getPlayerLocaleString("geyser.commands.version.outdated", sender.getLocale(), (latestBuildNum - buildNum), "http://ci.geysermc.org/"));
+                        sender.sendMessage(LanguageUtils.getPlayerLocaleString("geyser.commands.version.outdated", sender.getLocale(), (latestBuildNum - buildNum), "https://ci.geysermc.org/"));
                     }
                 } else {
                     throw new AssertionError("buildNumber missing");

--- a/connector/src/main/java/org/geysermc/connector/entity/Entity.java
+++ b/connector/src/main/java/org/geysermc/connector/entity/Entity.java
@@ -321,7 +321,7 @@ public class Entity {
                     Message message = (Message) entityMetadata.getValue();
                     if (message != null)
                         // Always translate even if it's a TextMessage since there could be translatable parameters
-                        metadata.put(EntityData.NAMETAG, MessageUtils.getTranslatedBedrockMessage(message, session.getClientData().getLanguageCode(), true));
+                        metadata.put(EntityData.NAMETAG, MessageUtils.getTranslatedBedrockMessage(message, session.getLocale(), true));
                 }
                 break;
             case 3: // is custom name visible

--- a/connector/src/main/java/org/geysermc/connector/network/UpstreamPacketHandler.java
+++ b/connector/src/main/java/org/geysermc/connector/network/UpstreamPacketHandler.java
@@ -165,7 +165,7 @@ public class UpstreamPacketHandler extends LoggingPacketHandler {
 
     @Override
     public boolean handle(SetLocalPlayerAsInitializedPacket packet) {
-        LanguageUtils.loadGeyserLocale(session.getClientData().getLanguageCode());
+        LanguageUtils.loadGeyserLocale(session.getLocale());
 
         if (!session.isLoggedIn() && !session.isLoggingIn() && session.getConnector().getAuthType() == AuthType.ONLINE) {
             // TODO it is safer to key authentication on something that won't change (UUID, not username)
@@ -180,7 +180,7 @@ public class UpstreamPacketHandler extends LoggingPacketHandler {
     @Override
     public boolean handle(MovePlayerPacket packet) {
         if (session.isLoggingIn()) {
-            session.sendMessage(LanguageUtils.getPlayerLocaleString("geyser.auth.login.wait", session.getClientData().getLanguageCode()));
+            session.sendMessage(LanguageUtils.getPlayerLocaleString("geyser.auth.login.wait", session.getLocale()));
         }
 
         return translateAndDefault(packet);

--- a/connector/src/main/java/org/geysermc/connector/network/session/GeyserSession.java
+++ b/connector/src/main/java/org/geysermc/connector/network/session/GeyserSession.java
@@ -446,7 +446,7 @@ public class GeyserSession implements CommandSender {
                         // as it has to be extracted from a JAR
                         if (locale.toLowerCase().equals("en_us") && !LocaleUtils.LOCALE_MAPPINGS.containsKey("en_us")) {
                             // This should probably be left hardcoded as it will only show for en_us clients
-                            sendMessage("Downloading your locale (en_us) this may take some time");
+                            sendMessage("Loading your locale (en_us); if this isn't already downloaded, this may take some time");
                         }
 
                         // Download and load the language for the player
@@ -565,6 +565,11 @@ public class GeyserSession implements CommandSender {
     public boolean isConsole() {
         return false;
     }
+
+     @Override
+     public String getLocale() {
+        return clientData.getLanguageCode();
+     }
 
     public void sendForm(FormWindow window, int id) {
         windowCache.showWindow(window, id);

--- a/connector/src/main/java/org/geysermc/connector/network/session/cache/BossBar.java
+++ b/connector/src/main/java/org/geysermc/connector/network/session/cache/BossBar.java
@@ -58,7 +58,7 @@ public class BossBar {
         BossEventPacket bossEventPacket = new BossEventPacket();
         bossEventPacket.setBossUniqueEntityId(entityId);
         bossEventPacket.setAction(BossEventPacket.Action.CREATE);
-        bossEventPacket.setTitle(MessageUtils.getTranslatedBedrockMessage(title, session.getClientData().getLanguageCode()));
+        bossEventPacket.setTitle(MessageUtils.getTranslatedBedrockMessage(title, session.getLocale()));
         bossEventPacket.setHealthPercentage(health);
         bossEventPacket.setColor(color); //ignored by client
         bossEventPacket.setOverlay(overlay);
@@ -72,7 +72,7 @@ public class BossBar {
         BossEventPacket bossEventPacket = new BossEventPacket();
         bossEventPacket.setBossUniqueEntityId(entityId);
         bossEventPacket.setAction(BossEventPacket.Action.UPDATE_NAME);
-        bossEventPacket.setTitle(MessageUtils.getTranslatedBedrockMessage(title, session.getClientData().getLanguageCode()));
+        bossEventPacket.setTitle(MessageUtils.getTranslatedBedrockMessage(title, session.getLocale()));
 
         session.sendUpstreamPacket(bossEventPacket);
     }

--- a/connector/src/main/java/org/geysermc/connector/network/translators/inventory/EnchantmentInventoryTranslator.java
+++ b/connector/src/main/java/org/geysermc/connector/network/translators/inventory/EnchantmentInventoryTranslator.java
@@ -199,7 +199,7 @@ public class EnchantmentInventoryTranslator extends BlockInventoryTranslator {
 
     private String toRomanNumeral(GeyserSession session, int level) {
         return LocaleUtils.getLocaleString("enchantment.level." + level,
-                session.getClientData().getLanguageCode());
+                session.getLocale());
     }
 
     /**
@@ -261,7 +261,7 @@ public class EnchantmentInventoryTranslator extends BlockInventoryTranslator {
 
         public String toString(GeyserSession session) {
             return LocaleUtils.getLocaleString("enchantment.minecraft." + this.toString().toLowerCase(),
-                    session.getClientData().getLanguageCode());
+                    session.getLocale());
         }
     }
 }

--- a/connector/src/main/java/org/geysermc/connector/network/translators/item/ItemTranslator.java
+++ b/connector/src/main/java/org/geysermc/connector/network/translators/item/ItemTranslator.java
@@ -400,7 +400,7 @@ public abstract class ItemTranslator {
                 // Check if its a message to translate
                 if (MessageUtils.isMessage(name)) {
                     // Get the translated name
-                    name = MessageUtils.getTranslatedBedrockMessage(MessageSerializer.fromString(name), session.getClientData().getLanguageCode());
+                    name = MessageUtils.getTranslatedBedrockMessage(MessageSerializer.fromString(name), session.getLocale());
 
                     // Add the new name tag
                     display.put(new StringTag("Name", name));

--- a/connector/src/main/java/org/geysermc/connector/network/translators/java/JavaChatTranslator.java
+++ b/connector/src/main/java/org/geysermc/connector/network/translators/java/JavaChatTranslator.java
@@ -59,7 +59,7 @@ public class JavaChatTranslator extends PacketTranslator<ServerChatPacket> {
                 break;
         }
 
-        String locale = session.getClientData().getLanguageCode();
+        String locale = session.getLocale();
 
         if (packet.getMessage() instanceof TranslationMessage) {
             textPacket.setType(TextPacket.Type.TRANSLATION);

--- a/connector/src/main/java/org/geysermc/connector/network/translators/java/JavaDisconnectPacket.java
+++ b/connector/src/main/java/org/geysermc/connector/network/translators/java/JavaDisconnectPacket.java
@@ -36,6 +36,6 @@ public class JavaDisconnectPacket extends PacketTranslator<ServerDisconnectPacke
 
     @Override
     public void translate(ServerDisconnectPacket packet, GeyserSession session) {
-        session.disconnect(MessageUtils.getTranslatedBedrockMessage(packet.getReason(), session.getClientData().getLanguageCode(), true));
+        session.disconnect(MessageUtils.getTranslatedBedrockMessage(packet.getReason(), session.getLocale(), true));
     }
 }

--- a/connector/src/main/java/org/geysermc/connector/network/translators/java/JavaJoinGameTranslator.java
+++ b/connector/src/main/java/org/geysermc/connector/network/translators/java/JavaJoinGameTranslator.java
@@ -89,7 +89,7 @@ public class JavaJoinGameTranslator extends PacketTranslator<ServerJoinGamePacke
         session.setRenderDistance(packet.getViewDistance());
 
         // We need to send our skin parts to the server otherwise java sees us with no hat, jacket etc
-        String locale = session.getClientData().getLanguageCode();
+        String locale = session.getLocale();
         List<SkinPart> skinParts = Arrays.asList(SkinPart.values());
         ClientSettingsPacket clientSettingsPacket = new ClientSettingsPacket(locale, (byte) session.getRenderDistance(), ChatVisibility.FULL, true, skinParts, HandPreference.RIGHT_HAND);
         session.sendDownstreamPacket(clientSettingsPacket);

--- a/connector/src/main/java/org/geysermc/connector/network/translators/java/JavaLoginDisconnectTranslator.java
+++ b/connector/src/main/java/org/geysermc/connector/network/translators/java/JavaLoginDisconnectTranslator.java
@@ -37,6 +37,6 @@ public class JavaLoginDisconnectTranslator extends PacketTranslator<LoginDisconn
     @Override
     public void translate(LoginDisconnectPacket packet, GeyserSession session) {
         // The client doesn't manually get disconnected so we have to do it ourselves
-        session.disconnect(MessageUtils.getTranslatedBedrockMessage(packet.getReason(), session.getClientData().getLanguageCode()));
+        session.disconnect(MessageUtils.getTranslatedBedrockMessage(packet.getReason(), session.getLocale()));
     }
 }

--- a/connector/src/main/java/org/geysermc/connector/network/translators/java/JavaTitleTranslator.java
+++ b/connector/src/main/java/org/geysermc/connector/network/translators/java/JavaTitleTranslator.java
@@ -39,7 +39,7 @@ public class JavaTitleTranslator extends PacketTranslator<ServerTitlePacket> {
     @Override
     public void translate(ServerTitlePacket packet, GeyserSession session) {
         SetTitlePacket titlePacket = new SetTitlePacket();
-        String locale = session.getClientData().getLanguageCode();
+        String locale = session.getLocale();
 
         switch (packet.getAction()) {
             case TITLE:

--- a/connector/src/main/java/org/geysermc/connector/network/translators/java/scoreboard/JavaTeamTranslator.java
+++ b/connector/src/main/java/org/geysermc/connector/network/translators/java/scoreboard/JavaTeamTranslator.java
@@ -62,8 +62,8 @@ public class JavaTeamTranslator extends PacketTranslator<ServerTeamPacket> {
                         .setName(MessageUtils.getBedrockMessage(packet.getDisplayName()))
                         .setColor(packet.getColor())
                         .setNameTagVisibility(packet.getNameTagVisibility())
-                        .setPrefix(MessageUtils.getTranslatedBedrockMessage(packet.getPrefix(), session.getClientData().getLanguageCode()))
-                        .setSuffix(MessageUtils.getTranslatedBedrockMessage(packet.getSuffix(), session.getClientData().getLanguageCode()));
+                        .setPrefix(MessageUtils.getTranslatedBedrockMessage(packet.getPrefix(), session.getLocale()))
+                        .setSuffix(MessageUtils.getTranslatedBedrockMessage(packet.getSuffix(), session.getLocale()));
                 break;
             case UPDATE:
                 if (team == null) {
@@ -77,8 +77,8 @@ public class JavaTeamTranslator extends PacketTranslator<ServerTeamPacket> {
                 team.setName(MessageUtils.getBedrockMessage(packet.getDisplayName()))
                         .setColor(packet.getColor())
                         .setNameTagVisibility(packet.getNameTagVisibility())
-                        .setPrefix(MessageUtils.getTranslatedBedrockMessage(packet.getPrefix(), session.getClientData().getLanguageCode()))
-                        .setSuffix(MessageUtils.getTranslatedBedrockMessage(packet.getSuffix(), session.getClientData().getLanguageCode()))
+                        .setPrefix(MessageUtils.getTranslatedBedrockMessage(packet.getPrefix(), session.getLocale()))
+                        .setSuffix(MessageUtils.getTranslatedBedrockMessage(packet.getSuffix(), session.getLocale()))
                         .setUpdateType(UpdateType.UPDATE);
                 break;
             case ADD_PLAYER:

--- a/connector/src/main/java/org/geysermc/connector/network/translators/java/window/JavaOpenWindowTranslator.java
+++ b/connector/src/main/java/org/geysermc/connector/network/translators/java/window/JavaOpenWindowTranslator.java
@@ -58,9 +58,9 @@ public class JavaOpenWindowTranslator extends PacketTranslator<ServerOpenWindowP
         }
 
         String name = MessageUtils.getTranslatedBedrockMessage(MessageSerializer.fromString(packet.getName()),
-                session.getClientData().getLanguageCode());
+                session.getLocale());
 
-        name = LocaleUtils.getLocaleString(name, session.getClientData().getLanguageCode());
+        name = LocaleUtils.getLocaleString(name, session.getLocale());
 
         Inventory newInventory = new Inventory(name, packet.getWindowId(), packet.getType(), newTranslator.size + 36);
         session.getInventoryCache().cacheInventory(newInventory);

--- a/connector/src/main/java/org/geysermc/connector/network/translators/java/world/JavaNotifyClientTranslator.java
+++ b/connector/src/main/java/org/geysermc/connector/network/translators/java/world/JavaNotifyClientTranslator.java
@@ -143,7 +143,7 @@ public class JavaNotifyClientTranslator extends PacketTranslator<ServerNotifyCli
             case INVALID_BED:
                 // Not sent as a proper message? Odd.
                 session.sendMessage(LocaleUtils.getLocaleString("block.minecraft.spawn.not_valid",
-                        session.getClientData().getLanguageCode()));
+                        session.getLocale()));
                 break;
             case ARROW_HIT_PLAYER:
                 PlaySoundPacket arrowSoundPacket = new PlaySoundPacket();

--- a/connector/src/main/java/org/geysermc/connector/network/translators/java/world/JavaPlayEffectTranslator.java
+++ b/connector/src/main/java/org/geysermc/connector/network/translators/java/world/JavaPlayEffectTranslator.java
@@ -78,7 +78,7 @@ public class JavaPlayEffectTranslator extends PacketTranslator<ServerPlayEffectP
                 textPacket.setMessage("record.nowPlaying");
                 List<String> params = new ArrayList<>();
                 String recordString = "%item." + soundEvent.name().toLowerCase(Locale.ROOT) + ".desc";
-                params.add(LocaleUtils.getLocaleString(recordString, session.getClientData().getLanguageCode()));
+                params.add(LocaleUtils.getLocaleString(recordString, session.getLocale()));
                 textPacket.setParameters(params);
                 session.sendUpstreamPacket(textPacket);
             }

--- a/connector/src/main/java/org/geysermc/connector/utils/LanguageUtils.java
+++ b/connector/src/main/java/org/geysermc/connector/utils/LanguageUtils.java
@@ -59,6 +59,8 @@ public class LanguageUtils {
      */
     public static void loadGeyserLocale(String locale) {
         locale = formatLocale(locale);
+        // Don't load the locale if it's already loaded.
+        if (LOCALE_MAPPINGS.containsKey(locale)) return;
 
         InputStream localeStream = GeyserConnector.class.getClassLoader().getResourceAsStream("languages/texts/" + locale + ".properties");
 
@@ -131,7 +133,7 @@ public class LanguageUtils {
      * @param locale The locale to format
      * @return The formatted locale
      */
-    private static String formatLocale(String locale) {
+    public static String formatLocale(String locale) {
         try {
             String[] parts = locale.toLowerCase().split("_");
             return parts[0] + "_" + parts[1].toUpperCase();

--- a/connector/src/main/java/org/geysermc/connector/utils/LocaleUtils.java
+++ b/connector/src/main/java/org/geysermc/connector/utils/LocaleUtils.java
@@ -35,7 +35,6 @@ import org.geysermc.connector.GeyserConnector;
 import java.io.*;
 import java.nio.file.Files;
 import java.nio.file.Path;
-import java.nio.file.Paths;
 import java.util.HashMap;
 import java.util.Iterator;
 import java.util.List;

--- a/connector/src/main/java/org/geysermc/connector/utils/LoginEncryptionUtils.java
+++ b/connector/src/main/java/org/geysermc/connector/utils/LoginEncryptionUtils.java
@@ -160,7 +160,7 @@ public class LoginEncryptionUtils {
     private static int AUTH_DETAILS_FORM_ID = 1337;
 
     public static void showLoginWindow(GeyserSession session) {
-        String userLanguage = session.getClientData().getLanguageCode();
+        String userLanguage = session.getLocale();
         SimpleFormWindow window = new SimpleFormWindow(LanguageUtils.getPlayerLocaleString("geyser.auth.login.form.notice.title", userLanguage), LanguageUtils.getPlayerLocaleString("geyser.auth.login.form.notice.desc", userLanguage));
         window.getButtons().add(new FormButton(LanguageUtils.getPlayerLocaleString("geyser.auth.login.form.notice.btn_login", userLanguage)));
         window.getButtons().add(new FormButton(LanguageUtils.getPlayerLocaleString("geyser.auth.login.form.notice.btn_disconnect", userLanguage)));
@@ -169,7 +169,7 @@ public class LoginEncryptionUtils {
     }
 
     public static void showLoginDetailsWindow(GeyserSession session) {
-        String userLanguage = session.getClientData().getLanguageCode();
+        String userLanguage = session.getLocale();
         CustomFormWindow window = new CustomFormBuilder(LanguageUtils.getPlayerLocaleString("geyser.auth.login.form.details.title", userLanguage))
                 .addComponent(new LabelComponent(LanguageUtils.getPlayerLocaleString("geyser.auth.login.form.details.desc", userLanguage)))
                 .addComponent(new InputComponent(LanguageUtils.getPlayerLocaleString("geyser.auth.login.form.details.email", userLanguage), "account@geysermc.org", ""))
@@ -210,7 +210,7 @@ public class LoginEncryptionUtils {
                         if (response.getClickedButtonId() == 0) {
                             showLoginDetailsWindow(session);
                         } else if(response.getClickedButtonId() == 1) {
-                            session.disconnect(LanguageUtils.getPlayerLocaleString("geyser.auth.login.form.disconnect", session.getClientData().getLanguageCode()));
+                            session.disconnect(LanguageUtils.getPlayerLocaleString("geyser.auth.login.form.disconnect", session.getLocale()));
                         }
                     } else {
                         showLoginWindow(session);

--- a/connector/src/main/java/org/geysermc/connector/utils/MessageUtils.java
+++ b/connector/src/main/java/org/geysermc/connector/utils/MessageUtils.java
@@ -485,7 +485,7 @@ public class MessageUtils {
      */
     public static boolean isTooLong(String message, GeyserSession session) {
         if (message.length() > 256) {
-            session.sendMessage(LanguageUtils.getPlayerLocaleString("geyser.chat.too_long", session.getClientData().getLanguageCode(), message.length()));
+            session.sendMessage(LanguageUtils.getPlayerLocaleString("geyser.chat.too_long", session.getLocale(), message.length()));
             return true;
         }
 

--- a/connector/src/main/java/org/geysermc/connector/utils/SettingsUtils.java
+++ b/connector/src/main/java/org/geysermc/connector/utils/SettingsUtils.java
@@ -58,7 +58,7 @@ public class SettingsUtils {
         builder.setIcon(new FormImage(FormImage.FormImageType.PATH, "textures/ui/settings_glyph_color_2x.png"));
 
         builder.addComponent(new LabelComponent(LanguageUtils.getPlayerLocaleString("geyser.settings.title.client", language)));
-        builder.addComponent(new ToggleComponent(LanguageUtils.getPlayerLocaleString("geyser.settings.option.coordinates", language, session.getWorldCache().isShowCoordinates())));
+        builder.addComponent(new ToggleComponent(LanguageUtils.getPlayerLocaleString("geyser.settings.option.coordinates", language), session.getWorldCache().isShowCoordinates()));
 
 
         if (session.getOpPermissionLevel() >= 2 || session.hasPermission("geyser.settings.server")) {

--- a/connector/src/main/java/org/geysermc/connector/utils/SettingsUtils.java
+++ b/connector/src/main/java/org/geysermc/connector/utils/SettingsUtils.java
@@ -52,7 +52,7 @@ public class SettingsUtils {
      */
     public static void buildForm(GeyserSession session) {
         // Cache the language for cleaner access
-        String language = session.getClientData().getLanguageCode();
+        String language = session.getLocale();
 
         CustomFormBuilder builder = new CustomFormBuilder(LanguageUtils.getPlayerLocaleString("geyser.settings.title.main", language));
         builder.setIcon(new FormImage(FormImage.FormImageType.PATH, "textures/ui/settings_glyph_color_2x.png"));


### PR DESCRIPTION
This allows Geyser-specific commands (e.g. `/geyser help`) to be displayed in the (Java or Bedrock) player's default language, which stops those commands from simply being displayed in the default locale.