### PR TITLE
Threading and ping improvements

### DIFF
--- a/connector/src/main/java/org/geysermc/connector/GeyserConnector.java
+++ b/connector/src/main/java/org/geysermc/connector/GeyserConnector.java
@@ -56,10 +56,7 @@ import org.geysermc.connector.network.translators.world.WorldManager;
 import org.geysermc.connector.network.translators.world.block.BlockTranslator;
 import org.geysermc.connector.network.translators.world.block.entity.BlockEntityTranslator;
 import org.geysermc.connector.network.translators.world.block.entity.SkullBlockEntityTranslator;
-import org.geysermc.connector.utils.DimensionUtils;
-import org.geysermc.connector.utils.LanguageUtils;
-import org.geysermc.connector.utils.LocaleUtils;
-import org.geysermc.connector.utils.ResourcePack;
+import org.geysermc.connector.utils.*;
 
 import javax.naming.directory.Attribute;
 import javax.naming.directory.InitialDirContext;
@@ -190,6 +187,7 @@ public class GeyserConnector {
         remoteServer = new RemoteServer(config.getRemote().getAddress(), remotePort);
         authType = AuthType.getByName(config.getRemote().getAuthType());
 
+        CooldownUtils.setShowCooldown(config.isShowCooldown());
         DimensionUtils.changeBedrockNetherId(config.isAboveBedrockNetherBuilding()); // Apply End dimension ID workaround to Nether
         SkullBlockEntityTranslator.ALLOW_CUSTOM_SKULLS = config.isAllowCustomSkulls();
 

--- a/connector/src/main/java/org/geysermc/connector/configuration/GeyserConfiguration.java
+++ b/connector/src/main/java/org/geysermc/connector/configuration/GeyserConfiguration.java
@@ -59,6 +59,8 @@ public interface GeyserConfiguration {
 
     int getPingPassthroughInterval();
 
+    boolean isForwardPlayerPing();
+
     int getMaxPlayers();
 
     boolean isDebugMode();

--- a/connector/src/main/java/org/geysermc/connector/configuration/GeyserJacksonConfiguration.java
+++ b/connector/src/main/java/org/geysermc/connector/configuration/GeyserJacksonConfiguration.java
@@ -74,6 +74,9 @@ public abstract class GeyserJacksonConfiguration implements GeyserConfiguration 
     @JsonProperty("ping-passthrough-interval")
     private int pingPassthroughInterval = 3;
 
+    @JsonProperty("forward-player-ping")
+    private boolean forwardPlayerPing = false;
+
     @JsonProperty("max-players")
     private int maxPlayers = 100;
 

--- a/connector/src/main/java/org/geysermc/connector/network/session/GeyserSession.java
+++ b/connector/src/main/java/org/geysermc/connector/network/session/GeyserSession.java
@@ -229,8 +229,7 @@ public class GeyserSession implements CommandSender {
     @Setter
     private double attackSpeed = 4.0d;
     /**
-     * The time of the last hit. Used to gauge how long the cooldown is taking.
-     * This is a session variable in order to prevent more scheduled threads than necessary.
+     * The time of the last hit. Used to gauge how long the cooldown has progressed.
      */
     @Setter
     private long lastHitTime = -1;

--- a/connector/src/main/java/org/geysermc/connector/network/session/GeyserSession.java
+++ b/connector/src/main/java/org/geysermc/connector/network/session/GeyserSession.java
@@ -229,10 +229,11 @@ public class GeyserSession implements CommandSender {
     @Setter
     private double attackSpeed = 4.0d;
     /**
-     * The time of the last hit. Used to gauge how long the cooldown has progressed.
+     * The time of the last hit. Used to gauge how long the cooldown is taking.
+     * This is a session variable in order to prevent more scheduled threads than necessary.
      */
     @Setter
-    private long lastHitTime = -1;
+    private long lastHitTime;
 
     /**
      * Saves if the client is steering left on a boat.
@@ -723,11 +724,6 @@ public class GeyserSession implements CommandSender {
                 sendDownstreamPacket(packet);
             }
             lastMovementTimestamp = System.currentTimeMillis();
-        }
-
-        if (CooldownUtils.isShowCooldown() && lastHitTime != -1) {
-            // Show cooldown, if necessary
-            CooldownUtils.computeCurrentCooldown(this);
         }
 
         for (Tickable entity : entityCache.getTickableEntities()) {

--- a/connector/src/main/java/org/geysermc/connector/network/translators/bedrock/BedrockNetworkStackLatencyTranslator.java
+++ b/connector/src/main/java/org/geysermc/connector/network/translators/bedrock/BedrockNetworkStackLatencyTranslator.java
@@ -33,23 +33,25 @@ import org.geysermc.connector.network.translators.Translator;
 import org.geysermc.floodgate.util.DeviceOS;
 
 /**
- * Used to send the keep alive packet back to the server
+ * Used to send the forwarded keep alive packet back to the server
  */
 @Translator(packet = NetworkStackLatencyPacket.class)
 public class BedrockNetworkStackLatencyTranslator extends PacketTranslator<NetworkStackLatencyPacket> {
 
     @Override
     public void translate(NetworkStackLatencyPacket packet, GeyserSession session) {
-        long pingId;
-        // so apparently, as of 1.16.200
-        // PS4 divides the network stack latency timestamp FOR US!!!
-        // WTF
-        if (session.getClientData().getDeviceOS().equals(DeviceOS.NX)) {
-            // Ignore the weird DeviceOS, our order is wrong and will be fixed in Floodgate 2.0
-            pingId = packet.getTimestamp();
-        } else {
-            pingId = packet.getTimestamp() / 1000;
+        if (session.getConnector().getConfig().isForwardPlayerPing()) {
+            long pingId;
+            // so apparently, as of 1.16.200
+            // PS4 divides the network stack latency timestamp FOR US!!!
+            // WTF
+            if (session.getClientData().getDeviceOS().equals(DeviceOS.NX)) {
+                // Ignore the weird DeviceOS, our order is wrong and will be fixed in Floodgate 2.0
+                pingId = packet.getTimestamp();
+            } else {
+                pingId = packet.getTimestamp() / 1000;
+            }
+            session.sendDownstreamPacket(new ClientKeepAlivePacket(pingId));
         }
-        session.sendDownstreamPacket(new ClientKeepAlivePacket(pingId));
     }
 }

--- a/connector/src/main/java/org/geysermc/connector/network/translators/bedrock/entity/player/BedrockActionTranslator.java
+++ b/connector/src/main/java/org/geysermc/connector/network/translators/bedrock/entity/player/BedrockActionTranslator.java
@@ -42,7 +42,6 @@ import com.nukkitx.protocol.bedrock.packet.EntityEventPacket;
 import com.nukkitx.protocol.bedrock.packet.LevelEventPacket;
 import com.nukkitx.protocol.bedrock.packet.PlayStatusPacket;
 import com.nukkitx.protocol.bedrock.packet.PlayerActionPacket;
-import org.geysermc.connector.GeyserConnector;
 import org.geysermc.connector.entity.Entity;
 import org.geysermc.connector.inventory.PlayerInventory;
 import org.geysermc.connector.network.session.GeyserSession;
@@ -57,11 +56,6 @@ import java.util.concurrent.TimeUnit;
 
 @Translator(packet = PlayerActionPacket.class)
 public class BedrockActionTranslator extends PacketTranslator<PlayerActionPacket> {
-    private final boolean cacheChunks;
-
-    public BedrockActionTranslator() {
-        this.cacheChunks = GeyserConnector.getInstance().getConfig().isCacheChunks();
-    }
 
     @Override
     public void translate(PlayerActionPacket packet, GeyserSession session) {
@@ -211,7 +205,7 @@ public class BedrockActionTranslator extends PacketTranslator<PlayerActionPacket
                 session.getEntityCache().updateBossBars();
                 break;
             case JUMP:
-                if (!cacheChunks) {
+                if (!session.getConnector().getConfig().isCacheChunks()) {
                     // Save the jumping status for determining teleport status
                     session.setJumping(true);
                     session.getConnector().getGeneralThreadPool().schedule(() -> session.setJumping(false), 1, TimeUnit.SECONDS);

--- a/connector/src/main/java/org/geysermc/connector/network/translators/java/JavaKeepAliveTranslator.java
+++ b/connector/src/main/java/org/geysermc/connector/network/translators/java/JavaKeepAliveTranslator.java
@@ -27,7 +27,6 @@ package org.geysermc.connector.network.translators.java;
 
 import com.github.steveice10.mc.protocol.packet.ingame.server.ServerKeepAlivePacket;
 import com.nukkitx.protocol.bedrock.packet.NetworkStackLatencyPacket;
-import org.geysermc.connector.GeyserConnector;
 import org.geysermc.connector.network.session.GeyserSession;
 import org.geysermc.connector.network.translators.PacketTranslator;
 import org.geysermc.connector.network.translators.Translator;
@@ -37,15 +36,10 @@ import org.geysermc.connector.network.translators.Translator;
  */
 @Translator(packet = ServerKeepAlivePacket.class)
 public class JavaKeepAliveTranslator extends PacketTranslator<ServerKeepAlivePacket> {
-    private final boolean shouldForwardPlayerPing;
-
-    public JavaKeepAliveTranslator() {
-        this.shouldForwardPlayerPing = GeyserConnector.getInstance().getConfig().isForwardPlayerPing();
-    }
 
     @Override
     public void translate(ServerKeepAlivePacket packet, GeyserSession session) {
-        if (!shouldForwardPlayerPing) {
+        if (!session.getConnector().getConfig().isForwardPlayerPing()) {
             return;
         }
         NetworkStackLatencyPacket latencyPacket = new NetworkStackLatencyPacket();

--- a/connector/src/main/java/org/geysermc/connector/network/translators/java/JavaKeepAliveTranslator.java
+++ b/connector/src/main/java/org/geysermc/connector/network/translators/java/JavaKeepAliveTranslator.java
@@ -27,6 +27,7 @@ package org.geysermc.connector.network.translators.java;
 
 import com.github.steveice10.mc.protocol.packet.ingame.server.ServerKeepAlivePacket;
 import com.nukkitx.protocol.bedrock.packet.NetworkStackLatencyPacket;
+import org.geysermc.connector.GeyserConnector;
 import org.geysermc.connector.network.session.GeyserSession;
 import org.geysermc.connector.network.translators.PacketTranslator;
 import org.geysermc.connector.network.translators.Translator;
@@ -36,9 +37,17 @@ import org.geysermc.connector.network.translators.Translator;
  */
 @Translator(packet = ServerKeepAlivePacket.class)
 public class JavaKeepAliveTranslator extends PacketTranslator<ServerKeepAlivePacket> {
+    private final boolean shouldForwardPlayerPing;
+
+    public JavaKeepAliveTranslator() {
+        this.shouldForwardPlayerPing = GeyserConnector.getInstance().getConfig().isForwardPlayerPing();
+    }
 
     @Override
     public void translate(ServerKeepAlivePacket packet, GeyserSession session) {
+        if (!shouldForwardPlayerPing) {
+            return;
+        }
         NetworkStackLatencyPacket latencyPacket = new NetworkStackLatencyPacket();
         latencyPacket.setFromServer(true);
         latencyPacket.setTimestamp(packet.getPingId() * 1000);

--- a/connector/src/main/java/org/geysermc/connector/network/translators/java/entity/player/JavaPlayerListEntryTranslator.java
+++ b/connector/src/main/java/org/geysermc/connector/network/translators/java/entity/player/JavaPlayerListEntryTranslator.java
@@ -41,7 +41,6 @@ import org.geysermc.connector.skin.SkinManager;
 public class JavaPlayerListEntryTranslator extends PacketTranslator<ServerPlayerListEntryPacket> {
     @Override
     public void translate(ServerPlayerListEntryPacket packet, GeyserSession session) {
-        System.out.println(packet);
         if (packet.getAction() != PlayerListEntryAction.ADD_PLAYER && packet.getAction() != PlayerListEntryAction.REMOVE_PLAYER)
             return;
 

--- a/connector/src/main/java/org/geysermc/connector/network/translators/java/entity/player/JavaPlayerListEntryTranslator.java
+++ b/connector/src/main/java/org/geysermc/connector/network/translators/java/entity/player/JavaPlayerListEntryTranslator.java
@@ -41,6 +41,7 @@ import org.geysermc.connector.skin.SkinManager;
 public class JavaPlayerListEntryTranslator extends PacketTranslator<ServerPlayerListEntryPacket> {
     @Override
     public void translate(ServerPlayerListEntryPacket packet, GeyserSession session) {
+        System.out.println(packet);
         if (packet.getAction() != PlayerListEntryAction.ADD_PLAYER && packet.getAction() != PlayerListEntryAction.REMOVE_PLAYER)
             return;
 

--- a/connector/src/main/java/org/geysermc/connector/utils/CooldownUtils.java
+++ b/connector/src/main/java/org/geysermc/connector/utils/CooldownUtils.java
@@ -61,6 +61,7 @@ public class CooldownUtils {
     /**
      * Keeps updating the cooldown until the bar is complete.
      * @param session GeyserSession
+     * @param lastHitTime The time of the last hit. Used to gauge how long the cooldown is taking.
      */
     private static void computeCooldown(GeyserSession session, long lastHitTime) {
         if (session.isClosed()) return; // Don't run scheduled tasks if the client left
@@ -75,7 +76,6 @@ public class CooldownUtils {
         if (hasCooldown(session)) {
             session.getConnector().getGeneralThreadPool().schedule(() -> computeCooldown(session, lastHitTime), 50, TimeUnit.MILLISECONDS); // Updated per tick. 1000 divided by 20 ticks equals 50
         } else {
-            session.setLastHitTime(-1);
             SetTitlePacket removeTitlePacket = new SetTitlePacket();
             removeTitlePacket.setType(SetTitlePacket.Type.SUBTITLE);
             removeTitlePacket.setText(" ");

--- a/connector/src/main/java/org/geysermc/connector/utils/CooldownUtils.java
+++ b/connector/src/main/java/org/geysermc/connector/utils/CooldownUtils.java
@@ -26,6 +26,8 @@
 package org.geysermc.connector.utils;
 
 import com.nukkitx.protocol.bedrock.packet.SetTitlePacket;
+import lombok.Getter;
+import lombok.Setter;
 import org.geysermc.connector.network.session.GeyserSession;
 
 /**
@@ -34,14 +36,15 @@ import org.geysermc.connector.network.session.GeyserSession;
  */
 public class CooldownUtils {
 
-    private static boolean SHOW_COOLDOWN;
+    @Getter @Setter
+    private static boolean showCooldown;
 
     /**
      * Starts sending the fake cooldown to the Bedrock client.
      * @param session GeyserSession
      */
     public static void sendCooldown(GeyserSession session) {
-        if (!SHOW_COOLDOWN) return;
+        if (!showCooldown) return;
         if (session.getAttackSpeed() == 0.0 || session.getAttackSpeed() > 20) return; // 0.0 usually happens on login and causes issues with visuals; anything above 20 means a plugin like OldCombatMechanics is being used
         // Needs to be sent or no subtitle packet is recognized by the client
         SetTitlePacket titlePacket = new SetTitlePacket();
@@ -103,13 +106,4 @@ public class CooldownUtils {
         }
         return builder.toString();
     }
-
-    public static boolean isShowCooldown() {
-        return SHOW_COOLDOWN;
-    }
-
-    public static void setShowCooldown(boolean showCooldown) {
-        SHOW_COOLDOWN = showCooldown;
-    }
-
 }

--- a/connector/src/main/resources/config.yml
+++ b/connector/src/main/resources/config.yml
@@ -81,7 +81,11 @@ legacy-ping-passthrough: false
 # Increase if you are getting BrokenPipe errors.
 ping-passthrough-interval: 3
 
-# Maximum amount of players that can connect
+# Whether to forward player ping to the server. While enabling this will allow Bedrock players to have more accurate
+# ping, it may also cause players to time out more easily.
+forward-player-ping: false
+
+# Maximum amount of players that can connect. This is only visual at this time and does not actually limit player count.
 max-players: 100
 
 # If debug messages should be sent through console


### PR DESCRIPTION
- Don't schedule for setting jumping on and off if cache chunks is enabled, since we don't need to know that
- Implement cooldown sending in the session's tick thread
- Add a new setting to disable player ping forwarding. Hopefully this helps with timeouts.