### PR TITLE
Update Protocol lib and fastutil

### DIFF
--- a/connector/pom.xml
+++ b/connector/pom.xml
@@ -28,15 +28,11 @@
             <scope>compile</scope>
         </dependency>
         <dependency>
-            <groupId>com.github.CloudburstMC.Protocol</groupId>
+            <groupId>com.nukkitx.protocol</groupId>
             <artifactId>bedrock-v422</artifactId>
-            <version>294e7e5</version>
+            <version>2.6.2-20210228.150048-4</version>
             <scope>compile</scope>
             <exclusions>
-                <exclusion>
-                    <groupId>net.sf.trove4j</groupId>
-                    <artifactId>trove</artifactId>
-                </exclusion>
                 <exclusion>
                     <groupId>com.nukkitx.network</groupId>
                     <artifactId>raknet</artifactId>
@@ -44,9 +40,9 @@
             </exclusions>
         </dependency>
         <dependency>
-            <groupId>com.github.CloudburstMC.Network</groupId>
+            <groupId>com.nukkitx.network</groupId>
             <artifactId>raknet</artifactId>
-            <version>a94d2dd</version>
+            <version>1.6.26-20210217.205834-2</version>
             <scope>compile</scope>
             <exclusions>
                 <exclusion>
@@ -58,61 +54,61 @@
         <dependency>
             <groupId>com.nukkitx.fastutil</groupId>
             <artifactId>fastutil-int-int-maps</artifactId>
-            <version>8.3.1</version>
+            <version>8.5.2</version>
             <scope>compile</scope>
         </dependency>
         <dependency>
             <groupId>com.nukkitx.fastutil</groupId>
             <artifactId>fastutil-int-float-maps</artifactId>
-            <version>8.3.1</version>
+            <version>8.5.2</version>
             <scope>compile</scope>
         </dependency>
         <dependency>
             <groupId>com.nukkitx.fastutil</groupId>
             <artifactId>fastutil-long-long-maps</artifactId>
-            <version>8.3.1</version>
+            <version>8.5.2</version>
             <scope>compile</scope>
         </dependency>
         <dependency>
             <groupId>com.nukkitx.fastutil</groupId>
             <artifactId>fastutil-object-long-maps</artifactId>
-            <version>8.3.1</version>
+            <version>8.5.2</version>
             <scope>compile</scope>
         </dependency>
         <dependency>
             <groupId>com.nukkitx.fastutil</groupId>
             <artifactId>fastutil-int-byte-maps</artifactId>
-            <version>8.3.1</version>
+            <version>8.5.2</version>
             <scope>compile</scope>
         </dependency>
         <dependency>
             <groupId>com.nukkitx.fastutil</groupId>
             <artifactId>fastutil-int-double-maps</artifactId>
-            <version>8.3.1</version>
+            <version>8.5.2</version>
             <scope>compile</scope>
         </dependency>
         <dependency>
             <groupId>com.nukkitx.fastutil</groupId>
             <artifactId>fastutil-int-boolean-maps</artifactId>
-            <version>8.3.1</version>
+            <version>8.5.2</version>
             <scope>compile</scope>
         </dependency>
         <dependency>
             <groupId>com.nukkitx.fastutil</groupId>
             <artifactId>fastutil-object-int-maps</artifactId>
-            <version>8.3.1</version>
+            <version>8.5.2</version>
             <scope>compile</scope>
         </dependency>
         <dependency>
             <groupId>com.nukkitx.fastutil</groupId>
             <artifactId>fastutil-object-byte-maps</artifactId>
-            <version>8.3.1</version>
+            <version>8.5.2</version>
             <scope>compile</scope>
         </dependency>
         <dependency>
             <groupId>com.nukkitx.fastutil</groupId>
             <artifactId>fastutil-object-object-maps</artifactId>
-            <version>8.3.1</version>
+            <version>8.5.2</version>
             <scope>compile</scope>
         </dependency>
         <dependency>

--- a/connector/pom.xml
+++ b/connector/pom.xml
@@ -12,6 +12,7 @@
 
     <properties>
         <netty.version>4.1.59.Final</netty.version>
+        <fastutil.version>8.5.2</fastutil.version>
     </properties>
 
     <dependencies>
