### PR TITLE
Fix block unique Java ids

### DIFF
--- a/connector/src/main/java/org/geysermc/connector/registry/populator/BlockRegistryPopulator.java
+++ b/connector/src/main/java/org/geysermc/connector/registry/populator/BlockRegistryPopulator.java
@@ -270,12 +270,6 @@ public class BlockRegistryPopulator {
                 builder.pickItem(pickItemNode.textValue());
             }
 
-            builder.javaIdentifier(javaId);
-            builder.javaBlockId(uniqueJavaId);
-
-            BlockRegistries.JAVA_IDENTIFIERS.register(javaId, javaRuntimeId);
-            BlockRegistries.JAVA_BLOCKS.register(javaRuntimeId, builder.build());
-
             BlockStateValues.storeBlockStateValues(entry.getKey(), javaRuntimeId, entry.getValue());
 
             String cleanJavaIdentifier = entry.getKey().split("\\[")[0];
@@ -285,6 +279,12 @@ public class BlockRegistryPopulator {
                 uniqueJavaId++;
                 BlockRegistries.JAVA_CLEAN_IDENTIFIERS.register(uniqueJavaId, cleanJavaIdentifier);
             }
+
+            builder.javaIdentifier(javaId);
+            builder.javaBlockId(uniqueJavaId);
+
+            BlockRegistries.JAVA_IDENTIFIERS.register(javaId, javaRuntimeId);
+            BlockRegistries.JAVA_BLOCKS.register(javaRuntimeId, builder.build());
 
             // Keeping this here since this is currently unchanged between versions
             if (!cleanJavaIdentifier.equals(bedrockIdentifier)) {


### PR DESCRIPTION
This fixes the break time for stone, gold blocks, mossy cobblestone, diamond ore, and netherrack. 

For reference: https://github.com/GeyserMC/Geyser/blob/887296ef788fbbd59b648b5361bc2c724188a43e/connector/src/main/java/org/geysermc/connector/network/translators/world/block/BlockTranslator.java#L171