### PR TITLE
No creation of thread for skin requesting

### DIFF
--- a/connector/src/main/java/org/geysermc/connector/skin/SkullSkinManager.java
+++ b/connector/src/main/java/org/geysermc/connector/skin/SkullSkinManager.java
@@ -52,7 +52,7 @@ public class SkullSkinManager extends SkinManager {
                                             Consumer<SkinProvider.Skin> skinConsumer) {
         GameProfileData data = GameProfileData.from(entity.getProfile());
 
-        SkinProvider.requestSkin(entity.getUuid(), data.getSkinUrl(), true)
+        SkinProvider.requestSkin(entity.getUuid(), data.getSkinUrl(), false)
                 .whenCompleteAsync((skin, throwable) -> {
                     try {
                         if (session.getUpstream().isInitialized()) {


### PR DESCRIPTION
When requesting a skin, it opens a new thread. This could lead to there being too many threads open and the process not being able to open more of them. Then you'll get an error complaining about not being able to open threads.

This is the error which was causing the threads not to be closed (I think)
```[WARNING] [Geyser-BungeeCord] Failed getting skin for 46814159-5b0b-4136-bfbc-4deeb3463b72
java.lang.NullPointerException
    at org.geysermc.connector.skin.SkullSkinManager.lambda$requestAndHandleSkin$0(SkullSkinManager.java:62)
    at java.base/java.util.concurrent.CompletableFuture.uniWhenComplete(CompletableFuture.java:859)
    at java.base/java.util.concurrent.CompletableFuture$UniWhenComplete.tryFire(CompletableFuture.java:837)
    at java.base/java.util.concurrent.CompletableFuture$Completion.exec(CompletableFuture.java:479)
    at java.base/java.util.concurrent.ForkJoinTask.doExec(ForkJoinTask.java:290)
    at java.base/java.util.concurrent.ForkJoinPool$WorkQueue.topLevelExec(ForkJoinPool.java:1020)
    at java.base/java.util.concurrent.ForkJoinPool.scan(ForkJoinPool.java:1656)
    at java.base/java.util.concurrent.ForkJoinPool.runWorker(ForkJoinPool.java:1594)
    at java.base/java.util.concurrent.ForkJoinWorkerThread.run(ForkJoinWorkerThread.java:183)```