### PR TITLE
Register permissions in Spigot plugin.yml

### DIFF
--- a/bootstrap/spigot/src/main/resources/plugin.yml
+++ b/bootstrap/spigot/src/main/resources/plugin.yml
@@ -9,3 +9,22 @@ commands:
   geyser:
     description: The main command for Geyser.
     usage: /geyser help
+permissions:
+  geyser.command.help:
+    description: Shows help for all registered commands.
+  geyser.command.advancement:
+    description: Shows the advancements of the player on the server.
+  geyser.command.dump:
+    description: Dumps Geyser debug information for bug reports.
+  geyser.command.list:
+    description: List all players connected through Geyser.
+  geyser.command.offhand:
+    description: Puts an items in your offhand.
+  geyser.command.reload:
+    description: Reloads the Geyser configurations. Kicks all players when used!
+  geyser.comamnd.shutdown:
+    description: Shuts down Geyser.
+  geyser.command.statistics:
+    description: Shows the statistics of the player on the server.
+  geyser.command.version:
+    description: Shows the current Geyser version and checks for updates.

--- a/bootstrap/spigot/src/main/resources/plugin.yml
+++ b/bootstrap/spigot/src/main/resources/plugin.yml
@@ -22,7 +22,7 @@ permissions:
     description: Puts an items in your offhand.
   geyser.command.reload:
     description: Reloads the Geyser configurations. Kicks all players when used!
-  geyser.comamnd.shutdown:
+  geyser.command.shutdown:
     description: Shuts down Geyser.
   geyser.command.statistics:
     description: Shows the statistics of the player on the server.


### PR DESCRIPTION
I'm not sure if having to specify a description will override anything. It doesn't affect Geyser's `geyser help` command (tested by setting a locale other than en_us)

Considering the permissions weren't defined in the first place, its not like this will break anything that uses spigot's command#getDescription() method.

Apart from that API method I don't know where permission descriptions are used.

Resolves the LuckPerms tree part of #2239 