### PR TITLE
Prevent invalid stonecutter recipes from causing bedrock players to not be able to craft

### DIFF
--- a/connector/src/main/java/org/geysermc/connector/network/translators/java/JavaDeclareRecipesTranslator.java
+++ b/connector/src/main/java/org/geysermc/connector/network/translators/java/JavaDeclareRecipesTranslator.java
@@ -163,6 +163,12 @@ public class JavaDeclareRecipesTranslator extends PacketTranslator<ServerDeclare
 
         Int2ObjectMap<IntList> stonecutterRecipeMap = new Int2ObjectOpenHashMap<>();
         for (Int2ObjectMap.Entry<List<StoneCuttingRecipeData>> data : unsortedStonecutterData.int2ObjectEntrySet()) {
+            // Filter out all entries that have null for the result item (i.e., invalid recipes)
+            data.setValue(data.getValue().stream().filter((stoneCuttingRecipeData) -> {
+                if (stoneCuttingRecipeData.getResult() == null) return false;
+                ItemEntry item = ItemRegistry.getItem(stoneCuttingRecipeData.getResult());
+                return item != null && item.getJavaIdentifier() != null;
+            }).collect(Collectors.toList()));
             // Sort the list by each output item's Java identifier - this is how it's sorted on Java, and therefore
             // We can get the correct order for button pressing
             data.getValue().sort(Comparator.comparing((stoneCuttingRecipeData ->

--- a/connector/src/main/java/org/geysermc/connector/network/translators/java/JavaDeclareRecipesTranslator.java
+++ b/connector/src/main/java/org/geysermc/connector/network/translators/java/JavaDeclareRecipesTranslator.java
@@ -165,6 +165,12 @@ public class JavaDeclareRecipesTranslator extends PacketTranslator<ServerDeclare
         for (Int2ObjectMap.Entry<List<StoneCuttingRecipeData>> data : unsortedStonecutterData.int2ObjectEntrySet()) {
             // Filter out all entries that have null for the result item (i.e., invalid recipes)
             data.setValue(data.getValue().stream().filter((stoneCuttingRecipeData) -> {
+                // validate ingredient items
+                for (ItemStack ingredientItem : stoneCuttingRecipeData.getIngredient().getOptions()) {
+                    if (ItemRegistry.getItem(ingredientItem) == null) return false;
+                    if (ItemRegistry.getItem(ingredientItem).getBedrockId() == 0) return false;
+                }
+                // validate result item
                 if (stoneCuttingRecipeData.getResult() == null) return false;
                 ItemEntry item = ItemRegistry.getItem(stoneCuttingRecipeData.getResult());
                 return item != null && item.getJavaIdentifier() != null;


### PR DESCRIPTION
I don't know if this can *only* occur when the server has block-adding mods, but I think completely failing to let players craft any items at all would qualify as "bad behavior". This PR filters items from the stonecutter recipe list which would otherwise trigger a NullPointerException, so only the invalid item will be uncraftable, not *all* items.