### PR TITLE
Send message to Java if command is Bedrock-only

### DIFF
--- a/bootstrap/bungeecord/src/main/java/org/geysermc/platform/bungeecord/command/GeyserBungeeCommandExecutor.java
+++ b/bootstrap/bungeecord/src/main/java/org/geysermc/platform/bungeecord/command/GeyserBungeeCommandExecutor.java
@@ -62,12 +62,15 @@ public class GeyserBungeeCommandExecutor extends Command implements TabExecutor 
                     commandSender.sendMessage(ChatColor.RED + message);
                     return;
                 }
-                GeyserSession session = this.commandExecutor.getGeyserSession(commandSender);
-                if (command.isBedrockOnly() && session == null) {
-                    String message = LanguageUtils.getPlayerLocaleString("geyser.bootstrap.command.bedrock_only", commandSender.getLocale());
+                GeyserSession session = null;
+                if (command.isBedrockOnly()) {
+                    session = this.commandExecutor.getGeyserSession(commandSender);
+                    if (session == null) {
+                        String message = LanguageUtils.getPlayerLocaleString("geyser.bootstrap.command.bedrock_only", commandSender.getLocale());
 
-                    commandSender.sendMessage(ChatColor.RED + message);
-                    return;
+                        commandSender.sendMessage(ChatColor.RED + message);
+                        return;
+                    }
                 }
                 command.execute(session, commandSender, args.length > 1 ? Arrays.copyOfRange(args, 1, args.length) : new String[0]);
             }

--- a/bootstrap/bungeecord/src/main/java/org/geysermc/platform/bungeecord/command/GeyserBungeeCommandExecutor.java
+++ b/bootstrap/bungeecord/src/main/java/org/geysermc/platform/bungeecord/command/GeyserBungeeCommandExecutor.java
@@ -30,7 +30,9 @@ import net.md_5.bungee.api.CommandSender;
 import net.md_5.bungee.api.plugin.Command;
 import net.md_5.bungee.api.plugin.TabExecutor;
 import org.geysermc.connector.GeyserConnector;
+import org.geysermc.connector.command.CommandExecutor;
 import org.geysermc.connector.command.GeyserCommand;
+import org.geysermc.connector.network.session.GeyserSession;
 import org.geysermc.connector.utils.LanguageUtils;
 
 import java.util.ArrayList;
@@ -38,29 +40,39 @@ import java.util.Arrays;
 
 public class GeyserBungeeCommandExecutor extends Command implements TabExecutor {
 
+    private final CommandExecutor commandExecutor;
     private final GeyserConnector connector;
 
     public GeyserBungeeCommandExecutor(GeyserConnector connector) {
         super("geyser");
 
+        this.commandExecutor = new CommandExecutor(connector);
         this.connector = connector;
     }
 
     @Override
     public void execute(CommandSender sender, String[] args) {
         if (args.length > 0) {
-            if (getCommand(args[0]) != null) {
-                if (!sender.hasPermission(getCommand(args[0]).getPermission())) {
-                    BungeeCommandSender commandSender = new BungeeCommandSender(sender);
+            GeyserCommand command = this.commandExecutor.getCommand(args[0]);
+            if (command != null) {
+                BungeeCommandSender commandSender = new BungeeCommandSender(sender);
+                if (!sender.hasPermission(command.getPermission())) {
                     String message = LanguageUtils.getPlayerLocaleString("geyser.bootstrap.command.permission_fail", commandSender.getLocale());
 
                     commandSender.sendMessage(ChatColor.RED + message);
                     return;
                 }
-                getCommand(args[0]).execute(new BungeeCommandSender(sender), args.length > 1 ? Arrays.copyOfRange(args, 1, args.length) : new String[0]);
+                GeyserSession session = this.commandExecutor.getGeyserSession(commandSender);
+                if (command.isBedrockOnly() && session == null) {
+                    String message = LanguageUtils.getPlayerLocaleString("geyser.bootstrap.command.bedrock_only", commandSender.getLocale());
+
+                    commandSender.sendMessage(ChatColor.RED + message);
+                    return;
+                }
+                command.execute(session, commandSender, args.length > 1 ? Arrays.copyOfRange(args, 1, args.length) : new String[0]);
             }
         } else {
-            getCommand("help").execute(new BungeeCommandSender(sender), new String[0]);
+            this.commandExecutor.getCommand("help").execute(null, new BungeeCommandSender(sender), new String[0]);
         }
     }
 
@@ -70,9 +82,5 @@ public class GeyserBungeeCommandExecutor extends Command implements TabExecutor 
             return connector.getCommandManager().getCommandNames();
         }
         return new ArrayList<>();
-    }
-
-    private GeyserCommand getCommand(String label) {
-        return connector.getCommandManager().getCommands().get(label);
     }
 }

--- a/bootstrap/spigot/src/main/java/org/geysermc/platform/spigot/command/GeyserSpigotCommandExecutor.java
+++ b/bootstrap/spigot/src/main/java/org/geysermc/platform/spigot/command/GeyserSpigotCommandExecutor.java
@@ -57,10 +57,13 @@ public class GeyserSpigotCommandExecutor extends CommandExecutor implements TabE
                     commandSender.sendMessage(ChatColor.RED + message);
                     return true;
                 }
