### PR TITLE
Fix logging into a server with Fabric Networking API

### DIFF
--- a/connector/pom.xml
+++ b/connector/pom.xml
@@ -30,9 +30,9 @@
             <scope>compile</scope>
         </dependency>
         <dependency>
-            <groupId>com.nukkitx.protocol</groupId>
+            <groupId>com.github.CloudburstMC.Protocol</groupId>
             <artifactId>bedrock-v422</artifactId>
-            <version>2.6.2-20210228.150048-4</version>
+            <version>42da92f</version>
             <scope>compile</scope>
             <exclusions>
                 <exclusion>

--- a/connector/src/main/java/org/geysermc/connector/network/session/GeyserSession.java
+++ b/connector/src/main/java/org/geysermc/connector/network/session/GeyserSession.java
@@ -34,6 +34,7 @@ import com.github.steveice10.mc.auth.service.MojangAuthenticationService;
 import com.github.steveice10.mc.auth.service.MsaAuthenticationService;
 import com.github.steveice10.mc.protocol.MinecraftConstants;
 import com.github.steveice10.mc.protocol.MinecraftProtocol;
+import com.github.steveice10.mc.protocol.data.SubProtocol;
 import com.github.steveice10.mc.protocol.data.game.entity.player.GameMode;
 import com.github.steveice10.mc.protocol.data.game.statistic.Statistic;
 import com.github.steveice10.mc.protocol.data.game.window.VillagerTrade;
@@ -41,6 +42,7 @@ import com.github.steveice10.mc.protocol.packet.handshake.client.HandshakePacket
 import com.github.steveice10.mc.protocol.packet.ingame.client.player.ClientPlayerPositionPacket;
 import com.github.steveice10.mc.protocol.packet.ingame.client.player.ClientPlayerPositionRotationPacket;
 import com.github.steveice10.mc.protocol.packet.ingame.client.world.ClientTeleportConfirmPacket;
+import com.github.steveice10.mc.protocol.packet.login.client.LoginPluginResponsePacket;
 import com.github.steveice10.mc.protocol.packet.login.server.LoginSuccessPacket;
 import com.github.steveice10.packetlib.BuiltinFlags;
 import com.github.steveice10.packetlib.Client;
@@ -955,7 +957,7 @@ public class GeyserSession implements CommandSender {
      * @param packet the java edition packet from MCProtocolLib
      */
     public void sendDownstreamPacket(Packet packet) {
-        if (downstream != null && downstream.getSession() != null) {
+        if (downstream != null && downstream.getSession() != null && (protocol.getSubProtocol().equals(SubProtocol.GAME) || (protocol.getSubProtocol().equals(SubProtocol.LOGIN) && packet instanceof LoginPluginResponsePacket))) {
             downstream.getSession().send(packet);
         } else {
             connector.getLogger().debug("Tried to send downstream packet " + packet.getClass().getSimpleName() + " before connected to the server");

--- a/connector/src/main/java/org/geysermc/connector/network/session/GeyserSession.java
+++ b/connector/src/main/java/org/geysermc/connector/network/session/GeyserSession.java
@@ -957,7 +957,7 @@ public class GeyserSession implements CommandSender {
      * @param packet the java edition packet from MCProtocolLib
      */
     public void sendDownstreamPacket(Packet packet) {
-        if (downstream != null && downstream.getSession() != null && (protocol.getSubProtocol().equals(SubProtocol.GAME) || (protocol.getSubProtocol().equals(SubProtocol.LOGIN) && packet instanceof LoginPluginResponsePacket))) {
+        if (downstream != null && downstream.getSession() != null && (protocol.getSubProtocol().equals(SubProtocol.GAME) || packet.getClass() == LoginPluginResponsePacket.class)) {
             downstream.getSession().send(packet);
         } else {
             connector.getLogger().debug("Tried to send downstream packet " + packet.getClass().getSimpleName() + " before connected to the server");

--- a/connector/src/main/java/org/geysermc/connector/network/session/GeyserSession.java
+++ b/connector/src/main/java/org/geysermc/connector/network/session/GeyserSession.java
@@ -34,7 +34,6 @@ import com.github.steveice10.mc.auth.service.MojangAuthenticationService;
 import com.github.steveice10.mc.auth.service.MsaAuthenticationService;
 import com.github.steveice10.mc.protocol.MinecraftConstants;
 import com.github.steveice10.mc.protocol.MinecraftProtocol;
-import com.github.steveice10.mc.protocol.data.SubProtocol;
 import com.github.steveice10.mc.protocol.data.game.entity.player.GameMode;
 import com.github.steveice10.mc.protocol.data.game.statistic.Statistic;
 import com.github.steveice10.mc.protocol.data.game.window.VillagerTrade;
@@ -69,10 +68,10 @@ import lombok.Setter;
 import org.geysermc.common.window.CustomFormWindow;
 import org.geysermc.common.window.FormWindow;
 import org.geysermc.connector.GeyserConnector;
-import org.geysermc.connector.entity.Tickable;
 import org.geysermc.connector.command.CommandSender;
 import org.geysermc.connector.common.AuthType;
 import org.geysermc.connector.entity.Entity;
+import org.geysermc.connector.entity.Tickable;
 import org.geysermc.connector.entity.player.SessionPlayerEntity;
 import org.geysermc.connector.entity.player.SkullPlayerEntity;
 import org.geysermc.connector.inventory.PlayerInventory;
@@ -956,7 +955,7 @@ public class GeyserSession implements CommandSender {
      * @param packet the java edition packet from MCProtocolLib
      */
     public void sendDownstreamPacket(Packet packet) {
-        if (downstream != null && downstream.getSession() != null && protocol.getSubProtocol().equals(SubProtocol.GAME)) {
+        if (downstream != null && downstream.getSession() != null) {
             downstream.getSession().send(packet);
         } else {
             connector.getLogger().debug("Tried to send downstream packet " + packet.getClass().getSimpleName() + " before connected to the server");

--- a/connector/src/main/java/org/geysermc/connector/network/translators/java/JavaLoginPluginRequestTranslator.java
+++ b/connector/src/main/java/org/geysermc/connector/network/translators/java/JavaLoginPluginRequestTranslator.java
@@ -33,10 +33,11 @@ import com.github.steveice10.mc.protocol.packet.login.client.LoginPluginResponse
 import com.github.steveice10.mc.protocol.packet.login.server.LoginPluginRequestPacket;
 
 @Translator(packet = LoginPluginRequestPacket.class)
-public class JavaLoginPluginMessageTranslator extends PacketTranslator<LoginPluginRequestPacket> {
+public class JavaLoginPluginRequestTranslator extends PacketTranslator<LoginPluginRequestPacket> {
     @Override
     public void translate(LoginPluginRequestPacket packet, GeyserSession session) {
         // A vanilla client doesn't know any PluginMessage in the Login state, so we don't know any either.
+        // Note: Fabric Networking API v1 will not let the client log in without sending this
         session.sendDownstreamPacket(
                 new LoginPluginResponsePacket(packet.getMessageId(), null)
         );


### PR DESCRIPTION
Turns out we prevented the response to LoginPluginRequestPacket. Fabric API 0.28 and later will not let a client join without this response.