### PR TITLE
Fix various horse bugs

### DIFF
--- a/connector/src/main/java/org/geysermc/connector/entity/living/animal/horse/AbstractHorseEntity.java
+++ b/connector/src/main/java/org/geysermc/connector/entity/living/animal/horse/AbstractHorseEntity.java
@@ -90,7 +90,7 @@ public class AbstractHorseEntity extends AnimalEntity {
         }
 
         // Needed to control horses
-        metadata.getFlags().setFlag(EntityFlag.CAN_POWER_JUMP, true);
+        metadata.getFlags().setFlag(EntityFlag.CAN_POWER_JUMP, entityType != EntityType.LLAMA);
         metadata.getFlags().setFlag(EntityFlag.WASD_CONTROLLED, true);
 
         super.updateBedrockMetadata(entityMetadata, session);

--- a/connector/src/main/java/org/geysermc/connector/entity/living/animal/horse/AbstractHorseEntity.java
+++ b/connector/src/main/java/org/geysermc/connector/entity/living/animal/horse/AbstractHorseEntity.java
@@ -32,6 +32,7 @@ import com.nukkitx.protocol.bedrock.data.entity.EntityEventType;
 import com.nukkitx.protocol.bedrock.data.entity.EntityFlag;
 import com.nukkitx.protocol.bedrock.data.inventory.ContainerType;
 import com.nukkitx.protocol.bedrock.packet.EntityEventPacket;
+import org.geysermc.connector.entity.attribute.AttributeType;
 import org.geysermc.connector.entity.living.animal.AnimalEntity;
 import org.geysermc.connector.entity.type.EntityType;
 import org.geysermc.connector.network.session.GeyserSession;
@@ -44,6 +45,8 @@ public class AbstractHorseEntity extends AnimalEntity {
 
         // Specifies the size of the entity's inventory. Required to place slots in the entity.
         metadata.put(EntityData.CONTAINER_BASE_SIZE, 2);
+        // Add dummy health attribute since LivingEntity updates the attribute for us
+        attributes.put(AttributeType.HEALTH, AttributeType.HEALTH.getAttribute(20, 20));
     }
 
     @Override
@@ -89,5 +92,10 @@ public class AbstractHorseEntity extends AnimalEntity {
         metadata.getFlags().setFlag(EntityFlag.WASD_CONTROLLED, true);
 
         super.updateBedrockMetadata(entityMetadata, session);
+
+        if (entityMetadata.getId() == 8) {
+            // Update the health attribute
+            updateBedrockAttributes(session);
+        }
     }
 }

--- a/connector/src/main/java/org/geysermc/connector/entity/living/animal/horse/AbstractHorseEntity.java
+++ b/connector/src/main/java/org/geysermc/connector/entity/living/animal/horse/AbstractHorseEntity.java
@@ -47,6 +47,8 @@ public class AbstractHorseEntity extends AnimalEntity {
         metadata.put(EntityData.CONTAINER_BASE_SIZE, 2);
         // Add dummy health attribute since LivingEntity updates the attribute for us
         attributes.put(AttributeType.HEALTH, AttributeType.HEALTH.getAttribute(20, 20));
+        // Add horse jump strength attribute to allow donkeys and mules to jump
+        attributes.put(AttributeType.HORSE_JUMP_STRENGTH, AttributeType.HORSE_JUMP_STRENGTH.getAttribute(0.5f, 2));
     }
 
     @Override

--- a/connector/src/main/java/org/geysermc/connector/entity/living/animal/horse/AbstractHorseEntity.java
+++ b/connector/src/main/java/org/geysermc/connector/entity/living/animal/horse/AbstractHorseEntity.java
@@ -90,7 +90,8 @@ public class AbstractHorseEntity extends AnimalEntity {
         }
 
         // Needed to control horses
-        metadata.getFlags().setFlag(EntityFlag.CAN_POWER_JUMP, entityType != EntityType.LLAMA);
+        boolean canPowerJump = entityType != EntityType.LLAMA && entityType != EntityType.TRADER_LLAMA;
+        metadata.getFlags().setFlag(EntityFlag.CAN_POWER_JUMP, canPowerJump);
         metadata.getFlags().setFlag(EntityFlag.WASD_CONTROLLED, true);
 
         super.updateBedrockMetadata(entityMetadata, session);

