### PR TITLE
add client setting for cooldown type, refactor show-coordinates

### DIFF
--- a/connector/src/main/java/org/geysermc/connector/GeyserConnector.java
+++ b/connector/src/main/java/org/geysermc/connector/GeyserConnector.java
@@ -188,7 +188,7 @@ public class GeyserConnector {
 
         defaultAuthType = AuthType.getByName(config.getRemote().getAuthType());
 
-        CooldownUtils.setShowCooldown(config.getShowCooldown());
+        CooldownUtils.setDefaultShowCooldown(config.getShowCooldown());
         DimensionUtils.changeBedrockNetherId(config.isAboveBedrockNetherBuilding()); // Apply End dimension ID workaround to Nether
         SkullBlockEntityTranslator.ALLOW_CUSTOM_SKULLS = config.isAllowCustomSkulls();
 

--- a/connector/src/main/java/org/geysermc/connector/network/session/GeyserSession.java
+++ b/connector/src/main/java/org/geysermc/connector/network/session/GeyserSession.java
@@ -146,7 +146,7 @@ public class GeyserSession implements CommandSender {
     private ChunkCache chunkCache;
     private EntityCache entityCache;
     private EntityEffectCache effectCache;
-    private PreferencesCache preferencesCache;
+    private final PreferencesCache preferencesCache;
     private final TagCache tagCache;
     private WorldCache worldCache;
     private WindowCache windowCache;

--- a/connector/src/main/java/org/geysermc/connector/network/session/GeyserSession.java
+++ b/connector/src/main/java/org/geysermc/connector/network/session/GeyserSession.java
@@ -146,6 +146,7 @@ public class GeyserSession implements CommandSender {
     private ChunkCache chunkCache;
     private EntityCache entityCache;
     private EntityEffectCache effectCache;
+    private PreferencesCache preferencesCache;
     private WorldCache worldCache;
     private WindowCache windowCache;
     private final Int2ObjectMap<TeleportCache> teleportMap = new Int2ObjectOpenHashMap<>();
@@ -452,6 +453,7 @@ public class GeyserSession implements CommandSender {
         this.chunkCache = new ChunkCache(this);
         this.entityCache = new EntityCache(this);
         this.effectCache = new EntityEffectCache();
+        this.preferencesCache = new PreferencesCache(this);
         this.worldCache = new WorldCache(this);
         this.windowCache = new WindowCache(this);
 
@@ -841,6 +843,7 @@ public class GeyserSession implements CommandSender {
         this.chunkCache = null;
         this.entityCache = null;
         this.effectCache = null;
+        this.preferencesCache = null;
         this.worldCache = null;
         this.windowCache = null;
 
@@ -1224,7 +1227,7 @@ public class GeyserSession implements CommandSender {
     public void setReducedDebugInfo(boolean value) {
         reducedDebugInfo = value;
         // Set the showCoordinates data. This is done because updateShowCoordinates() uses this gamerule as a variable.
-        getWorldCache().updateShowCoordinates();
+        getPreferencesCache().updateShowCoordinates();
     }
 
     /**

--- a/connector/src/main/java/org/geysermc/connector/network/session/GeyserSession.java
+++ b/connector/src/main/java/org/geysermc/connector/network/session/GeyserSession.java
@@ -1226,7 +1226,7 @@ public class GeyserSession implements CommandSender {
     public void setReducedDebugInfo(boolean value) {
         reducedDebugInfo = value;
         // Set the showCoordinates data. This is done because updateShowCoordinates() uses this gamerule as a variable.
-        getPreferencesCache().updateShowCoordinates();
+        preferencesCache.updateShowCoordinates();
     }
 
     /**

--- a/connector/src/main/java/org/geysermc/connector/network/session/cache/PreferencesCache.java
+++ b/connector/src/main/java/org/geysermc/connector/network/session/cache/PreferencesCache.java
@@ -1,0 +1,71 @@
+/*
+ * Copyright (c) 2019-2021 GeyserMC. http://geysermc.org
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ *
+ * @author GeyserMC
+ * @link https://github.com/GeyserMC/Geyser
+ */
+
+package org.geysermc.connector.network.session.cache;
+
+import lombok.Getter;
+import lombok.Setter;
+import org.geysermc.connector.configuration.GeyserConfiguration;
+import org.geysermc.connector.network.session.GeyserSession;
+import org.geysermc.connector.utils.CooldownUtils;
+
+@Getter
+public class PreferencesCache {
+    private final GeyserSession session;
+
+    /**
+     * True if the client prefers being shown their coordinates, regardless if they're being shown or not.
+     * This will be true everytime the client joins the server because neither the client nor server store the preference permanently.
+     */
+    @Setter
+    private boolean prefersShowCoordinates = true;
+    /**
+     * If the client's preference will be ignored, this will return false.
+     */
+    private boolean allowShowCoordinates;
+
+    /**
+     * Which CooldownType the client prefers. Initially set to {@link CooldownUtils#getDefaultShowCooldown()}.
+     */
+    @Setter
+    private CooldownUtils.CooldownType cooldownPreference = CooldownUtils.getDefaultShowCooldown();
+
+    public PreferencesCache(GeyserSession session) {
+        this.session = session;
+    }
+
+    /**
+     * Tell the client to hide or show the coordinates.
+     *
+     * If {@link #prefersShowCoordinates} is true, coordinates will be shown, unless either of the following conditions apply: <br>
+     * <br>
+     * {@link GeyserSession#reducedDebugInfo} is enabled
+     * {@link GeyserConfiguration#isShowCoordinates()} is disabled
+     */
+    public void updateShowCoordinates() {
+        allowShowCoordinates = !session.isReducedDebugInfo() && session.getConnector().getConfig().isShowCoordinates();
+        session.sendGameRule("showcoordinates", allowShowCoordinates && prefersShowCoordinates);
+    }
+}

--- a/connector/src/main/java/org/geysermc/connector/network/session/cache/WorldCache.java
+++ b/connector/src/main/java/org/geysermc/connector/network/session/cache/WorldCache.java
@@ -28,7 +28,6 @@ package org.geysermc.connector.network.session.cache;
 import com.github.steveice10.mc.protocol.data.game.setting.Difficulty;
 import lombok.Getter;
 import lombok.Setter;
-import org.geysermc.connector.configuration.GeyserConfiguration;
 import org.geysermc.connector.network.session.GeyserSession;
 import org.geysermc.connector.scoreboard.Objective;
 import org.geysermc.connector.scoreboard.Scoreboard;
@@ -39,13 +38,6 @@ public class WorldCache {
     private final GeyserSession session;
     @Setter
     private Difficulty difficulty = Difficulty.EASY;
-
-    /**
-     * True if the client prefers being shown their coordinates, regardless if they're being shown or not.
-     * This will be true everytime the client joins the server because neither the client nor server store the preference permanently.
-     */
-    @Setter
-    private boolean prefersShowCoordinates = true;
 
     private Scoreboard scoreboard;
     private final ScoreboardUpdater scoreboardUpdater;
@@ -70,18 +62,5 @@ public class WorldCache {
         int pendingPps = scoreboardUpdater.incrementAndGetPacketsPerSecond();
         int pps = scoreboardUpdater.getPacketsPerSecond();
         return Math.max(pps, pendingPps);
-    }
-
-    /**
-     * Tell the client to hide or show the coordinates.
-     *
-     * If {@link #prefersShowCoordinates} is true, coordinates will be shown, unless either of the following conditions apply: <br>
-     * <br>
-     * {@link GeyserSession#reducedDebugInfo} is enabled
-     * {@link GeyserConfiguration#isShowCoordinates()} is disabled
-     */
-    public void updateShowCoordinates() {
-        boolean allowShowCoordinates = !session.isReducedDebugInfo() && session.getConnector().getConfig().isShowCoordinates();
-        session.sendGameRule("showcoordinates", allowShowCoordinates && prefersShowCoordinates);
     }
 }

--- a/connector/src/main/java/org/geysermc/connector/utils/CooldownUtils.java
+++ b/connector/src/main/java/org/geysermc/connector/utils/CooldownUtils.java
@@ -158,7 +158,7 @@ public class CooldownUtils {
                     return type;
                 }
             }
-            return TITLE;
+            return DISABLED;
         }
     }
 }

--- a/connector/src/main/java/org/geysermc/connector/utils/CooldownUtils.java
+++ b/connector/src/main/java/org/geysermc/connector/utils/CooldownUtils.java
@@ -142,7 +142,7 @@ public class CooldownUtils {
         public static final CooldownType[] VALUES = values();
 
         /**
-         * Convert the CooldownType string (from config) to the enum, TITLE on fail
+         * Convert the CooldownType string (from config) to the enum, DISABLED on fail
          *
          * @param name CooldownType string
          *

--- a/connector/src/main/java/org/geysermc/connector/utils/CooldownUtils.java
+++ b/connector/src/main/java/org/geysermc/connector/utils/CooldownUtils.java
@@ -42,6 +42,7 @@ public class CooldownUtils {
     public static void setDefaultShowCooldown(String showCooldown) {
         DEFAULT_SHOW_COOLDOWN = CooldownType.getByName(showCooldown);
     }
+
     public static CooldownType getDefaultShowCooldown() {
         return DEFAULT_SHOW_COOLDOWN;
     }

--- a/connector/src/main/java/org/geysermc/connector/utils/CooldownUtils.java
+++ b/connector/src/main/java/org/geysermc/connector/utils/CooldownUtils.java
@@ -28,6 +28,7 @@ package org.geysermc.connector.utils;
 import com.nukkitx.protocol.bedrock.packet.SetTitlePacket;
 import lombok.Getter;
 import org.geysermc.connector.network.session.GeyserSession;
+import org.geysermc.connector.network.session.cache.PreferencesCache;
 
 import java.util.concurrent.TimeUnit;
 
@@ -36,18 +37,24 @@ import java.util.concurrent.TimeUnit;
  * Much of the work here is from the wonderful folks from ViaRewind: https://github.com/ViaVersion/ViaRewind
  */
 public class CooldownUtils {
-    private static CooldownType SHOW_COOLDOWN;
+    private static CooldownType DEFAULT_SHOW_COOLDOWN;
 
-    public static void setShowCooldown(String showCooldown) {
-        SHOW_COOLDOWN = CooldownType.getByName(showCooldown);
+    public static void setDefaultShowCooldown(String showCooldown) {
+        DEFAULT_SHOW_COOLDOWN = CooldownType.getByName(showCooldown);
+    }
+    public static CooldownType getDefaultShowCooldown() {
+        return DEFAULT_SHOW_COOLDOWN;
     }
 
     /**
-     * Starts sending the fake cooldown to the Bedrock client.
+     * Starts sending the fake cooldown to the Bedrock client. If the cooldown is not disabled, the sent type is {@link PreferencesCache#getCooldownPreference()}
      * @param session GeyserSession
      */
     public static void sendCooldown(GeyserSession session) {
-        if (SHOW_COOLDOWN == CooldownType.DISABLED) return;
+        if (DEFAULT_SHOW_COOLDOWN == CooldownType.DISABLED) return;
+        CooldownType sessionPreference = session.getPreferencesCache().getCooldownPreference();
+        if (sessionPreference == CooldownType.DISABLED) return;
+
         if (session.getAttackSpeed() == 0.0 || session.getAttackSpeed() > 20) return; // 0.0 usually happens on login and causes issues with visuals; anything above 20 means a plugin like OldCombatMechanics is being used
         // Needs to be sent or no subtitle packet is recognized by the client
         SetTitlePacket titlePacket = new SetTitlePacket();
@@ -56,19 +63,20 @@ public class CooldownUtils {
         session.sendUpstreamPacket(titlePacket);
         session.setLastHitTime(System.currentTimeMillis());
         long lastHitTime = session.getLastHitTime(); // Used later to prevent multiple scheduled cooldown threads
-        computeCooldown(session, lastHitTime);
+        computeCooldown(session, sessionPreference, lastHitTime);
     }
 
     /**
      * Keeps updating the cooldown until the bar is complete.
      * @param session GeyserSession
+     * @param sessionPreference The type of cooldown the client prefers
      * @param lastHitTime The time of the last hit. Used to gauge how long the cooldown is taking.
      */
-    private static void computeCooldown(GeyserSession session, long lastHitTime) {
+    private static void computeCooldown(GeyserSession session, CooldownType sessionPreference, long lastHitTime) {
         if (session.isClosed()) return; // Don't run scheduled tasks if the client left
         if (lastHitTime != session.getLastHitTime()) return; // Means another cooldown has started so there's no need to continue this one
         SetTitlePacket titlePacket = new SetTitlePacket();
-        if (SHOW_COOLDOWN == CooldownType.ACTIONBAR) {
+        if (sessionPreference == CooldownType.ACTIONBAR) {
             titlePacket.setType(SetTitlePacket.Type.ACTIONBAR);
         } else {
             titlePacket.setType(SetTitlePacket.Type.SUBTITLE);
@@ -79,10 +87,10 @@ public class CooldownUtils {
         titlePacket.setStayTime(2);
         session.sendUpstreamPacket(titlePacket);
         if (hasCooldown(session)) {
-            session.getConnector().getGeneralThreadPool().schedule(() -> computeCooldown(session, lastHitTime), 50, TimeUnit.MILLISECONDS); // Updated per tick. 1000 divided by 20 ticks equals 50
+            session.getConnector().getGeneralThreadPool().schedule(() -> computeCooldown(session, sessionPreference, lastHitTime), 50, TimeUnit.MILLISECONDS); // Updated per tick. 1000 divided by 20 ticks equals 50
         } else {
             SetTitlePacket removeTitlePacket = new SetTitlePacket();
-            if (SHOW_COOLDOWN == CooldownType.ACTIONBAR) {
+            if (sessionPreference == CooldownType.ACTIONBAR) {
                 removeTitlePacket.setType(SetTitlePacket.Type.ACTIONBAR);
             } else {
                 removeTitlePacket.setType(SetTitlePacket.Type.SUBTITLE);
@@ -149,7 +157,7 @@ public class CooldownUtils {
                     return type;
                 }
             }
-            return DISABLED;
+            return TITLE;
         }
     }
 }

--- a/connector/src/main/java/org/geysermc/connector/utils/SettingsUtils.java
+++ b/connector/src/main/java/org/geysermc/connector/utils/SettingsUtils.java
@@ -68,11 +68,11 @@ public class SettingsUtils {
 
             if (CooldownUtils.getDefaultShowCooldown() != CooldownUtils.CooldownType.DISABLED) {
                 DropdownComponent cooldownDropdown = new DropdownComponent();
-                cooldownDropdown.setText(LocaleUtils.getLocaleString("geyser.settings.option.cooldown_animation", language));
+                cooldownDropdown.setText(LocaleUtils.getLocaleString("options.attackIndicator", language));
                 cooldownDropdown.setOptions(new ArrayList<>());
-                for (CooldownUtils.CooldownType animation : CooldownUtils.CooldownType.values()) {
-                    cooldownDropdown.addOption(LocaleUtils.getLocaleString("geyser.settings.option.cooldown_animation." + animation.name().toLowerCase(), language), session.getPreferencesCache().getCooldownPreference() == animation);
-                }
+                cooldownDropdown.addOption(LocaleUtils.getLocaleString("options.attack.crosshair", language), session.getPreferencesCache().getCooldownPreference() == CooldownUtils.CooldownType.TITLE);
+                cooldownDropdown.addOption(LocaleUtils.getLocaleString("options.attack.hotbar", language), session.getPreferencesCache().getCooldownPreference() == CooldownUtils.CooldownType.ACTIONBAR);
+                cooldownDropdown.addOption(LocaleUtils.getLocaleString("options.off", language), session.getPreferencesCache().getCooldownPreference() == CooldownUtils.CooldownType.DISABLED);
                 builder.addComponent(cooldownDropdown);
             }
         }

--- a/connector/src/main/java/org/geysermc/connector/utils/SettingsUtils.java
+++ b/connector/src/main/java/org/geysermc/connector/utils/SettingsUtils.java
@@ -145,10 +145,8 @@ public class SettingsUtils {
             }
 
             if (CooldownUtils.getDefaultShowCooldown() != CooldownUtils.CooldownType.DISABLED) {
-                CooldownUtils.CooldownType cooldownType = CooldownUtils.CooldownType.values()[settingsResponse.getDropdownResponses().get(offset).getElementID()];
-                if (cooldownType != null) {
-                    session.getPreferencesCache().setCooldownPreference(cooldownType);
-                }
+                CooldownUtils.CooldownType cooldownType = CooldownUtils.CooldownType.VALUES[settingsResponse.getDropdownResponses().get(offset).getElementID()];
+                session.getPreferencesCache().setCooldownPreference(cooldownType);
                 offset++;
             }
         }

--- a/connector/src/main/java/org/geysermc/connector/utils/SettingsUtils.java
+++ b/connector/src/main/java/org/geysermc/connector/utils/SettingsUtils.java
@@ -58,7 +58,7 @@ public class SettingsUtils {
         builder.setIcon(new FormImage(FormImage.FormImageType.PATH, "textures/ui/settings_glyph_color_2x.png"));
 
         // Only show the client title if any of the client settings are available
-        if (session.getPreferencesCache().isAllowShowCoordinates() || !(CooldownUtils.getDefaultShowCooldown() == CooldownUtils.CooldownType.DISABLED)) {
+        if (session.getPreferencesCache().isAllowShowCoordinates() || CooldownUtils.getDefaultShowCooldown() != CooldownUtils.CooldownType.DISABLED) {
             builder.addComponent(new LabelComponent(LanguageUtils.getPlayerLocaleString("geyser.settings.title.client", language)));
 
             // Client can only see its coordinates if reducedDebugInfo is disabled and coordinates are enabled in geyser config.
@@ -66,7 +66,7 @@ public class SettingsUtils {
                 builder.addComponent(new ToggleComponent(LanguageUtils.getPlayerLocaleString("geyser.settings.option.coordinates", language), session.getPreferencesCache().isPrefersShowCoordinates()));
             }
 
-            if (!(CooldownUtils.getDefaultShowCooldown() == CooldownUtils.CooldownType.DISABLED)) {
+            if (CooldownUtils.getDefaultShowCooldown() != CooldownUtils.CooldownType.DISABLED) {
                 DropdownComponent cooldownDropdown = new DropdownComponent();
                 cooldownDropdown.setText("Attack Cooldown Animation");
                 cooldownDropdown.setOptions(new ArrayList<>());
@@ -134,7 +134,7 @@ public class SettingsUtils {
         }
         int offset = 0;
 
-        if (session.getPreferencesCache().isAllowShowCoordinates() || !(CooldownUtils.getDefaultShowCooldown() == CooldownUtils.CooldownType.DISABLED)) {
+        if (session.getPreferencesCache().isAllowShowCoordinates() || CooldownUtils.getDefaultShowCooldown() != CooldownUtils.CooldownType.DISABLED) {
             offset++; // Client settings title
 
             // Client can only see its coordinates if reducedDebugInfo is disabled and coordinates are enabled in geyser config.
@@ -144,7 +144,7 @@ public class SettingsUtils {
                 offset++;
             }
 
-            if (!(CooldownUtils.getDefaultShowCooldown() == CooldownUtils.CooldownType.DISABLED)) {
+            if (CooldownUtils.getDefaultShowCooldown() != CooldownUtils.CooldownType.DISABLED) {
                 CooldownUtils.CooldownType cooldownType = CooldownUtils.CooldownType.values()[settingsResponse.getDropdownResponses().get(offset).getElementID()];
                 if (cooldownType != null) {
                     session.getPreferencesCache().setCooldownPreference(cooldownType);

--- a/connector/src/main/java/org/geysermc/connector/utils/SettingsUtils.java
+++ b/connector/src/main/java/org/geysermc/connector/utils/SettingsUtils.java
@@ -38,7 +38,7 @@ import org.geysermc.common.window.response.CustomFormResponse;
 import org.geysermc.connector.GeyserConnector;
 import org.geysermc.connector.network.session.GeyserSession;
 
-import java.util.Collections;
+import java.util.ArrayList;
 
 public class SettingsUtils {
 
@@ -68,11 +68,11 @@ public class SettingsUtils {
 
             if (CooldownUtils.getDefaultShowCooldown() != CooldownUtils.CooldownType.DISABLED) {
                 DropdownComponent cooldownDropdown = new DropdownComponent();
-                cooldownDropdown.setText("Attack Cooldown Animation");
-                cooldownDropdown.setOptions(Collections.emptyList());
-                cooldownDropdown.addOption("Under Crosshair", session.getPreferencesCache().getCooldownPreference() == CooldownUtils.CooldownType.TITLE);
-                cooldownDropdown.addOption("Action Bar", session.getPreferencesCache().getCooldownPreference() == CooldownUtils.CooldownType.ACTIONBAR);
-                cooldownDropdown.addOption("Hide Animation", session.getPreferencesCache().getCooldownPreference() == CooldownUtils.CooldownType.DISABLED);
+                cooldownDropdown.setText(LocaleUtils.getLocaleString("geyser.settings.option.cooldown_animation", language));
+                cooldownDropdown.setOptions(new ArrayList<>());
+                for (CooldownUtils.CooldownType animation : CooldownUtils.CooldownType.values()) {
+                    cooldownDropdown.addOption(LocaleUtils.getLocaleString("geyser.settings.option.cooldown_animation." + animation.name().toLowerCase(), language), session.getPreferencesCache().getCooldownPreference() == animation);
+                }
                 builder.addComponent(cooldownDropdown);
             }
         }
@@ -83,7 +83,7 @@ public class SettingsUtils {
 
             DropdownComponent gamemodeDropdown = new DropdownComponent();
             gamemodeDropdown.setText("%createWorldScreen.gameMode.personal");
-            gamemodeDropdown.setOptions(Collections.emptyList());
+            gamemodeDropdown.setOptions(new ArrayList<>());
             for (GameMode gamemode : GameMode.values()) {
                 gamemodeDropdown.addOption(LocaleUtils.getLocaleString("selectWorld.gameMode." + gamemode.name().toLowerCase(), language), session.getGameMode() == gamemode);
             }
@@ -91,7 +91,7 @@ public class SettingsUtils {
 
             DropdownComponent difficultyDropdown = new DropdownComponent();
             difficultyDropdown.setText("%options.difficulty");
-            difficultyDropdown.setOptions(Collections.emptyList());
+            difficultyDropdown.setOptions(new ArrayList<>());
             for (Difficulty difficulty : Difficulty.values()) {
                 difficultyDropdown.addOption("%options.difficulty." + difficulty.name().toLowerCase(), session.getWorldCache().getDifficulty() == difficulty);
             }

--- a/connector/src/main/java/org/geysermc/connector/utils/SettingsUtils.java
+++ b/connector/src/main/java/org/geysermc/connector/utils/SettingsUtils.java
@@ -38,7 +38,7 @@ import org.geysermc.common.window.response.CustomFormResponse;
 import org.geysermc.connector.GeyserConnector;
 import org.geysermc.connector.network.session.GeyserSession;
 
-import java.util.ArrayList;
+import java.util.Collections;
 
 public class SettingsUtils {
 
@@ -69,7 +69,7 @@ public class SettingsUtils {
             if (CooldownUtils.getDefaultShowCooldown() != CooldownUtils.CooldownType.DISABLED) {
                 DropdownComponent cooldownDropdown = new DropdownComponent();
                 cooldownDropdown.setText("Attack Cooldown Animation");
-                cooldownDropdown.setOptions(new ArrayList<>());
+                cooldownDropdown.setOptions(Collections.emptyList());
                 cooldownDropdown.addOption("Under Crosshair", session.getPreferencesCache().getCooldownPreference() == CooldownUtils.CooldownType.TITLE);
                 cooldownDropdown.addOption("Action Bar", session.getPreferencesCache().getCooldownPreference() == CooldownUtils.CooldownType.ACTIONBAR);
                 cooldownDropdown.addOption("Hide Animation", session.getPreferencesCache().getCooldownPreference() == CooldownUtils.CooldownType.DISABLED);
@@ -83,7 +83,7 @@ public class SettingsUtils {
 
             DropdownComponent gamemodeDropdown = new DropdownComponent();
             gamemodeDropdown.setText("%createWorldScreen.gameMode.personal");
-            gamemodeDropdown.setOptions(new ArrayList<>());
+            gamemodeDropdown.setOptions(Collections.emptyList());
             for (GameMode gamemode : GameMode.values()) {
                 gamemodeDropdown.addOption(LocaleUtils.getLocaleString("selectWorld.gameMode." + gamemode.name().toLowerCase(), language), session.getGameMode() == gamemode);
             }
@@ -91,7 +91,7 @@ public class SettingsUtils {
 
             DropdownComponent difficultyDropdown = new DropdownComponent();
             difficultyDropdown.setText("%options.difficulty");
-            difficultyDropdown.setOptions(new ArrayList<>());
+            difficultyDropdown.setOptions(Collections.emptyList());
             for (Difficulty difficulty : Difficulty.values()) {
                 difficultyDropdown.addOption("%options.difficulty." + difficulty.name().toLowerCase(), session.getWorldCache().getDifficulty() == difficulty);
             }


### PR DESCRIPTION
This allows the user to choose what kind of cooldown they want to see (title, action bar, or false) through a dropdown. Similarly to the show coordinate option, they aren't shown the option if it is disabled globally through the geyser config (at least that is the only setter of `DEFAULT_SHOW_COOLDOWN` currently). 

This was was done in a new PreferencesCache in the session. I threw the show coordinates code in there as well since it seemed more appropriate. Also turned the `allowShowCoordinates` boolean into a @Getter field so that the form constructor is a bit nicer. 

~~Relies on https://github.com/GeyserMC/languages/pull/69~~