### PR TITLE
Enable debug property in Log4J config if applicable

### DIFF
--- a/bootstrap/standalone/src/main/java/org/geysermc/platform/standalone/GeyserStandaloneBootstrap.java
+++ b/bootstrap/standalone/src/main/java/org/geysermc/platform/standalone/GeyserStandaloneBootstrap.java
@@ -32,6 +32,7 @@ import com.fasterxml.jackson.databind.introspect.AnnotatedField;
 import com.fasterxml.jackson.databind.introspect.BeanPropertyDefinition;
 import lombok.Getter;
 import net.minecrell.terminalconsole.TerminalConsoleAppender;
+import org.apache.logging.log4j.Level;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.core.Appender;
 import org.apache.logging.log4j.core.Logger;
@@ -167,11 +168,6 @@ public class GeyserStandaloneBootstrap implements GeyserBootstrap {
         this.onEnable();
     }
 
-    public void onEnable(boolean useGui) {
-        this.useGui = useGui;
-        this.onEnable();
-    }
-
     @Override
     public void onEnable() {
         Logger logger = (Logger) LogManager.getRootLogger();
@@ -212,6 +208,9 @@ public class GeyserStandaloneBootstrap implements GeyserBootstrap {
             }
         }
         GeyserConfiguration.checkGeyserConfiguration(geyserConfig, geyserLogger);
+
+        // Allow libraries like Protocol to have their debug information passthrough
+        logger.get().setLevel(geyserConfig.isDebugMode() ? Level.DEBUG : Level.INFO);
 
         connector = GeyserConnector.start(PlatformType.STANDALONE, this);
         geyserCommandManager = new GeyserCommandManager(connector);

--- a/connector/src/main/java/org/geysermc/connector/network/translators/PacketTranslatorRegistry.java
+++ b/connector/src/main/java/org/geysermc/connector/network/translators/PacketTranslatorRegistry.java
@@ -30,6 +30,7 @@ import com.github.steveice10.mc.protocol.packet.ingame.server.world.ServerUpdate
 import com.github.steveice10.packetlib.packet.Packet;
 import com.nukkitx.protocol.bedrock.BedrockPacket;
 import it.unimi.dsi.fastutil.objects.ObjectArrayList;
+import org.geysermc.common.PlatformType;
 import org.geysermc.connector.GeyserConnector;
 import org.geysermc.connector.network.session.GeyserSession;
 import org.geysermc.connector.utils.FileUtils;
@@ -89,12 +90,15 @@ public class PacketTranslatorRegistry<T> {
     public <P extends T> boolean translate(Class<? extends P> clazz, P packet, GeyserSession session) {
         if (!session.getUpstream().isClosed() && !session.isClosed()) {
             try {
-                if (translators.containsKey(clazz)) {
-                    ((PacketTranslator<P>) translators.get(clazz)).translate(packet, session);
+                PacketTranslator<P> translator = (PacketTranslator<P>) translators.get(clazz);
+                if (translator != null) {
+                    translator.translate(packet, session);
                     return true;
                 } else {
-                    if (!IGNORED_PACKETS.contains(clazz))
+                    if ((GeyserConnector.getInstance().getPlatformType() != PlatformType.STANDALONE || !(packet instanceof BedrockPacket)) && !IGNORED_PACKETS.contains(clazz)) {
+                        // Other debug logs already take care of Bedrock packets for us if on standalone
                         GeyserConnector.getInstance().getLogger().debug("Could not find packet for " + (packet.toString().length() > 25 ? packet.getClass().getSimpleName() : packet));
+                    }
                 }
             } catch (Throwable ex) {
                 GeyserConnector.getInstance().getLogger().error(LanguageUtils.getLocaleStringLog("geyser.network.translator.packet.failed", packet.getClass().getSimpleName()), ex);


### PR DESCRIPTION
With this commit, debug messages in Netty and Protocol will now show if debug mode is enabled in the Geyser standalone config.

There is also some small tuning to the PacketTranslatorRegistry for cleanliness and maybe some minor performance.