### PR TITLE
Fix area effect cloud particle type for 1.16.220

### DIFF
--- a/connector/pom.xml
+++ b/connector/pom.xml
@@ -32,7 +32,7 @@
         <dependency>
             <groupId>com.github.CloudburstMC.Protocol</groupId>
             <artifactId>bedrock-v431</artifactId>
-            <version>9947665</version>
+            <version>530a0e3</version>
             <scope>compile</scope>
             <exclusions>
                 <exclusion>

--- a/connector/src/main/java/org/geysermc/connector/entity/AreaEffectCloudEntity.java
+++ b/connector/src/main/java/org/geysermc/connector/entity/AreaEffectCloudEntity.java
@@ -59,7 +59,7 @@ public class AreaEffectCloudEntity extends Entity {
             metadata.put(EntityData.EFFECT_COLOR, entityMetadata.getValue());
         } else if (entityMetadata.getId() == 10) {
             Particle particle = (Particle) entityMetadata.getValue();
-            int particleId = EffectRegistry.getParticleId(particle.getType());
+            int particleId = EffectRegistry.getParticleId(session, particle.getType());
             if (particleId != -1) {
                 metadata.put(EntityData.AREA_EFFECT_CLOUD_PARTICLE_ID, particleId);
             }

--- a/connector/src/main/java/org/geysermc/connector/network/translators/effect/EffectRegistry.java
+++ b/connector/src/main/java/org/geysermc/connector/network/translators/effect/EffectRegistry.java
@@ -32,10 +32,9 @@ import com.nukkitx.protocol.bedrock.data.LevelEventType;
 import com.nukkitx.protocol.bedrock.data.SoundEvent;
 import it.unimi.dsi.fastutil.ints.Int2ObjectMap;
 import it.unimi.dsi.fastutil.ints.Int2ObjectOpenHashMap;
-import it.unimi.dsi.fastutil.objects.Object2IntMap;
-import it.unimi.dsi.fastutil.objects.Object2IntOpenHashMap;
 import lombok.NonNull;
 import org.geysermc.connector.GeyserConnector;
+import org.geysermc.connector.network.session.GeyserSession;
 import org.geysermc.connector.utils.FileUtils;
 
 import java.io.InputStream;
@@ -51,11 +50,6 @@ public class EffectRegistry {
     public static final Map<SoundEffect, Effect> SOUND_EFFECTS = new HashMap<>();
     public static final Int2ObjectMap<SoundEvent> RECORDS = new Int2ObjectOpenHashMap<>();
 
-    /**
-     * Java particle type to Bedrock particle ID
-     * Used for area effect clouds.
-     */
-    private static final Object2IntMap<ParticleType> PARTICLE_TO_ID = new Object2IntOpenHashMap<>();
     /**
      * Java particle type to Bedrock level event
      */
@@ -84,11 +78,7 @@ public class EffectRegistry {
             while (particlesIterator.hasNext()) {
                 Map.Entry<String, JsonNode> entry = particlesIterator.next();
                 JsonNode bedrockId = entry.getValue().get("bedrockId");
-                JsonNode bedrockIdNumeric = entry.getValue().get("bedrockNumericId");
                 JsonNode eventType = entry.getValue().get("eventType");
-                if (bedrockIdNumeric != null) {
-                    PARTICLE_TO_ID.put(ParticleType.valueOf(entry.getKey().toUpperCase()), bedrockIdNumeric.asInt());
-                }
                 if (bedrockId != null) {
                     PARTICLE_TO_STRING.put(ParticleType.valueOf(entry.getKey().toUpperCase()), bedrockId.asText());
                 }
@@ -164,11 +154,19 @@ public class EffectRegistry {
     }
 
     /**
+     * Used for area effect clouds.
+     *
      * @param type the Java particle to search for
      * @return the Bedrock integer ID of the particle, or -1 if it does not exist
      */
-    public static int getParticleId(@NonNull ParticleType type) {
-        return PARTICLE_TO_ID.getOrDefault(type, -1);
+    public static int getParticleId(GeyserSession session, @NonNull ParticleType type) {
+        LevelEventType levelEventType = getParticleLevelEventType(type);
+        if (levelEventType == null) {
+            return -1;
+        }
+
+        // Remove the legacy bit applied to particles for LevelEventType serialization
+        return session.getUpstream().getSession().getPacketCodec().getHelper().getLevelEventId(levelEventType) & ~0x4000;
     }
 
     /**


### PR DESCRIPTION
This commit stops hardcoded particle IDs from being used and instead uses the internal IDs per-version.