### PR TITLE
Fix Bedrock crash with extended world heights

### DIFF
--- a/connector/src/main/java/org/geysermc/connector/utils/ChunkUtils.java
+++ b/connector/src/main/java/org/geysermc/connector/utils/ChunkUtils.java
@@ -135,10 +135,12 @@ public class ChunkUtils {
         BitSet pistonOrFlowerPaletteIds = new BitSet();
 
         boolean overworld = session.getChunkCache().isExtendedHeight();
+        int maxBedrockSectionY = (overworld ? MAXIMUM_ACCEPTED_HEIGHT_OVERWORLD : MAXIMUM_ACCEPTED_HEIGHT) >> 4;
 
         for (int sectionY = 0; sectionY < javaSections.length; sectionY++) {
-            if (yOffset < ((overworld ? MINIMUM_ACCEPTED_HEIGHT_OVERWORLD : MINIMUM_ACCEPTED_HEIGHT) >> 4) && sectionY < -yOffset) {
-                // Ignore this chunk since it goes below the accepted height limit
+            int bedrockSectionY = sectionY + (yOffset - ((overworld ? MINIMUM_ACCEPTED_HEIGHT_OVERWORLD : MINIMUM_ACCEPTED_HEIGHT) >> 4));
+            if (!(0 <= bedrockSectionY && bedrockSectionY < maxBedrockSectionY)) {
+                // Ignore this chunk section since it goes outside the bounds accepted by the Bedrock client
                 continue;
             }
 
@@ -173,7 +175,7 @@ public class ChunkUtils {
                         ));
                     }
                 }
-                sections[sectionY + (yOffset - ((overworld ? MINIMUM_ACCEPTED_HEIGHT_OVERWORLD : MINIMUM_ACCEPTED_HEIGHT) >> 4))] = section;
+                sections[bedrockSectionY] = section;
                 continue;
             }
 
@@ -246,7 +248,7 @@ public class ChunkUtils {
                 layers = new BlockStorage[]{ layer0, new BlockStorage(BitArrayVersion.V1.createArray(BlockStorage.SIZE, layer1Data), layer1Palette) };
             }
 
-            sections[sectionY + (yOffset - ((overworld ? MINIMUM_ACCEPTED_HEIGHT_OVERWORLD : MINIMUM_ACCEPTED_HEIGHT) >> 4))] = new ChunkSection(layers);
+            sections[bedrockSectionY] = new ChunkSection(layers);
         }
 
         CompoundTag[] blockEntities = column.getTileEntities();

--- a/connector/src/main/java/org/geysermc/connector/utils/ChunkUtils.java
+++ b/connector/src/main/java/org/geysermc/connector/utils/ChunkUtils.java
@@ -135,11 +135,11 @@ public class ChunkUtils {
         BitSet pistonOrFlowerPaletteIds = new BitSet();
 
         boolean overworld = session.getChunkCache().isExtendedHeight();
-        int maxBedrockSectionY = (overworld ? MAXIMUM_ACCEPTED_HEIGHT_OVERWORLD : MAXIMUM_ACCEPTED_HEIGHT) >> 4;
+        int maxBedrockSectionY = ((overworld ? MAXIMUM_ACCEPTED_HEIGHT_OVERWORLD : MAXIMUM_ACCEPTED_HEIGHT) >> 4) - 1;
 
         for (int sectionY = 0; sectionY < javaSections.length; sectionY++) {
             int bedrockSectionY = sectionY + (yOffset - ((overworld ? MINIMUM_ACCEPTED_HEIGHT_OVERWORLD : MINIMUM_ACCEPTED_HEIGHT) >> 4));
-            if (!(0 <= bedrockSectionY && bedrockSectionY < maxBedrockSectionY)) {
+            if (bedrockSectionY < 0 || maxBedrockSectionY < bedrockSectionY) {
                 // Ignore this chunk section since it goes outside the bounds accepted by the Bedrock client
                 continue;
             }

--- a/connector/src/main/java/org/geysermc/connector/utils/ChunkUtils.java
+++ b/connector/src/main/java/org/geysermc/connector/utils/ChunkUtils.java
@@ -170,7 +170,7 @@ public class ChunkUtils {
                     // Check if block is piston or flower to see if we'll need to create additional block entities, as they're only block entities in Bedrock
                     if (BlockStateValues.getFlowerPotValues().containsKey(javaId) || BlockStateValues.getPistonValues().containsKey(javaId)) {
                         bedrockOnlyBlockEntities.add(BedrockOnlyBlockEntity.getTag(session,
-                                Vector3i.from((column.getX() << 4) + (yzx & 0xF), (sectionY << 4) + ((yzx >> 8) & 0xF), (column.getZ() << 4) + ((yzx >> 4) & 0xF)),
+                                Vector3i.from((column.getX() << 4) + (yzx & 0xF), ((sectionY + yOffset) << 4) + ((yzx >> 8) & 0xF), (column.getZ() << 4) + ((yzx >> 4) & 0xF)),
                                 javaId
                         ));
                     }
@@ -206,7 +206,7 @@ public class ChunkUtils {
                     int paletteId = javaData.get(yzx);
                     if (pistonOrFlowerPaletteIds.get(paletteId)) {
                         bedrockOnlyBlockEntities.add(BedrockOnlyBlockEntity.getTag(session,
-                                Vector3i.from((column.getX() << 4) + (yzx & 0xF), (sectionY << 4) + ((yzx >> 8) & 0xF), (column.getZ() << 4) + ((yzx >> 4) & 0xF)),
+                                Vector3i.from((column.getX() << 4) + (yzx & 0xF), ((sectionY + yOffset) << 4) + ((yzx >> 8) & 0xF), (column.getZ() << 4) + ((yzx >> 4) & 0xF)),
                                 javaPalette.idToState(paletteId)
                         ));
                     }


### PR DESCRIPTION
This fixes a crash caused by sending chunks with more than 32 sections.
This also fixes the y position for bedrock only block entities such as pistons and flower pots.

I've attached a world that crashes with the master branch. Placing a block at `-96 448 -240` will crash the Bedrock player on join, but removing that block will allow the player to join without any problems.
[large-world.zip](https://github.com/GeyserMC/Geyser/files/6920049/large-world.zip)

