### PR TITLE
Use artifactory jenkins plugin

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -24,8 +24,29 @@ pipeline {
             when {
                 branch "master"
             }
+
             steps {
-                sh 'mvn javadoc:jar source:jar deploy -DskipTests'
+                rtMavenDeployer(
+                        id: "maven-deployer",
+                        serverId: "opencollab-artifactory",
+                        releaseRepo: "maven-releases",
+                        snapshotRepo: "maven-snapshots"
+                )
+                rtMavenResolver(
+                        id: "maven-resolver",
+                        serverId: "opencollab-artifactory",
+                        releaseRepo: "release",
+                        snapshotRepo: "snapshot"
+                )
+                rtMavenRun(
+                        pom: 'pom.xml',
+                        goals: 'javadoc:jar source:jar install -DskipTests',
+                        deployerId: "maven-deployer",
+                        resolverId: "maven-resolver"
+                )
+                rtPublishBuildInfo(
+                        serverId: "opencollab-artifactory"
+                )
             }
         }
     }

--- a/bootstrap/bungeecord/pom.xml
+++ b/bootstrap/bungeecord/pom.xml
@@ -6,10 +6,10 @@
     <parent>
         <groupId>org.geysermc</groupId>
         <artifactId>bootstrap-parent</artifactId>
-        <version>1.1.0</version>
-        <relativePath>../</relativePath>
+        <version>1.1.0-SNAPSHOT</version>
     </parent>
     <artifactId>bootstrap-bungeecord</artifactId>
+
     <dependencies>
         <dependency>
             <groupId>org.geysermc</groupId>

--- a/bootstrap/bungeecord/pom.xml
+++ b/bootstrap/bungeecord/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>org.geysermc</groupId>
         <artifactId>bootstrap-parent</artifactId>
-        <version>1.1.0-SNAPSHOT</version>
+        <version>1.2.0-SNAPSHOT</version>
     </parent>
     <artifactId>bootstrap-bungeecord</artifactId>
 
@@ -14,7 +14,7 @@
         <dependency>
             <groupId>org.geysermc</groupId>
             <artifactId>connector</artifactId>
-            <version>1.1.0</version>
+            <version>1.2.0-SNAPSHOT</version>
             <scope>compile</scope>
         </dependency>
         <dependency>

--- a/bootstrap/pom.xml
+++ b/bootstrap/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>org.geysermc</groupId>
         <artifactId>geyser-parent</artifactId>
-        <version>1.1.0-SNAPSHOT</version>
+        <version>1.2.0-SNAPSHOT</version>
     </parent>
     <artifactId>bootstrap-parent</artifactId>
     <packaging>pom</packaging>

--- a/bootstrap/pom.xml
+++ b/bootstrap/pom.xml
@@ -6,12 +6,11 @@
     <parent>
         <groupId>org.geysermc</groupId>
         <artifactId>geyser-parent</artifactId>
-        <version>parent</version>
-        <relativePath>../</relativePath>
+        <version>1.1.0-SNAPSHOT</version>
     </parent>
     <artifactId>bootstrap-parent</artifactId>
-    <version>1.1.0</version>
     <packaging>pom</packaging>
+
     <repositories>
         <repository>
             <id>spigot-public</id>

--- a/bootstrap/spigot/pom.xml
+++ b/bootstrap/spigot/pom.xml
@@ -6,10 +6,10 @@
     <parent>
         <groupId>org.geysermc</groupId>
         <artifactId>bootstrap-parent</artifactId>
-        <version>1.1.0</version>
-        <relativePath>../</relativePath>
+        <version>1.1.0-SNAPSHOT</version>
     </parent>
     <artifactId>bootstrap-spigot</artifactId>
+
     <dependencies>
         <dependency>
             <groupId>org.geysermc</groupId>

--- a/bootstrap/spigot/pom.xml
+++ b/bootstrap/spigot/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>org.geysermc</groupId>
         <artifactId>bootstrap-parent</artifactId>
