### PR TITLE
Shade in the entire net.kyori package

### DIFF
--- a/bootstrap/bungeecord/pom.xml
+++ b/bootstrap/bungeecord/pom.xml
@@ -86,8 +86,8 @@
                                     <shadedPattern>org.geysermc.platform.bungeecord.shaded.dom4j</shadedPattern>
                                 </relocation>
                                 <relocation>
-                                    <pattern>net.kyori.adventure</pattern>
-                                    <shadedPattern>org.geysermc.platform.bungeecord.shaded.adventure</shadedPattern>
+                                    <pattern>net.kyori</pattern>
+                                    <shadedPattern>org.geysermc.platform.bungeecord.shaded.kyori</shadedPattern>
                                 </relocation>
                             </relocations>
                         </configuration>

--- a/bootstrap/spigot/pom.xml
+++ b/bootstrap/spigot/pom.xml
@@ -97,8 +97,8 @@
                                     <shadedPattern>org.geysermc.platform.spigot.shaded.dom4j</shadedPattern>
                                 </relocation>
                                 <relocation>
-                                    <pattern>net.kyori.adventure</pattern>
-                                    <shadedPattern>org.geysermc.platform.spigot.shaded.adventure</shadedPattern>
+                                    <pattern>net.kyori</pattern>
+                                    <shadedPattern>org.geysermc.platform.spigot.shaded.kyori</shadedPattern>
                                 </relocation>
                             </relocations>
                         </configuration>

--- a/bootstrap/sponge/pom.xml
+++ b/bootstrap/sponge/pom.xml
@@ -86,8 +86,8 @@
                                     <shadedPattern>org.geysermc.platform.sponge.shaded.dom4j</shadedPattern>
                                 </relocation>
                                 <relocation>
-                                    <pattern>net.kyori.adventure</pattern>
-                                    <shadedPattern>org.geysermc.platform.sponge.shaded.adventure</shadedPattern>
+                                    <pattern>net.kyori</pattern>
+                                    <shadedPattern>org.geysermc.platform.sponge.shaded.kyori</shadedPattern>
                                 </relocation>
                             </relocations>
                         </configuration>

--- a/bootstrap/velocity/pom.xml
+++ b/bootstrap/velocity/pom.xml
@@ -82,8 +82,8 @@
                                     <shadedPattern>org.geysermc.platform.velocity.shaded.dom4j</shadedPattern>
                                 </relocation>
                                 <relocation>
-                                    <pattern>net.kyori.adventure</pattern>
-                                    <shadedPattern>org.geysermc.platform.velocity.shaded.adventure</shadedPattern>
+                                    <pattern>net.kyori</pattern>
+                                    <shadedPattern>org.geysermc.platform.velocity.shaded.kyori</shadedPattern>
                                 </relocation>
                             </relocations>
                         </configuration>


### PR DESCRIPTION
Otherwise (from the Kyori Discord):

```
[11:41:23 INFO]: [TownWars] Enabling TownWars v1.0-SNAPSHOT
[11:41:23 WARN]: [TownWars] Loaded class net.kyori.examination.Examinable from Geyser-Spigot v1.2.0-SNAPSHOT which is not a depend, softdepend or loadbefore of this plugin.
[11:41:23 WARN]: [TownWars] Loaded class net.kyori.examination.Examiner from mcMMO v2.1.163-SNAPSHOT which is not a depend, softdepend or loadbefore of this plugin.
```