### PR TITLE
Use authenticated resolver for Jenkins builds

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -35,8 +35,8 @@ pipeline {
                 rtMavenResolver(
                         id: "maven-resolver",
                         serverId: "opencollab-artifactory",
-                        releaseRepo: "release",
-                        snapshotRepo: "snapshot"
+                        releaseRepo: "maven-deploy-release",
+                        snapshotRepo: "maven-deploy-snapshot"
                 )
                 rtMavenRun(
                         pom: 'pom.xml',


### PR DESCRIPTION
Allows us to cache dependencies for faster resolution whilst building via Jenkins.