### PR TITLE
Add Dockerfile for standalone use

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,2 @@
+.dockerignore
+*Dockerfile

--- a/standalone.Dockerfile
+++ b/standalone.Dockerfile
@@ -1,0 +1,22 @@
+FROM maven:3.6-jdk-11 as build
+
+COPY . .
+
+RUN git submodule update --init --recursive&&\
+	mvn clean install
+
+FROM adoptopenjdk/openjdk11:alpine-jre
+
+COPY --from=build ./bootstrap/standalone/target /opt/Geyser
+
+ARG UID=1000
+ARG GID=1000
+RUN adduser --system --shell /bin/false -u $UID -g $GID --home /opt/Geyser geyser
+
+RUN mkdir -v /var/lib/geyser && chown -v -R ${UID}:0 /var/lib/geyser
+VOLUME /var/lib/geyser
+
+USER geyser
+WORKDIR /var/lib/geyser
+EXPOSE 19132/udp
+CMD ["java", "-jar", "/opt/Geyser/Geyser.jar"]

--- a/standalone.Dockerfile
+++ b/standalone.Dockerfile
@@ -2,7 +2,7 @@ FROM maven:3.6-jdk-11 as build
 
 COPY . .
 
-RUN git submodule update --init --recursive&&\
+RUN git submodule update --init --recursive &&\
 	mvn clean install
 
 FROM adoptopenjdk/openjdk11:alpine-jre


### PR DESCRIPTION
I don't know how widespread use this would get, but here it is if you want it.

If you wanted to give it a test run:

```bash
docker build -t geyser -f standalone.Dockerfile https://github.com/JamesTheAwesomeDude/Geyser.git
docker run -p 19132:19132/udp -v `pwd`/geyser:/var/lib/geyser geyser
```