### PR TITLE
Fix banners on entity heads

### DIFF
--- a/connector/src/main/java/org/geysermc/connector/entity/LivingEntity.java
+++ b/connector/src/main/java/org/geysermc/connector/entity/LivingEntity.java
@@ -113,9 +113,28 @@ public class LivingEntity extends Entity {
         super.updateBedrockMetadata(entityMetadata, session);
     }
 
-    public void updateEquipment(GeyserSession session) {
-        if (!valid)
-            return;
+    public void updateAllEquipment(GeyserSession session) {
+        if (!valid) return;
+
+        updateArmor(session);
+        updateMainHand(session);
+        updateOffHand(session);
+    }
+
+    public void updateArmor(GeyserSession session) {
+        if (!valid) return;
+
+        ItemData helmet = this.helmet;
+        ItemData chestplate = this.chestplate;
+        // If an entity has a banner on them, it will be in the helmet slot in Java but the chestplate spot in Bedrock
+        // But don't overwrite the chestplate if it isn't empty
+        if (chestplate.getId() == ItemData.AIR.getId() && helmet.getId() == ItemRegistry.BANNER.getBedrockId()) {
+            chestplate = this.helmet;
+            helmet = ItemData.AIR;
+        } else if (chestplate.getId() == ItemRegistry.BANNER.getBedrockId()) {
+            // Prevent chestplate banners from showing erroneously
+            chestplate = ItemData.AIR;
+        }
 
         MobArmorEquipmentPacket armorEquipmentPacket = new MobArmorEquipmentPacket();
         armorEquipmentPacket.setRuntimeEntityId(geyserId);
@@ -124,12 +143,24 @@ public class LivingEntity extends Entity {
         armorEquipmentPacket.setLeggings(leggings);
         armorEquipmentPacket.setBoots(boots);
 
+        session.sendUpstreamPacket(armorEquipmentPacket);
+    }
+
+    public void updateMainHand(GeyserSession session) {
+        if (!valid) return;
+
         MobEquipmentPacket handPacket = new MobEquipmentPacket();
         handPacket.setRuntimeEntityId(geyserId);
         handPacket.setItem(hand);
         handPacket.setHotbarSlot(-1);
         handPacket.setInventorySlot(0);
         handPacket.setContainerId(ContainerId.INVENTORY);
+
+        session.sendUpstreamPacket(handPacket);
+    }
+
+    public void updateOffHand(GeyserSession session) {
+        if (!valid) return;
 
         MobEquipmentPacket offHandPacket = new MobEquipmentPacket();
         offHandPacket.setRuntimeEntityId(geyserId);
@@ -138,8 +169,6 @@ public class LivingEntity extends Entity {
         offHandPacket.setInventorySlot(0);
         offHandPacket.setContainerId(ContainerId.OFFHAND);
 
-        session.sendUpstreamPacket(armorEquipmentPacket);
-        session.sendUpstreamPacket(handPacket);
         session.sendUpstreamPacket(offHandPacket);
     }
 

--- a/connector/src/main/java/org/geysermc/connector/entity/living/monster/PiglinEntity.java
+++ b/connector/src/main/java/org/geysermc/connector/entity/living/monster/PiglinEntity.java
@@ -59,11 +59,13 @@ public class PiglinEntity extends BasePiglinEntity {
     }
 
     @Override
-    public void updateEquipment(GeyserSession session) {
-        // Check if the Piglin is holding Gold and set the ADMIRING flag accordingly
-        metadata.getFlags().setFlag(EntityFlag.ADMIRING, offHand.getId() == ItemRegistry.GOLD.getBedrockId());
-        super.updateBedrockMetadata(session);
+    public void updateOffHand(GeyserSession session) {
+        // Check if the Piglin is holding Gold and set the ADMIRING flag accordingly so its pose updates
+        boolean changed = metadata.getFlags().setFlag(EntityFlag.ADMIRING, offHand.getId() == ItemRegistry.GOLD.getBedrockId());
+        if (changed) {
+            super.updateBedrockMetadata(session);
+        }
 
-        super.updateEquipment(session);
+        super.updateOffHand(session);
     }
 }

--- a/connector/src/main/java/org/geysermc/connector/entity/living/monster/raid/PillagerEntity.java
+++ b/connector/src/main/java/org/geysermc/connector/entity/living/monster/raid/PillagerEntity.java
@@ -25,11 +25,11 @@
 
 package org.geysermc.connector.entity.living.monster.raid;
 
-import com.github.steveice10.mc.protocol.data.game.entity.metadata.EntityMetadata;
 import com.nukkitx.math.vector.Vector3f;
 import com.nukkitx.protocol.bedrock.data.entity.EntityFlag;
 import org.geysermc.connector.entity.type.EntityType;
 import org.geysermc.connector.network.session.GeyserSession;
+import org.geysermc.connector.network.translators.item.ItemRegistry;
 
 public class PillagerEntity extends AbstractIllagerEntity {
 
@@ -38,12 +38,30 @@ public class PillagerEntity extends AbstractIllagerEntity {
     }
 
     @Override
-    public void updateBedrockMetadata(EntityMetadata entityMetadata, GeyserSession session) {
-        if (entityMetadata.getId() == 16) {
-            // Java Edition always has the Pillager entity as positioning the crossbow
-            metadata.getFlags().setFlag(EntityFlag.USING_ITEM, true);
-            metadata.getFlags().setFlag(EntityFlag.CHARGED, true);
+    public void updateMainHand(GeyserSession session) {
+        checkForCrossbow(session);
+
+        super.updateMainHand(session);
+    }
+
+    @Override
+    public void updateOffHand(GeyserSession session) {
+        checkForCrossbow(session);
+
+        super.updateOffHand(session);
+    }
+
+    /**
+     * Check for a crossbow in either the mainhand or offhand. If one exists, indicate that the pillager should be posing
+     */
+    protected void checkForCrossbow(GeyserSession session) {
+        boolean hasCrossbow = this.hand.getId() == ItemRegistry.CROSSBOW.getBedrockId()
+                || this.offHand.getId() == ItemRegistry.CROSSBOW.getBedrockId();
+        boolean usingItemChanged = metadata.getFlags().setFlag(EntityFlag.USING_ITEM, hasCrossbow);
+        boolean chargedChanged = metadata.getFlags().setFlag(EntityFlag.CHARGED, hasCrossbow);
+
+        if (usingItemChanged || chargedChanged) {
+            updateBedrockMetadata(session);
         }
-        super.updateBedrockMetadata(entityMetadata, session);
     }
 }

--- a/connector/src/main/java/org/geysermc/connector/entity/player/PlayerEntity.java
+++ b/connector/src/main/java/org/geysermc/connector/entity/player/PlayerEntity.java
@@ -112,7 +112,7 @@ public class PlayerEntity extends LivingEntity {
         valid = true;
         session.sendUpstreamPacket(addPlayerPacket);
 
-        updateEquipment(session);
+        updateAllEquipment(session);
         updateBedrockAttributes(session);
     }
 

--- a/connector/src/main/java/org/geysermc/connector/entity/player/SkullPlayerEntity.java
+++ b/connector/src/main/java/org/geysermc/connector/entity/player/SkullPlayerEntity.java
@@ -88,7 +88,7 @@ public class SkullPlayerEntity extends PlayerEntity {
         valid = true;
         session.sendUpstreamPacket(addPlayerPacket);
 
-        updateEquipment(session);
+        updateAllEquipment(session);
         updateBedrockAttributes(session);
     }
 

--- a/connector/src/main/java/org/geysermc/connector/network/translators/item/ItemRegistry.java
+++ b/connector/src/main/java/org/geysermc/connector/network/translators/item/ItemRegistry.java
@@ -241,7 +241,7 @@ public class ItemRegistry {
                 case "minecraft:wheat":
                     WHEAT = itemEntry;
                     break;
-                case "minecraft:white_banner": // As of 1.16.220, all banners share the same Bedrock ID
+                case "minecraft:white_banner": // As of 1.16.220, all banners share the same Bedrock ID and differ their colors through their damage value
                     BANNER = itemEntry;
                     break;
                 case "minecraft:writable_book":

--- a/connector/src/main/java/org/geysermc/connector/network/translators/item/ItemRegistry.java
+++ b/connector/src/main/java/org/geysermc/connector/network/translators/item/ItemRegistry.java
@@ -36,10 +36,7 @@ import com.nukkitx.nbt.NbtUtils;
 import com.nukkitx.protocol.bedrock.data.inventory.ComponentItemData;
 import com.nukkitx.protocol.bedrock.data.inventory.ItemData;
 import com.nukkitx.protocol.bedrock.packet.StartGamePacket;
-import it.unimi.dsi.fastutil.ints.Int2ObjectMap;
-import it.unimi.dsi.fastutil.ints.Int2ObjectOpenHashMap;
-import it.unimi.dsi.fastutil.ints.IntArrayList;
-import it.unimi.dsi.fastutil.ints.IntList;
+import it.unimi.dsi.fastutil.ints.*;
 import it.unimi.dsi.fastutil.objects.ObjectOpenHashSet;
 import org.geysermc.connector.GeyserConnector;
 import org.geysermc.connector.network.translators.world.block.BlockTranslator1_16_210;
@@ -78,13 +75,21 @@ public class ItemRegistry {
      */
     public static ItemEntry BAMBOO;
     /**
+     * Banner item entry, used in LivingEntity.java
+     */
+    public static ItemEntry BANNER;
+    /**
      * Boat item entries, used in BedrockInventoryTransactionTranslator.java
      */
-    public static IntList BOATS = new IntArrayList();
+    public static final IntSet BOATS = new IntArraySet();
     /**
      * Bucket item entries (excluding the milk bucket), used in BedrockInventoryTransactionTranslator.java
      */
-    public static IntList BUCKETS = new IntArrayList();
+    public static final IntSet BUCKETS = new IntArraySet();
+    /**
+     * Crossbow item entry, used in PillagerEntity.java
+     */
+    public static ItemEntry CROSSBOW;
     /**
      * Empty item bucket, used in BedrockInventoryTransactionTranslator.java
      */
@@ -218,6 +223,9 @@ public class ItemRegistry {
                 case "minecraft:bamboo":
                     BAMBOO = itemEntry;
                     break;
+                case "minecraft:crossbow":
+                    CROSSBOW = itemEntry;
+                    break;
                 case "minecraft:egg":
                     EGG = itemEntry;
                     break;
@@ -232,6 +240,9 @@ public class ItemRegistry {
                     break;
                 case "minecraft:wheat":
                     WHEAT = itemEntry;
+                    break;
+                case "minecraft:white_banner": // As of 1.16.220, all banners share the same Bedrock ID
+                    BANNER = itemEntry;
                     break;
                 case "minecraft:writable_book":
                     WRITABLE_BOOK = itemEntry;

--- a/connector/src/main/java/org/geysermc/connector/network/translators/java/entity/JavaEntityEquipmentTranslator.java
+++ b/connector/src/main/java/org/geysermc/connector/network/translators/java/entity/JavaEntityEquipmentTranslator.java
@@ -40,9 +40,11 @@ public class JavaEntityEquipmentTranslator extends PacketTranslator<ServerEntity
 
     @Override
     public void translate(ServerEntityEquipmentPacket packet, GeyserSession session) {
-        Entity entity = session.getEntityCache().getEntityByJavaId(packet.getEntityId());
+        Entity entity;
         if (packet.getEntityId() == session.getPlayerEntity().getEntityId()) {
             entity = session.getPlayerEntity();
+        } else {
+            entity = session.getEntityCache().getEntityByJavaId(packet.getEntityId());
         }
 
         if (entity == null)
@@ -54,30 +56,48 @@ public class JavaEntityEquipmentTranslator extends PacketTranslator<ServerEntity
             return;
         }
 
+        boolean armorUpdated = false;
+        boolean mainHandUpdated = false;
+        boolean offHandUpdated = false;
         LivingEntity livingEntity = (LivingEntity) entity;
         for (Equipment equipment : packet.getEquipment()) {
             ItemData item = ItemTranslator.translateToBedrock(session, equipment.getItem());
             switch (equipment.getSlot()) {
                 case HELMET:
                     livingEntity.setHelmet(item);
+                    armorUpdated = true;
                     break;
                 case CHESTPLATE:
                     livingEntity.setChestplate(item);
+                    armorUpdated = true;
                     break;
                 case LEGGINGS:
                     livingEntity.setLeggings(item);
+                    armorUpdated = true;
                     break;
                 case BOOTS:
                     livingEntity.setBoots(item);
+                    armorUpdated = true;
                     break;
                 case MAIN_HAND:
                     livingEntity.setHand(item);
+                    mainHandUpdated = true;
                     break;
                 case OFF_HAND:
                     livingEntity.setOffHand(item);
+                    offHandUpdated = true;
                     break;
             }
         }
-        livingEntity.updateEquipment(session);
+
+        if (armorUpdated) {
+            livingEntity.updateArmor(session);
+        }
+        if (mainHandUpdated) {
+            livingEntity.updateMainHand(session);
+        }
+        if (offHandUpdated) {
+            livingEntity.updateOffHand(session);
+        }
     }
 }


### PR DESCRIPTION
On Bedrock, a banner must be placed in the chestplate slot in order to be visible. On Java Edition, banners are placed in the helmet slot. This commit fixes the issue by migrating banners to the chestplate spot if the chestplate spot is empty.

This commit also fixes pillager poses if they're not holding a crossbow, along with a couple other optimizations.