### PR TITLE
Auth type refactor in internal config

### DIFF
--- a/bootstrap/bungeecord/src/main/java/org/geysermc/platform/bungeecord/GeyserBungeePlugin.java
+++ b/bootstrap/bungeecord/src/main/java/org/geysermc/platform/bungeecord/GeyserBungeePlugin.java
@@ -31,6 +31,7 @@ import org.geysermc.common.PlatformType;
 import org.geysermc.connector.GeyserConnector;
 import org.geysermc.connector.bootstrap.GeyserBootstrap;
 import org.geysermc.connector.command.CommandManager;
+import org.geysermc.connector.common.AuthType;
 import org.geysermc.connector.configuration.GeyserConfiguration;
 import org.geysermc.connector.dump.BootstrapDumpInfo;
 import org.geysermc.connector.ping.GeyserLegacyPingPassthrough;
@@ -100,13 +101,13 @@ public class GeyserBungeePlugin extends Plugin implements GeyserBootstrap {
             return;
         }
 
-        if (geyserConfig.getRemote().getAuthType().equals("floodgate") && getProxy().getPluginManager().getPlugin("floodgate") == null) {
+        if (geyserConfig.getRemote().getAuthType() == AuthType.FLOODGATE && getProxy().getPluginManager().getPlugin("floodgate") == null) {
             geyserLogger.severe(LanguageUtils.getLocaleStringLog("geyser.bootstrap.floodgate.not_installed") + " " + LanguageUtils.getLocaleStringLog("geyser.bootstrap.floodgate.disabling"));
             return;
         } else if (geyserConfig.isAutoconfiguredRemote() && getProxy().getPluginManager().getPlugin("floodgate") != null) {
             // Floodgate installed means that the user wants Floodgate authentication
             geyserLogger.debug("Auto-setting to Floodgate authentication.");
-            geyserConfig.getRemote().setAuthType("floodgate");
+            geyserConfig.getRemote().setAuthType(AuthType.FLOODGATE);
         }
 
         geyserConfig.loadFloodgate(this);

--- a/bootstrap/spigot/src/main/java/org/geysermc/platform/spigot/GeyserSpigotPlugin.java
+++ b/bootstrap/spigot/src/main/java/org/geysermc/platform/spigot/GeyserSpigotPlugin.java
@@ -36,6 +36,7 @@ import org.geysermc.common.PlatformType;
 import org.geysermc.connector.GeyserConnector;
 import org.geysermc.connector.bootstrap.GeyserBootstrap;
 import org.geysermc.connector.command.CommandManager;
+import org.geysermc.connector.common.AuthType;
 import org.geysermc.connector.configuration.GeyserConfiguration;
 import org.geysermc.connector.dump.BootstrapDumpInfo;
 import org.geysermc.connector.network.translators.world.WorldManager;
@@ -127,14 +128,14 @@ public class GeyserSpigotPlugin extends JavaPlugin implements GeyserBootstrap {
             return;
         }
 
-        if (geyserConfig.getRemote().getAuthType().equals("floodgate") && Bukkit.getPluginManager().getPlugin("floodgate") == null) {
+        if (geyserConfig.getRemote().getAuthType() == AuthType.FLOODGATE && Bukkit.getPluginManager().getPlugin("floodgate") == null) {
             geyserLogger.severe(LanguageUtils.getLocaleStringLog("geyser.bootstrap.floodgate.not_installed") + " " + LanguageUtils.getLocaleStringLog("geyser.bootstrap.floodgate.disabling"));
             this.getPluginLoader().disablePlugin(this);
             return;
         } else if (geyserConfig.isAutoconfiguredRemote() && Bukkit.getPluginManager().getPlugin("floodgate") != null) {
             // Floodgate installed means that the user wants Floodgate authentication
             geyserLogger.debug("Auto-setting to Floodgate authentication.");
-            geyserConfig.getRemote().setAuthType("floodgate");
+            geyserConfig.getRemote().setAuthType(AuthType.FLOODGATE);
         }
 
         geyserConfig.loadFloodgate(this);

--- a/bootstrap/velocity/src/main/java/org/geysermc/platform/velocity/GeyserVelocityPlugin.java
+++ b/bootstrap/velocity/src/main/java/org/geysermc/platform/velocity/GeyserVelocityPlugin.java
@@ -36,6 +36,7 @@ import lombok.Getter;
 import org.geysermc.common.PlatformType;
 import org.geysermc.connector.GeyserConnector;
 import org.geysermc.connector.bootstrap.GeyserBootstrap;
+import org.geysermc.connector.common.AuthType;
 import org.geysermc.connector.configuration.GeyserConfiguration;
 import org.geysermc.connector.dump.BootstrapDumpInfo;
 import org.geysermc.connector.ping.GeyserLegacyPingPassthrough;
@@ -116,13 +117,13 @@ public class GeyserVelocityPlugin implements GeyserBootstrap {
         } catch (ClassNotFoundException ignored) {
         }
 
-        if (geyserConfig.getRemote().getAuthType().equals("floodgate") && !proxyServer.getPluginManager().getPlugin("floodgate").isPresent()) {
+        if (geyserConfig.getRemote().getAuthType() == AuthType.FLOODGATE && !proxyServer.getPluginManager().getPlugin("floodgate").isPresent()) {
             geyserLogger.severe(LanguageUtils.getLocaleStringLog("geyser.bootstrap.floodgate.not_installed") + " " + LanguageUtils.getLocaleStringLog("geyser.bootstrap.floodgate.disabling"));
             return;
         } else if (geyserConfig.isAutoconfiguredRemote() && proxyServer.getPluginManager().getPlugin("floodgate").isPresent()) {
             // Floodgate installed means that the user wants Floodgate authentication
             geyserLogger.debug("Auto-setting to Floodgate authentication.");
-            geyserConfig.getRemote().setAuthType("floodgate");
+            geyserConfig.getRemote().setAuthType(AuthType.FLOODGATE);
         }
 
         geyserConfig.loadFloodgate(this, proxyServer, configFolder.toFile());

--- a/connector/src/main/java/org/geysermc/connector/FloodgateKeyLoader.java
+++ b/connector/src/main/java/org/geysermc/connector/FloodgateKeyLoader.java
@@ -25,6 +25,7 @@
 
 package org.geysermc.connector;
 
+import org.geysermc.connector.common.AuthType;
 import org.geysermc.connector.configuration.GeyserJacksonConfiguration;
 import org.geysermc.connector.utils.LanguageUtils;
 
@@ -33,7 +34,7 @@ import java.nio.file.Path;
 
 public class FloodgateKeyLoader {
     public static Path getKeyPath(GeyserJacksonConfiguration config, Object floodgate, Path floodgateDataFolder, Path geyserDataFolder, GeyserLogger logger) {
-        if (!config.getRemote().getAuthType().equals("floodgate")) {
+        if (config.getRemote().getAuthType() != AuthType.FLOODGATE) {
             return geyserDataFolder.resolve(config.getFloodgateKeyFile());
         }
 

--- a/connector/src/main/java/org/geysermc/connector/GeyserConnector.java
+++ b/connector/src/main/java/org/geysermc/connector/GeyserConnector.java
@@ -106,9 +106,6 @@ public class GeyserConnector {
     @Setter
     private static boolean shouldStartListener = true;
 
-    @Setter
-    private AuthType defaultAuthType;
-
     private final TimeSyncer timeSyncer;
     private FloodgateCipher cipher;
     private FloodgateSkinUploader skinUploader;
@@ -192,10 +189,8 @@ public class GeyserConnector {
             }
         }
 
-        defaultAuthType = config.getRemote().getAuthType();
-
         TimeSyncer timeSyncer = null;
-        if (defaultAuthType == AuthType.FLOODGATE) {
+        if (config.getRemote().getAuthType() == AuthType.FLOODGATE) {
             timeSyncer = new TimeSyncer(Constants.NTP_SERVER);
             try {
                 Key key = new AesKeyProducer().produceFrom(config.getFloodgateKeyPath());
@@ -432,7 +427,6 @@ public class GeyserConnector {
         }
         newsHandler.shutdown();
         players.clear();
-        defaultAuthType = null;
         this.getCommandManager().getCommands().clear();
 
         bootstrap.getGeyserLogger().info(LanguageUtils.getLocaleStringLog("geyser.core.shutdown.done"));
@@ -522,6 +516,15 @@ public class GeyserConnector {
     public boolean isProductionEnvironment() {
         //noinspection ConstantConditions - changes in production
         return !"DEV".equals(GeyserConnector.VERSION);
+    }
+
+    /**
+     * Deprecated. Get the AuthType from the GeyserConfiguration through {@link GeyserConnector#getConfig()}
+     * @return The
+     */
+    @Deprecated
+    public AuthType getDefaultAuthType() {
+        return getConfig().getRemote().getAuthType();
     }
 
     public static GeyserConnector getInstance() {

--- a/connector/src/main/java/org/geysermc/connector/GeyserConnector.java
+++ b/connector/src/main/java/org/geysermc/connector/GeyserConnector.java
@@ -192,7 +192,7 @@ public class GeyserConnector {
             }
         }
 
-        defaultAuthType = AuthType.getByName(config.getRemote().getAuthType());
+        defaultAuthType = config.getRemote().getAuthType();
 
         TimeSyncer timeSyncer = null;
         if (defaultAuthType == AuthType.FLOODGATE) {
@@ -273,7 +273,7 @@ public class GeyserConnector {
             metrics = new Metrics(this, "GeyserMC", config.getMetrics().getUniqueId(), false, java.util.logging.Logger.getLogger(""));
             metrics.addCustomChart(new Metrics.SingleLineChart("players", players::size));
             // Prevent unwanted words best we can
-            metrics.addCustomChart(new Metrics.SimplePie("authMode", () -> AuthType.getByName(config.getRemote().getAuthType()).toString().toLowerCase()));
+            metrics.addCustomChart(new Metrics.SimplePie("authMode", () -> config.getRemote().getAuthType().toString().toLowerCase()));
             metrics.addCustomChart(new Metrics.SimplePie("platform", platformType::getPlatformName));
             metrics.addCustomChart(new Metrics.SimplePie("defaultLocale", LanguageUtils::getDefaultLocale));
             metrics.addCustomChart(new Metrics.SimplePie("version", () -> GeyserConnector.VERSION));

--- a/connector/src/main/java/org/geysermc/connector/common/AuthType.java
+++ b/connector/src/main/java/org/geysermc/connector/common/AuthType.java
@@ -40,7 +40,7 @@ public enum AuthType {
     }
 
     /**
-     * Convert the AuthType string (from config) to the enum, OFFLINE on fail
+     * Convert the AuthType string (from config) to the enum, ONLINE on fail
      *
      * @param name AuthType string
      *
@@ -53,6 +53,6 @@ public enum AuthType {
                 return type;
             }
         }
-        return OFFLINE;
+        return ONLINE;
     }
 }

--- a/connector/src/main/java/org/geysermc/connector/common/AuthType.java
+++ b/connector/src/main/java/org/geysermc/connector/common/AuthType.java
@@ -25,7 +25,12 @@
 
 package org.geysermc.connector.common;
 
+import com.fasterxml.jackson.core.JsonParser;
+import com.fasterxml.jackson.databind.DeserializationContext;
+import com.fasterxml.jackson.databind.JsonDeserializer;
 import lombok.Getter;
+
+import java.io.IOException;
 
 @Getter
 public enum AuthType {
@@ -54,5 +59,12 @@ public enum AuthType {
             }
         }
         return ONLINE;
+    }
+
+    public static class Deserializer extends JsonDeserializer<AuthType> {
+        @Override
+        public AuthType deserialize(JsonParser p, DeserializationContext ctxt) throws IOException {
+            return getByName(p.getValueAsString());
+        }
     }
 }

--- a/connector/src/main/java/org/geysermc/connector/configuration/GeyserConfiguration.java
+++ b/connector/src/main/java/org/geysermc/connector/configuration/GeyserConfiguration.java
@@ -27,6 +27,7 @@ package org.geysermc.connector.configuration;
 
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import org.geysermc.connector.GeyserLogger;
+import org.geysermc.connector.common.AuthType;
 import org.geysermc.connector.network.CIDRMatcher;
 import org.geysermc.connector.utils.LanguageUtils;
 
@@ -135,7 +136,7 @@ public interface GeyserConfiguration {
 
         void setPort(int port);
 
-        String getAuthType();
+        AuthType getAuthType();
 
         boolean isPasswordAuthentication();
 

--- a/connector/src/main/java/org/geysermc/connector/configuration/GeyserJacksonConfiguration.java
+++ b/connector/src/main/java/org/geysermc/connector/configuration/GeyserJacksonConfiguration.java
@@ -184,30 +184,27 @@ public abstract class GeyserJacksonConfiguration implements GeyserConfiguration 
         }
     }
 
+    @Getter
     @JsonIgnoreProperties(ignoreUnknown = true)
     public static class RemoteConfiguration implements IRemoteConfiguration {
-        @Getter @Setter
+        @Setter
         @AsteriskSerializer.Asterisk(isIp = true)
         private String address = "auto";
 
-        @Getter @Setter
+        @Setter
         private int port = 25565;
 
+        @Setter
+        @JsonDeserialize(using = AuthType.Deserializer.class)
         @JsonProperty("auth-type")
-        private String authTypeName = "online";
+        private AuthType authType = AuthType.ONLINE;
 
-        @Getter @Setter
-        private AuthType authType = AuthType.getByName(authTypeName);
-
-        @Getter
         @JsonProperty("allow-password-authentication")
         private boolean passwordAuthentication = true;
 
-        @Getter
         @JsonProperty("use-proxy-protocol")
         private boolean useProxyProtocol = false;
 
-        @Getter
         @JsonProperty("forward-hostname")
         private boolean forwardHost = false;
     }

--- a/connector/src/main/java/org/geysermc/connector/configuration/GeyserJacksonConfiguration.java
+++ b/connector/src/main/java/org/geysermc/connector/configuration/GeyserJacksonConfiguration.java
@@ -32,6 +32,7 @@ import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import lombok.Getter;
 import lombok.Setter;
 import org.geysermc.connector.GeyserConnector;
+import org.geysermc.connector.common.AuthType;
 import org.geysermc.connector.common.serializer.AsteriskSerializer;
 import org.geysermc.connector.network.CIDRMatcher;
 
@@ -59,7 +60,7 @@ public abstract class GeyserJacksonConfiguration implements GeyserConfiguration 
     private boolean extendedWorldHeight = false;
 
     @JsonProperty("floodgate-key-file")
-    private String floodgateKeyFile = "public-key.pem";
+    private String floodgateKeyFile = "key.pem";
 
     public abstract Path getFloodgateKeyPath();
 
@@ -183,26 +184,30 @@ public abstract class GeyserJacksonConfiguration implements GeyserConfiguration 
         }
     }
 
-    @Getter
     @JsonIgnoreProperties(ignoreUnknown = true)
     public static class RemoteConfiguration implements IRemoteConfiguration {
-        @Setter
+        @Getter @Setter
         @AsteriskSerializer.Asterisk(isIp = true)
         private String address = "auto";
 
-        @Setter
+        @Getter @Setter
         private int port = 25565;
 
-        @Setter
         @JsonProperty("auth-type")
-        private String authType = "online";
+        private String authTypeName = "online";
 
+        @Getter @Setter
+        private AuthType authType = AuthType.getByName(authTypeName);
+
+        @Getter
         @JsonProperty("allow-password-authentication")
         private boolean passwordAuthentication = true;
 
+        @Getter
         @JsonProperty("use-proxy-protocol")
         private boolean useProxyProtocol = false;
 
+        @Getter
         @JsonProperty("forward-hostname")
         private boolean forwardHost = false;
     }

--- a/connector/src/main/java/org/geysermc/connector/network/session/GeyserSession.java
+++ b/connector/src/main/java/org/geysermc/connector/network/session/GeyserSession.java
@@ -489,7 +489,7 @@ public class GeyserSession implements CommandSender {
         startGame();
         this.remoteAddress = connector.getConfig().getRemote().getAddress();
         this.remotePort = connector.getConfig().getRemote().getPort();
-        this.remoteAuthType = connector.getDefaultAuthType();
+        this.remoteAuthType = connector.getConfig().getRemote().getAuthType();
 
         // Set the hardcoded shield ID to the ID we just defined in StartGamePacket
         upstream.getSession().getHardcodedBlockingId().set(this.itemMappings.getStoredItems().shield().getBedrockId());

--- a/connector/src/main/java/org/geysermc/connector/network/translators/java/JavaJoinGameTranslator.java
+++ b/connector/src/main/java/org/geysermc/connector/network/translators/java/JavaJoinGameTranslator.java
@@ -104,7 +104,7 @@ public class JavaJoinGameTranslator extends PacketTranslator<ServerJoinGamePacke
         session.sendDownstreamPacket(new ClientPluginMessagePacket("minecraft:brand", PluginMessageUtils.getGeyserBrandData()));
 
         // register the plugin messaging channels used in Floodgate
-        if (session.getConnector().getDefaultAuthType() == AuthType.FLOODGATE) {
+        if (session.getRemoteAuthType() == AuthType.FLOODGATE) {
             session.sendDownstreamPacket(new ClientPluginMessagePacket("minecraft:register", PluginMessageUtils.getFloodgateRegisterData()));
         }
 

--- a/connector/src/main/java/org/geysermc/connector/network/translators/java/JavaPluginMessageTranslator.java
+++ b/connector/src/main/java/org/geysermc/connector/network/translators/java/JavaPluginMessageTranslator.java
@@ -43,7 +43,7 @@ public class JavaPluginMessageTranslator extends PacketTranslator<ServerPluginMe
     @Override
     public void translate(ServerPluginMessagePacket packet, GeyserSession session) {
         // The only plugin messages it has to listen for are Floodgate plugin messages
-        if (session.getConnector().getDefaultAuthType() != AuthType.FLOODGATE) {
+        if (session.getRemoteAuthType() != AuthType.FLOODGATE) {
             return;
         }
 

--- a/connector/src/main/java/org/geysermc/connector/skin/SkinManager.java
+++ b/connector/src/main/java/org/geysermc/connector/skin/SkinManager.java
@@ -286,7 +286,7 @@ public class SkinManager {
 
             String skinUrl = isAlex ? SkinProvider.EMPTY_SKIN_ALEX.getTextureUrl() : SkinProvider.EMPTY_SKIN.getTextureUrl();
             String capeUrl = SkinProvider.EMPTY_CAPE.getTextureUrl();
-            if (("steve".equals(skinUrl) || "alex".equals(skinUrl)) && GeyserConnector.getInstance().getDefaultAuthType() != AuthType.ONLINE) {
+            if (("steve".equals(skinUrl) || "alex".equals(skinUrl)) && GeyserConnector.getInstance().getConfig().getRemote().getAuthType() != AuthType.ONLINE) {
                 GeyserSession session = GeyserConnector.getInstance().getPlayerByUuid(profile.getId());
 
                 if (session != null) {


### PR DESCRIPTION
`getAuthType()` now returns an enum value instead of a string. This will help with user error when the wrong case is used (any case is okay now). 

Also sets the default for `floodgate-key-file` to be `key.pem` instead of `public-key.pem`.
Also makes `AuthType#getByName()` return `ONLINE` instead of `OFFLINE` if no match was found.