### PR TITLE
Fix interact entity packet

### DIFF
--- a/connector/src/main/java/org/geysermc/connector/network/translators/bedrock/BedrockInventoryTransactionTranslator.java
+++ b/connector/src/main/java/org/geysermc/connector/network/translators/bedrock/BedrockInventoryTransactionTranslator.java
@@ -321,7 +321,7 @@ public class BedrockInventoryTransactionTranslator extends PacketTranslator<Inve
                             session.sendUpstreamPacket(openPacket);
                             break;
                         }
-                        Vector3f vector = packet.getClickPosition();
+                        Vector3f vector = packet.getClickPosition().sub(entity.getPosition());
                         ClientPlayerInteractEntityPacket interactPacket = new ClientPlayerInteractEntityPacket((int) entity.getEntityId(),
                                 InteractAction.INTERACT, Hand.MAIN_HAND, session.isSneaking());
                         ClientPlayerInteractEntityPacket interactAtPacket = new ClientPlayerInteractEntityPacket((int) entity.getEntityId(),
@@ -329,7 +329,7 @@ public class BedrockInventoryTransactionTranslator extends PacketTranslator<Inve
                         session.sendDownstreamPacket(interactPacket);
                         session.sendDownstreamPacket(interactAtPacket);
 
-                        EntitySoundInteractionHandler.handleEntityInteraction(session, vector, entity);
+                        EntitySoundInteractionHandler.handleEntityInteraction(session, packet.getClickPosition(), entity);
                         break;
                     case 1: //Attack
                         if (entity.getEntityType() == EntityType.ENDER_DRAGON) {


### PR DESCRIPTION
For the InteractAt type of packet of the PlayerInteractEntityPacket, Java sends a diff between the entity's current position and the hit result of its cursor. Bedrock sends the full vector location in its interaction. Therefore, we just do the diff ourselves.

This fixes taking armor off of armor stands.