### PR TITLE
Clear the Reflections scanners to stop it trying to scan

### DIFF
--- a/connector/src/main/java/org/geysermc/connector/utils/FileUtils.java
+++ b/connector/src/main/java/org/geysermc/connector/utils/FileUtils.java
@@ -201,7 +201,7 @@ public class FileUtils {
      * @return The created Reflections object
      */
     public static Reflections getReflections(String path) {
-        Reflections reflections = new Reflections(new ConfigurationBuilder());
+        Reflections reflections = new Reflections(new ConfigurationBuilder().setScanners());
         XmlSerializer serializer = new XmlSerializer();
         URL resource = FileUtils.class.getClassLoader().getResource("META-INF/reflections/" + path + "-reflections.xml");
         try (InputStream inputStream = resource.openConnection().getInputStream()) {


### PR DESCRIPTION
This PR clears the scanners passed to the Reflections config to stop it trying to scan when we load the data from an XML file.

Fixes #1252 

See: https://github.com/ronmamo/reflections/blob/master/src/main/java/org/reflections/Reflections.java#L132