### PR TITLE
GUI: Don't exit if there is a config error

### DIFF
--- a/bootstrap/standalone/src/main/java/org/geysermc/platform/standalone/GeyserStandaloneBootstrap.java
+++ b/bootstrap/standalone/src/main/java/org/geysermc/platform/standalone/GeyserStandaloneBootstrap.java
@@ -204,7 +204,12 @@ public class GeyserStandaloneBootstrap implements GeyserBootstrap {
             }
         } catch (IOException ex) {
             geyserLogger.severe(LanguageUtils.getLocaleStringLog("geyser.config.failed"), ex);
-            System.exit(0);
+            if (gui == null) {
+                System.exit(1);
+            } else {
+                // Leave the process running so the GUI is still visible
+                return;
+            }
         }
         GeyserConfiguration.checkGeyserConfiguration(geyserConfig, geyserLogger);
 


### PR DESCRIPTION
Leave the window open so the user understands there is an error.

This also changes the exit code to 1 when exiting without a GUI since we have an error.