### PR TITLE
Added IGeyserPingPassthrough#getPingInformation(InetSocketAddress)

### DIFF
--- a/bootstrap/bungeecord/src/main/java/org/geysermc/platform/bungeecord/GeyserBungeePingPassthrough.java
+++ b/bootstrap/bungeecord/src/main/java/org/geysermc/platform/bungeecord/GeyserBungeePingPassthrough.java
@@ -47,14 +47,12 @@ import java.util.concurrent.CompletableFuture;
 @AllArgsConstructor
 public class GeyserBungeePingPassthrough implements IGeyserPingPassthrough, Listener {
 
-    private static final GeyserPendingConnection PENDING_CONNECTION = new GeyserPendingConnection();
-
     private final ProxyServer proxyServer;
 
     @Override
-    public GeyserPingInfo getPingInformation() {
+    public GeyserPingInfo getPingInformation(InetSocketAddress inetSocketAddress) {
         CompletableFuture<ProxyPingEvent> future = new CompletableFuture<>();
-        proxyServer.getPluginManager().callEvent(new ProxyPingEvent(PENDING_CONNECTION, getPingInfo(), (event, throwable) -> {
+        proxyServer.getPluginManager().callEvent(new ProxyPingEvent(new GeyserPendingConnection(inetSocketAddress), getPingInfo(), (event, throwable) -> {
             if (throwable != null) future.completeExceptionally(throwable);
             else future.complete(event);
         }));
@@ -89,7 +87,12 @@ public class GeyserBungeePingPassthrough implements IGeyserPingPassthrough, List
     private static class GeyserPendingConnection implements PendingConnection {
 
         private static final UUID FAKE_UUID = UUID.nameUUIDFromBytes("geyser!internal".getBytes());
-        private static final InetSocketAddress FAKE_REMOTE = new InetSocketAddress(Inet4Address.getLoopbackAddress(), 69);
+
+        private final InetSocketAddress remote;
+
+        public GeyserPendingConnection(InetSocketAddress remote) {
+            this.remote = remote;
+        }
 
         @Override
         public String getName() {
@@ -143,7 +146,7 @@ public class GeyserBungeePingPassthrough implements IGeyserPingPassthrough, List
 
         @Override
         public InetSocketAddress getAddress() {
-            return FAKE_REMOTE;
+            return remote;
         }
 
         @Override

--- a/bootstrap/spigot/src/main/java/org/geysermc/platform/spigot/GeyserSpigotPingPassthrough.java
+++ b/bootstrap/spigot/src/main/java/org/geysermc/platform/spigot/GeyserSpigotPingPassthrough.java
@@ -35,6 +35,7 @@ import org.geysermc.connector.common.ping.GeyserPingInfo;
 import org.geysermc.connector.ping.IGeyserPingPassthrough;
 
 import java.net.InetAddress;
+import java.net.InetSocketAddress;
 import java.util.Collections;
 import java.util.Iterator;
 
@@ -44,9 +45,9 @@ public class GeyserSpigotPingPassthrough implements IGeyserPingPassthrough {
     private final GeyserSpigotLogger logger;
 
     @Override
-    public GeyserPingInfo getPingInformation() {
+    public GeyserPingInfo getPingInformation(InetSocketAddress inetSocketAddress) {
         try {
-            ServerListPingEvent event = new GeyserPingEvent(InetAddress.getLocalHost(), Bukkit.getMotd(), Bukkit.getOnlinePlayers().size(), Bukkit.getMaxPlayers());
+            ServerListPingEvent event = new GeyserPingEvent(inetSocketAddress.getAddress(), Bukkit.getMotd(), Bukkit.getOnlinePlayers().size(), Bukkit.getMaxPlayers());
             Bukkit.getPluginManager().callEvent(event);
             GeyserPingInfo geyserPingInfo = new GeyserPingInfo(event.getMotd(),
                     new GeyserPingInfo.Players(event.getMaxPlayers(), event.getNumPlayers()),

--- a/bootstrap/velocity/src/main/java/org/geysermc/platform/velocity/GeyserVelocityPingPassthrough.java
+++ b/bootstrap/velocity/src/main/java/org/geysermc/platform/velocity/GeyserVelocityPingPassthrough.java
@@ -43,15 +43,13 @@ import java.util.concurrent.ExecutionException;
 @AllArgsConstructor
 public class GeyserVelocityPingPassthrough implements IGeyserPingPassthrough {
 
-    private static final GeyserInboundConnection FAKE_INBOUND_CONNECTION = new GeyserInboundConnection();
-
     private final ProxyServer server;
 
     @Override
-    public GeyserPingInfo getPingInformation() {
+    public GeyserPingInfo getPingInformation(InetSocketAddress inetSocketAddress) {
         ProxyPingEvent event;
         try {
-            event = server.getEventManager().fire(new ProxyPingEvent(FAKE_INBOUND_CONNECTION, ServerPing.builder()
+            event = server.getEventManager().fire(new ProxyPingEvent(new GeyserInboundConnection(inetSocketAddress), ServerPing.builder()
                     .description(server.getConfiguration().getMotdComponent()).onlinePlayers(server.getPlayerCount())
                     .maximumPlayers(server.getConfiguration().getShowMaxPlayers()).build())).get();
         } catch (ExecutionException | InterruptedException e) {
@@ -74,11 +72,15 @@ public class GeyserVelocityPingPassthrough implements IGeyserPingPassthrough {
 
     private static class GeyserInboundConnection implements InboundConnection {
 
-        private static final InetSocketAddress FAKE_REMOTE = new InetSocketAddress(Inet4Address.getLoopbackAddress(), 69);
+        private final InetSocketAddress remote;
+
+        public GeyserInboundConnection(InetSocketAddress remote) {
+            this.remote = remote;
+        }
 
         @Override
         public InetSocketAddress getRemoteAddress() {
-            return FAKE_REMOTE;
+            return this.remote;
         }
 
         @Override

--- a/connector/src/main/java/org/geysermc/connector/network/ConnectorServerEventHandler.java
+++ b/connector/src/main/java/org/geysermc/connector/network/ConnectorServerEventHandler.java
@@ -63,7 +63,7 @@ public class ConnectorServerEventHandler implements BedrockServerEventHandler {
         GeyserPingInfo pingInfo = null;
         if (config.isPassthroughMotd() || config.isPassthroughPlayerCounts()) {
             IGeyserPingPassthrough pingPassthrough = connector.getBootstrap().getGeyserPingPassthrough();
-            pingInfo = pingPassthrough.getPingInformation();
+            pingInfo = pingPassthrough.getPingInformation(inetSocketAddress);
         }
 
         BedrockPong pong = new BedrockPong();

--- a/connector/src/main/java/org/geysermc/connector/ping/GeyserLegacyPingPassthrough.java
+++ b/connector/src/main/java/org/geysermc/connector/ping/GeyserLegacyPingPassthrough.java
@@ -70,7 +70,7 @@ public class GeyserLegacyPingPassthrough implements IGeyserPingPassthrough, Runn
     }
 
     @Override
-    public GeyserPingInfo getPingInformation() {
+    public GeyserPingInfo getPingInformation(InetSocketAddress inetSocketAddress) {
         return pingInfo;
     }
 

--- a/connector/src/main/java/org/geysermc/connector/ping/IGeyserPingPassthrough.java
+++ b/connector/src/main/java/org/geysermc/connector/ping/IGeyserPingPassthrough.java
@@ -27,15 +27,29 @@ package org.geysermc.connector.ping;
 
 import org.geysermc.connector.common.ping.GeyserPingInfo;
 
+import java.net.Inet4Address;
+import java.net.InetSocketAddress;
+
 /**
  * Interface that retrieves ping passthrough information from the Java server
  */
 public interface IGeyserPingPassthrough {
 
     /**
-     * Get the MOTD of the server displayed on the multiplayer screen
+     * Get the MOTD of the server displayed on the multiplayer screen. It uses a fake remote, as the remote isn't important in this context.
+     *
      * @return string of the MOTD
      */
-    GeyserPingInfo getPingInformation();
+    default GeyserPingInfo getPingInformation() {
+        return this.getPingInformation(new InetSocketAddress(Inet4Address.getLoopbackAddress(), 69));
+    }
+
+    /**
+     * Get the MOTD of the server displayed on the multiplayer screen
+     *
+     * @param inetSocketAddress the ip address of the client pinging the server
+     * @return string of the MOTD
+     */
+    GeyserPingInfo getPingInformation(InetSocketAddress inetSocketAddress);
 
 }


### PR DESCRIPTION
Many server owners, just as me, want to log the hashed IPs of players pinging their servers so they can create statistics and estimate how many users will come to the server launch. That's the reason I implemented the IGeyserPingPassthrough#getPingInformation(InetSocketAddress) method so I can use the pingers' ip addresses in the ProxyPingEvent, just as usual.