--- a/connector/src/main/java/org/geysermc/connector/network/session/GeyserSession.java
+++ b/connector/src/main/java/org/geysermc/connector/network/session/GeyserSession.java
@@ -328,6 +328,12 @@ public class GeyserSession implements CommandSender {
     private long lastMovementTimestamp = System.currentTimeMillis();
 
     /**
+     * Used to send a ClientVehicleMovePacket for every PlayerInputPacket after idling on a boat/horse for more than 100ms
+     */
+    @Setter
+    private long lastVehicleMoveTimestamp = System.currentTimeMillis();
+
+    /**
      * Controls whether the daylight cycle gamerule has been sent to the client, so the sun/moon remain motionless.
      */
     private boolean daylightCycle = true;

--- a/connector/src/main/java/org/geysermc/connector/network/translators/bedrock/BedrockMoveEntityAbsoluteTranslator.java
+++ b/connector/src/main/java/org/geysermc/connector/network/translators/bedrock/BedrockMoveEntityAbsoluteTranslator.java
@@ -41,6 +41,8 @@ public class BedrockMoveEntityAbsoluteTranslator extends PacketTranslator<MoveEn
 
     @Override
     public void translate(MoveEntityAbsolutePacket packet, GeyserSession session) {
+        session.setLastVehicleMoveTimestamp(System.currentTimeMillis());
+
         float y = packet.getPosition().getY();
         if (session.getRidingVehicleEntity() instanceof BoatEntity) {
             // Remove some Y position to prevents boats from looking like they're floating in water

--- a/connector/src/main/java/org/geysermc/connector/network/translators/bedrock/BedrockPlayerInputTranslator.java
+++ b/connector/src/main/java/org/geysermc/connector/network/translators/bedrock/BedrockPlayerInputTranslator.java
@@ -65,7 +65,7 @@ public class BedrockPlayerInputTranslator extends PacketTranslator<PlayerInputPa
                 sendMovement = true;
             } else {
                 // Check if the player is the front rider
-                Vector3f seatPos = session.getPlayerEntity().getMetadata().getVector3f(EntityData.RIDER_SEAT_POSITION);
+                Vector3f seatPos = session.getPlayerEntity().getMetadata().getVector3f(EntityData.RIDER_SEAT_POSITION, null);
                 if (seatPos != null && seatPos.getX() > 0) {
                     sendMovement = true;
                 }

--- a/connector/src/main/java/org/geysermc/connector/network/translators/bedrock/entity/player/BedrockRiderJumpTranslator.java
+++ b/connector/src/main/java/org/geysermc/connector/network/translators/bedrock/entity/player/BedrockRiderJumpTranslator.java
@@ -40,7 +40,7 @@ public class BedrockRiderJumpTranslator extends PacketTranslator<RiderJumpPacket
     public void translate(RiderJumpPacket packet, GeyserSession session) {
         Entity vehicle = session.getRidingVehicleEntity();
         if (vehicle instanceof AbstractHorseEntity) {
-            ClientPlayerStatePacket playerStatePacket = new ClientPlayerStatePacket((int)vehicle.getEntityId(),  PlayerState.START_HORSE_JUMP, packet.getJumpStrength());
+            ClientPlayerStatePacket playerStatePacket = new ClientPlayerStatePacket((int) vehicle.getEntityId(),  PlayerState.START_HORSE_JUMP, packet.getJumpStrength());
             session.sendDownstreamPacket(playerStatePacket);
         }
     }

--- a/connector/src/main/java/org/geysermc/connector/network/translators/bedrock/entity/player/BedrockRiderJumpTranslator.java
+++ b/connector/src/main/java/org/geysermc/connector/network/translators/bedrock/entity/player/BedrockRiderJumpTranslator.java
@@ -1,0 +1,47 @@
+/*
+ * Copyright (c) 2019-2021 GeyserMC. http://geysermc.org
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ *
+ * @author GeyserMC
+ * @link https://github.com/GeyserMC/Geyser
+ */
+
+package org.geysermc.connector.network.translators.bedrock.entity.player;
+
+import com.github.steveice10.mc.protocol.data.game.entity.player.PlayerState;
+import com.github.steveice10.mc.protocol.packet.ingame.client.player.ClientPlayerStatePacket;
+import com.nukkitx.protocol.bedrock.packet.RiderJumpPacket;
+import org.geysermc.connector.entity.Entity;
+import org.geysermc.connector.entity.living.animal.horse.AbstractHorseEntity;
+import org.geysermc.connector.network.session.GeyserSession;
+import org.geysermc.connector.network.translators.PacketTranslator;
+import org.geysermc.connector.network.translators.Translator;
+
+@Translator(packet = RiderJumpPacket.class)
+public class BedrockRiderJumpTranslator extends PacketTranslator<RiderJumpPacket> {
+    @Override
+    public void translate(RiderJumpPacket packet, GeyserSession session) {
+        Entity vehicle = session.getRidingVehicleEntity();
+        if (vehicle instanceof AbstractHorseEntity) {
+            ClientPlayerStatePacket playerStatePacket = new ClientPlayerStatePacket((int)vehicle.getEntityId(),  PlayerState.START_HORSE_JUMP, packet.getJumpStrength());
+            session.sendDownstreamPacket(playerStatePacket);
+        }
+    }
+}

--- a/connector/src/main/java/org/geysermc/connector/network/translators/java/entity/JavaEntityVelocityTranslator.java
+++ b/connector/src/main/java/org/geysermc/connector/network/translators/java/entity/JavaEntityVelocityTranslator.java
@@ -26,6 +26,7 @@
 package org.geysermc.connector.network.translators.java.entity;
 
 import org.geysermc.connector.entity.Entity;
+import org.geysermc.connector.entity.living.animal.horse.AbstractHorseEntity;
 import org.geysermc.connector.network.session.GeyserSession;
 import org.geysermc.connector.network.translators.PacketTranslator;
 import org.geysermc.connector.network.translators.Translator;
@@ -46,6 +47,12 @@ public class JavaEntityVelocityTranslator extends PacketTranslator<ServerEntityV
         if (entity == null) return;
 
         entity.setMotion(Vector3f.from(packet.getMotionX(), packet.getMotionY(), packet.getMotionZ()));
+
+        if (entity == session.getRidingVehicleEntity() && entity instanceof AbstractHorseEntity) {
+            // Horses for some reason teleport back when a SetEntityMotionPacket is sent while
+            // a player is riding on them. Java clients seem to ignore it anyways.
+            return;
+        }
 
         SetEntityMotionPacket entityMotionPacket = new SetEntityMotionPacket();
         entityMotionPacket.setRuntimeEntityId(entity.getGeyserId());


### PR DESCRIPTION
- Fixes the health display not updating while riding horses
- Fixes players riding on horses warping after taking damage (3rd bug of https://github.com/GeyserMC/Geyser/issues/2089)
- Fixes the jumping animation on Bedrock and Java (1st bug of https://github.com/GeyserMC/Geyser/issues/2089)
- Fixes horses not taking damage while idling on magma blocks
- Allows Bedrock players to jump with mules and donkeys

This may need some additional testing. I once got randomly kicked for flying while jumping on a horse, but I can't seem to reproduce it.