### PR TITLE
Fix visual glitch when swapping out armor that's already equipped

### DIFF
--- a/connector/src/main/java/org/geysermc/connector/network/translators/bedrock/BedrockInventoryTransactionTranslator.java
+++ b/connector/src/main/java/org/geysermc/connector/network/translators/bedrock/BedrockInventoryTransactionTranslator.java
@@ -238,7 +238,16 @@ public class BedrockInventoryTransactionTranslator extends PacketTranslator<Inve
                         session.setInteracting(true);
                         break;
                     case 1:
-                        // Handled in Entity.java
+                        if (packet.getActions().size() == 1) {
+                            InventoryActionData actionData = packet.getActions().get(0);
+                            if (actionData.getSlot() == 6 && actionData.getToItem().getId() != 0) {
+                                // The player is trying to swap out an armor piece that already has an item in it
+                                // Java Edition does not allow this; let's revert it
+                                session.getInventoryTranslator().updateInventory(session, session.getPlayerInventory());
+                            }
+                        }
+
+                        // Handled when sneaking
                         if (session.getPlayerInventory().getItemInHand().getJavaId() == ItemRegistry.SHIELD.getJavaId()) {
                             break;
                         }


### PR DESCRIPTION
Bedrock Edition allows you to swap out armor by right-clicking an item in your inventory, even when armor in that slot is already equipped. This PR prevents Bedrock from performing this action if both slots are occupied (which Java Edition will not do).