@@ -54,61 +55,61 @@
         <dependency>
             <groupId>com.nukkitx.fastutil</groupId>
             <artifactId>fastutil-int-int-maps</artifactId>
-            <version>8.5.2</version>
+            <version>${fastutil.version}</version>
             <scope>compile</scope>
         </dependency>
         <dependency>
             <groupId>com.nukkitx.fastutil</groupId>
             <artifactId>fastutil-int-float-maps</artifactId>
-            <version>8.5.2</version>
+            <version>${fastutil.version}</version>
             <scope>compile</scope>
         </dependency>
         <dependency>
             <groupId>com.nukkitx.fastutil</groupId>
             <artifactId>fastutil-long-long-maps</artifactId>
-            <version>8.5.2</version>
+            <version>${fastutil.version}</version>
             <scope>compile</scope>
         </dependency>
         <dependency>
             <groupId>com.nukkitx.fastutil</groupId>
             <artifactId>fastutil-object-long-maps</artifactId>
-            <version>8.5.2</version>
+            <version>${fastutil.version}</version>
             <scope>compile</scope>
         </dependency>
         <dependency>
             <groupId>com.nukkitx.fastutil</groupId>
             <artifactId>fastutil-int-byte-maps</artifactId>
-            <version>8.5.2</version>
+            <version>${fastutil.version}</version>
             <scope>compile</scope>
         </dependency>
         <dependency>
             <groupId>com.nukkitx.fastutil</groupId>
             <artifactId>fastutil-int-double-maps</artifactId>
-            <version>8.5.2</version>
+            <version>${fastutil.version}</version>
             <scope>compile</scope>
         </dependency>
         <dependency>
             <groupId>com.nukkitx.fastutil</groupId>
             <artifactId>fastutil-int-boolean-maps</artifactId>
-            <version>8.5.2</version>
+            <version>${fastutil.version}</version>
             <scope>compile</scope>
         </dependency>
         <dependency>
             <groupId>com.nukkitx.fastutil</groupId>
             <artifactId>fastutil-object-int-maps</artifactId>
-            <version>8.5.2</version>
+            <version>${fastutil.version}</version>
             <scope>compile</scope>
         </dependency>
         <dependency>
             <groupId>com.nukkitx.fastutil</groupId>
             <artifactId>fastutil-object-byte-maps</artifactId>
-            <version>8.5.2</version>
+            <version>${fastutil.version}</version>
             <scope>compile</scope>
         </dependency>
         <dependency>
             <groupId>com.nukkitx.fastutil</groupId>
             <artifactId>fastutil-object-object-maps</artifactId>
-            <version>8.5.2</version>
+            <version>${fastutil.version}</version>
             <scope>compile</scope>
         </dependency>
         <dependency>

--- a/connector/pom.xml
+++ b/connector/pom.xml
@@ -13,6 +13,7 @@
     <properties>
         <netty.version>4.1.59.Final</netty.version>
         <fastutil.version>8.5.2</fastutil.version>
+        <adventure.version>4.5.0</adventure.version>
     </properties>
 
     <dependencies>
@@ -211,25 +212,25 @@
         <dependency>
             <groupId>net.kyori</groupId>
             <artifactId>adventure-api</artifactId>
-            <version>4.5.0</version>
+            <version>${adventure.version}</version>
             <scope>compile</scope>
         </dependency>
         <dependency>
             <groupId>net.kyori</groupId>
             <artifactId>adventure-text-serializer-gson</artifactId>
-            <version>4.5.0</version>
+            <version>${adventure.version}</version>
             <scope>compile</scope>
         </dependency>
         <dependency>
             <groupId>net.kyori</groupId>
             <artifactId>adventure-text-serializer-legacy</artifactId>
-            <version>4.5.0</version>
+            <version>${adventure.version}</version>
             <scope>compile</scope>
         </dependency>
         <dependency>
             <groupId>net.kyori</groupId>
             <artifactId>adventure-text-serializer-gson-legacy-impl</artifactId>
-            <version>4.5.0</version>
+            <version>${adventure.version}</version>
             <scope>compile</scope>
         </dependency>
         <dependency>


### PR DESCRIPTION
- Update from fastutil version 8.3.1 to 8.5.2.
- Move away from jitpack since we store each unique snapshot build in the opencollab maven repo.
- Also, trove hasn't existed in the protocol lib for quite some time so the exclusion isn't needed anymore.