### PR TITLE
Add Open Collective as a donation option

### DIFF
--- a/.github/FUNDING.yml
+++ b/.github/FUNDING.yml
@@ -1,12 +1,2 @@
 # These are supported funding model platforms
-
-github: # Replace with up to 4 GitHub Sponsors-enabled usernames e.g., [user1, user2]
-patreon: #GeyserMC # Disabled currently
-open_collective: # Replace with a single Open Collective username
-ko_fi: # Replace with a single Ko-fi username
-tidelift: # Replace with a single Tidelift platform-name/package-name e.g., npm/babel
-community_bridge: # Replace with a single Community Bridge project-name e.g., cloud-foundry
-liberapay: # Replace with a single Liberapay username
-issuehunt: # Replace with a single IssueHunt username
-otechie: # Replace with a single Otechie username
-custom: # Replace with up to 4 custom sponsorship URLs e.g., ['link1', 'link2']
+open_collective: GeyserMC


### PR DESCRIPTION
Open Collective is a better choice than Patreon for accepting donations as everything is transparent.

Currently, the fiscal host is set to the Open Source Collective 501(c)(6), which means they control the money. If anyone (including myself) wants to withdraw money we have to submit an invoice (don't worry, its easy and they provide a template) which i can then accept or deny and the Open Source Collective will also have to accept it.

This may sound problematic, but as long as you fill out the fields correctly it is very likely to be accepted by the fiscal host.

**This should be seen as a stop-gap until we get a unified [Open Collaboration](https://github.com/OpenCollaboration) donation method**

---

On the collective page, I currently state the following:
> This collective is run by and for the benefit of the independent contributors to the Geyser open source project. This collective is not endorsed or administered by Digital Tree Media Ltd. All donations made will be expended for the private benefit of or otherwise to reimburse individuals that do not have an employer/employee, contractor, or other agency relationship with Digital Tree Media Ltd.

I am not sure if this is required to use the Open Source Collective, but its what [webpack](https://opencollective.com/webpack) states on their collective. The downside to this message is that @RednedEpic will not be able to receive donations (but it could be worse as he works for CubeCraft). It may be possible to remove the message as it's probably no big deal.