-        <version>1.1.0-SNAPSHOT</version>
+        <version>1.2.0-SNAPSHOT</version>
     </parent>
     <artifactId>bootstrap-spigot</artifactId>
 
@@ -14,7 +14,7 @@
         <dependency>
             <groupId>org.geysermc</groupId>
             <artifactId>connector</artifactId>
-            <version>1.1.0</version>
+            <version>1.2.0-SNAPSHOT</version>
             <scope>compile</scope>
         </dependency>
         <dependency>

--- a/bootstrap/sponge/pom.xml
+++ b/bootstrap/sponge/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>org.geysermc</groupId>
         <artifactId>bootstrap-parent</artifactId>
-        <version>1.1.0-SNAPSHOT</version>
+        <version>1.2.0-SNAPSHOT</version>
     </parent>
     <artifactId>bootstrap-sponge</artifactId>
 
@@ -14,7 +14,7 @@
         <dependency>
             <groupId>org.geysermc</groupId>
             <artifactId>connector</artifactId>
-            <version>1.1.0</version>
+            <version>1.2.0-SNAPSHOT</version>
             <scope>compile</scope>
         </dependency>
         <dependency>

--- a/bootstrap/sponge/pom.xml
+++ b/bootstrap/sponge/pom.xml
@@ -6,10 +6,10 @@
     <parent>
         <groupId>org.geysermc</groupId>
         <artifactId>bootstrap-parent</artifactId>
-        <version>1.1.0</version>
-        <relativePath>../</relativePath>
+        <version>1.1.0-SNAPSHOT</version>
     </parent>
     <artifactId>bootstrap-sponge</artifactId>
+
     <dependencies>
         <dependency>
             <groupId>org.geysermc</groupId>

--- a/bootstrap/standalone/pom.xml
+++ b/bootstrap/standalone/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>org.geysermc</groupId>
         <artifactId>bootstrap-parent</artifactId>
-        <version>1.1.0-SNAPSHOT</version>
+        <version>1.2.0-SNAPSHOT</version>
     </parent>
     <artifactId>bootstrap-standalone</artifactId>
 
@@ -14,7 +14,7 @@
         <dependency>
             <groupId>org.geysermc</groupId>
             <artifactId>connector</artifactId>
-            <version>1.1.0</version>
+            <version>1.2.0-SNAPSHOT</version>
             <scope>compile</scope>
         </dependency>
         <dependency>

--- a/bootstrap/standalone/pom.xml
+++ b/bootstrap/standalone/pom.xml
@@ -6,10 +6,10 @@
     <parent>
         <groupId>org.geysermc</groupId>
         <artifactId>bootstrap-parent</artifactId>
-        <version>1.1.0</version>
-        <relativePath>../</relativePath>
+        <version>1.1.0-SNAPSHOT</version>
     </parent>
     <artifactId>bootstrap-standalone</artifactId>
+
     <dependencies>
         <dependency>
             <groupId>org.geysermc</groupId>

--- a/bootstrap/velocity/pom.xml
+++ b/bootstrap/velocity/pom.xml
@@ -6,10 +6,10 @@
     <parent>
         <groupId>org.geysermc</groupId>
         <artifactId>bootstrap-parent</artifactId>
-        <version>1.1.0</version>
-        <relativePath>../</relativePath>
+        <version>1.1.0-SNAPSHOT</version>
     </parent>
     <artifactId>bootstrap-velocity</artifactId>
+
     <dependencies>
         <dependency>
             <groupId>org.geysermc</groupId>

--- a/bootstrap/velocity/pom.xml
+++ b/bootstrap/velocity/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>org.geysermc</groupId>
         <artifactId>bootstrap-parent</artifactId>
-        <version>1.1.0-SNAPSHOT</version>
+        <version>1.2.0-SNAPSHOT</version>
     </parent>
     <artifactId>bootstrap-velocity</artifactId>
 
