### PR TITLE
Prevent NPEs from GeyserConnector.getPlayerByUuid

### DIFF
--- a/connector/src/main/java/org/geysermc/connector/GeyserConnector.java
+++ b/connector/src/main/java/org/geysermc/connector/GeyserConnector.java
@@ -57,6 +57,7 @@ import org.geysermc.connector.network.translators.world.block.BlockTranslator;
 import org.geysermc.connector.network.translators.world.block.entity.BlockEntityTranslator;
 import org.geysermc.connector.network.translators.world.block.entity.SkullBlockEntityTranslator;
 import org.geysermc.connector.utils.*;
+import org.jetbrains.annotations.Contract;
 
 import javax.naming.directory.Attribute;
 import javax.naming.directory.InitialDirContext;
@@ -351,9 +352,14 @@ public class GeyserConnector {
      * @param uuid the uuid
      * @return the player or <code>null</code> if there is no player online with this UUID
      */
+    @Contract("null -> null")
     public GeyserSession getPlayerByUuid(UUID uuid) {
+        if (uuid == null) {
+            return null;
+        }
+
         for (GeyserSession session : players) {
-            if (session.getPlayerEntity().getUuid().equals(uuid)) {
+            if (uuid.equals(session.getPlayerEntity().getUuid())) {
                 return session;
             }
         }

--- a/connector/src/main/java/org/geysermc/connector/network/session/GeyserSession.java
+++ b/connector/src/main/java/org/geysermc/connector/network/session/GeyserSession.java
@@ -100,6 +100,7 @@ import org.geysermc.floodgate.util.EncryptionUtil;
 import java.io.IOException;
 import java.net.InetAddress;
 import java.net.InetSocketAddress;
+import java.nio.charset.StandardCharsets;
 import java.security.NoSuchAlgorithmException;
 import java.security.PublicKey;
 import java.security.spec.InvalidKeySpecException;
@@ -686,7 +687,16 @@ public class GeyserSession implements CommandSender {
                     return;
                 }
                 connector.getLogger().info(LanguageUtils.getLocaleStringLog("geyser.network.remote.connect", authData.getName(), protocol.getProfile().getName(), remoteAddress));
-                playerEntity.setUuid(protocol.getProfile().getId());
+                UUID uuid = protocol.getProfile().getId();
+                if (uuid == null) {
+                    // Set what our UUID *probably* is going to be
+                    if (remoteAuthType == AuthType.FLOODGATE) {
+                        uuid = new UUID(0, Long.parseLong(authData.getXboxUUID()));
+                    } else {
+                        uuid = UUID.nameUUIDFromBytes(("OfflinePlayer:" + protocol.getProfile().getName()).getBytes(StandardCharsets.UTF_8));
+                    }
+                }
+                playerEntity.setUuid(uuid);
                 playerEntity.setUsername(protocol.getProfile().getName());
 
                 String locale = clientData.getLanguageCode();


### PR DESCRIPTION
- If GeyserConnector.getPlayerByUuid is given null, it will return null
- Never set a session's UUID to null if possible - but have precautions if for some reason it is