### PR TITLE
Improve doDaylightCycle translation

### DIFF
--- a/connector/src/main/java/org/geysermc/connector/network/session/GeyserSession.java
+++ b/connector/src/main/java/org/geysermc/connector/network/session/GeyserSession.java
@@ -250,6 +250,12 @@ public class GeyserSession implements CommandSender {
     @Setter
     private ScheduledFuture<?> movementSendIfIdle;
 
+    /**
+     * Controls whether the daylight cycle gamerule has been sent to the client, so the sun/moon remain motionless.
+     */
+    @Setter
+    private boolean daylightCycle = true;
+
     private boolean reducedDebugInfo = false;
 
     @Setter


### PR DESCRIPTION
Previously, we wouldn't send the time if the server was sending the same time with doDaylightCycle on. However, this isn't vanilla behavior (for Bedrock nor Java) and can occasionally cause irregularities. The time is now always sent to Bedrock clients, and a daylightCycle field is added to GeyserSession to keep track of the doDaylightCycle gamerule we need to send to Bedrock. Removing the map we used to store the time may also improve memory usage since this was never cleaned up.