@@ -14,7 +14,7 @@
         <dependency>
             <groupId>org.geysermc</groupId>
             <artifactId>connector</artifactId>
-            <version>1.1.0</version>
+            <version>1.2.0-SNAPSHOT</version>
             <scope>compile</scope>
         </dependency>
         <dependency>

--- a/common/pom.xml
+++ b/common/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>org.geysermc</groupId>
         <artifactId>geyser-parent</artifactId>
-        <version>1.1.0-SNAPSHOT</version>
+        <version>1.2.0-SNAPSHOT</version>
     </parent>
     <artifactId>common</artifactId>
 

--- a/common/pom.xml
+++ b/common/pom.xml
@@ -6,11 +6,10 @@
     <parent>
         <groupId>org.geysermc</groupId>
         <artifactId>geyser-parent</artifactId>
-        <version>parent</version>
-        <relativePath>../</relativePath>
+        <version>1.1.0-SNAPSHOT</version>
     </parent>
     <artifactId>common</artifactId>
-    <version>1.1.0</version>
+
     <dependencies>
         <dependency>
             <groupId>com.google.code.gson</groupId>

--- a/connector/pom.xml
+++ b/connector/pom.xml
@@ -6,11 +6,10 @@
     <parent>
         <groupId>org.geysermc</groupId>
         <artifactId>geyser-parent</artifactId>
-        <version>parent</version>
-        <relativePath>../</relativePath>
+        <version>1.1.0-SNAPSHOT</version>
     </parent>
     <artifactId>connector</artifactId>
-    <version>1.1.0</version>
+
     <dependencies>
         <dependency>
             <groupId>org.geysermc</groupId>

--- a/connector/pom.xml
+++ b/connector/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>org.geysermc</groupId>
         <artifactId>geyser-parent</artifactId>
-        <version>1.1.0-SNAPSHOT</version>
+        <version>1.2.0-SNAPSHOT</version>
     </parent>
     <artifactId>connector</artifactId>
 
@@ -14,7 +14,7 @@
         <dependency>
             <groupId>org.geysermc</groupId>
             <artifactId>common</artifactId>
-            <version>1.1.0</version>
+            <version>1.2.0-SNAPSHOT</version>
             <scope>compile</scope>
         </dependency>
         <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>org.geysermc</groupId>
     <artifactId>geyser-parent</artifactId>
-    <version>parent</version>
+    <version>1.1.0-SNAPSHOT</version>
     <packaging>pom</packaging>
     <name>Geyser</name>
     <description>Allows for players from Minecraft Bedrock Edition to join Minecraft Java Edition servers.</description>
@@ -70,19 +70,6 @@
             <url>https://oss.sonatype.org/content/repositories/snapshots/</url>
         </repository>
     </repositories>
-
-    <distributionManagement>
-        <repository>
-            <id>releases</id>
-            <name>opencollab-releases</name>
-            <url>https://repo.opencollab.dev/maven-releases</url>
-        </repository>
-        <snapshotRepository>
-            <id>snapshots</id>
-            <name>opencollab-snapshots</name>
-            <url>https://repo.opencollab.dev/maven-snapshots</url>
-        </snapshotRepository>
-    </distributionManagement>
 
     <dependencies>
         <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>org.geysermc</groupId>
     <artifactId>geyser-parent</artifactId>
-    <version>1.1.0-SNAPSHOT</version>
+    <version>1.2.0-SNAPSHOT</version>
     <packaging>pom</packaging>
     <name>Geyser</name>
     <description>Allows for players from Minecraft Bedrock Edition to join Minecraft Java Edition servers.</description>


### PR DESCRIPTION
- Relegates deployment configuration to the `Jenkinsfile` instead of it being stored in the maven `pom.xml`
- With the Artifactory jenkins plugin we are able to store more build info in the maven repository and use it's APIs.