-                GeyserSession session = getGeyserSession(commandSender);
-                if (geyserCommand.isBedrockOnly() && session == null) {
-                    sender.sendMessage(ChatColor.RED + LanguageUtils.getPlayerLocaleString("geyser.bootstrap.command.bedrock_only", commandSender.getLocale()));
-                    return true;
+                GeyserSession session = null;
+                if (geyserCommand.isBedrockOnly()) {
+                    session = getGeyserSession(commandSender);
+                    if (session == null) {
+                        sender.sendMessage(ChatColor.RED + LanguageUtils.getPlayerLocaleString("geyser.bootstrap.command.bedrock_only", commandSender.getLocale()));
+                        return true;
+                    }
                 }
                 geyserCommand.execute(session, commandSender, args.length > 1 ? Arrays.copyOfRange(args, 1, args.length) : new String[0]);
                 return true;

--- a/bootstrap/spigot/src/main/java/org/geysermc/platform/spigot/command/GeyserSpigotCommandExecutor.java
+++ b/bootstrap/spigot/src/main/java/org/geysermc/platform/spigot/command/GeyserSpigotCommandExecutor.java
@@ -25,40 +25,48 @@
 
 package org.geysermc.platform.spigot.command;
 
-import lombok.AllArgsConstructor;
 import org.bukkit.ChatColor;
 import org.bukkit.command.Command;
 import org.bukkit.command.CommandSender;
 import org.bukkit.command.TabExecutor;
 import org.geysermc.connector.GeyserConnector;
+import org.geysermc.connector.command.CommandExecutor;
 import org.geysermc.connector.command.GeyserCommand;
+import org.geysermc.connector.network.session.GeyserSession;
 import org.geysermc.connector.utils.LanguageUtils;
 
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 
-@AllArgsConstructor
-public class GeyserSpigotCommandExecutor implements TabExecutor {
+public class GeyserSpigotCommandExecutor extends CommandExecutor implements TabExecutor {
 
-    private final GeyserConnector connector;
+    public GeyserSpigotCommandExecutor(GeyserConnector connector) {
+        super(connector);
+    }
 
     @Override
     public boolean onCommand(CommandSender sender, Command command, String label, String[] args) {
         if (args.length > 0) {
-            if (getCommand(args[0]) != null) {
-                if (!sender.hasPermission(getCommand(args[0]).getPermission())) {
-                    SpigotCommandSender commandSender = new SpigotCommandSender(sender);
-                    String message = LanguageUtils.getPlayerLocaleString("geyser.bootstrap.command.permission_fail", commandSender.getLocale());;
+            GeyserCommand geyserCommand = getCommand(args[0]);
+            if (geyserCommand != null) {
+                SpigotCommandSender commandSender = new SpigotCommandSender(sender);
+                if (!sender.hasPermission(geyserCommand.getPermission())) {
+                    String message = LanguageUtils.getPlayerLocaleString("geyser.bootstrap.command.permission_fail", commandSender.getLocale());
 
                     commandSender.sendMessage(ChatColor.RED + message);
                     return true;
                 }
-                getCommand(args[0]).execute(new SpigotCommandSender(sender), args.length > 1 ? Arrays.copyOfRange(args, 1, args.length) : new String[0]);
+                GeyserSession session = getGeyserSession(commandSender);
+                if (geyserCommand.isBedrockOnly() && session == null) {
+                    sender.sendMessage(ChatColor.RED + LanguageUtils.getPlayerLocaleString("geyser.bootstrap.command.bedrock_only", commandSender.getLocale()));
+                    return true;
+                }
+                geyserCommand.execute(session, commandSender, args.length > 1 ? Arrays.copyOfRange(args, 1, args.length) : new String[0]);
                 return true;
             }
         } else {
-            getCommand("help").execute(new SpigotCommandSender(sender), new String[0]);
+            getCommand("help").execute(null, new SpigotCommandSender(sender), new String[0]);
             return true;
         }
         return true;
@@ -70,9 +78,5 @@ public class GeyserSpigotCommandExecutor implements TabExecutor {
             return connector.getCommandManager().getCommandNames();
         }
         return new ArrayList<>();
-    }
-
-    private GeyserCommand getCommand(String label) {
-        return connector.getCommandManager().getCommands().get(label);
     }
 }

--- a/bootstrap/sponge/src/main/java/org/geysermc/platform/sponge/command/GeyserSpongeCommandExecutor.java
+++ b/bootstrap/sponge/src/main/java/org/geysermc/platform/sponge/command/GeyserSpongeCommandExecutor.java
@@ -25,10 +25,12 @@
 
 package org.geysermc.platform.sponge.command;
 
-import lombok.AllArgsConstructor;
 import org.geysermc.connector.GeyserConnector;
-import org.geysermc.connector.common.ChatColor;
+import org.geysermc.connector.command.CommandExecutor;
+import org.geysermc.connector.command.CommandSender;
 import org.geysermc.connector.command.GeyserCommand;
+import org.geysermc.connector.common.ChatColor;
+import org.geysermc.connector.network.session.GeyserSession;
 import org.geysermc.connector.utils.LanguageUtils;
 import org.spongepowered.api.command.CommandCallable;
 import org.spongepowered.api.command.CommandException;
@@ -44,25 +46,33 @@ import java.util.Arrays;
 import java.util.List;
 import java.util.Optional;
 
-@AllArgsConstructor
-public class GeyserSpongeCommandExecutor implements CommandCallable {
+public class GeyserSpongeCommandExecutor extends CommandExecutor implements CommandCallable {
 
-    private GeyserConnector connector;
+    public GeyserSpongeCommandExecutor(GeyserConnector connector) {
+        super(connector);
+    }
 
     @Override
-    public CommandResult process(CommandSource source, String arguments) throws CommandException {
+    public CommandResult process(CommandSource source, String arguments) {
         String[] args = arguments.split(" ");
         if (args.length > 0) {
-            if (getCommand(args[0]) != null) {
-                if (!source.hasPermission(getCommand(args[0]).getPermission())) {
+            GeyserCommand command = getCommand(args[0]);
+            if (command != null) {
+                CommandSender commandSender = new SpongeCommandSender(source);
+                if (!source.hasPermission(command.getPermission())) {
                     // Not ideal to use log here but we dont get a session
                     source.sendMessage(Text.of(ChatColor.RED + LanguageUtils.getLocaleStringLog("geyser.bootstrap.command.permission_fail")));
                     return CommandResult.success();
                 }
-                getCommand(args[0]).execute(new SpongeCommandSender(source), args.length > 1 ? Arrays.copyOfRange(args, 1, args.length) : new String[0]);
+                GeyserSession session = getGeyserSession(commandSender);
+                if (command.isBedrockOnly() && session == null) {
+                    source.sendMessage(Text.of(ChatColor.RED + LanguageUtils.getLocaleStringLog("geyser.bootstrap.command.bedrock_only")));
+                    return CommandResult.success();
+                }
+                getCommand(args[0]).execute(session, commandSender, args.length > 1 ? Arrays.copyOfRange(args, 1, args.length) : new String[0]);
             }
         } else {
-            getCommand("help").execute(new SpongeCommandSender(source), new String[0]);
+            getCommand("help").execute(null, new SpongeCommandSender(source), new String[0]);
         }
         return CommandResult.success();
     }
@@ -93,9 +103,5 @@ public class GeyserSpongeCommandExecutor implements CommandCallable {
     @Override
     public Text getUsage(CommandSource source) {
         return Text.of("/geyser help");
-    }
-
-    private GeyserCommand getCommand(String label) {
-        return connector.getCommandManager().getCommands().get(label);
     }
 }

--- a/bootstrap/sponge/src/main/java/org/geysermc/platform/sponge/command/GeyserSpongeCommandExecutor.java
+++ b/bootstrap/sponge/src/main/java/org/geysermc/platform/sponge/command/GeyserSpongeCommandExecutor.java
@@ -64,10 +64,13 @@ public class GeyserSpongeCommandExecutor extends CommandExecutor implements Comm
                     source.sendMessage(Text.of(ChatColor.RED + LanguageUtils.getLocaleStringLog("geyser.bootstrap.command.permission_fail")));
                     return CommandResult.success();
                 }
-                GeyserSession session = getGeyserSession(commandSender);
-                if (command.isBedrockOnly() && session == null) {
-                    source.sendMessage(Text.of(ChatColor.RED + LanguageUtils.getLocaleStringLog("geyser.bootstrap.command.bedrock_only")));
-                    return CommandResult.success();
+                GeyserSession session = null;
+                if (command.isBedrockOnly()) {
+                    session = getGeyserSession(commandSender);
+                    if (session == null) {
+                        source.sendMessage(Text.of(ChatColor.RED + LanguageUtils.getLocaleStringLog("geyser.bootstrap.command.bedrock_only")));
+                        return CommandResult.success();
+                    }
                 }
                 getCommand(args[0]).execute(session, commandSender, args.length > 1 ? Arrays.copyOfRange(args, 1, args.length) : new String[0]);
             }

--- a/bootstrap/standalone/src/main/java/org/geysermc/platform/standalone/gui/GeyserStandaloneGUI.java
+++ b/bootstrap/standalone/src/main/java/org/geysermc/platform/standalone/gui/GeyserStandaloneGUI.java
@@ -271,17 +271,17 @@ public class GeyserStandaloneGUI {
             JMenuItem commandButton = hasSubCommands ? new JMenu(command.getValue().getName()) : new JMenuItem(command.getValue().getName());
             commandButton.getAccessibleContext().setAccessibleDescription(command.getValue().getDescription());
             if (!hasSubCommands) {
-                commandButton.addActionListener(e -> command.getValue().execute(geyserStandaloneLogger, new String[]{ }));
+                commandButton.addActionListener(e -> command.getValue().execute(null, geyserStandaloneLogger, new String[]{ }));
             } else {
                 // Add a submenu that's the same name as the menu can't be pressed
                 JMenuItem otherCommandButton = new JMenuItem(command.getValue().getName());
                 otherCommandButton.getAccessibleContext().setAccessibleDescription(command.getValue().getDescription());
-                otherCommandButton.addActionListener(e -> command.getValue().execute(geyserStandaloneLogger, new String[]{ }));
+                otherCommandButton.addActionListener(e -> command.getValue().execute(null, geyserStandaloneLogger, new String[]{ }));
                 commandButton.add(otherCommandButton);
                 // Add a menu option for all possible subcommands
                 for (String subCommandName : command.getValue().getSubCommands()) {
                     JMenuItem item = new JMenuItem(subCommandName);
-                    item.addActionListener(e -> command.getValue().execute(geyserStandaloneLogger, new String[]{subCommandName}));
+                    item.addActionListener(e -> command.getValue().execute(null, geyserStandaloneLogger, new String[]{subCommandName}));
                     commandButton.add(item);
                 }
             }

--- a/bootstrap/velocity/pom.xml
+++ b/bootstrap/velocity/pom.xml
@@ -82,8 +82,8 @@
                                     <shadedPattern>org.geysermc.platform.velocity.shaded.dom4j</shadedPattern>
                                 </relocation>
                                 <relocation>
-                                    <pattern>net.kyori</pattern>
-                                    <shadedPattern>org.geysermc.platform.velocity.shaded.kyori</shadedPattern>
+                                    <pattern>net.kyori.adventure.text.serializer.gson.legacyimpl</pattern>
+                                    <shadedPattern>org.geysermc.platform.velocity.shaded.kyori.legacyimpl</shadedPattern>
                                 </relocation>
                             </relocations>
                         </configuration>
@@ -105,6 +105,13 @@
                             <exclude>io.netty:netty-codec:*</exclude>
                             <exclude>org.slf4j:*</exclude>
                             <exclude>org.ow2.asm:*</exclude>
+                            <!-- Exclude all Kyori dependencies except the legacy NBT serializer -->
+                            <exclude>net.kyori:adventure-api:*</exclude>
+                            <exclude>net.kyori:examination-api:*</exclude>
+                            <exclude>net.kyori:examination-string:*</exclude>
+                            <exclude>net.kyori:adventure-text-serializer-gson:*</exclude>
+                            <exclude>net.kyori:adventure-text-serializer-legacy:*</exclude>
+                            <exclude>net.kyori:adventure-nbt:*</exclude>
                         </excludes>
                     </artifactSet>
                 </configuration>

--- a/bootstrap/velocity/src/main/java/org/geysermc/platform/velocity/GeyserVelocityPingPassthrough.java
+++ b/bootstrap/velocity/src/main/java/org/geysermc/platform/velocity/GeyserVelocityPingPassthrough.java
@@ -31,11 +31,10 @@ import com.velocitypowered.api.proxy.InboundConnection;
 import com.velocitypowered.api.proxy.ProxyServer;
 import com.velocitypowered.api.proxy.server.ServerPing;
 import lombok.AllArgsConstructor;
-import net.kyori.text.serializer.legacy.LegacyComponentSerializer;
+import net.kyori.adventure.text.serializer.legacy.LegacyComponentSerializer;
 import org.geysermc.connector.common.ping.GeyserPingInfo;
 import org.geysermc.connector.ping.IGeyserPingPassthrough;
 
-import java.net.Inet4Address;
 import java.net.InetSocketAddress;
 import java.util.Optional;
 import java.util.concurrent.ExecutionException;
@@ -50,13 +49,13 @@ public class GeyserVelocityPingPassthrough implements IGeyserPingPassthrough {
         ProxyPingEvent event;
         try {
             event = server.getEventManager().fire(new ProxyPingEvent(new GeyserInboundConnection(inetSocketAddress), ServerPing.builder()
-                    .description(server.getConfiguration().getMotdComponent()).onlinePlayers(server.getPlayerCount())
+                    .description(server.getConfiguration().getMotd()).onlinePlayers(server.getPlayerCount())
                     .maximumPlayers(server.getConfiguration().getShowMaxPlayers()).build())).get();
         } catch (ExecutionException | InterruptedException e) {
             throw new RuntimeException(e);
         }
         GeyserPingInfo geyserPingInfo = new GeyserPingInfo(
-                LegacyComponentSerializer.legacy().serialize(event.getPing().getDescription(), '§'),
+                LegacyComponentSerializer.legacy('§').serialize(event.getPing().getDescriptionComponent()),
                 new GeyserPingInfo.Players(
                         event.getPing().getPlayers().orElseThrow(IllegalStateException::new).getMax(),
                         event.getPing().getPlayers().orElseThrow(IllegalStateException::new).getOnline()

--- a/bootstrap/velocity/src/main/java/org/geysermc/platform/velocity/command/GeyserVelocityCommandExecutor.java
+++ b/bootstrap/velocity/src/main/java/org/geysermc/platform/velocity/command/GeyserVelocityCommandExecutor.java
@@ -54,10 +54,13 @@ public class GeyserVelocityCommandExecutor extends CommandExecutor implements Si
                     sender.sendMessage(ChatColor.RED + LanguageUtils.getPlayerLocaleString("geyser.bootstrap.command.permission_fail", sender.getLocale()));
                     return;
                 }
-                GeyserSession session = getGeyserSession(sender);
-                if (command.isBedrockOnly() && session == null) {
-                    sender.sendMessage(ChatColor.RED + LanguageUtils.getPlayerLocaleString("geyser.bootstrap.command.bedrock_only", sender.getLocale()));
-                    return;
+                GeyserSession session = null;
+                if (command.isBedrockOnly()) {
+                    session = getGeyserSession(sender);
+                    if (session == null) {
+                        sender.sendMessage(ChatColor.RED + LanguageUtils.getPlayerLocaleString("geyser.bootstrap.command.bedrock_only", sender.getLocale()));
+                        return;
+                    }
                 }
                 command.execute(session, sender, invocation.arguments().length > 1 ? Arrays.copyOfRange(invocation.arguments(), 1, invocation.arguments().length) : new String[0]);
             }

--- a/bootstrap/velocity/src/main/java/org/geysermc/platform/velocity/command/GeyserVelocityCommandExecutor.java
+++ b/bootstrap/velocity/src/main/java/org/geysermc/platform/velocity/command/GeyserVelocityCommandExecutor.java
@@ -25,37 +25,44 @@
 
 package org.geysermc.platform.velocity.command;
 
-import com.velocitypowered.api.command.CommandSource;
 import com.velocitypowered.api.command.SimpleCommand;
-import lombok.AllArgsConstructor;
 import org.geysermc.connector.GeyserConnector;
+import org.geysermc.connector.command.CommandExecutor;
 import org.geysermc.connector.command.CommandSender;
 import org.geysermc.connector.command.GeyserCommand;
 import org.geysermc.connector.common.ChatColor;
+import org.geysermc.connector.network.session.GeyserSession;
 import org.geysermc.connector.utils.LanguageUtils;
 
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 
-@AllArgsConstructor
-public class GeyserVelocityCommandExecutor implements SimpleCommand {
+public class GeyserVelocityCommandExecutor extends CommandExecutor implements SimpleCommand {
 
-    private final GeyserConnector connector;
+    public GeyserVelocityCommandExecutor(GeyserConnector connector) {
+        super(connector);
+    }
 
     @Override
     public void execute(Invocation invocation) {
         if (invocation.arguments().length > 0) {
-            if (getCommand(invocation.arguments()[0]) != null) {
+            GeyserCommand command = getCommand(invocation.arguments()[0]);
+            if (command != null) {
+                CommandSender sender = new VelocityCommandSender(invocation.source());
                 if (!invocation.source().hasPermission(getCommand(invocation.arguments()[0]).getPermission())) {
-                    CommandSender sender = new VelocityCommandSender(invocation.source());
                     sender.sendMessage(ChatColor.RED + LanguageUtils.getPlayerLocaleString("geyser.bootstrap.command.permission_fail", sender.getLocale()));
                     return;
                 }
-                getCommand(invocation.arguments()[0]).execute(new VelocityCommandSender(invocation.source()), invocation.arguments().length > 1 ? Arrays.copyOfRange(invocation.arguments(), 1, invocation.arguments().length) : new String[0]);
+                GeyserSession session = getGeyserSession(sender);
+                if (command.isBedrockOnly() && session == null) {
+                    sender.sendMessage(ChatColor.RED + LanguageUtils.getPlayerLocaleString("geyser.bootstrap.command.bedrock_only", sender.getLocale()));
+                    return;
+                }
+                command.execute(session, sender, invocation.arguments().length > 1 ? Arrays.copyOfRange(invocation.arguments(), 1, invocation.arguments().length) : new String[0]);
             }
         } else {
-            getCommand("help").execute(new VelocityCommandSender(invocation.source()), new String[0]);
+            getCommand("help").execute(null, new VelocityCommandSender(invocation.source()), new String[0]);
         }
     }
 
@@ -65,9 +72,5 @@ public class GeyserVelocityCommandExecutor implements SimpleCommand {
             return connector.getCommandManager().getCommandNames();
         }
         return new ArrayList<>();
-    }
-
-    private GeyserCommand getCommand(String label) {
-        return connector.getCommandManager().getCommands().get(label);
     }
 }

--- a/connector/src/main/java/org/geysermc/connector/command/CommandExecutor.java
+++ b/connector/src/main/java/org/geysermc/connector/command/CommandExecutor.java
@@ -23,35 +23,34 @@
  * @link https://github.com/GeyserMC/Geyser
  */
 
-package org.geysermc.connector.command.defaults;
+package org.geysermc.connector.command;
 
+import lombok.AllArgsConstructor;
 import org.geysermc.connector.GeyserConnector;
-import org.geysermc.connector.command.CommandSender;
-import org.geysermc.connector.command.GeyserCommand;
 import org.geysermc.connector.network.session.GeyserSession;
-import org.geysermc.connector.utils.SettingsUtils;
 
-public class SettingsCommand extends GeyserCommand {
+/**
+ * Represents helper functions for listening to {@code /geyser} commands.
+ */
+@AllArgsConstructor
+public class CommandExecutor {
 
-    public SettingsCommand(GeyserConnector connector, String name, String description, String permission) {
-        super(name, description, permission);
+    protected final GeyserConnector connector;
+
+    public GeyserCommand getCommand(String label) {
+        return connector.getCommandManager().getCommands().get(label);
     }
 
-    @Override
-    public void execute(GeyserSession session, CommandSender sender, String[] args) {
-        if (session == null) return;
+    public GeyserSession getGeyserSession(CommandSender sender) {
+        if (sender.isConsole()) {
+            return null;
+        }
 
-        SettingsUtils.buildForm(session);
-        session.sendForm(session.getSettingsForm(), SettingsUtils.SETTINGS_FORM_ID);
-    }
-
-    @Override
-    public boolean isExecutableOnConsole() {
-        return false;
-    }
-
-    @Override
-    public boolean isBedrockOnly() {
-        return true;
+        for (GeyserSession session : connector.getPlayers()) {
+            if (sender.getName().equals(session.getPlayerEntity().getUsername())) {
+                return session;
+            }
+        }
+        return null;
     }
 }

--- a/connector/src/main/java/org/geysermc/connector/command/CommandManager.java
+++ b/connector/src/main/java/org/geysermc/connector/command/CommandManager.java
@@ -29,6 +29,7 @@ import lombok.Getter;
 
 import org.geysermc.connector.GeyserConnector;
 import org.geysermc.connector.command.defaults.*;
+import org.geysermc.connector.network.session.GeyserSession;
 import org.geysermc.connector.utils.LanguageUtils;
 
 import java.util.*;
@@ -89,7 +90,15 @@ public abstract class CommandManager {
             return;
         }
 
-        cmd.execute(sender, args);
+        if (sender instanceof GeyserSession) {
+            cmd.execute((GeyserSession) sender, sender, args);
+        } else {
+            if (!cmd.isBedrockOnly()) {
+                cmd.execute(null, sender, args);
+            } else {
+                connector.getLogger().error(LanguageUtils.getLocaleStringLog("geyser.bootstrap.command.bedrock_only"));
+            }
+        }
     }
 
     /**

--- a/connector/src/main/java/org/geysermc/connector/command/GeyserCommand.java
+++ b/connector/src/main/java/org/geysermc/connector/command/GeyserCommand.java
@@ -28,7 +28,9 @@ package org.geysermc.connector.command;
 import lombok.Getter;
 import lombok.RequiredArgsConstructor;
 import lombok.Setter;
+import org.geysermc.connector.network.session.GeyserSession;
 
+import javax.annotation.Nullable;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
@@ -47,7 +49,7 @@ public abstract class GeyserCommand {
     @Setter
     private List<String> aliases = new ArrayList<>();
 
-    public abstract void execute(CommandSender sender, String[] args);
+    public abstract void execute(@Nullable GeyserSession session, CommandSender sender, String[] args);
 
     /**
      * If false, hides the command from being shown on the Geyser Standalone GUI.
@@ -74,5 +76,14 @@ public abstract class GeyserCommand {
      */
     public boolean hasSubCommands() {
         return !getSubCommands().isEmpty();
+    }
+
+    /**
+     * Used to send a deny message to Java players if this command can only be used by Bedrock players.
+     *
+     * @return true if this command can only be used by Bedrock players.
+     */
+    public boolean isBedrockOnly() {
+        return false;
     }
 }

--- a/connector/src/main/java/org/geysermc/connector/command/defaults/AdvancementsCommand.java
+++ b/connector/src/main/java/org/geysermc/connector/command/defaults/AdvancementsCommand.java
@@ -34,33 +34,12 @@ import org.geysermc.connector.network.session.cache.AdvancementsCache;
 
 public class AdvancementsCommand extends GeyserCommand {
 
-    private final GeyserConnector connector;
-
     public AdvancementsCommand(GeyserConnector connector, String name, String description, String permission) {
         super(name, description, permission);
-
-        this.connector = connector;
     }
 
     @Override
-    public void execute(CommandSender sender, String[] args) {
-        if (sender.isConsole()) {
-            return;
-        }
-
-        // Make sure the sender is a Bedrock edition client
-        GeyserSession session = null;
-        if (sender instanceof GeyserSession) {
-            session = (GeyserSession) sender;
-        } else {
-            // Needed for Spigot - sender is not an instance of GeyserSession
-            for (GeyserSession otherSession : connector.getPlayers()) {
-                if (sender.getName().equals(otherSession.getPlayerEntity().getUsername())) {
-                    session = otherSession;
-                    break;
-                }
-            }
-        }
+    public void execute(GeyserSession session, CommandSender sender, String[] args) {
         if (session == null) return;
 
         SimpleFormWindow window = session.getAdvancementsCache().buildMenuForm();
@@ -70,5 +49,10 @@ public class AdvancementsCommand extends GeyserCommand {
     @Override
     public boolean isExecutableOnConsole() {
         return false;
+    }
+
+    @Override
+    public boolean isBedrockOnly() {
+        return true;
     }
 }

--- a/connector/src/main/java/org/geysermc/connector/command/defaults/DumpCommand.java
+++ b/connector/src/main/java/org/geysermc/connector/command/defaults/DumpCommand.java
@@ -33,6 +33,7 @@ import org.geysermc.connector.command.GeyserCommand;
 import org.geysermc.connector.common.ChatColor;
 import org.geysermc.connector.common.serializer.AsteriskSerializer;
 import org.geysermc.connector.dump.DumpInfo;
+import org.geysermc.connector.network.session.GeyserSession;
 import org.geysermc.connector.utils.LanguageUtils;
 import org.geysermc.connector.utils.WebUtils;
 
@@ -54,7 +55,7 @@ public class DumpCommand extends GeyserCommand {
     }
 
     @Override
-    public void execute(CommandSender sender, String[] args) {
+    public void execute(GeyserSession session, CommandSender sender, String[] args) {
         boolean showSensitive = false;
         boolean offlineDump = false;
         if (args.length >= 1) {

--- a/connector/src/main/java/org/geysermc/connector/command/defaults/HelpCommand.java
+++ b/connector/src/main/java/org/geysermc/connector/command/defaults/HelpCommand.java
@@ -29,6 +29,7 @@ import org.geysermc.connector.GeyserConnector;
 import org.geysermc.connector.command.CommandSender;
 import org.geysermc.connector.command.GeyserCommand;
 import org.geysermc.connector.common.ChatColor;
+import org.geysermc.connector.network.session.GeyserSession;
 import org.geysermc.connector.utils.LanguageUtils;
 
 import java.util.Collections;
@@ -48,7 +49,7 @@ public class HelpCommand extends GeyserCommand {
     }
 
     @Override
-    public void execute(CommandSender sender, String[] args) {
+    public void execute(GeyserSession session, CommandSender sender, String[] args) {
         int page = 1;
         int maxPage = 1;
         String header = LanguageUtils.getPlayerLocaleString("geyser.commands.help.header", sender.getLocale(), page, maxPage);

--- a/connector/src/main/java/org/geysermc/connector/command/defaults/ListCommand.java
+++ b/connector/src/main/java/org/geysermc/connector/command/defaults/ListCommand.java
@@ -44,7 +44,7 @@ public class ListCommand extends GeyserCommand {
     }
 
     @Override
-    public void execute(CommandSender sender, String[] args) {
+    public void execute(GeyserSession session, CommandSender sender, String[] args) {
         String message = "";
         message = LanguageUtils.getPlayerLocaleString("geyser.commands.list.message", sender.getLocale(),
                 connector.getPlayers().size(),

--- a/connector/src/main/java/org/geysermc/connector/command/defaults/OffhandCommand.java
+++ b/connector/src/main/java/org/geysermc/connector/command/defaults/OffhandCommand.java
@@ -45,32 +45,23 @@ public class OffhandCommand extends GeyserCommand {
     }
 
     @Override
-    public void execute(CommandSender sender, String[] args) {
-        if (sender.isConsole()) {
+    public void execute(GeyserSession session, CommandSender sender, String[] args) {
+        if (session == null) {
             return;
         }
 
-        // Make sure the sender is a Bedrock edition client
-        if (sender instanceof GeyserSession) {
-            GeyserSession session = (GeyserSession) sender;
-            ClientPlayerActionPacket releaseItemPacket = new ClientPlayerActionPacket(PlayerAction.SWAP_HANDS, new Position(0,0,0),
-                    BlockFace.DOWN);
-            session.sendDownstreamPacket(releaseItemPacket);
-            return;
-        }
-        // Needed for Spigot - sender is not an instance of GeyserSession
-        for (GeyserSession session : connector.getPlayers()) {
-            if (sender.getName().equals(session.getPlayerEntity().getUsername())) {
-                ClientPlayerActionPacket releaseItemPacket = new ClientPlayerActionPacket(PlayerAction.SWAP_HANDS, new Position(0,0,0),
-                        BlockFace.DOWN);
-                session.sendDownstreamPacket(releaseItemPacket);
-                break;
-            }
-        }
+        ClientPlayerActionPacket releaseItemPacket = new ClientPlayerActionPacket(PlayerAction.SWAP_HANDS, new Position(0,0,0),
+                BlockFace.DOWN);
+        session.sendDownstreamPacket(releaseItemPacket);
     }
 
     @Override
     public boolean isExecutableOnConsole() {
         return false;
+    }
+
+    @Override
+    public boolean isBedrockOnly() {
+        return true;
     }
 }

--- a/connector/src/main/java/org/geysermc/connector/command/defaults/ReloadCommand.java
+++ b/connector/src/main/java/org/geysermc/connector/command/defaults/ReloadCommand.java
@@ -34,7 +34,7 @@ import org.geysermc.connector.utils.LanguageUtils;
 
 public class ReloadCommand extends GeyserCommand {
 
-    private GeyserConnector connector;
+    private final GeyserConnector connector;
 
     public ReloadCommand(GeyserConnector connector, String name, String description, String permission) {
         super(name, description, permission);
@@ -42,7 +42,7 @@ public class ReloadCommand extends GeyserCommand {
     }
 
     @Override
-    public void execute(CommandSender sender, String[] args) {
+    public void execute(GeyserSession session, CommandSender sender, String[] args) {
         if (!sender.isConsole() && connector.getPlatformType() == PlatformType.STANDALONE) {
             return;
         }
@@ -51,8 +51,8 @@ public class ReloadCommand extends GeyserCommand {
 
         sender.sendMessage(message);
 
-        for (GeyserSession session : connector.getPlayers()) {
-            session.disconnect(LanguageUtils.getPlayerLocaleString("geyser.commands.reload.kick", session.getLocale()));
+        for (GeyserSession otherSession : connector.getPlayers()) {
+            otherSession.disconnect(LanguageUtils.getPlayerLocaleString("geyser.commands.reload.kick", session.getLocale()));
         }
         connector.reload();
     }

--- a/connector/src/main/java/org/geysermc/connector/command/defaults/StatisticsCommand.java
+++ b/connector/src/main/java/org/geysermc/connector/command/defaults/StatisticsCommand.java
@@ -34,34 +34,14 @@ import org.geysermc.connector.network.session.GeyserSession;
 
 public class StatisticsCommand extends GeyserCommand {
 
-    private final GeyserConnector connector;
-
     public StatisticsCommand(GeyserConnector connector, String name, String description, String permission) {
         super(name, description, permission);
-
-        this.connector = connector;
     }
 
     @Override
-    public void execute(CommandSender sender, String[] args) {
-        if (sender.isConsole()) {
-            return;
-        }
-
-        // Make sure the sender is a Bedrock edition client
-        GeyserSession session = null;
-        if (sender instanceof GeyserSession) {
-            session = (GeyserSession) sender;
-        } else {
-            // Needed for Spigot - sender is not an instance of GeyserSession
-            for (GeyserSession otherSession : connector.getPlayers()) {
-                if (sender.getName().equals(otherSession.getPlayerEntity().getUsername())) {
-                    session = otherSession;
-                    break;
-                }
-            }
-        }
+    public void execute(GeyserSession session, CommandSender sender, String[] args) {
         if (session == null) return;
+
         session.setWaitingForStatistics(true);
         ClientRequestPacket clientRequestPacket = new ClientRequestPacket(ClientRequest.STATS);
         session.sendDownstreamPacket(clientRequestPacket);
@@ -70,5 +50,10 @@ public class StatisticsCommand extends GeyserCommand {
     @Override
     public boolean isExecutableOnConsole() {
         return false;
+    }
+
+    @Override
+    public boolean isBedrockOnly() {
+        return true;
     }
 }

--- a/connector/src/main/java/org/geysermc/connector/command/defaults/StopCommand.java
+++ b/connector/src/main/java/org/geysermc/connector/command/defaults/StopCommand.java
@@ -29,12 +29,13 @@ import org.geysermc.common.PlatformType;
 import org.geysermc.connector.GeyserConnector;
 import org.geysermc.connector.command.CommandSender;
 import org.geysermc.connector.command.GeyserCommand;
+import org.geysermc.connector.network.session.GeyserSession;
 
 import java.util.Collections;
 
 public class StopCommand extends GeyserCommand {
 
-    private GeyserConnector connector;
+    private final GeyserConnector connector;
 
     public StopCommand(GeyserConnector connector, String name, String description, String permission) {
         super(name, description, permission);
@@ -44,7 +45,7 @@ public class StopCommand extends GeyserCommand {
     }
 
     @Override
-    public void execute(CommandSender sender, String[] args) {
+    public void execute(GeyserSession session, CommandSender sender, String[] args) {
         if (!sender.isConsole() && connector.getPlatformType() == PlatformType.STANDALONE) {
             return;
         }

--- a/connector/src/main/java/org/geysermc/connector/command/defaults/VersionCommand.java
+++ b/connector/src/main/java/org/geysermc/connector/command/defaults/VersionCommand.java
@@ -32,6 +32,7 @@ import org.geysermc.connector.command.CommandSender;
 import org.geysermc.connector.command.GeyserCommand;
 import org.geysermc.connector.common.ChatColor;
 import org.geysermc.connector.network.BedrockProtocol;
+import org.geysermc.connector.network.session.GeyserSession;
 import org.geysermc.connector.utils.FileUtils;
 import org.geysermc.connector.utils.LanguageUtils;
 import org.geysermc.connector.utils.WebUtils;
@@ -44,15 +45,12 @@ import java.util.Properties;
 
 public class VersionCommand extends GeyserCommand {
 
-    public GeyserConnector connector;
-
     public VersionCommand(GeyserConnector connector, String name, String description, String permission) {
         super(name, description, permission);
-        this.connector = connector;
     }
 
     @Override
-    public void execute(CommandSender sender, String[] args) {
+    public void execute(GeyserSession session, CommandSender sender, String[] args) {
         String bedrockVersions;
         List<BedrockPacketCodec> supportedCodecs = BedrockProtocol.SUPPORTED_BEDROCK_CODECS;
         if (supportedCodecs.size() > 1) {

--- a/connector/src/main/java/org/geysermc/connector/network/translators/bedrock/BedrockCommandRequestTranslator.java
+++ b/connector/src/main/java/org/geysermc/connector/network/translators/bedrock/BedrockCommandRequestTranslator.java
@@ -43,7 +43,7 @@ public class BedrockCommandRequestTranslator extends PacketTranslator<CommandReq
     public void translate(CommandRequestPacket packet, GeyserSession session) {
         String command = packet.getCommand().replace("/", "");
         CommandManager commandManager = GeyserConnector.getInstance().getCommandManager();
-        if (session.getConnector().getPlatformType() == PlatformType.STANDALONE && command.startsWith("geyser ") && commandManager.getCommands().containsKey(command.split(" ")[1])) {
+        if (session.getConnector().getPlatformType() == PlatformType.STANDALONE && command.trim().startsWith("geyser ") && commandManager.getCommands().containsKey(command.split(" ")[1])) {
             commandManager.runCommand(session, command);
         } else {
             String message = packet.getCommand().trim();


### PR DESCRIPTION
If a Java player attempts to use a Bedrock-only command, such as `geyser statistics`, they will get an error message stating that this command is only for Bedrock players.

This commit also cleans up Velocity Adventure dependency usage. Issues were caused because of the way relocation works and because Velocity also uses Adventure.