### PR TITLE
Add furnace minecart item translation

### DIFF
--- a/connector/src/main/java/org/geysermc/connector/configuration/GeyserConfiguration.java
+++ b/connector/src/main/java/org/geysermc/connector/configuration/GeyserConfiguration.java
@@ -81,6 +81,8 @@ public interface GeyserConfiguration {
 
     Path getFloodgateKeyPath();
 
+    boolean isAddFurnaceMinecart();
+
     boolean isAboveBedrockNetherBuilding();
 
     boolean isCacheChunks();

--- a/connector/src/main/java/org/geysermc/connector/configuration/GeyserJacksonConfiguration.java
+++ b/connector/src/main/java/org/geysermc/connector/configuration/GeyserJacksonConfiguration.java
@@ -115,6 +115,9 @@ public abstract class GeyserJacksonConfiguration implements GeyserConfiguration 
     @JsonProperty("allow-custom-skulls")
     private boolean allowCustomSkulls = true;
 
+    @JsonProperty("add-furnace-minecart")
+    private boolean addFurnaceMinecart = true;
+
     @JsonProperty("above-bedrock-nether-building")
     private boolean aboveBedrockNetherBuilding = false;
 

--- a/connector/src/main/java/org/geysermc/connector/network/UpstreamPacketHandler.java
+++ b/connector/src/main/java/org/geysermc/connector/network/UpstreamPacketHandler.java
@@ -26,8 +26,9 @@
 package org.geysermc.connector.network;
 
 import com.nukkitx.protocol.bedrock.BedrockPacket;
-import com.nukkitx.protocol.bedrock.data.ResourcePackType;
 import com.nukkitx.protocol.bedrock.BedrockPacketCodec;
+import com.nukkitx.protocol.bedrock.data.ExperimentData;
+import com.nukkitx.protocol.bedrock.data.ResourcePackType;
 import com.nukkitx.protocol.bedrock.packet.*;
 import org.geysermc.connector.GeyserConnector;
 import org.geysermc.connector.common.AuthType;
@@ -35,6 +36,7 @@ import org.geysermc.connector.configuration.GeyserConfiguration;
 import org.geysermc.connector.network.session.GeyserSession;
 import org.geysermc.connector.network.session.cache.AdvancementsCache;
 import org.geysermc.connector.network.translators.PacketTranslatorRegistry;
+import org.geysermc.connector.network.translators.item.ItemRegistry;
 import org.geysermc.connector.utils.*;
 
 import java.io.FileInputStream;
@@ -124,6 +126,11 @@ public class UpstreamPacketHandler extends LoggingPacketHandler {
                 for (ResourcePack pack : ResourcePack.PACKS.values()) {
                     ResourcePackManifest.Header header = pack.getManifest().getHeader();
                     stackPacket.getResourcePacks().add(new ResourcePackStackPacket.Entry(header.getUuid().toString(), header.getVersionString(), ""));
+                }
+
+                if (ItemRegistry.FURNACE_MINECART_DATA != null) {
+                    // Allow custom items to work
+                    stackPacket.getExperiments().add(new ExperimentData("data_driven_items", true));
                 }
 
                 session.sendUpstreamPacket(stackPacket);

--- a/connector/src/main/java/org/geysermc/connector/network/session/GeyserSession.java
+++ b/connector/src/main/java/org/geysermc/connector/network/session/GeyserSession.java
@@ -395,6 +395,12 @@ public class GeyserSession implements CommandSender {
         // Set the hardcoded shield ID to the ID we just defined in StartGamePacket
         upstream.getSession().getHardcodedBlockingId().set(ItemRegistry.SHIELD.getBedrockId());
 
+        if (ItemRegistry.FURNACE_MINECART_DATA != null) {
+            ItemComponentPacket componentPacket = new ItemComponentPacket();
+            componentPacket.getItems().add(ItemRegistry.FURNACE_MINECART_DATA);
+            upstream.sendPacket(componentPacket);
+        }
+
         ChunkUtils.sendEmptyChunks(this, playerEntity.getPosition().toInt(), 0, false);
 
         BiomeDefinitionListPacket biomeDefinitionListPacket = new BiomeDefinitionListPacket();

--- a/connector/src/main/java/org/geysermc/connector/network/translators/item/ItemRegistry.java
+++ b/connector/src/main/java/org/geysermc/connector/network/translators/item/ItemRegistry.java
@@ -29,7 +29,9 @@ import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.github.steveice10.mc.protocol.data.game.entity.metadata.ItemStack;
 import com.nukkitx.nbt.NbtMap;
+import com.nukkitx.nbt.NbtMapBuilder;
 import com.nukkitx.nbt.NbtUtils;
+import com.nukkitx.protocol.bedrock.data.inventory.ComponentItemData;
 import com.nukkitx.protocol.bedrock.data.inventory.ItemData;
 import com.nukkitx.protocol.bedrock.packet.StartGamePacket;
 import it.unimi.dsi.fastutil.ints.Int2ObjectMap;
@@ -107,6 +109,11 @@ public class ItemRegistry {
 
     public static int BARRIER_INDEX = 0;
 
+    /**
+     * Stores the properties and data of the "custom" furnace minecart item.
+     */
+    public static final ComponentItemData FURNACE_MINECART_DATA;
+
     public static void init() {
         // no-op
     }
@@ -150,9 +157,16 @@ public class ItemRegistry {
         }
 
         int itemIndex = 0;
+        int javaFurnaceMinecartId = 0;
+        boolean usingFurnaceMinecart = GeyserConnector.getInstance().getConfig().isAddFurnaceMinecart();
         Iterator<Map.Entry<String, JsonNode>> iterator = items.fields();
         while (iterator.hasNext()) {
             Map.Entry<String, JsonNode> entry = iterator.next();
+            if (usingFurnaceMinecart && entry.getKey().equals("minecraft:furnace_minecart")) {
+                javaFurnaceMinecartId = itemIndex;
+                itemIndex++;
+                continue;
+            }
             int bedrockId = entry.getValue().get("bedrock_id").intValue();
             String bedrockIdentifier = bedrockIdToIdentifier.get(bedrockId);
             if (bedrockIdentifier == null) {
@@ -219,6 +233,9 @@ public class ItemRegistry {
             itemIndex++;
         }
 
+        itemNames.add("minecraft:furnace_minecart");
+        itemNames.add("minecraft:spectral_arrow");
+
         if (lodestoneCompassId == 0) {
             throw new RuntimeException("Lodestone compass not found in item palette!");
         }
@@ -243,6 +260,39 @@ public class ItemRegistry {
             ItemData item = getBedrockItemFromJson(itemNode);
             creativeItems.add(ItemData.fromNet(netId++, item.getId(), item.getDamage(), item.getCount(), item.getTag()));
         }
+
+        if (usingFurnaceMinecart) {
+            // Add the furnace minecart as an item
+            int furnaceMinecartId = ITEMS.size() + 1;
+
+            ITEMS.add(new StartGamePacket.ItemEntry("geysermc:furnace_minecart", (short) furnaceMinecartId, true));
+            ITEM_ENTRIES.put(javaFurnaceMinecartId, new ItemEntry("minecraft:furnace_minecart", "geysermc:furnace_minecart", javaFurnaceMinecartId,
+                    furnaceMinecartId, 0, false));
+            creativeItems.add(ItemData.fromNet(netId, furnaceMinecartId, (short) 0, 1, null));
+
+            NbtMapBuilder builder = NbtMap.builder();
+            builder.putString("name", "geysermc:furnace_minecart")
+                    .putInt("id", furnaceMinecartId);
+
+            NbtMapBuilder componentBuilder = NbtMap.builder();
+            // Conveniently, as of 1.16.200, the furnace minecart has a texture AND translation string already.
+            componentBuilder.putCompound("minecraft:icon", NbtMap.builder().putString("texture", "minecart_furnace").build());
+            componentBuilder.putCompound("minecraft:display_name", NbtMap.builder().putString("value", "item.minecartFurnace.name").build());
+
+            NbtMapBuilder itemProperties = NbtMap.builder();
+            itemProperties.putBoolean("allow_off_hand", true);
+            itemProperties.putBoolean("hand_equipped", false);
+            itemProperties.putInt("max_stack_size", 1);
+            itemProperties.putString("creative_group", "itemGroup.name.minecart");
+            itemProperties.putInt("creative_category", 4);
+
+            componentBuilder.putCompound("item_properties", itemProperties.build());
+            builder.putCompound("components", componentBuilder.build());
+            FURNACE_MINECART_DATA = new ComponentItemData("geysermc:furnace_minecart", builder.build());
+        } else {
+            FURNACE_MINECART_DATA = null;
+        }
+
         CREATIVE_ITEMS = creativeItems.toArray(new ItemData[0]);
 
         ITEM_NAMES = itemNames.toArray(new String[0]);

--- a/connector/src/main/resources/config.yml
+++ b/connector/src/main/resources/config.yml
@@ -139,6 +139,11 @@ cache-images: 0
 # Allows custom skulls to be displayed. Keeping them enabled may cause a performance decrease on older/weaker devices.
 allow-custom-skulls: true
 
+# Whether to add the furnace minecart as a separate item in the game, which normally does not exist in Bedrock Edition.
+# This should only need to be disabled if using a proxy that does not use the "transfer packet" style of server switching.
+# This option requires a restart of Geyser in order to change its setting.
+add-furnace-minecart: true
+
 # Bedrock prevents building and displaying blocks above Y127 in the Nether -
 # enabling this config option works around that by changing the Nether dimension ID
 # to the End ID. The main downside to this is that the sky will resemble that of


### PR DESCRIPTION
Conveniently enough, the minecart furnace icon still exists in the vanilla Bedrock Edition game (thanks to Kastle for this discovery). With this and the translation string still being present, we can add the item into the game with only minor issues.