### PR TITLE
Move the "Please wait until you are logged in..." message to the Action Bar

### DIFF
--- a/connector/src/main/java/org/geysermc/connector/network/UpstreamPacketHandler.java
+++ b/connector/src/main/java/org/geysermc/connector/network/UpstreamPacketHandler.java
@@ -187,7 +187,13 @@ public class UpstreamPacketHandler extends LoggingPacketHandler {
     @Override
     public boolean handle(MovePlayerPacket packet) {
         if (session.isLoggingIn()) {
-            session.sendMessage(LanguageUtils.getPlayerLocaleString("geyser.auth.login.wait", session.getLocale()));
+            SetTitlePacket titlePacket = new SetTitlePacket();
+            titlePacket.setType(SetTitlePacket.Type.ACTIONBAR);
+            titlePacket.setText(LanguageUtils.getPlayerLocaleString("geyser.auth.login.wait", session.getLocale()));
+            titlePacket.setFadeInTime(0);
+            titlePacket.setFadeOutTime(1);
+            titlePacket.setStayTime(2);
+            session.sendUpstreamPacket(titlePacket);
         }
 
         return translateAndDefault(packet);


### PR DESCRIPTION
I moved the "Please wait until you are logged in..." message that displays in chat when logging in to the Action Bar as was discussed in #1517 . It's a fairly simple change but it definitely looks better than the chat getting spammed while loading.