### PR TITLE
Trigger builds of Geyser-Fabric and GeyserAndroid after a build success

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -72,8 +72,8 @@ pipeline {
         success {
             script {
                 if (env.BRANCH_NAME == 'master') {
-                    build propagate: false, job: 'GeyserMC/Geyser-Fabric/java-1.16'
-                    build propagate: false, job: 'GeyserMC/GeyserAndroid/master'
+                    build propagate: false, wait: false, job: 'GeyserMC/Geyser-Fabric/java-1.16'
+                    build propagate: false, wait: false, job: 'GeyserMC/GeyserAndroid/master'
                 }
             }
         }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -72,8 +72,8 @@ pipeline {
         success {
             script {
                 if (env.BRANCH_NAME == 'master') {
-                    build 'GeyserMC/Geyser-Fabric/java-1.16'
-                    build 'GeyserMC/GeyserAndroid/master'
+                    build propagate: false, job: 'GeyserMC/Geyser-Fabric/java-1.16'
+                    build propagate: false, job: 'GeyserMC/GeyserAndroid/master'
                 }
             }
         }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -69,5 +69,9 @@ pipeline {
                 discordSend description: "**Build:** [${currentBuild.id}](${env.BUILD_URL})\n**Status:** [${currentBuild.currentResult}](${env.BUILD_URL})\n${changes}\n\n[**Artifacts on Jenkins**](https://ci.opencollab.dev/job/GeyserMC/job/Geyser)", footer: 'Open Collaboration Jenkins', link: env.BUILD_URL, successful: currentBuild.resultIsBetterOrEqualTo('SUCCESS'), title: "${env.JOB_NAME} #${currentBuild.id}", webhookURL: DISCORD_WEBHOOK
             }
         }
+        success {
+            build 'Geyser-Fabric/java-1.16'
+            //build 'GeyserAndroid/master'
+        }
     }
 }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -70,8 +70,12 @@ pipeline {
             }
         }
         success {
-            build 'GeyserMC/Geyser-Fabric/java-1.16'
-            build 'GeyserMC/GeyserAndroid/master'
+            script {
+                if (env.BRANCH_NAME == 'master') {
+                    build 'GeyserMC/Geyser-Fabric/java-1.16'
+                    build 'GeyserMC/GeyserAndroid/master'
+                }
+            }
         }
     }
 }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -70,8 +70,8 @@ pipeline {
             }
         }
         success {
-            build 'Geyser-Fabric/java-1.16'
-            //build 'GeyserAndroid/master'
+            build 'GeyserMC/Geyser-Fabric/java-1.16'
+            build 'GeyserMC/GeyserAndroid/master'
         }
     }
 }


### PR DESCRIPTION
This should trigger builds of Geyser-Fabric and GeyserAndroid after a build success, this is to make sure things as up to date and mean we don't need to manually trigger builds for these projects when there is a Geyser update.
~~Currently, GeyserAndroid is disabled due to it not building on the new CI as the Android SDK licence has not been accepted on it.~~

Relevant Jenkins documentation:
https://plugins.jenkins.io/pipeline-build-step/
https://www.jenkins.io/doc/pipeline/tour/post/