### PR TITLE
Update MCProtocolLib + PacketLib

### DIFF
--- a/bootstrap/bungeecord/pom.xml
+++ b/bootstrap/bungeecord/pom.xml
@@ -66,8 +66,10 @@
                                     <shadedPattern>org.geysermc.platform.bungeecord.shaded.jackson</shadedPattern>
                                 </relocation>
                                 <relocation>
-                                    <pattern>io.netty</pattern>
-                                    <shadedPattern>org.geysermc.platform.bungeecord.shaded.netty</shadedPattern>
+                                    <!-- This is not used because relocating breaks natives, but we must include it
+                                     or else we get ClassDefNotFound -->
+                                    <pattern>io.netty.channel.kqueue</pattern>
+                                    <shadedPattern>org.geysermc.platform.bungeecord.shaded.io.netty.channel.kqueue</shadedPattern>
                                 </relocation>
                                 <relocation>
                                     <pattern>org.reflections</pattern>
@@ -98,6 +100,15 @@
                         <excludes>
                             <exclude>com.google.code.gson:*</exclude>
                             <exclude>org.yaml:*</exclude>
+                            <exclude>io.netty:netty-transport-native-epoll:*</exclude>
+                            <exclude>io.netty:netty-transport-native-unix-common:*</exclude>
+                            <exclude>io.netty:netty-handler:*</exclude>
+                            <exclude>io.netty:netty-common:*</exclude>
+                            <exclude>io.netty:netty-buffer:*</exclude>
+                            <exclude>io.netty:netty-resolver:*</exclude>
+                            <exclude>io.netty:netty-transport:*</exclude>
+                            <exclude>io.netty:netty-codec:*</exclude>
+                            <exclude>io.netty:netty-resolver-dns:*</exclude>
                         </excludes>
                     </artifactSet>
                 </configuration>

--- a/bootstrap/spigot/pom.xml
+++ b/bootstrap/spigot/pom.xml
@@ -69,10 +69,6 @@
                         <configuration>
                             <relocations>
                                 <relocation>
-                                    <pattern>io.netty</pattern>
-                                    <shadedPattern>org.geysermc.platform.spigot.shaded.netty</shadedPattern>
-                                </relocation>
-                                <relocation>
                                     <pattern>it.unimi.dsi.fastutil</pattern>
                                     <shadedPattern>org.geysermc.platform.spigot.shaded.fastutil</shadedPattern>
                                 </relocation>
@@ -109,6 +105,20 @@
                         <excludes>
                             <exclude>com.google.code.gson:*</exclude>
                             <exclude>org.yaml:*</exclude>
+                            <!-- We cannot shade Netty, or else native libraries will not load -->
+                            <!-- Needed because older Spigot builds do not provide the haproxy module -->
+                            <exclude>io.netty:netty-transport-native-epoll:*</exclude>
+                            <exclude>io.netty:netty-transport-native-unix-common:*</exclude>
+                            <exclude>io.netty:netty-transport-native-kqueue:*</exclude>
+                            <exclude>io.netty:netty-handler:*</exclude>
+                            <exclude>io.netty:netty-common:*</exclude>
+                            <exclude>io.netty:netty-buffer:*</exclude>
+                            <exclude>io.netty:netty-resolver:*</exclude>
+                            <exclude>io.netty:netty-transport:*</exclude>
+                            <exclude>io.netty:netty-codec:*</exclude>
+                            <exclude>io.netty:netty-codec-dns:*</exclude>
+                            <exclude>io.netty:netty-resolver-dns:*</exclude>
+                            <exclude>io.netty:netty-resolver-dns-native-macos:*</exclude>
                         </excludes>
                     </artifactSet>
                 </configuration>

--- a/bootstrap/spigot/src/main/java/org/geysermc/platform/spigot/GeyserSpigotPlugin.java
+++ b/bootstrap/spigot/src/main/java/org/geysermc/platform/spigot/GeyserSpigotPlugin.java
@@ -95,6 +95,23 @@ public class GeyserSpigotPlugin extends JavaPlugin implements GeyserBootstrap {
             ex.printStackTrace();
         }
 
