### PR TITLE
WolfEntity: fix entire wolf being set to a color in rare instances

### DIFF
--- a/connector/src/main/java/org/geysermc/connector/entity/living/animal/tameable/WolfEntity.java
+++ b/connector/src/main/java/org/geysermc/connector/entity/living/animal/tameable/WolfEntity.java
@@ -60,6 +60,11 @@ public class WolfEntity extends TameableEntity {
         // Relies on EntityData.OWNER_EID being set in TameableEntity.java
         if (entityMetadata.getId() == 19 && !metadata.getFlags().getFlag(EntityFlag.ANGRY)) {
             metadata.put(EntityData.COLOR, collarColor = (byte) (int) entityMetadata.getValue());
+            if (!metadata.containsKey(EntityData.OWNER_EID)) {
+                // If a color is set and there is no owner entity ID, set one.
+                // Otherwise, the entire wolf is set to that color: https://user-images.githubusercontent.com/9083212/99209989-92691200-2792-11eb-911d-9a315c955be9.png
+                metadata.put(EntityData.OWNER_EID, session.getPlayerEntity().getGeyserId());
+            }
         }
 
         // Wolf anger (1.16+)


### PR DESCRIPTION
For some reason, the owner UUID metadata was not being sent, but Java still displays the wolf collar correctly.