### PR TITLE
Fix Error when a TitlePacket of type TIMES is sent

### DIFF
--- a/connector/src/main/java/org/geysermc/connector/network/translators/java/JavaTitleTranslator.java
+++ b/connector/src/main/java/org/geysermc/connector/network/translators/java/JavaTitleTranslator.java
@@ -71,6 +71,7 @@ public class JavaTitleTranslator extends PacketTranslator<ServerTitlePacket> {
                 titlePacket.setFadeInTime(packet.getFadeIn());
                 titlePacket.setFadeOutTime(packet.getFadeOut());
                 titlePacket.setStayTime(packet.getStay());
+                titlePacket.setText("");
                 break;
         }
 


### PR DESCRIPTION
When a Title of type TIMES is sent no text is provided and it will throw an error in Protocol which requires nonnull

References: https://github.com/bundabrg/GeyserReversion/issues/29