### PR TITLE
Update MCProtocolLib to fix datapacks that send empty result recipes

### DIFF
--- a/connector/pom.xml
+++ b/connector/pom.xml
@@ -109,9 +109,9 @@
             <scope>compile</scope>
         </dependency>
         <dependency>
-            <groupId>com.github.GeyserMC</groupId>
+            <groupId>com.github.steveice10</groupId>
             <artifactId>mcprotocollib</artifactId>
-            <version>e4181064d1</version>
+            <version>6ac79c14d6</version>
             <scope>compile</scope>
             <exclusions>
                 <exclusion>


### PR DESCRIPTION
Example: https://www.planetminecraft.com/data-pack/true-survival-a-hardcore-minecraft-experience/