### PR TITLE
Trigger builds of GeyserConnect after a Geyser build success

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -94,6 +94,7 @@ pipeline {
                 if (env.BRANCH_NAME == 'master') {
                     build propagate: false, wait: false, job: 'GeyserMC/Geyser-Fabric/java-1.16'
                     build propagate: false, wait: false, job: 'GeyserMC/GeyserAndroid/master'
+                    build propagate: false, wait: false, job: 'GeyserMC/GeyserConnect/master'
                 }
             }
         }


### PR DESCRIPTION
It was recently made so that Geyser-Fabric and GeyserAndroid get a fresh build each time Geyser is updated and this PR makes it so that GeyserConnect gets a build too.