### PR TITLE
Don't allow the sub-MOTD to be empty

### DIFF
--- a/connector/src/main/java/org/geysermc/connector/network/ConnectorServerEventHandler.java
+++ b/connector/src/main/java/org/geysermc/connector/network/ConnectorServerEventHandler.java
@@ -117,7 +117,7 @@ public class ConnectorServerEventHandler implements BedrockServerEventHandler {
             }
             if (motdArray.length > (338 - MINECRAFT_VERSION_BYTES_LENGTH - BRAND_BYTES_LENGTH)) {
                 // If the top MOTD is still too long, we chop it down
-                byte[] newMotdArray = new byte[337 - MINECRAFT_VERSION_BYTES_LENGTH - BRAND_BYTES_LENGTH + 1];
+                byte[] newMotdArray = new byte[338 - MINECRAFT_VERSION_BYTES_LENGTH - BRAND_BYTES_LENGTH + 1];
                 System.arraycopy(motdArray, 0, newMotdArray, 0, newMotdArray.length);
                 pong.setMotd(new String(newMotdArray, StandardCharsets.UTF_8));
             }

--- a/connector/src/main/java/org/geysermc/connector/network/ConnectorServerEventHandler.java
+++ b/connector/src/main/java/org/geysermc/connector/network/ConnectorServerEventHandler.java
@@ -80,7 +80,7 @@ public class ConnectorServerEventHandler implements BedrockServerEventHandler {
         if (config.isPassthroughMotd() && pingInfo != null && pingInfo.getDescription() != null) {
             String[] motd = MessageTranslator.convertMessageLenient(pingInfo.getDescription()).split("\n");
             String mainMotd = motd[0]; // First line of the motd.
-            String subMotd = (motd.length != 1) ? motd[1] : ""; // Second line of the motd if present, otherwise blank.
+            String subMotd = (motd.length != 1) ? motd[1] : GeyserConnector.NAME; // Second line of the motd if present, otherwise default.
 
             pong.setMotd(mainMotd.trim());
             pong.setSubMotd(subMotd.trim()); // Trimmed to shift it to the left, prevents the universe from collapsing on us just because we went 2 characters over the text box's limit.

--- a/connector/src/main/java/org/geysermc/connector/network/ConnectorServerEventHandler.java
+++ b/connector/src/main/java/org/geysermc/connector/network/ConnectorServerEventHandler.java
@@ -74,7 +74,7 @@ public class ConnectorServerEventHandler implements BedrockServerEventHandler {
         pong.setGameType("Survival"); // Can only be Survival or Creative as of 1.16.210.59
         pong.setNintendoLimited(false);
         pong.setProtocolVersion(BedrockProtocol.DEFAULT_BEDROCK_CODEC.getProtocolVersion());
-        pong.setVersion(BedrockProtocol.DEFAULT_BEDROCK_CODEC.getMinecraftVersion()); // Required to not be empty as of 1.16.210.59
+        pong.setVersion(BedrockProtocol.DEFAULT_BEDROCK_CODEC.getMinecraftVersion()); // Required to not be empty as of 1.16.210.59. Can only contain . and numbers.
         pong.setIpv4Port(config.getBedrock().getPort());
 
         if (config.isPassthroughMotd() && pingInfo != null && pingInfo.getDescription() != null) {
@@ -118,7 +118,7 @@ public class ConnectorServerEventHandler implements BedrockServerEventHandler {
             }
             if (motdArray.length > (338 - MINECRAFT_VERSION_BYTES_LENGTH - subMotdLength)) {
                 // If the top MOTD is still too long, we chop it down
-                byte[] newMotdArray = new byte[338 - MINECRAFT_VERSION_BYTES_LENGTH - subMotdLength + 1];
+                byte[] newMotdArray = new byte[338 - MINECRAFT_VERSION_BYTES_LENGTH - subMotdLength];
                 System.arraycopy(motdArray, 0, newMotdArray, 0, newMotdArray.length);
                 pong.setMotd(new String(newMotdArray, StandardCharsets.UTF_8));
             }

--- a/connector/src/main/java/org/geysermc/connector/network/ConnectorServerEventHandler.java
+++ b/connector/src/main/java/org/geysermc/connector/network/ConnectorServerEventHandler.java
@@ -114,10 +114,11 @@ public class ConnectorServerEventHandler implements BedrockServerEventHandler {
             // Shorten the sub-MOTD first since that only appears locally
             if (subMotdLength > BRAND_BYTES_LENGTH) {
                 pong.setSubMotd(GeyserConnector.NAME);
+                subMotdLength = BRAND_BYTES_LENGTH;
             }
-            if (motdArray.length > (338 - MINECRAFT_VERSION_BYTES_LENGTH - BRAND_BYTES_LENGTH)) {
+            if (motdArray.length > (338 - MINECRAFT_VERSION_BYTES_LENGTH - subMotdLength)) {
                 // If the top MOTD is still too long, we chop it down
-                byte[] newMotdArray = new byte[338 - MINECRAFT_VERSION_BYTES_LENGTH - BRAND_BYTES_LENGTH + 1];
+                byte[] newMotdArray = new byte[338 - MINECRAFT_VERSION_BYTES_LENGTH - subMotdLength + 1];
                 System.arraycopy(motdArray, 0, newMotdArray, 0, newMotdArray.length);
                 pong.setMotd(new String(newMotdArray, StandardCharsets.UTF_8));
             }

--- a/connector/src/main/resources/config.yml
+++ b/connector/src/main/resources/config.yml
@@ -18,6 +18,7 @@ bedrock:
   # This option is for the plugin version only.
   clone-remote-port: false
   # The MOTD that will be broadcasted to Minecraft: Bedrock Edition clients. This is irrelevant if "passthrough-motd" is set to true
+  # If either of these are empty, the string will default to "Geyser"
   motd1: "GeyserMC"
   motd2: "Another GeyserMC forced host."
   # The Server Name that will be sent to Minecraft: Bedrock Edition clients. This is visible in both the pause menu and the settings menu.

--- a/connector/src/main/resources/config.yml
+++ b/connector/src/main/resources/config.yml
@@ -18,9 +18,9 @@ bedrock:
   # This option is for the plugin version only.
   clone-remote-port: false
   # The MOTD that will be broadcasted to Minecraft: Bedrock Edition clients. This is irrelevant if "passthrough-motd" is set to true
-  # If either of these are empty, the string will default to "Geyser"
-  motd1: "GeyserMC"
-  motd2: "Another GeyserMC forced host."
+  # If either of these are empty, the respective string will default to "Geyser"
+  motd1: "Geyser"
+  motd2: "Another Geyser server."
   # The Server Name that will be sent to Minecraft: Bedrock Edition clients. This is visible in both the pause menu and the settings menu.
   server-name: "Geyser"
 remote:


### PR DESCRIPTION
As of 1.16.210.59, the sub-MOTD cannot be blank: https://bugs.mojang.com/browse/MCPE-117979

This workaround will be implemented now so the widest range of Geyser versions will properly show a ping in 1.16.210 - better an 'outdated server' message than 'unable to connect to world.'