### PR TITLE
Fix unwanted behaviour with show-coordinates

### DIFF
--- a/connector/src/main/java/org/geysermc/connector/network/session/GeyserSession.java
+++ b/connector/src/main/java/org/geysermc/connector/network/session/GeyserSession.java
@@ -1205,8 +1205,8 @@ public class GeyserSession implements CommandSender {
      */
     public void setReducedDebugInfo(boolean value) {
         reducedDebugInfo = value;
-        // Set the showCoordinates data. This is done because setShowCoordinates() uses this gamerule as a variable.
-        getWorldCache().setShowCoordinates();
+        // Set the showCoordinates data. This is done because updateShowCoordinates() uses this gamerule as a variable.
+        getWorldCache().updateShowCoordinates();
     }
 
     /**

--- a/connector/src/main/java/org/geysermc/connector/network/session/GeyserSession.java
+++ b/connector/src/main/java/org/geysermc/connector/network/session/GeyserSession.java
@@ -493,9 +493,6 @@ public class GeyserSession implements CommandSender {
         this.remotePort = connector.getConfig().getRemote().getPort();
         this.remoteAuthType = connector.getDefaultAuthType();
 
-        // Update the ShowCoordinates data based on the config setting
-        getWorldCache().setShowCoordinates(connector.getConfig().isShowCoordinates());
-
         // Set the hardcoded shield ID to the ID we just defined in StartGamePacket
         upstream.getSession().getHardcodedBlockingId().set(ItemRegistry.SHIELD.getBedrockId());
 
@@ -1202,13 +1199,14 @@ public class GeyserSession implements CommandSender {
 
     /**
      * Update the cached value for the reduced debug info gamerule.
-     * This also toggles the coordinates display
+     * If enabled, also hides the player's coordinates.
      *
      * @param value The new value for reducedDebugInfo
      */
     public void setReducedDebugInfo(boolean value) {
         reducedDebugInfo = value;
-        worldCache.setShowCoordinates(!value);
+        // Set the showCoordinates data. This is done because setShowCoordinates() uses this gamerule as a variable.
+        getWorldCache().setShowCoordinates();
     }
 
     /**

--- a/connector/src/main/java/org/geysermc/connector/network/session/GeyserSession.java
+++ b/connector/src/main/java/org/geysermc/connector/network/session/GeyserSession.java
@@ -1007,7 +1007,6 @@ public class GeyserSession implements CommandSender {
         startGamePacket.setLightningLevel(0);
         startGamePacket.setMultiplayerGame(true);
         startGamePacket.setBroadcastingToLan(true);
-        startGamePacket.getGamerules().add(new GameRuleData<>("showcoordinates", connector.getConfig().isShowCoordinates()));
         startGamePacket.setPlatformBroadcastMode(GamePublishSetting.PUBLIC);
         startGamePacket.setXblBroadcastMode(GamePublishSetting.PUBLIC);
         startGamePacket.setCommandsEnabled(!connector.getConfig().isXboxAchievementsEnabled());

--- a/connector/src/main/java/org/geysermc/connector/network/session/cache/WorldCache.java
+++ b/connector/src/main/java/org/geysermc/connector/network/session/cache/WorldCache.java
@@ -86,7 +86,7 @@ public class WorldCache {
      * <li> {@link GeyserConfiguration#isShowCoordinates()} is disabled.
      *
      */
-    public void setShowCoordinates() {
+    public void updateShowCoordinates() {
         boolean allowShowCoordinates = !session.isReducedDebugInfo() && session.getConnector().getConfig().isShowCoordinates();
         showCoordinates = allowShowCoordinates && prefersShowCoordinates;
         session.sendGameRule("showcoordinates", showCoordinates);

--- a/connector/src/main/java/org/geysermc/connector/network/session/cache/WorldCache.java
+++ b/connector/src/main/java/org/geysermc/connector/network/session/cache/WorldCache.java
@@ -28,6 +28,7 @@ package org.geysermc.connector.network.session.cache;
 import com.github.steveice10.mc.protocol.data.game.setting.Difficulty;
 import lombok.Getter;
 import lombok.Setter;
+import org.geysermc.connector.configuration.GeyserConfiguration;
 import org.geysermc.connector.network.session.GeyserSession;
 import org.geysermc.connector.scoreboard.Objective;
 import org.geysermc.connector.scoreboard.Scoreboard;
@@ -38,6 +39,17 @@ public class WorldCache {
     private final GeyserSession session;
     @Setter
     private Difficulty difficulty = Difficulty.EASY;
+
+    /**
+     * True if the client prefers being shown their coordinates, regardless if they're being shown or not.
+     * This will be true everytime the client joins the server because neither the client nor server store the preference permanently.
+     */
+    @Setter
+    private boolean prefersShowCoordinates = true;
+
+    /**
+     * True if the client is being shown their coordinates.
+     */
     private boolean showCoordinates = true;
 
     private Scoreboard scoreboard;
@@ -66,13 +78,17 @@ public class WorldCache {
     }
 
     /**
-     * Tell the client to hide or show the coordinates
+     * Tell the client to hide or show the coordinates.
      *
-     * @param value True to show, false to hide
+     * If {@link #isPrefersShowCoordinates()} is true, coordinates will be shown, unless either of the following conditions apply:
+     *
+     * <li> {@link GeyserSession#isReducedDebugInfo()} is enabled
+     * <li> {@link GeyserConfiguration#isShowCoordinates()} is disabled.
+     *
      */
-    public void setShowCoordinates(boolean value) {
-        boolean allowUserSetting = !session.isReducedDebugInfo() && session.getConnector().getConfig().isShowCoordinates();
-        showCoordinates = allowUserSetting && value;
-        session.sendGameRule("showcoordinates", allowUserSetting && value);
+    public void setShowCoordinates() {
+        boolean allowShowCoordinates = !session.isReducedDebugInfo() && session.getConnector().getConfig().isShowCoordinates();
+        showCoordinates = allowShowCoordinates && prefersShowCoordinates;
+        session.sendGameRule("showcoordinates", showCoordinates);
     }
 }

--- a/connector/src/main/java/org/geysermc/connector/network/session/cache/WorldCache.java
+++ b/connector/src/main/java/org/geysermc/connector/network/session/cache/WorldCache.java
@@ -47,11 +47,6 @@ public class WorldCache {
     @Setter
     private boolean prefersShowCoordinates = true;
 
-    /**
-     * True if the client is being shown their coordinates.
-     */
-    private boolean showCoordinates = true;
-
     private Scoreboard scoreboard;
     private final ScoreboardUpdater scoreboardUpdater;
 
@@ -83,12 +78,11 @@ public class WorldCache {
      * If {@link #isPrefersShowCoordinates()} is true, coordinates will be shown, unless either of the following conditions apply:
      *
      * <li> {@link GeyserSession#isReducedDebugInfo()} is enabled
-     * <li> {@link GeyserConfiguration#isShowCoordinates()} is disabled.
+     * <li> {@link GeyserConfiguration#isShowCoordinates()} is disabled
      *
      */
     public void updateShowCoordinates() {
         boolean allowShowCoordinates = !session.isReducedDebugInfo() && session.getConnector().getConfig().isShowCoordinates();
-        showCoordinates = allowShowCoordinates && prefersShowCoordinates;
-        session.sendGameRule("showcoordinates", showCoordinates);
+        session.sendGameRule("showcoordinates", allowShowCoordinates && prefersShowCoordinates);
     }
 }

--- a/connector/src/main/java/org/geysermc/connector/network/translators/java/JavaJoinGameTranslator.java
+++ b/connector/src/main/java/org/geysermc/connector/network/translators/java/JavaJoinGameTranslator.java
@@ -86,6 +86,8 @@ public class JavaJoinGameTranslator extends PacketTranslator<ServerJoinGamePacke
         gamerulePacket.getGameRules().add(new GameRuleData<>("doimmediaterespawn", !packet.isEnableRespawnScreen()));
         session.sendUpstreamPacket(gamerulePacket);
 
+        session.setReducedDebugInfo(packet.isReducedDebugInfo());
+
         session.setRenderDistance(packet.getViewDistance());
 
         // We need to send our skin parts to the server otherwise java sees us with no hat, jacket etc

--- a/connector/src/main/java/org/geysermc/connector/utils/SettingsUtils.java
+++ b/connector/src/main/java/org/geysermc/connector/utils/SettingsUtils.java
@@ -57,8 +57,12 @@ public class SettingsUtils {
         CustomFormBuilder builder = new CustomFormBuilder(LanguageUtils.getPlayerLocaleString("geyser.settings.title.main", language));
         builder.setIcon(new FormImage(FormImage.FormImageType.PATH, "textures/ui/settings_glyph_color_2x.png"));
 
-        builder.addComponent(new LabelComponent(LanguageUtils.getPlayerLocaleString("geyser.settings.title.client", language)));
-        builder.addComponent(new ToggleComponent(LanguageUtils.getPlayerLocaleString("geyser.settings.option.coordinates", language), session.getWorldCache().isShowCoordinates()));
+        // Client can only see its coordinates if reducedDebugInfo is disabled and coordinates are enabled in geyser config.
+        if (!session.isReducedDebugInfo() && session.getConnector().getConfig().isShowCoordinates()) {
+            builder.addComponent(new LabelComponent(LanguageUtils.getPlayerLocaleString("geyser.settings.title.client", language)));
+
+            builder.addComponent(new ToggleComponent(LanguageUtils.getPlayerLocaleString("geyser.settings.option.coordinates", language), session.getWorldCache().isPrefersShowCoordinates()));
+        }
 
 
         if (session.getOpPermissionLevel() >= 2 || session.hasPermission("geyser.settings.server")) {
@@ -117,10 +121,14 @@ public class SettingsUtils {
         }
         int offset = 0;
 
-        offset++; // Client settings title
+        // Client can only see its coordinates if reducedDebugInfo is disabled and coordinates are enabled in geyser config.
+        if (!session.isReducedDebugInfo() && session.getConnector().getConfig().isShowCoordinates()) {
+            offset++; // Client settings title
 
-        session.getWorldCache().setShowCoordinates(settingsResponse.getToggleResponses().get(offset));
-        offset++;
+            session.getWorldCache().setPrefersShowCoordinates(settingsResponse.getToggleResponses().get(offset));
+            session.getWorldCache().setShowCoordinates();
+            offset++;
+        }
 
         if (session.getOpPermissionLevel() >= 2 || session.hasPermission("geyser.settings.server")) {
             offset++; // Server settings title

--- a/connector/src/main/java/org/geysermc/connector/utils/SettingsUtils.java
+++ b/connector/src/main/java/org/geysermc/connector/utils/SettingsUtils.java
@@ -126,7 +126,7 @@ public class SettingsUtils {
             offset++; // Client settings title
 
             session.getWorldCache().setPrefersShowCoordinates(settingsResponse.getToggleResponses().get(offset));
-            session.getWorldCache().setShowCoordinates();
+            session.getWorldCache().updateShowCoordinates();
             offset++;
         }
 


### PR DESCRIPTION
- If reducedDebugInfo gamerule is enabled, clients will not have the coordinate display. Whenever the gamerule is set/toggled the changes will apply immediately. Note that gamerules are dimensions specific. 
- If show-coords is disabled in the geyser config, clients will not have the coordinate display. 
- Removes the option in the client's settings if either of the above apply

Client preference is only remembered during a single session (it is enabled by default at the start). From what I understand it would require us to start storing information. Creating a whole database just for this would seem overkill. We could implement another config option that dictates whether the client preference is initially enabled or disabled. 

The concern with rtm's [PR](https://github.com/GeyserMC/Geyser/pull/1864) was that the javadoc wasn't accurate (I would have PR'd into his fork but there were dependency issues).

resolves #1700 