### PR TITLE
Entity link cache fixes

### DIFF
--- a/connector/src/main/java/org/geysermc/connector/entity/player/SkullPlayerEntity.java
+++ b/connector/src/main/java/org/geysermc/connector/entity/player/SkullPlayerEntity.java
@@ -28,10 +28,14 @@ package org.geysermc.connector.entity.player;
 import com.github.steveice10.mc.auth.data.GameProfile;
 import com.nukkitx.math.vector.Vector3f;
 import com.nukkitx.math.vector.Vector3i;
+import com.nukkitx.protocol.bedrock.data.PlayerPermission;
+import com.nukkitx.protocol.bedrock.data.command.CommandPermission;
 import com.nukkitx.protocol.bedrock.data.entity.EntityData;
 import com.nukkitx.protocol.bedrock.data.entity.EntityFlag;
+import com.nukkitx.protocol.bedrock.packet.AddPlayerPacket;
 import lombok.Getter;
 import lombok.Setter;
+import org.geysermc.connector.entity.type.EntityType;
 import org.geysermc.connector.network.session.GeyserSession;
 
 /**
@@ -59,6 +63,33 @@ public class SkullPlayerEntity extends PlayerEntity {
         metadata.put(EntityData.BOUNDING_BOX_WIDTH, 0.001f);
         metadata.getOrCreateFlags().setFlag(EntityFlag.CAN_SHOW_NAME, false);
         metadata.getFlags().setFlag(EntityFlag.INVISIBLE, true); // Until the skin is loaded
+    }
+
+    /**
+     * Overwritten so each entity doesn't check for a linked entity
+     */
+    @Override
+    public void spawnEntity(GeyserSession session) {
+        AddPlayerPacket addPlayerPacket = new AddPlayerPacket();
+        addPlayerPacket.setUuid(getUuid());
+        addPlayerPacket.setUsername(getUsername());
+        addPlayerPacket.setRuntimeEntityId(geyserId);
+        addPlayerPacket.setUniqueEntityId(geyserId);
+        addPlayerPacket.setPosition(position.clone().sub(0, EntityType.PLAYER.getOffset(), 0));
+        addPlayerPacket.setRotation(getBedrockRotation());
+        addPlayerPacket.setMotion(motion);
+        addPlayerPacket.setHand(hand);
+        addPlayerPacket.getAdventureSettings().setCommandPermission(CommandPermission.NORMAL);
+        addPlayerPacket.getAdventureSettings().setPlayerPermission(PlayerPermission.MEMBER);
+        addPlayerPacket.setDeviceId("");
+        addPlayerPacket.setPlatformChatId("");
+        addPlayerPacket.getMetadata().putAll(metadata);
+
+        valid = true;
+        session.sendUpstreamPacket(addPlayerPacket);
+
+        updateEquipment(session);
+        updateBedrockAttributes(session);
     }
 
     public void despawnEntity(GeyserSession session, Vector3i position) {

--- a/connector/src/main/java/org/geysermc/connector/network/session/cache/EntityCache.java
+++ b/connector/src/main/java/org/geysermc/connector/network/session/cache/EntityCache.java
@@ -59,6 +59,7 @@ public class EntityCache {
 
     public EntityCache(GeyserSession session) {
         this.session = session;
+        cachedPlayerEntityLinks.defaultReturnValue(-1L);
     }
 
     public void spawnEntity(Entity entity) {
@@ -100,6 +101,9 @@ public class EntityCache {
         for (Entity entity : entities) {
             session.getEntityCache().removeEntity(entity, false);
         }
+
+        // As a precaution
+        cachedPlayerEntityLinks.clear();
     }
 
     public Entity getEntityByGeyserId(long geyserId) {
@@ -160,7 +164,7 @@ public class EntityCache {
     }
 
     public long getCachedPlayerEntityLink(long playerId) {
-        return cachedPlayerEntityLinks.getOrDefault(playerId, -1);
+        return cachedPlayerEntityLinks.remove(playerId);
     }
 
     public void addCachedPlayerEntityLink(long playerId, long linkedEntityId) {

--- a/connector/src/main/java/org/geysermc/connector/network/translators/java/entity/JavaEntitySetPassengersTranslator.java
+++ b/connector/src/main/java/org/geysermc/connector/network/translators/java/entity/JavaEntitySetPassengersTranslator.java
@@ -47,9 +47,11 @@ public class JavaEntitySetPassengersTranslator extends PacketTranslator<ServerEn
 
     @Override
     public void translate(ServerEntitySetPassengersPacket packet, GeyserSession session) {
-        Entity entity = session.getEntityCache().getEntityByJavaId(packet.getEntityId());
+        Entity entity;
         if (packet.getEntityId() == session.getPlayerEntity().getEntityId()) {
             entity = session.getPlayerEntity();
+        } else {
+            entity = session.getEntityCache().getEntityByJavaId(packet.getEntityId());
         }
 
         if (entity == null) return;
@@ -66,7 +68,8 @@ public class JavaEntitySetPassengersTranslator extends PacketTranslator<ServerEn
                     session.confirmTeleport(passenger.getPosition().sub(0, EntityType.PLAYER.getOffset(), 0).toDouble());
                 }
             }
-            // Passenger hasn't loaded in and entity link needs to be set later
+            // Passenger hasn't loaded in (likely since we're waiting for a skin response)
+            // and entity link needs to be set later
             if (passenger == null && passengerId != 0) {
                 session.getEntityCache().addCachedPlayerEntityLink(passengerId, packet.getEntityId());
             }


### PR DESCRIPTION
Note that this needs to be revisited to see if it's even needed, or perhaps some sort of Guava cache.

- `getCachedPlayerEntityLink` now removes the entry if found
- Skulls will not have player entity links so we shouldn't bother checking
- Clear the entity link cache on dimension switch