### PR TITLE
Allow more blocks to have a place sound on standalone

### DIFF
--- a/connector/src/main/java/org/geysermc/connector/network/translators/java/world/JavaBlockChangeTranslator.java
+++ b/connector/src/main/java/org/geysermc/connector/network/translators/java/world/JavaBlockChangeTranslator.java
@@ -68,7 +68,7 @@ public class JavaBlockChangeTranslator extends PacketTranslator<ServerBlockChang
         // We need to check if the identifier is the same, else a packet with the sound of what the
         // player has in their hand is played, despite if the block is being placed or not
         boolean contains = false;
-        String identifier = BlockTranslator.getJavaIdBlockMap().inverse().get(packet.getRecord().getBlock()).split("\\[")[0];
+        String identifier = BlockTranslator.getItem(packet.getRecord().getBlock());
         if (identifier.equals(session.getLastBlockPlacedId())) {
             contains = true;
         }

--- a/connector/src/main/java/org/geysermc/connector/network/translators/world/block/BlockTranslator.java
+++ b/connector/src/main/java/org/geysermc/connector/network/translators/world/block/BlockTranslator.java
@@ -464,8 +464,26 @@ public abstract class BlockTranslator {
      * @return The Java identifier of the item
      */
     public static String getPickItem(int javaId) {
+        return getItem(javaId, true);
+    }
+
+    /**
+     * Get the item that represents this block. Differs from {@link #getPickItem(int)} as we should not allow air if
+     * a pick item is mapped to that.
+     *
+     * @param javaId The Java runtime id of the block
+     * @return The Java identifier of the item
+     */
+    public static String getItem(int javaId) {
+        return getItem(javaId, false);
+    }
+
+    /**
+     * @param acceptAir whether air is an acceptable identifier to receive from the pick item map
+     */
+    private static String getItem(int javaId, boolean acceptAir) {
         String itemIdentifier = JAVA_RUNTIME_ID_TO_PICK_ITEM.get(javaId);
-        if (itemIdentifier == null) {
+        if (itemIdentifier == null || (!acceptAir && itemIdentifier.equals("minecraft:air"))) {
             return JAVA_ID_BLOCK_MAP.inverse().get(javaId).split("\\[")[0];
         }
         return itemIdentifier;


### PR DESCRIPTION
Items such as wall torch blocks currently do not have a place sound on standalone, as their block identifier differs from their item identifier. This commit uses the pick item logic in order to fix place sounds for such blocks.