### PR TITLE
Allow connections even if encryption failed to initialize post-1.16.220

### DIFF
--- a/connector/pom.xml
+++ b/connector/pom.xml
@@ -32,7 +32,7 @@
         <dependency>
             <groupId>com.github.CloudburstMC.Protocol</groupId>
             <artifactId>bedrock-v431</artifactId>
-            <version>824420b</version>
+            <version>9947665</version>
             <scope>compile</scope>
             <exclusions>
                 <exclusion>

--- a/connector/pom.xml
+++ b/connector/pom.xml
@@ -32,7 +32,7 @@
         <dependency>
             <groupId>com.github.CloudburstMC.Protocol</groupId>
             <artifactId>bedrock-v431</artifactId>
-            <version>f8ecf54</version>
+            <version>824420b</version>
             <scope>compile</scope>
             <exclusions>
                 <exclusion>

--- a/connector/src/main/java/org/geysermc/connector/utils/LoginEncryptionUtils.java
+++ b/connector/src/main/java/org/geysermc/connector/utils/LoginEncryptionUtils.java
@@ -60,6 +60,8 @@ import java.util.UUID;
 public class LoginEncryptionUtils {
     private static final ObjectMapper JSON_MAPPER = new ObjectMapper().disable(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES);
 
+    private static boolean HAS_SENT_ENCRYPTION_MESSAGE = false;
+
     private static boolean validateChainData(JsonNode data) throws Exception {
         ECPublicKey lastKey = null;
         boolean validChain = false;
@@ -134,6 +136,10 @@ public class LoginEncryptionUtils {
 
             if (EncryptionUtils.canUseEncryption()) {
                 LoginEncryptionUtils.startEncryptionHandshake(session, identityPublicKey);
+            } else if (!HAS_SENT_ENCRYPTION_MESSAGE) {
+                session.getConnector().getLogger().warning(LanguageUtils.getLocaleStringLog("geyser.network.encryption.line_1"));
+                session.getConnector().getLogger().warning(LanguageUtils.getLocaleStringLog("geyser.network.encryption.line_2", "https://geysermc.org/supported_java"));
+                HAS_SENT_ENCRYPTION_MESSAGE = true;
             }
         } catch (Exception ex) {
             session.disconnect("disconnectionScreen.internalError.cantConnect");


### PR DESCRIPTION
This allows Java 16 to still be compatible with Geyser.