### PR TITLE
HAProxy PROXY protocol support for upstream connections

### DIFF
--- a/connector/src/main/java/org/geysermc/connector/GeyserConnector.java
+++ b/connector/src/main/java/org/geysermc/connector/GeyserConnector.java
@@ -29,6 +29,7 @@ import com.fasterxml.jackson.core.JsonParser;
 import com.fasterxml.jackson.databind.DeserializationFeature;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.nukkitx.network.raknet.RakNetConstants;
+import com.nukkitx.network.util.EventLoops;
 import com.nukkitx.protocol.bedrock.BedrockServer;
 import lombok.Getter;
 import lombok.Setter;
@@ -196,7 +197,13 @@ public class GeyserConnector {
         RakNetConstants.MAXIMUM_MTU_SIZE = (short) config.getMtu();
         logger.debug("Setting MTU to " + config.getMtu());
 
-        bedrockServer = new BedrockServer(new InetSocketAddress(config.getBedrock().getAddress(), config.getBedrock().getPort()));
+        boolean enableProxyProtocol = config.getBedrock().isEnableProxyProtocol();
+        bedrockServer = new BedrockServer(
+                new InetSocketAddress(config.getBedrock().getAddress(), config.getBedrock().getPort()),
+                1,
+                EventLoops.commonGroup(),
+                enableProxyProtocol
+        );
         bedrockServer.setHandler(new ConnectorServerEventHandler(this));
         bedrockServer.bind().whenComplete((avoid, throwable) -> {
             if (throwable == null) {

--- a/connector/src/main/java/org/geysermc/connector/configuration/GeyserConfiguration.java
+++ b/connector/src/main/java/org/geysermc/connector/configuration/GeyserConfiguration.java
@@ -27,9 +27,11 @@ package org.geysermc.connector.configuration;
 
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import org.geysermc.connector.GeyserLogger;
+import org.geysermc.connector.network.CIDRMatcher;
 import org.geysermc.connector.utils.LanguageUtils;
 
 import java.nio.file.Path;
+import java.util.List;
 import java.util.Map;
 
 public interface GeyserConfiguration {
@@ -106,6 +108,15 @@ public interface GeyserConfiguration {
         String getMotd2();
 
         String getServerName();
+
+        boolean isEnableProxyProtocol();
+
+        List<String> getProxyProtocolWhitelistedIPs();
+
+        /**
+         * @return Unmodifiable list of {@link CIDRMatcher}s from {@link #getProxyProtocolWhitelistedIPs()}
+         */
+        List<CIDRMatcher> getWhitelistedIPsMatchers();
     }
 
     interface IRemoteConfiguration {

--- a/connector/src/main/java/org/geysermc/connector/configuration/GeyserJacksonConfiguration.java
+++ b/connector/src/main/java/org/geysermc/connector/configuration/GeyserJacksonConfiguration.java
@@ -25,16 +25,21 @@
 
 package org.geysermc.connector.configuration;
 
+import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import lombok.Getter;
 import lombok.Setter;
 import org.geysermc.connector.GeyserConnector;
 import org.geysermc.connector.common.serializer.AsteriskSerializer;
+import org.geysermc.connector.network.CIDRMatcher;
 
 import java.nio.file.Path;
+import java.util.Collections;
+import java.util.List;
 import java.util.Map;
 import java.util.UUID;
+import java.util.stream.Collectors;
 
 @Getter
 @JsonIgnoreProperties(ignoreUnknown = true)
@@ -138,6 +143,29 @@ public abstract class GeyserJacksonConfiguration implements GeyserConfiguration 
 
         @JsonProperty("server-name")
         private String serverName = GeyserConnector.NAME;
+
+        @JsonProperty("enable-proxy-protocol")
+        private boolean enableProxyProtocol = false;
+
+        @JsonProperty("proxy-protocol-whitelisted-ips")
+        private List<String> proxyProtocolWhitelistedIPs = Collections.emptyList();
+
+        @JsonIgnore
+        private List<CIDRMatcher> whitelistedIPsMatchers = null;
+
+        @Override
+        public List<CIDRMatcher> getWhitelistedIPsMatchers() {
+            // Effective Java, Third Edition; Item 83: Use lazy initialization judiciously
+            List<CIDRMatcher> matchers = this.whitelistedIPsMatchers;
+            if (matchers == null) {
+                synchronized (this) {
+                    this.whitelistedIPsMatchers = matchers = proxyProtocolWhitelistedIPs.stream()
+                            .map(CIDRMatcher::new)
+                            .collect(Collectors.toList());
+                }
+            }
+            return Collections.unmodifiableList(matchers);
+        }
     }
 
     @Getter

--- a/connector/src/main/java/org/geysermc/connector/configuration/GeyserJacksonConfiguration.java
+++ b/connector/src/main/java/org/geysermc/connector/configuration/GeyserJacksonConfiguration.java
@@ -122,6 +122,7 @@ public abstract class GeyserJacksonConfiguration implements GeyserConfiguration 
     private MetricsInfo metrics = new MetricsInfo();
 
     @Getter
+    @JsonIgnoreProperties(ignoreUnknown = true)
     public static class BedrockConfiguration implements IBedrockConfiguration {
         @AsteriskSerializer.Asterisk(sensitive = true)
         private String address = "0.0.0.0";
@@ -140,6 +141,7 @@ public abstract class GeyserJacksonConfiguration implements GeyserConfiguration 
     }
 
     @Getter
+    @JsonIgnoreProperties(ignoreUnknown = true)
     public static class RemoteConfiguration implements IRemoteConfiguration {
         @Setter
         @AsteriskSerializer.Asterisk(sensitive = true)
@@ -173,6 +175,7 @@ public abstract class GeyserJacksonConfiguration implements GeyserConfiguration 
     }
 
     @Getter
+    @JsonIgnoreProperties(ignoreUnknown = true)
     public static class MetricsInfo implements IMetricsInfo {
         private boolean enabled = true;
 

--- a/connector/src/main/java/org/geysermc/connector/network/CIDRMatcher.java
+++ b/connector/src/main/java/org/geysermc/connector/network/CIDRMatcher.java
@@ -1,0 +1,95 @@
+/*
+ * Copyright (c) 2019-2021 GeyserMC. http://geysermc.org
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ *
+ * @author GeyserMC
+ * @link https://github.com/GeyserMC/Geyser
+ */
+
+package org.geysermc.connector.network;
+
+import java.net.InetAddress;
+import java.net.UnknownHostException;
+
+/*
+ * Taken & modified from TCPShield, licensed under MIT. See https://github.com/TCPShield/RealIP/blob/master/LICENSE
+ *
+ * https://github.com/TCPShield/RealIP/blob/32d422a9523cb6e25b571072851f3306bb8bbc4f/src/main/java/net/tcpshield/tcpshield/validation/cidr/CIDRMatcher.java
+ */
+public class CIDRMatcher {
+    private final int maskBits;
+    private final int maskBytes;
+    private final boolean simpleCIDR;
+    private final InetAddress cidrAddress;
+
+    public CIDRMatcher(String ipAddress) {
+        String[] split = ipAddress.split("/", 2);
+
+        String parsedIPAddress;
+        if (split.length == 2) {
+            parsedIPAddress = split[0];
+
+            this.maskBits = Integer.parseInt(split[1]);
+            this.simpleCIDR = maskBits == 32;
+        } else {
+            parsedIPAddress = ipAddress;
+
+            this.maskBits = -1;
+            this.simpleCIDR = true;
+        }
+
+        this.maskBytes = simpleCIDR ? -1 : maskBits / 8;
+
+        try {
+            cidrAddress = InetAddress.getByName(parsedIPAddress);
+        } catch (UnknownHostException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    public boolean matches(InetAddress inetAddress) {
+        // check if IP is IPv4 or IPv6
+        if (cidrAddress.getClass() != inetAddress.getClass()) {
+            return false;
+        }
+
+        // check for equality if it's a simple CIDR
+        if (simpleCIDR) {
+            return inetAddress.equals(cidrAddress);
+        }
+
+        byte[] inetAddressBytes = inetAddress.getAddress();
+        byte[] requiredAddressBytes = cidrAddress.getAddress();
+
+        byte finalByte = (byte) (0xFF00 >> (maskBits & 0x07));
+
+        for (int i = 0; i < maskBytes; i++) {
+            if (inetAddressBytes[i] != requiredAddressBytes[i]) {
+                return false;
+            }
+        }
+
+        if (finalByte != 0) {
+            return (inetAddressBytes[maskBytes] & finalByte) == (requiredAddressBytes[maskBytes] & finalByte);
+        }
+
+        return true;
+    }
+}

--- a/connector/src/main/java/org/geysermc/connector/network/ConnectorServerEventHandler.java
+++ b/connector/src/main/java/org/geysermc/connector/network/ConnectorServerEventHandler.java
@@ -40,6 +40,7 @@ import org.geysermc.connector.utils.LanguageUtils;
 
 import java.net.InetSocketAddress;
 import java.nio.charset.StandardCharsets;
+import java.util.List;
 
 public class ConnectorServerEventHandler implements BedrockServerEventHandler {
     /*
@@ -60,6 +61,21 @@ public class ConnectorServerEventHandler implements BedrockServerEventHandler {
 
     @Override
     public boolean onConnectionRequest(InetSocketAddress inetSocketAddress) {
+        List<String> allowedProxyIPs = connector.getConfig().getBedrock().getProxyProtocolWhitelistedIPs();
+        if (connector.getConfig().getBedrock().isEnableProxyProtocol() && !allowedProxyIPs.isEmpty()) {
+            boolean isWhitelistedIP = false;
+            for (CIDRMatcher matcher : connector.getConfig().getBedrock().getWhitelistedIPsMatchers()) {
+                if (matcher.matches(inetSocketAddress.getAddress())) {
+                    isWhitelistedIP = true;
+                    break;
+                }
+            }
+
+            if (!isWhitelistedIP) {
+                return false;
+            }
+        }
+
         connector.getLogger().info(LanguageUtils.getLocaleStringLog("geyser.network.attempt_connect", inetSocketAddress));
         return true;
     }

--- a/connector/src/main/java/org/geysermc/connector/network/session/GeyserSession.java
+++ b/connector/src/main/java/org/geysermc/connector/network/session/GeyserSession.java
@@ -93,6 +93,7 @@ import org.geysermc.floodgate.util.BedrockData;
 import org.geysermc.floodgate.util.EncryptionUtil;
 
 import java.io.IOException;
+import java.net.InetAddress;
 import java.net.InetSocketAddress;
 import java.security.NoSuchAlgorithmException;
 import java.security.PublicKey;
@@ -378,7 +379,8 @@ public class GeyserSession implements CommandSender {
         tmpPlayers.forEach(player -> this.emotes.addAll(player.getEmotes()));
 
         bedrockServerSession.addDisconnectHandler(disconnectReason -> {
-            connector.getLogger().info(LanguageUtils.getLocaleStringLog("geyser.network.disconnect", bedrockServerSession.getAddress().getAddress(), disconnectReason));
+            InetAddress address = bedrockServerSession.getRealAddress().getAddress();
+            connector.getLogger().info(LanguageUtils.getLocaleStringLog("geyser.network.disconnect", address, disconnectReason));
 
             disconnect(disconnectReason.name());
             connector.removePlayer(this);
@@ -588,7 +590,7 @@ public class GeyserSession implements CommandSender {
                                 clientData.getDeviceOS().ordinal(),
                                 clientData.getLanguageCode(),
                                 clientData.getCurrentInputMode().ordinal(),
-                                upstream.getSession().getAddress().getAddress().getHostAddress()
+                                upstream.getAddress().getAddress().getHostAddress()
                         ));
                     } catch (Exception e) {
                         connector.getLogger().error(LanguageUtils.getLocaleStringLog("geyser.auth.floodgate.encrypt_fail"), e);

--- a/connector/src/main/java/org/geysermc/connector/network/session/UpstreamSession.java
+++ b/connector/src/main/java/org/geysermc/connector/network/session/UpstreamSession.java
@@ -61,6 +61,6 @@ public class UpstreamSession {
     }
 
     public InetSocketAddress getAddress() {
-        return session.getAddress();
+        return session.getRealAddress();
     }
 }

--- a/connector/src/main/resources/config.yml
+++ b/connector/src/main/resources/config.yml
@@ -23,6 +23,14 @@ bedrock:
   motd2: "Another Geyser server."
   # The Server Name that will be sent to Minecraft: Bedrock Edition clients. This is visible in both the pause menu and the settings menu.
   server-name: "Geyser"
+  # Whether to enable PROXY protocol or not for clients. You DO NOT WANT this feature unless you run UDP reverse proxy
+  # in front of your Geyser instance.
+  enable-proxy-protocol: false
+  # A list of allowed PROXY protocol speaking proxy IP addresses/subnets. Only effective when "enable-proxy-protocol" is enabled, and
+  # should really only be used when you are not able to use a proper firewall (usually true with shared hosting providers etc.).
+  # Keeping this list empty means there is no IP address whitelist.
+  # Both IP addresses and subnets are supported.
+  #proxy-protocol-whitelisted-ips: [ "127.0.0.1", "172.18.0.0/16" ]
 remote:
   # The IP address of the remote (Java Edition) server
   # If it is "auto", for standalone version the remote address will be set to 127.0.0.1,


### PR DESCRIPTION
Addresses second half of #677 - allowing UDP reverse proxies to pass correct client address to Geyser.

Checklist:
- [x] https://github.com/CloudburstMC/Network/pull/18
- [x] https://github.com/CloudburstMC/Protocol/pull/108

Closes #677 