### PR TITLE
Improve annotation processing

### DIFF
--- a/ap/src/main/java/org/geysermc/processor/BlockEntityProcessor.java
+++ b/ap/src/main/java/org/geysermc/processor/BlockEntityProcessor.java
@@ -29,7 +29,7 @@ import javax.annotation.processing.SupportedAnnotationTypes;
 import javax.annotation.processing.SupportedSourceVersion;
 import javax.lang.model.SourceVersion;
 
-@SupportedAnnotationTypes("org.geysermc.connector.network.translators.world.block.entity.BlockEntity")
+@SupportedAnnotationTypes("*")
 @SupportedSourceVersion(SourceVersion.RELEASE_8)
 public class BlockEntityProcessor extends ClassProcessor {
     public BlockEntityProcessor() {

--- a/ap/src/main/java/org/geysermc/processor/ClassProcessor.java
+++ b/ap/src/main/java/org/geysermc/processor/ClassProcessor.java
@@ -128,7 +128,7 @@ public class ClassProcessor extends AbstractProcessor {
 
     public void complete() {
         // Read existing annotation list and verify each class still has this annotation
-        try (BufferedReader reader = this.createReader()){
+        try (BufferedReader reader = this.createReader()) {
             if (reader != null) {
                 reader.lines().forEach(canonicalName -> {
                     if (!locations.contains(canonicalName)) {

--- a/ap/src/main/java/org/geysermc/processor/ClassProcessor.java
+++ b/ap/src/main/java/org/geysermc/processor/ClassProcessor.java
@@ -143,15 +143,18 @@ public class ClassProcessor extends AbstractProcessor {
             e.printStackTrace();
         }
 
-        try (BufferedWriter writer = this.createWriter()) {
-            for (String location : this.locations) {
-                writer.write(location);
-                writer.newLine();
+        if (!locations.isEmpty()) {
+            try (BufferedWriter writer = this.createWriter()) {
+                for (String location : this.locations) {
+                    writer.write(location);
+                    writer.newLine();
+                }
+            } catch (IOException ex) {
+                ex.printStackTrace();
             }
-        } catch (IOException ex) {
-            ex.printStackTrace();
+        } else {
+            this.processingEnv.getMessager().printMessage(Diagnostic.Kind.NOTE, "Did not find any classes annotated with " + this.annotationClassName);
         }
-
         this.processingEnv.getMessager().printMessage(Diagnostic.Kind.NOTE, "Completed processing for " + this.annotationClassName);
     }
 

--- a/ap/src/main/java/org/geysermc/processor/CollisionRemapperProcessor.java
+++ b/ap/src/main/java/org/geysermc/processor/CollisionRemapperProcessor.java
@@ -29,7 +29,7 @@ import javax.annotation.processing.SupportedAnnotationTypes;
 import javax.annotation.processing.SupportedSourceVersion;
 import javax.lang.model.SourceVersion;
 
-@SupportedAnnotationTypes("org.geysermc.connector.network.translators.collision.CollisionRemapper")
+@SupportedAnnotationTypes("*")
 @SupportedSourceVersion(SourceVersion.RELEASE_8)
 public class CollisionRemapperProcessor extends ClassProcessor {
     public CollisionRemapperProcessor() {

--- a/ap/src/main/java/org/geysermc/processor/ItemRemapperProcessor.java
+++ b/ap/src/main/java/org/geysermc/processor/ItemRemapperProcessor.java
@@ -29,7 +29,7 @@ import javax.annotation.processing.SupportedAnnotationTypes;
 import javax.annotation.processing.SupportedSourceVersion;
 import javax.lang.model.SourceVersion;
 
-@SupportedAnnotationTypes("org.geysermc.connector.network.translators.ItemRemapper")
+@SupportedAnnotationTypes("*")
 @SupportedSourceVersion(SourceVersion.RELEASE_8)
 public class ItemRemapperProcessor extends ClassProcessor {
     public ItemRemapperProcessor() {

--- a/ap/src/main/java/org/geysermc/processor/PacketTranslatorProcessor.java
+++ b/ap/src/main/java/org/geysermc/processor/PacketTranslatorProcessor.java
@@ -29,7 +29,7 @@ import javax.annotation.processing.SupportedAnnotationTypes;
 import javax.annotation.processing.SupportedSourceVersion;
 import javax.lang.model.SourceVersion;
 
-@SupportedAnnotationTypes("org.geysermc.connector.network.translators.Translator")
+@SupportedAnnotationTypes("*")
 @SupportedSourceVersion(SourceVersion.RELEASE_8)
 public class PacketTranslatorProcessor extends ClassProcessor {
     public PacketTranslatorProcessor() {

--- a/ap/src/main/java/org/geysermc/processor/SoundHandlerProcessor.java
+++ b/ap/src/main/java/org/geysermc/processor/SoundHandlerProcessor.java
@@ -29,7 +29,7 @@ import javax.annotation.processing.SupportedAnnotationTypes;
 import javax.annotation.processing.SupportedSourceVersion;
 import javax.lang.model.SourceVersion;
 
-@SupportedAnnotationTypes("org.geysermc.connector.network.translators.sound.SoundHandler")
+@SupportedAnnotationTypes("*")
 @SupportedSourceVersion(SourceVersion.RELEASE_8)
 public class SoundHandlerProcessor extends ClassProcessor {
     public SoundHandlerProcessor() {


### PR DESCRIPTION
When building on IntelliJ, the annotation processors only process classes that were changed or rebuilt. The generated annotation files would then be incomplete or contain deleted classes. 
These changes should remedy this by loading the previously generated annotation lists.