### PR TITLE
Bedrock doesn't support custom armor stand poses.

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,6 +55,7 @@ The following things can't be fixed because of Bedrock limitations. They might b
 - Custom heads in inventories
 - Clickable links in chat
 - Glowing effect
+- Custom armor stand poses
 
 ## Compiling
 1. Clone the repo to your computer


### PR DESCRIPTION
Added the line that states that custom armor stand poses aren't possible in bedrock.