### PR TITLE
Allow GeyserWorldManager to be overwritten while still holding a cache

### DIFF
--- a/bootstrap/spigot/src/main/java/org/geysermc/platform/spigot/world/manager/GeyserSpigotFallbackWorldManager.java
+++ b/bootstrap/spigot/src/main/java/org/geysermc/platform/spigot/world/manager/GeyserSpigotFallbackWorldManager.java
@@ -52,7 +52,7 @@ public class GeyserSpigotFallbackWorldManager extends GeyserSpigotWorldManager {
     }
 
     @Override
-    public boolean hasMoreBlockDataThanChunkCache() {
+    public boolean hasOwnChunkCache() {
         return false;
     }
 

--- a/bootstrap/spigot/src/main/java/org/geysermc/platform/spigot/world/manager/GeyserSpigotWorldManager.java
+++ b/bootstrap/spigot/src/main/java/org/geysermc/platform/spigot/world/manager/GeyserSpigotWorldManager.java
@@ -140,7 +140,7 @@ public class GeyserSpigotWorldManager extends GeyserWorldManager {
     }
 
     @Override
-    public boolean hasMoreBlockDataThanChunkCache() {
+    public boolean hasOwnChunkCache() {
         return true;
     }
 

--- a/connector/src/main/java/org/geysermc/connector/network/session/cache/ChunkCache.java
+++ b/connector/src/main/java/org/geysermc/connector/network/session/cache/ChunkCache.java
@@ -29,7 +29,6 @@ import com.github.steveice10.mc.protocol.data.game.chunk.Chunk;
 import com.github.steveice10.mc.protocol.data.game.chunk.Column;
 import it.unimi.dsi.fastutil.longs.Long2ObjectMap;
 import it.unimi.dsi.fastutil.longs.Long2ObjectOpenHashMap;
-import org.geysermc.connector.bootstrap.GeyserBootstrap;
 import org.geysermc.connector.network.session.GeyserSession;
 import org.geysermc.connector.network.translators.world.block.BlockTranslator;
 import org.geysermc.connector.utils.MathUtils;
@@ -38,14 +37,15 @@ public class ChunkCache {
 
     private final boolean cache;
 
-    private final Long2ObjectMap<Column> chunks = new Long2ObjectOpenHashMap<>();
+    private final Long2ObjectMap<Column> chunks;
 
     public ChunkCache(GeyserSession session) {
-        if (session.getConnector().getWorldManager().getClass() == GeyserBootstrap.DEFAULT_CHUNK_MANAGER.getClass()) {
-            this.cache = session.getConnector().getConfig().isCacheChunks();
-        } else {
+        if (session.getConnector().getWorldManager().hasOwnChunkCache()) {
             this.cache = false; // To prevent Spigot from initializing
+        } else {
+            this.cache = session.getConnector().getConfig().isCacheChunks();
         }
+        chunks = cache ? new Long2ObjectOpenHashMap<>() : null;
     }
 
     public Column addToCache(Column chunk) {

--- a/connector/src/main/java/org/geysermc/connector/network/translators/world/GeyserWorldManager.java
+++ b/connector/src/main/java/org/geysermc/connector/network/translators/world/GeyserWorldManager.java
@@ -73,7 +73,7 @@ public class GeyserWorldManager extends WorldManager {
     }
 
     @Override
-    public boolean hasMoreBlockDataThanChunkCache() {
+    public boolean hasOwnChunkCache() {
         // This implementation can only fetch data from the session chunk cache
         return false;
     }

--- a/connector/src/main/java/org/geysermc/connector/network/translators/world/WorldManager.java
+++ b/connector/src/main/java/org/geysermc/connector/network/translators/world/WorldManager.java
@@ -88,14 +88,14 @@ public abstract class WorldManager {
     public abstract void getBlocksInSection(GeyserSession session, int x, int y, int z, Chunk section);
 
     /**
-     * Checks whether or not this world manager has access to more block data than the chunk cache.
+     * Checks whether or not this world manager requires a separate chunk cache/has access to more block data than the chunk cache.
      * <p>
      * Some world managers (e.g. Spigot) can provide access to block data outside of the chunk cache, and even with chunk caching disabled. This
      * method provides a means to check if this manager has this capability.
      *
      * @return whether or not this world manager has access to more block data than the chunk cache
      */
-    public abstract boolean hasMoreBlockDataThanChunkCache();
+    public abstract boolean hasOwnChunkCache();
 
     /**
      * Gets the Java biome data for the specified chunk.

--- a/connector/src/main/java/org/geysermc/connector/utils/ChunkUtils.java
+++ b/connector/src/main/java/org/geysermc/connector/utils/ChunkUtils.java
@@ -91,7 +91,7 @@ public class ChunkUtils {
         BitSet waterloggedPaletteIds = new BitSet();
         BitSet pistonOrFlowerPaletteIds = new BitSet();
 
-        boolean worldManagerHasMoreBlockDataThanCache = session.getConnector().getWorldManager().hasMoreBlockDataThanChunkCache();
+        boolean worldManagerHasMoreBlockDataThanCache = session.getConnector().getWorldManager().hasOwnChunkCache();
 
         // If the received packet was a full chunk update, null sections in the chunk are guaranteed to also be null in the world manager
         boolean shouldCheckWorldManagerOnMissingSections = isNonFullChunk && worldManagerHasMoreBlockDataThanCache;


### PR DESCRIPTION
To allow Geyser-Fabric to handle lecterns properly.