### PR TITLE
Fix show-coordinates not disabling the coordinates display

### DIFF
--- a/connector/src/main/java/org/geysermc/connector/network/session/GeyserSession.java
+++ b/connector/src/main/java/org/geysermc/connector/network/session/GeyserSession.java
@@ -836,6 +836,8 @@ public class GeyserSession implements CommandSender {
         startGamePacket.setVanillaVersion("*");
         startGamePacket.setAuthoritativeMovementMode(AuthoritativeMovementMode.CLIENT);
         upstream.sendPacket(startGamePacket);
+
+        getWorldCache().setShowCoordinates(connector.getConfig().isShowCoordinates());
     }
 
     public void addTeleport(TeleportCache teleportCache) {
@@ -956,8 +958,8 @@ public class GeyserSession implements CommandSender {
      * @param value The new value for reducedDebugInfo
      */
     public void setReducedDebugInfo(boolean value) {
-        worldCache.setShowCoordinates(!value);
         reducedDebugInfo = value;
+        worldCache.setShowCoordinates(!value);
     }
 
     /**

--- a/connector/src/main/java/org/geysermc/connector/network/session/GeyserSession.java
+++ b/connector/src/main/java/org/geysermc/connector/network/session/GeyserSession.java
@@ -386,6 +386,9 @@ public class GeyserSession implements CommandSender {
         startGame();
         this.remoteServer = remoteServer;
 
+        // Update the ShowCoordinates data based on the config setting
+        getWorldCache().setShowCoordinates(connector.getConfig().isShowCoordinates());
+
         // Set the hardcoded shield ID to the ID we just defined in StartGamePacket
         upstream.getSession().getHardcodedBlockingId().set(ItemRegistry.SHIELD.getBedrockId());
 
@@ -836,8 +839,6 @@ public class GeyserSession implements CommandSender {
         startGamePacket.setVanillaVersion("*");
         startGamePacket.setAuthoritativeMovementMode(AuthoritativeMovementMode.CLIENT);
         upstream.sendPacket(startGamePacket);
-
-        getWorldCache().setShowCoordinates(connector.getConfig().isShowCoordinates());
     }
 
     public void addTeleport(TeleportCache teleportCache) {

--- a/connector/src/main/java/org/geysermc/connector/network/session/cache/WorldCache.java
+++ b/connector/src/main/java/org/geysermc/connector/network/session/cache/WorldCache.java
@@ -71,8 +71,8 @@ public class WorldCache {
      * @param value True to show, false to hide
      */
     public void setShowCoordinates(boolean value) {
-        boolean check = !session.isReducedDebugInfo() && session.getConnector().getConfig().isShowCoordinates();
-        showCoordinates = check && value;
-        session.sendGameRule("showcoordinates", check && value);
+        boolean allowUserSetting = !session.isReducedDebugInfo() && session.getConnector().getConfig().isShowCoordinates();
+        showCoordinates = allowUserSetting && value;
+        session.sendGameRule("showcoordinates", allowUserSetting && value);
     }
 }

--- a/connector/src/main/java/org/geysermc/connector/network/session/cache/WorldCache.java
+++ b/connector/src/main/java/org/geysermc/connector/network/session/cache/WorldCache.java
@@ -71,7 +71,8 @@ public class WorldCache {
      * @param value True to show, false to hide
      */
     public void setShowCoordinates(boolean value) {
-        showCoordinates = value;
-        session.sendGameRule("showcoordinates", value);
+        boolean check = !session.isReducedDebugInfo() && session.getConnector().getConfig().isShowCoordinates();
+        showCoordinates = check && value;
+        session.sendGameRule("showcoordinates", check && value);
     }
 }


### PR DESCRIPTION
This fixes the `show-coordinates` config option. It makes it so if `show-coordinates` is false then the client cannot choose to display coords and fixes the `reducedDebugInfo` to do the same but if it's true.