### PR TITLE
Fix NPE in ServerEntityAnimationPacket

### DIFF
--- a/connector/src/main/java/org/geysermc/connector/network/translators/java/entity/JavaEntityAnimationTranslator.java
+++ b/connector/src/main/java/org/geysermc/connector/network/translators/java/entity/JavaEntityAnimationTranslator.java
@@ -60,6 +60,9 @@ public class JavaEntityAnimationTranslator extends PacketTranslator<ServerEntity
             case LEAVE_BED:
                 animatePacket.setAction(AnimatePacket.Action.WAKE_UP);
                 break;
+            default:
+                // Unknown Animation
+                return;
         }
 
         session.sendUpstreamPacket(animatePacket);


### PR DESCRIPTION
If an unknown animation is sent by the java server we will ignore it.

Closes: https://github.com/bundabrg/GeyserReversion/issues/41