+        try {
+            // Required for the Cloudburst Network dependency to initialize.
+            Class.forName("io.netty.channel.kqueue.KQueue");
+        } catch (ClassNotFoundException e) {
+            // While we could support these older versions, the downside is not having KQueue working at all
+            // And since there are alternative ways to get Geyser working for these aging platforms, it's not worth it.
+            getLogger().severe("*********************************************");
+            getLogger().severe("");
+            getLogger().severe(LanguageUtils.getLocaleStringLog("geyser.bootstrap.unsupported_server.header"));
+            getLogger().severe(LanguageUtils.getLocaleStringLog("geyser.bootstrap.unsupported_server.message", "1.12.2"));
+            getLogger().severe("");
+            getLogger().severe("*********************************************");
+
+            Bukkit.getPluginManager().disablePlugin(this);
+            return;
+        }
+
         // By default this should be localhost but may need to be changed in some circumstances
         if (this.geyserConfig.getRemote().getAddress().equalsIgnoreCase("auto")) {
             geyserConfig.setAutoconfiguredRemote(true);

--- a/bootstrap/velocity/pom.xml
+++ b/bootstrap/velocity/pom.xml
@@ -103,6 +103,7 @@
                             <exclude>io.netty:netty-resolver:*</exclude>
                             <exclude>io.netty:netty-transport:*</exclude>
                             <exclude>io.netty:netty-codec:*</exclude>
+                            <exclude>io.netty:netty-codec-haproxy:*</exclude>
                             <exclude>org.slf4j:*</exclude>
                             <exclude>org.ow2.asm:*</exclude>
                             <!-- Exclude all Kyori dependencies except the legacy NBT serializer -->

--- a/connector/pom.xml
+++ b/connector/pom.xml
@@ -122,7 +122,7 @@
         <dependency>
             <groupId>com.github.steveice10</groupId>
             <artifactId>mcprotocollib</artifactId>
-            <version>26201a4</version>
+            <version>8c204eb</version>
             <scope>compile</scope>
             <exclusions>
                 <exclusion>
@@ -140,9 +140,9 @@
             </exclusions>
         </dependency>
         <dependency>
-            <groupId>com.github.GeyserMC</groupId>
-            <artifactId>PacketLib</artifactId>
-            <version>b77a427</version>
+            <groupId>com.github.steveice10</groupId>
+            <artifactId>packetlib</artifactId>
+            <version>ac56007</version>
             <scope>compile</scope>
             <exclusions>
                 <exclusion> <!-- Move this exclusion back to MCProtocolLib it gets the latest PacketLib -->

--- a/connector/pom.xml
+++ b/connector/pom.xml
@@ -140,9 +140,9 @@
             </exclusions>
         </dependency>
         <dependency>
-            <groupId>com.github.steveice10</groupId>
-            <artifactId>packetlib</artifactId>
-            <version>ac56007</version>
+            <groupId>com.github.GeyserMC</groupId>
+            <artifactId>PacketLib</artifactId>
+            <version>6e5dea9</version>
             <scope>compile</scope>
             <exclusions>
                 <exclusion> <!-- Move this exclusion back to MCProtocolLib it gets the latest PacketLib -->

--- a/connector/src/main/java/org/geysermc/connector/GeyserConnector.java
+++ b/connector/src/main/java/org/geysermc/connector/GeyserConnector.java
@@ -31,6 +31,8 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import com.nukkitx.network.raknet.RakNetConstants;
 import com.nukkitx.network.util.EventLoops;
 import com.nukkitx.protocol.bedrock.BedrockServer;
+import io.netty.channel.epoll.Epoll;
+import io.netty.channel.kqueue.KQueue;
 import lombok.Getter;
 import lombok.Setter;
 import org.geysermc.common.PlatformType;
@@ -203,7 +205,17 @@ public class GeyserConnector {
                 EventLoops.commonGroup(),
                 enableProxyProtocol
         );
+
         logger.debug("EventLoop type: " + EventLoops.getChannelType());
+        if (EventLoops.getChannelType() == EventLoops.ChannelType.NIO) {
+            if (System.getProperties().contains("disableNativeEventLoop")) {
+                logger.debug("EventLoop type is NIO because native event loops are disabled.");
+            } else {
+                logger.debug("Reason for no Epoll: " + Epoll.unavailabilityCause().getMessage());
+                logger.debug("Reason for no KQueue: " + KQueue.unavailabilityCause().getMessage());
+            }
+        }
+
         bedrockServer.setHandler(new ConnectorServerEventHandler(this));
         bedrockServer.bind().whenComplete((avoid, throwable) -> {
             if (throwable == null) {

--- a/connector/src/main/java/org/geysermc/connector/GeyserConnector.java
+++ b/connector/src/main/java/org/geysermc/connector/GeyserConnector.java
@@ -206,13 +206,15 @@ public class GeyserConnector {
                 enableProxyProtocol
         );
 
-        logger.debug("EventLoop type: " + EventLoops.getChannelType());
-        if (EventLoops.getChannelType() == EventLoops.ChannelType.NIO) {
-            if (System.getProperties().contains("disableNativeEventLoop")) {
-                logger.debug("EventLoop type is NIO because native event loops are disabled.");
-            } else {
-                logger.debug("Reason for no Epoll: " + Epoll.unavailabilityCause().getMessage());
-                logger.debug("Reason for no KQueue: " + KQueue.unavailabilityCause().getMessage());
+        if (config.isDebugMode()) {
+            logger.debug("EventLoop type: " + EventLoops.getChannelType());
+            if (EventLoops.getChannelType() == EventLoops.ChannelType.NIO) {
+                if (System.getProperties().contains("disableNativeEventLoop")) {
+                    logger.debug("EventLoop type is NIO because native event loops are disabled.");
+                } else {
+                    logger.debug("Reason for no Epoll: " + Epoll.unavailabilityCause().toString());
+                    logger.debug("Reason for no KQueue: " + KQueue.unavailabilityCause().toString());
+                }
             }
         }
 

--- a/connector/src/main/java/org/geysermc/connector/GeyserConnector.java
+++ b/connector/src/main/java/org/geysermc/connector/GeyserConnector.java
@@ -203,6 +203,7 @@ public class GeyserConnector {
                 EventLoops.commonGroup(),
                 enableProxyProtocol
         );
+        logger.debug("EventLoop type: " + EventLoops.getChannelType());
         bedrockServer.setHandler(new ConnectorServerEventHandler(this));
         bedrockServer.bind().whenComplete((avoid, throwable) -> {
             if (throwable == null) {

--- a/connector/src/main/java/org/geysermc/connector/network/session/GeyserSession.java
+++ b/connector/src/main/java/org/geysermc/connector/network/session/GeyserSession.java
@@ -46,10 +46,9 @@ import com.github.steveice10.mc.protocol.packet.ingame.client.world.ClientTelepo
 import com.github.steveice10.mc.protocol.packet.login.client.LoginPluginResponsePacket;
 import com.github.steveice10.mc.protocol.packet.login.server.LoginSuccessPacket;
 import com.github.steveice10.packetlib.BuiltinFlags;
-import com.github.steveice10.packetlib.Client;
 import com.github.steveice10.packetlib.event.session.*;
 import com.github.steveice10.packetlib.packet.Packet;
-import com.github.steveice10.packetlib.tcp.TcpSessionFactory;
+import com.github.steveice10.packetlib.tcp.TcpClientSession;
 import com.nukkitx.math.GenericMath;
 import com.nukkitx.math.vector.*;
 import com.nukkitx.protocol.bedrock.BedrockPacket;
@@ -118,7 +117,7 @@ public class GeyserSession implements CommandSender {
 
     private final GeyserConnector connector;
     private final UpstreamSession upstream;
-    private Client downstream;
+    private TcpClientSession downstream;
     @Setter
     private AuthData authData;
     @Setter
@@ -585,7 +584,7 @@ public class GeyserSession implements CommandSender {
                     authenticationService.setPassword(password);
                     authenticationService.login();
 
-                    protocol = new MinecraftProtocol(authenticationService);
+                    protocol = new MinecraftProtocol(authenticationService.getSelectedProfile(), authenticationService.getAccessToken());
                 } else {
                     protocol = new MinecraftProtocol(username);
                 }
@@ -643,7 +642,7 @@ public class GeyserSession implements CommandSender {
         }
         try {
             msaAuthenticationService.login();
-            protocol = new MinecraftProtocol(msaAuthenticationService);
+            protocol = new MinecraftProtocol(msaAuthenticationService.getSelectedProfile(), msaAuthenticationService.getAccessToken());
 
             connectDownstream();
         } catch (RequestException e) {
@@ -683,17 +682,17 @@ public class GeyserSession implements CommandSender {
         // Start ticking
         tickThread = connector.getGeneralThreadPool().scheduleAtFixedRate(this::tick, 50, 50, TimeUnit.MILLISECONDS);
 
-        downstream = new Client(this.remoteAddress, this.remotePort, protocol, new TcpSessionFactory());
+        downstream = new TcpClientSession(this.remoteAddress, this.remotePort, protocol);
         disableSrvResolving();
         if (connector.getConfig().getRemote().isUseProxyProtocol()) {
-            downstream.getSession().setFlag(BuiltinFlags.ENABLE_CLIENT_PROXY_PROTOCOL, true);
-            downstream.getSession().setFlag(BuiltinFlags.CLIENT_PROXIED_ADDRESS, upstream.getAddress());
+            downstream.setFlag(BuiltinFlags.ENABLE_CLIENT_PROXY_PROTOCOL, true);
+            downstream.setFlag(BuiltinFlags.CLIENT_PROXIED_ADDRESS, upstream.getAddress());
         }
         if (connector.getConfig().isForwardPlayerPing()) {
             // Let Geyser handle sending the keep alive
-            downstream.getSession().setFlag(MinecraftConstants.AUTOMATIC_KEEP_ALIVE_MANAGEMENT, false);
+            downstream.setFlag(MinecraftConstants.AUTOMATIC_KEEP_ALIVE_MANAGEMENT, false);
         }
-        downstream.getSession().addListener(new SessionAdapter() {
+        downstream.addListener(new SessionAdapter() {
             @Override
             public void packetSending(PacketSendingEvent event) {
                 //todo move this somewhere else
@@ -816,15 +815,15 @@ public class GeyserSession implements CommandSender {
         if (!daylightCycle) {
             setDaylightCycle(true);
         }
-        downstream.getSession().connect();
+        downstream.connect();
         connector.addPlayer(this);
     }
 
     public void disconnect(String reason) {
         if (!closed) {
             loggedIn = false;
-            if (downstream != null && downstream.getSession() != null) {
-                downstream.getSession().disconnect(reason);
+            if (downstream != null) {
+                downstream.disconnect(reason);
             }
             if (upstream != null && !upstream.isClosed()) {
                 connector.getPlayers().remove(this);
@@ -952,7 +951,7 @@ public class GeyserSession implements CommandSender {
      * Will be overwritten for GeyserConnect.
      */
     protected void disableSrvResolving() {
-        this.downstream.getSession().setFlag(BuiltinFlags.ATTEMPT_SRV_RESOLVE, false);
+        this.downstream.setFlag(BuiltinFlags.ATTEMPT_SRV_RESOLVE, false);
     }
 
     @Override
@@ -1208,8 +1207,8 @@ public class GeyserSession implements CommandSender {
      * @param packet the java edition packet from MCProtocolLib
      */
     public void sendDownstreamPacket(Packet packet) {
-        if (downstream != null && downstream.getSession() != null && (protocol.getSubProtocol().equals(SubProtocol.GAME) || packet.getClass() == LoginPluginResponsePacket.class)) {
-            downstream.getSession().send(packet);
+        if (downstream != null && (protocol.getSubProtocol().equals(SubProtocol.GAME) || packet.getClass() == LoginPluginResponsePacket.class)) {
+            downstream.send(packet);
         } else {
             connector.getLogger().debug("Tried to send downstream packet " + packet.getClass().getSimpleName() + " before connected to the server");
         }

--- a/connector/src/main/java/org/geysermc/connector/network/session/cache/BookEditCache.java
+++ b/connector/src/main/java/org/geysermc/connector/network/session/cache/BookEditCache.java
@@ -68,7 +68,7 @@ public class BookEditCache {
             packet = null;
             return;
         }
-        session.getDownstream().getSession().send(packet);
+        session.sendDownstreamPacket(packet);
         packet = null;
         lastBookUpdate = System.currentTimeMillis();
     }


### PR DESCRIPTION
By updating these dependencies, we bring in a couple fixes that should improve network performance:

- Use TCP_NODELAY for the Java connection
- Use Epoll/KQueue if possible for the Java connection
- Only use one event loop for the Java connection
- Fix Netty dependencies so Spigot and BungeeCord can use native network types

Currently, Geyser-Spigot pre-1.12 breaks with these changes. It is unlikely that this will be fixed.