### PR TITLE
Add Tickable interface

### DIFF
--- a/connector/src/main/java/org/geysermc/connector/entity/ThrowableEntity.java
+++ b/connector/src/main/java/org/geysermc/connector/entity/ThrowableEntity.java
@@ -33,48 +33,33 @@ import org.geysermc.connector.entity.type.EntityType;
 import org.geysermc.connector.network.session.GeyserSession;
 import org.geysermc.connector.network.translators.world.block.BlockTranslator;
 
-import java.util.concurrent.ScheduledFuture;
-import java.util.concurrent.TimeUnit;
-
 /**
  * Used as a class for any object-like entity that moves as a projectile
  */
-public class ThrowableEntity extends Entity {
+public class ThrowableEntity extends Entity implements Tickable {
 
     private Vector3f lastPosition;
-    /**
-     * Updates the position for the Bedrock client.
-     *
-     * Java clients assume the next positions of moving items. Bedrock needs to be explicitly told positions
-     */
-    protected ScheduledFuture<?> positionUpdater;
 
     public ThrowableEntity(long entityId, long geyserId, EntityType entityType, Vector3f position, Vector3f motion, Vector3f rotation) {
         super(entityId, geyserId, entityType, position, motion, rotation);
         this.lastPosition = position;
     }
 
+    /**
+     * Updates the position for the Bedrock client.
+     *
+     * Java clients assume the next positions of moving items. Bedrock needs to be explicitly told positions
+     */
     @Override
-    public void spawnEntity(GeyserSession session) {
-        super.spawnEntity(session);
-        positionUpdater = session.getConnector().getGeneralThreadPool().scheduleAtFixedRate(() -> {
-            if (session.isClosed()) {
-                positionUpdater.cancel(true);
-                return;
-            }
-            updatePosition(session);
-        }, 0, 50, TimeUnit.MILLISECONDS);
-    }
-
-    protected void moveAbsoluteImmediate(GeyserSession session, Vector3f position, Vector3f rotation, boolean isOnGround, boolean teleported) {
-        super.moveAbsolute(session, position, rotation, isOnGround, teleported);
-    }
-
-    protected void updatePosition(GeyserSession session) {
+    public void tick(GeyserSession session) {
         super.moveRelative(session, motion.getX(), motion.getY(), motion.getZ(), rotation, onGround);
         float drag = getDrag(session);
         float gravity = getGravity();
         motion = motion.mul(drag).down(gravity);
+    }
+
+    protected void moveAbsoluteImmediate(GeyserSession session, Vector3f position, Vector3f rotation, boolean isOnGround, boolean teleported) {
+        super.moveAbsolute(session, position, rotation, isOnGround, teleported);
     }
 
     /**
@@ -140,7 +125,6 @@ public class ThrowableEntity extends Entity {
 
     @Override
     public boolean despawnEntity(GeyserSession session) {
-        positionUpdater.cancel(true);
         if (entityType == EntityType.THROWN_ENDERPEARL) {
             LevelEventPacket particlePacket = new LevelEventPacket();
             particlePacket.setType(LevelEventType.PARTICLE_TELEPORT);

--- a/connector/src/main/java/org/geysermc/connector/entity/Tickable.java
+++ b/connector/src/main/java/org/geysermc/connector/entity/Tickable.java
@@ -25,26 +25,11 @@
 
 package org.geysermc.connector.entity;
 
-import com.nukkitx.math.vector.Vector3f;
-import org.geysermc.connector.entity.type.EntityType;
 import org.geysermc.connector.network.session.GeyserSession;
 
-public class ItemedFireballEntity extends ThrowableEntity {
-    private final Vector3f acceleration;
-
-    public ItemedFireballEntity(long entityId, long geyserId, EntityType entityType, Vector3f position, Vector3f motion, Vector3f rotation) {
-        super(entityId, geyserId, entityType, position, Vector3f.ZERO, rotation);
-        acceleration = motion;
-    }
-
-    @Override
-    public void tick(GeyserSession session) {
-        position = position.add(motion);
-        // TODO: While this reduces latency in position updating (needed for better fireball reflecting),
-        // TODO: movement is incredibly stiff.
-        // TODO: Only use this laggy movement for fireballs that be reflected
-        moveAbsoluteImmediate(session, position, rotation, false, true);
-        float drag = getDrag(session);
-        motion = motion.add(acceleration).mul(drag);
-    }
+/**
+ * Implemented onto anything that should have code ran every Minecraft tick - 50 milliseconds.
+ */
+public interface Tickable {
+    void tick(GeyserSession session);
 }

--- a/connector/src/main/java/org/geysermc/connector/entity/living/monster/EnderDragonEntity.java
+++ b/connector/src/main/java/org/geysermc/connector/entity/living/monster/EnderDragonEntity.java
@@ -33,14 +33,12 @@ import com.nukkitx.protocol.bedrock.data.entity.EntityFlag;
 import com.nukkitx.protocol.bedrock.packet.AddEntityPacket;
 import com.nukkitx.protocol.bedrock.packet.EntityEventPacket;
 import lombok.Data;
+import org.geysermc.connector.entity.Tickable;
 import org.geysermc.connector.entity.living.InsentientEntity;
 import org.geysermc.connector.entity.type.EntityType;
 import org.geysermc.connector.network.session.GeyserSession;
 
-import java.util.concurrent.ScheduledFuture;
-import java.util.concurrent.TimeUnit;
-
-public class EnderDragonEntity extends InsentientEntity {
+public class EnderDragonEntity extends InsentientEntity implements Tickable {
     /**
      * The Ender Dragon has multiple hit boxes, which
      * are each its own invisible entity
@@ -62,8 +60,6 @@ public class EnderDragonEntity extends InsentientEntity {
     private int latestSegment = -1;
 
     private boolean hovering;
-
-    private ScheduledFuture<?> partPositionUpdater;
 
     public EnderDragonEntity(long entityId, long geyserId, EntityType entityType, Vector3f position, Vector3f motion, Vector3f rotation) {
         super(entityId, geyserId, entityType, position, motion, rotation);
@@ -130,22 +126,21 @@ public class EnderDragonEntity extends InsentientEntity {
             segmentHistory[i].y = position.getY();
         }
 
-        partPositionUpdater = session.getConnector().getGeneralThreadPool().scheduleAtFixedRate(() -> {
-            pushSegment();
-            updateBoundingBoxes(session);
-        }, 0, 50, TimeUnit.MILLISECONDS);
-
         session.getConnector().getLogger().debug("Spawned entity " + entityType + " at location " + position + " with id " + geyserId + " (java id " + entityId + ")");
     }
 
     @Override
     public boolean despawnEntity(GeyserSession session) {
-        partPositionUpdater.cancel(true);
-
         for (EnderDragonPartEntity part : allParts) {
             part.despawnEntity(session);
         }
         return super.despawnEntity(session);
+    }
+
+    @Override
+    public void tick(GeyserSession session) {
+        pushSegment();
+        updateBoundingBoxes(session);
     }
 
     /**

--- a/connector/src/main/java/org/geysermc/connector/network/session/cache/EntityCache.java
+++ b/connector/src/main/java/org/geysermc/connector/network/session/cache/EntityCache.java
@@ -99,7 +99,6 @@ public class EntityCache {
         for (Entity entity : entities) {
             session.getEntityCache().removeEntity(entity, false);
         }
-        tickableEntities.clear();
     }
 
     public Entity getEntityByGeyserId(long geyserId) {

--- a/connector/src/main/java/org/geysermc/connector/network/session/cache/EntityCache.java
+++ b/connector/src/main/java/org/geysermc/connector/network/session/cache/EntityCache.java
@@ -28,6 +28,7 @@ package org.geysermc.connector.network.session.cache;
 import it.unimi.dsi.fastutil.longs.*;
 import it.unimi.dsi.fastutil.objects.ObjectOpenHashSet;
 import lombok.Getter;
+import org.geysermc.connector.entity.Tickable;
 import org.geysermc.connector.entity.Entity;
 import org.geysermc.connector.entity.player.PlayerEntity;
 import org.geysermc.connector.network.session.GeyserSession;
@@ -40,17 +41,21 @@ import java.util.concurrent.atomic.AtomicLong;
  * for that player (e.g. seeing vanished players from /vanish)
  */
 public class EntityCache {
-    private GeyserSession session;
+    private final GeyserSession session;
 
     @Getter
     private Long2ObjectMap<Entity> entities = Long2ObjectMaps.synchronize(new Long2ObjectOpenHashMap<>());
+    /**
+     * A list of all entities that must be ticked.
+     */
+    private final List<Tickable> tickableEntities = Collections.synchronizedList(new ArrayList<>());
     private Long2LongMap entityIdTranslations = Long2LongMaps.synchronize(new Long2LongOpenHashMap());
     private Map<UUID, PlayerEntity> playerEntities = Collections.synchronizedMap(new HashMap<>());
     private Map<UUID, BossBar> bossBars = Collections.synchronizedMap(new HashMap<>());
-    private Long2LongMap cachedPlayerEntityLinks = Long2LongMaps.synchronize(new Long2LongOpenHashMap());
+    private final Long2LongMap cachedPlayerEntityLinks = Long2LongMaps.synchronize(new Long2LongOpenHashMap());
 
     @Getter
-    private AtomicLong nextEntityId = new AtomicLong(2L);
+    private final AtomicLong nextEntityId = new AtomicLong(2L);
 
     public EntityCache(GeyserSession session) {
         this.session = session;
@@ -59,6 +64,10 @@ public class EntityCache {
     public void spawnEntity(Entity entity) {
         if (cacheEntity(entity)) {
             entity.spawnEntity(session);
+        }
+        if (entity instanceof Tickable) {
+            // Start ticking it
+            tickableEntities.add((Tickable) entity);
         }
     }
 
@@ -76,6 +85,10 @@ public class EntityCache {
         if (entity != null && entity.isValid() && (force || entity.despawnEntity(session))) {
             long geyserId = entityIdTranslations.remove(entity.getEntityId());
             entities.remove(geyserId);
+
+            if (entity instanceof Tickable) {
+                tickableEntities.remove(entity);
+            }
             return true;
         }
         return false;
@@ -86,6 +99,7 @@ public class EntityCache {
         for (Entity entity : entities) {
             session.getEntityCache().removeEntity(entity, false);
         }
+        tickableEntities.clear();
     }
 
     public Entity getEntityByGeyserId(long geyserId) {
@@ -151,5 +165,9 @@ public class EntityCache {
 
     public void addCachedPlayerEntityLink(long playerId, long linkedEntityId) {
         cachedPlayerEntityLinks.put(playerId, linkedEntityId);
+    }
+
+    public List<Tickable> getTickableEntities() {
+        return tickableEntities;
     }
 }

--- a/connector/src/main/java/org/geysermc/connector/network/session/cache/EntityCache.java
+++ b/connector/src/main/java/org/geysermc/connector/network/session/cache/EntityCache.java
@@ -64,10 +64,11 @@ public class EntityCache {
     public void spawnEntity(Entity entity) {
         if (cacheEntity(entity)) {
             entity.spawnEntity(session);
-        }
-        if (entity instanceof Tickable) {
-            // Start ticking it
-            tickableEntities.add((Tickable) entity);
+
+            if (entity instanceof Tickable) {
+                // Start ticking it
+                tickableEntities.add((Tickable) entity);
+            }
         }
     }
 

--- a/connector/src/main/java/org/geysermc/connector/network/translators/bedrock/entity/player/BedrockMovePlayerTranslator.java
+++ b/connector/src/main/java/org/geysermc/connector/network/translators/bedrock/entity/player/BedrockMovePlayerTranslator.java
@@ -33,16 +33,12 @@ import com.nukkitx.math.vector.Vector3d;
 import com.nukkitx.math.vector.Vector3f;
 import com.nukkitx.protocol.bedrock.packet.MoveEntityAbsolutePacket;
 import com.nukkitx.protocol.bedrock.packet.MovePlayerPacket;
-import com.nukkitx.protocol.bedrock.packet.SetEntityDataPacket;
 import org.geysermc.connector.common.ChatColor;
 import org.geysermc.connector.entity.player.PlayerEntity;
 import org.geysermc.connector.entity.type.EntityType;
 import org.geysermc.connector.network.session.GeyserSession;
 import org.geysermc.connector.network.translators.PacketTranslator;
 import org.geysermc.connector.network.translators.Translator;
-import org.geysermc.connector.network.translators.collision.CollisionManager;
-
-import java.util.concurrent.TimeUnit;
 
 @Translator(packet = MovePlayerPacket.class)
 public class BedrockMovePlayerTranslator extends PacketTranslator<MovePlayerPacket> {
@@ -63,9 +59,7 @@ public class BedrockMovePlayerTranslator extends PacketTranslator<MovePlayerPack
             return;
         }
 
-        if (session.getMovementSendIfIdle() != null) {
-            session.getMovementSendIfIdle().cancel(true);
-        }
+        session.setLastMovementTimestamp(System.currentTimeMillis());
 
         if (session.confirmTeleport(packet.getPosition().toDouble().sub(0, EntityType.PLAYER.getOffset(), 0))) {
             // head yaw, pitch, head yaw
@@ -86,7 +80,7 @@ public class BedrockMovePlayerTranslator extends PacketTranslator<MovePlayerPack
 
                 session.sendDownstreamPacket(playerRotationPacket);
             } else {
-                Vector3d position = adjustBedrockPosition(session, packet.getPosition(), packet.isOnGround());
+                Vector3d position = session.getCollisionManager().adjustBedrockPosition(packet.getPosition(), packet.isOnGround());
                 if (position != null) { // A null return value cancels the packet
                     if (isValidMove(session, packet.getMode(), entity.getPosition(), packet.getPosition())) {
                         Packet movePacket;
@@ -128,7 +122,7 @@ public class BedrockMovePlayerTranslator extends PacketTranslator<MovePlayerPack
                     } else {
                         // Not a valid move
                         session.getConnector().getLogger().debug("Recalculating position...");
-                        recalculatePosition(session);
+                        session.getCollisionManager().recalculatePosition();
                     }
                 }
             }
@@ -141,13 +135,9 @@ public class BedrockMovePlayerTranslator extends PacketTranslator<MovePlayerPack
         if (entity.getRightParrot() != null) {
             entity.getRightParrot().moveAbsolute(session, entity.getPosition(), entity.getRotation(), true, false);
         }
-
-        // Schedule a position send loop if the player is idle
-        session.setMovementSendIfIdle(session.getConnector().getGeneralThreadPool().schedule(() -> sendPositionIfIdle(session),
-                3, TimeUnit.SECONDS));
     }
 
-    public boolean isValidMove(GeyserSession session, MovePlayerPacket.Mode mode, Vector3f currentPosition, Vector3f newPosition) {
+    private boolean isValidMove(GeyserSession session, MovePlayerPacket.Mode mode, Vector3f currentPosition, Vector3f newPosition) {
         if (mode != MovePlayerPacket.Mode.NORMAL)
             return true;
 
@@ -170,82 +160,6 @@ public class BedrockMovePlayerTranslator extends PacketTranslator<MovePlayerPack
         }
 
         return true;
-    }
-
-    /**
-     * Adjust the Bedrock position before sending to the Java server to account for inaccuracies in movement between
-     * the two versions.
-     *
-     * @param session the current GeyserSession
-     * @param bedrockPosition the current Bedrock position of the client
-     * @param onGround whether the Bedrock player is on the ground
-     * @return the position to send to the Java server, or null to cancel sending the packet
-     */
-    private Vector3d adjustBedrockPosition(GeyserSession session, Vector3f bedrockPosition, boolean onGround) {
-        // We need to parse the float as a string since casting a float to a double causes us to
-        // lose precision and thus, causes players to get stuck when walking near walls
-        double javaY = bedrockPosition.getY() - EntityType.PLAYER.getOffset();
-
-        Vector3d position = Vector3d.from(Double.parseDouble(Float.toString(bedrockPosition.getX())), javaY,
-                Double.parseDouble(Float.toString(bedrockPosition.getZ())));
-
-        if (session.getConnector().getConfig().isCacheChunks()) {
-            // With chunk caching, we can do some proper collision checks
-            CollisionManager collisionManager = session.getCollisionManager();
-            collisionManager.updatePlayerBoundingBox(position);
-
-            // Correct player position
-            if (!collisionManager.correctPlayerPosition()) {
-                // Cancel the movement if it needs to be cancelled
-                recalculatePosition(session);
-                return null;
-            }
-
-            position = Vector3d.from(collisionManager.getPlayerBoundingBox().getMiddleX(),
-                    collisionManager.getPlayerBoundingBox().getMiddleY() - (collisionManager.getPlayerBoundingBox().getSizeY() / 2),
-                    collisionManager.getPlayerBoundingBox().getMiddleZ());
-        } else {
-            // When chunk caching is off, we have to rely on this
-            // It rounds the Y position up to the nearest 0.5
-            // This snaps players to snap to the top of stairs and slabs like on Java Edition
-            // However, it causes issues such as the player floating on carpets
-            if (onGround) javaY = Math.ceil(javaY * 2) / 2;
-            position = position.up(javaY - position.getY());
-        }
-
-        return position;
-    }
-
-    // TODO: This makes the player look upwards for some reason, rotation values must be wrong
-    public void recalculatePosition(GeyserSession session) {
-        PlayerEntity entity = session.getPlayerEntity();
-        // Gravity might need to be reset...
-        SetEntityDataPacket entityDataPacket = new SetEntityDataPacket();
-        entityDataPacket.setRuntimeEntityId(entity.getGeyserId());
-        entityDataPacket.getMetadata().putAll(entity.getMetadata());
-        session.sendUpstreamPacket(entityDataPacket);
-
-        MovePlayerPacket movePlayerPacket = new MovePlayerPacket();
-        movePlayerPacket.setRuntimeEntityId(entity.getGeyserId());
-        movePlayerPacket.setPosition(entity.getPosition());
-        movePlayerPacket.setRotation(entity.getBedrockRotation());
-        movePlayerPacket.setMode(MovePlayerPacket.Mode.NORMAL);
-        session.sendUpstreamPacket(movePlayerPacket);
-    }
-
-    private void sendPositionIfIdle(GeyserSession session) {
-        if (session.isClosed()) return;
-        PlayerEntity entity = session.getPlayerEntity();
-        // Recalculate in case something else changed position
-        Vector3d position = adjustBedrockPosition(session, entity.getPosition(), entity.isOnGround());
-        // A null return value cancels the packet
-        if (position != null) {
-            ClientPlayerPositionPacket packet = new ClientPlayerPositionPacket(session.getPlayerEntity().isOnGround(),
-                    position.getX(), position.getY(), position.getZ());
-            session.sendDownstreamPacket(packet);
-        }
-        session.setMovementSendIfIdle(session.getConnector().getGeneralThreadPool().schedule(() -> sendPositionIfIdle(session),
-                3, TimeUnit.SECONDS));
     }
 }
 

--- a/connector/src/main/java/org/geysermc/connector/network/translators/collision/CollisionManager.java
+++ b/connector/src/main/java/org/geysermc/connector/network/translators/collision/CollisionManager.java
@@ -30,8 +30,12 @@ import com.nukkitx.math.vector.Vector3f;
 import com.nukkitx.math.vector.Vector3i;
 import com.nukkitx.protocol.bedrock.data.entity.EntityFlag;
 import com.nukkitx.protocol.bedrock.data.entity.EntityFlags;
+import com.nukkitx.protocol.bedrock.packet.MovePlayerPacket;
+import com.nukkitx.protocol.bedrock.packet.SetEntityDataPacket;
 import lombok.Getter;
 import lombok.Setter;
+import org.geysermc.connector.entity.player.PlayerEntity;
+import org.geysermc.connector.entity.type.EntityType;
 import org.geysermc.connector.network.session.GeyserSession;
 import org.geysermc.connector.network.translators.collision.translators.BlockCollision;
 
@@ -105,12 +109,72 @@ public class CollisionManager {
             // According to the Minecraft Wiki, when sneaking:
             // - In Bedrock Edition, the height becomes 1.65 blocks, allowing movement through spaces as small as 1.75 (2 - 1⁄4) blocks high.
             // - In Java Edition, the height becomes 1.5 blocks.
+            // TODO: Have this depend on the player's literal bounding box variable
             if (session.isSneaking()) {
                 playerBoundingBox.setSizeY(1.5);
             } else {
                 playerBoundingBox.setSizeY(1.8);
             }
         }
+    }
+
+    /**
+     * Adjust the Bedrock position before sending to the Java server to account for inaccuracies in movement between
+     * the two versions.
+     *
+     * @param bedrockPosition the current Bedrock position of the client
+     * @param onGround whether the Bedrock player is on the ground
+     * @return the position to send to the Java server, or null to cancel sending the packet
+     */
+    public Vector3d adjustBedrockPosition(Vector3f bedrockPosition, boolean onGround) {
+        // We need to parse the float as a string since casting a float to a double causes us to
+        // lose precision and thus, causes players to get stuck when walking near walls
+        double javaY = bedrockPosition.getY() - EntityType.PLAYER.getOffset();
+
+        Vector3d position = Vector3d.from(Double.parseDouble(Float.toString(bedrockPosition.getX())), javaY,
+                Double.parseDouble(Float.toString(bedrockPosition.getZ())));
+
+        if (session.getConnector().getConfig().isCacheChunks()) {
+            // With chunk caching, we can do some proper collision checks
+            updatePlayerBoundingBox(position);
+
+            // Correct player position
+            if (!correctPlayerPosition()) {
+                // Cancel the movement if it needs to be cancelled
+                recalculatePosition();
+                return null;
+            }
+
+            position = Vector3d.from(playerBoundingBox.getMiddleX(),
+                    playerBoundingBox.getMiddleY() - (playerBoundingBox.getSizeY() / 2),
+                    playerBoundingBox.getMiddleZ());
+        } else {
+            // When chunk caching is off, we have to rely on this
+            // It rounds the Y position up to the nearest 0.5
+            // This snaps players to snap to the top of stairs and slabs like on Java Edition
+            // However, it causes issues such as the player floating on carpets
+            if (onGround) javaY = Math.ceil(javaY * 2) / 2;
+            position = position.up(javaY - position.getY());
+        }
+
+        return position;
+    }
+
+    // TODO: This makes the player look upwards for some reason, rotation values must be wrong
+    public void recalculatePosition() {
+        PlayerEntity entity = session.getPlayerEntity();
+        // Gravity might need to be reset...
+        SetEntityDataPacket entityDataPacket = new SetEntityDataPacket();
+        entityDataPacket.setRuntimeEntityId(entity.getGeyserId());
+        entityDataPacket.getMetadata().putAll(entity.getMetadata());
+        session.sendUpstreamPacket(entityDataPacket);
+
+        MovePlayerPacket movePlayerPacket = new MovePlayerPacket();
+        movePlayerPacket.setRuntimeEntityId(entity.getGeyserId());
+        movePlayerPacket.setPosition(entity.getPosition());
+        movePlayerPacket.setRotation(entity.getBedrockRotation());
+        movePlayerPacket.setMode(MovePlayerPacket.Mode.NORMAL);
+        session.sendUpstreamPacket(movePlayerPacket);
     }
 
     public List<Vector3i> getPlayerCollidableBlocks() {

--- a/connector/src/main/java/org/geysermc/connector/utils/DimensionUtils.java
+++ b/connector/src/main/java/org/geysermc/connector/utils/DimensionUtils.java
@@ -60,10 +60,6 @@ public class DimensionUtils {
         if (javaDimension.equals(session.getDimension()))
             return;
 
-        if (session.getMovementSendIfIdle() != null) {
-            session.getMovementSendIfIdle().cancel(true);
-        }
-
         session.getEntityCache().removeAllEntities();
         session.getItemFrameCache().clear();
         session.getSkullCache().clear();


### PR DESCRIPTION
By having a tickable interface, we're only dedicating one thread to ticking entities and running tasks as opposed to several. This will also help with implementing world border support.