### PR TITLE
Ensure every packet is ran on the same thread per player 

### DIFF
--- a/connector/pom.xml
+++ b/connector/pom.xml
@@ -13,8 +13,8 @@
     <properties>
         <adventure.version>4.8.0</adventure.version>
         <fastutil.version>8.5.2</fastutil.version>
-        <jackson.version>2.10.2</jackson.version>
-        <netty.version>4.1.59.Final</netty.version>
+        <jackson.version>2.12.4</jackson.version>
+        <netty.version>4.1.66.Final</netty.version>
     </properties>
 
     <dependencies>
@@ -167,7 +167,7 @@
         <dependency>
             <groupId>com.github.GeyserMC</groupId>
             <artifactId>PacketLib</artifactId>
-            <version>25eb4c4</version>
+            <version>86c9c38</version>
             <scope>compile</scope>
             <exclusions>
                 <exclusion>

--- a/connector/src/main/java/org/geysermc/connector/network/ConnectorServerEventHandler.java
+++ b/connector/src/main/java/org/geysermc/connector/network/ConnectorServerEventHandler.java
@@ -30,6 +30,7 @@ import com.nukkitx.protocol.bedrock.BedrockServerEventHandler;
 import com.nukkitx.protocol.bedrock.BedrockServerSession;
 import io.netty.buffer.ByteBuf;
 import io.netty.channel.ChannelHandlerContext;
+import io.netty.channel.DefaultEventLoopGroup;
 import io.netty.channel.socket.DatagramPacket;
 import org.geysermc.connector.GeyserConnector;
 import org.geysermc.connector.common.ping.GeyserPingInfo;
@@ -56,6 +57,7 @@ public class ConnectorServerEventHandler implements BedrockServerEventHandler {
     private static final int MAGIC_RAKNET_LENGTH = 338;
 
     private final GeyserConnector connector;
+    private final DefaultEventLoopGroup eventLoopGroup = new DefaultEventLoopGroup();
 
     public ConnectorServerEventHandler(GeyserConnector connector) {
         this.connector = connector;
@@ -162,7 +164,7 @@ public class ConnectorServerEventHandler implements BedrockServerEventHandler {
     public void onSessionCreation(BedrockServerSession bedrockServerSession) {
         bedrockServerSession.setLogging(true);
         bedrockServerSession.setCompressionLevel(connector.getConfig().getBedrock().getCompressionLevel());
-        bedrockServerSession.setPacketHandler(new UpstreamPacketHandler(connector, new GeyserSession(connector, bedrockServerSession)));
+        bedrockServerSession.setPacketHandler(new UpstreamPacketHandler(connector, new GeyserSession(connector, bedrockServerSession, eventLoopGroup.next())));
         // Set the packet codec to default just in case we need to send disconnect packets.
         bedrockServerSession.setPacketCodec(BedrockProtocol.DEFAULT_BEDROCK_CODEC);
     }

--- a/connector/src/main/java/org/geysermc/connector/network/ConnectorServerEventHandler.java
+++ b/connector/src/main/java/org/geysermc/connector/network/ConnectorServerEventHandler.java
@@ -32,6 +32,7 @@ import io.netty.buffer.ByteBuf;
 import io.netty.channel.ChannelHandlerContext;
 import io.netty.channel.DefaultEventLoopGroup;
 import io.netty.channel.socket.DatagramPacket;
+import io.netty.util.concurrent.DefaultThreadFactory;
 import org.geysermc.connector.GeyserConnector;
 import org.geysermc.connector.common.ping.GeyserPingInfo;
 import org.geysermc.connector.configuration.GeyserConfiguration;
@@ -57,7 +58,7 @@ public class ConnectorServerEventHandler implements BedrockServerEventHandler {
     private static final int MAGIC_RAKNET_LENGTH = 338;
 
     private final GeyserConnector connector;
-    private final DefaultEventLoopGroup eventLoopGroup = new DefaultEventLoopGroup();
+    private final DefaultEventLoopGroup eventLoopGroup = new DefaultEventLoopGroup(new DefaultThreadFactory("Geyser player thread"));
 
     public ConnectorServerEventHandler(GeyserConnector connector) {
         this.connector = connector;

--- a/connector/src/main/java/org/geysermc/connector/network/UpstreamPacketHandler.java
+++ b/connector/src/main/java/org/geysermc/connector/network/UpstreamPacketHandler.java
@@ -53,6 +53,11 @@ public class UpstreamPacketHandler extends LoggingPacketHandler {
     }
 
     @Override
+    boolean defaultHandler(BedrockPacket packet) {
+        return translateAndDefault(packet);
+    }
+
+    @Override
     public boolean handle(LoginPacket loginPacket) {
         BedrockPacketCodec packetCodec = BedrockProtocol.getBedrockCodec(loginPacket.getProtocolVersion());
         if (packetCodec == null) {
@@ -156,7 +161,7 @@ public class UpstreamPacketHandler extends LoggingPacketHandler {
 
     @Override
     public boolean handle(ModalFormResponsePacket packet) {
-        session.getFormCache().handleResponse(packet);
+        session.getEventLoop().execute(() -> session.getFormCache().handleResponse(packet));
         return true;
     }
 
@@ -206,11 +211,6 @@ public class UpstreamPacketHandler extends LoggingPacketHandler {
             session.sendUpstreamPacket(titlePacket);
         }
 
-        return translateAndDefault(packet);
-    }
-
-    @Override
-    boolean defaultHandler(BedrockPacket packet) {
         return translateAndDefault(packet);
     }
 

--- a/connector/src/main/java/org/geysermc/connector/network/session/GeyserSession.java
+++ b/connector/src/main/java/org/geysermc/connector/network/session/GeyserSession.java
@@ -1202,18 +1202,19 @@ public class GeyserSession implements CommandSender {
     public void sendDownstreamPacket(Packet packet) {
         if (!closed && this.downstream != null) {
             EventLoop eventLoop = this.downstream.getChannel().eventLoop();
-            final Runnable packetSend = () -> {
-                if (protocol.getSubProtocol().equals(SubProtocol.GAME) || packet.getClass() == LoginPluginResponsePacket.class) {
-                    downstream.send(packet);
-                } else {
-                    connector.getLogger().debug("Tried to send downstream packet " + packet.getClass().getSimpleName() + " before connected to the server");
-                }
-            };
             if (eventLoop.inEventLoop()) {
-                packetSend.run();
+                sendDownstreamPacket0(packet);
             } else {
-                eventLoop.execute(packetSend);
+                eventLoop.execute(() -> sendDownstreamPacket0(packet));
             }
+        }
+    }
+
+    private void sendDownstreamPacket0(Packet packet) {
+        if (protocol.getSubProtocol().equals(SubProtocol.GAME) || packet.getClass() == LoginPluginResponsePacket.class) {
+            downstream.send(packet);
+        } else {
+            connector.getLogger().debug("Tried to send downstream packet " + packet.getClass().getSimpleName() + " before connected to the server");
         }
     }
 

--- a/connector/src/main/java/org/geysermc/connector/network/session/GeyserSession.java
+++ b/connector/src/main/java/org/geysermc/connector/network/session/GeyserSession.java
@@ -25,7 +25,6 @@
 
 package org.geysermc.connector.network.session;
 
-import com.github.steveice10.mc.auth.data.GameProfile;
 import com.github.steveice10.mc.auth.exception.request.AuthPendingException;
 import com.github.steveice10.mc.auth.exception.request.InvalidCredentialsException;
 import com.github.steveice10.mc.auth.exception.request.RequestException;
@@ -45,7 +44,6 @@ import com.github.steveice10.mc.protocol.packet.ingame.client.player.ClientPlaye
 import com.github.steveice10.mc.protocol.packet.ingame.client.player.ClientPlayerPositionRotationPacket;
 import com.github.steveice10.mc.protocol.packet.ingame.client.world.ClientTeleportConfirmPacket;
 import com.github.steveice10.mc.protocol.packet.login.client.LoginPluginResponsePacket;
-import com.github.steveice10.mc.protocol.packet.login.server.LoginSuccessPacket;
 import com.github.steveice10.packetlib.BuiltinFlags;
 import com.github.steveice10.packetlib.event.session.*;
 import com.github.steveice10.packetlib.packet.Packet;
@@ -94,7 +92,6 @@ import org.geysermc.connector.registry.Registries;
 import org.geysermc.connector.registry.type.BlockMappings;
 import org.geysermc.connector.registry.type.ItemMappings;
 import org.geysermc.connector.skin.FloodgateSkinUploader;
-import org.geysermc.connector.skin.SkinManager;
 import org.geysermc.connector.utils.*;
 import org.geysermc.cumulus.Form;
 import org.geysermc.cumulus.util.FormBuilder;
@@ -808,24 +805,6 @@ public class GeyserSession implements CommandSender {
             @Override
             public void packetReceived(PacketReceivedEvent event) {
                 if (!closed) {
-                    // Required, or else Floodgate players break with Bukkit chunk caching
-                    if (event.getPacket() instanceof LoginSuccessPacket) {
-                        GameProfile profile = ((LoginSuccessPacket) event.getPacket()).getProfile();
-                        playerEntity.setUsername(profile.getName());
-                        playerEntity.setUuid(profile.getId());
-
-                        // Check if they are not using a linked account
-                        if (remoteAuthType == AuthType.OFFLINE || playerEntity.getUuid().getMostSignificantBits() == 0) {
-                            SkinManager.handleBedrockSkin(playerEntity, clientData);
-                        }
-
-                        if (remoteAuthType == AuthType.FLOODGATE) {
-                            // We'll send the skin upload a bit after the handshake packet (aka this packet),
-                            // because otherwise the global server returns the data too fast.
-                            getAuthData().upload(connector);
-                        }
-                    }
-
                     PacketTranslatorRegistry.JAVA_TRANSLATOR.translate(event.getPacket().getClass(), event.getPacket(), GeyserSession.this);
                 }
             }

--- a/connector/src/main/java/org/geysermc/connector/network/session/GeyserSession.java
+++ b/connector/src/main/java/org/geysermc/connector/network/session/GeyserSession.java
@@ -57,9 +57,9 @@ import com.nukkitx.protocol.bedrock.data.command.CommandPermission;
 import com.nukkitx.protocol.bedrock.data.entity.EntityData;
 import com.nukkitx.protocol.bedrock.data.entity.EntityFlag;
 import com.nukkitx.protocol.bedrock.packet.*;
+import io.netty.channel.EventLoop;
 import it.unimi.dsi.fastutil.ints.*;
 import it.unimi.dsi.fastutil.longs.Long2ObjectMap;
-import it.unimi.dsi.fastutil.longs.Long2ObjectMaps;
 import it.unimi.dsi.fastutil.longs.Long2ObjectOpenHashMap;
 import it.unimi.dsi.fastutil.objects.Object2ObjectOpenHashMap;
 import it.unimi.dsi.fastutil.objects.ObjectIterator;
@@ -102,7 +102,10 @@ import java.net.InetAddress;
 import java.net.InetSocketAddress;
 import java.nio.charset.StandardCharsets;
 import java.util.*;
-import java.util.concurrent.*;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CompletionException;
+import java.util.concurrent.ScheduledFuture;
+import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicInteger;
 
 @Getter
@@ -110,6 +113,10 @@ public class GeyserSession implements CommandSender {
 
     private final GeyserConnector connector;
     private final UpstreamSession upstream;
+    /**
+     * The loop where all packets and ticking is processed to prevent concurrency issues.
+     */
+    private final EventLoop eventLoop;
     private TcpClientSession downstream;
     @Setter
     private AuthData authData;
@@ -158,11 +165,6 @@ public class GeyserSession implements CommandSender {
     @Getter(AccessLevel.NONE)
     private final AtomicInteger itemNetId = new AtomicInteger(2);
 
-    @Getter(AccessLevel.NONE)
-    private final Object inventoryLock = new Object();
-    @Getter(AccessLevel.NONE)
-    private CompletableFuture<Void> inventoryFuture;
-
     @Setter
     private ScheduledFuture<?> craftingGridFuture;
 
@@ -183,8 +185,8 @@ public class GeyserSession implements CommandSender {
     @Setter
     private ItemMappings itemMappings;
 
-    private final Map<Vector3i, SkullPlayerEntity> skullCache = new ConcurrentHashMap<>();
-    private final Long2ObjectMap<ClientboundMapItemDataPacket> storedMaps = Long2ObjectMaps.synchronize(new Long2ObjectOpenHashMap<>());
+    private final Map<Vector3i, SkullPlayerEntity> skullCache = new Object2ObjectOpenHashMap<>();
+    private final Long2ObjectMap<ClientboundMapItemDataPacket> storedMaps = new Long2ObjectOpenHashMap<>();
 
     /**
      * Stores the differences between Java and Bedrock biome network IDs.
@@ -428,9 +430,10 @@ public class GeyserSession implements CommandSender {
 
     private MinecraftProtocol protocol;
 
-    public GeyserSession(GeyserConnector connector, BedrockServerSession bedrockServerSession) {
+    public GeyserSession(GeyserConnector connector, BedrockServerSession bedrockServerSession, EventLoop eventLoop) {
         this.connector = connector;
         this.upstream = new UpstreamSession(bedrockServerSession);
+        this.eventLoop = eventLoop;
 
         this.advancementsCache = new AdvancementsCache(this);
         this.bookEditCache = new BookEditCache(this);
@@ -449,7 +452,6 @@ public class GeyserSession implements CommandSender {
 
         this.playerInventory = new PlayerInventory();
         this.openInventory = null;
-        this.inventoryFuture = CompletableFuture.completedFuture(null);
         this.craftingRecipes = new Int2ObjectOpenHashMap<>();
         this.unlockedRecipes = new ObjectOpenHashSet<>();
         this.lastRecipeNetId = new AtomicInteger(1);
@@ -666,7 +668,7 @@ public class GeyserSession implements CommandSender {
         boolean floodgate = this.remoteAuthType == AuthType.FLOODGATE;
 
         // Start ticking
-        tickThread = connector.getGeneralThreadPool().scheduleAtFixedRate(this::tick, 50, 50, TimeUnit.MILLISECONDS);
+        tickThread = eventLoop.scheduleAtFixedRate(this::tick, 50, 50, TimeUnit.MILLISECONDS);
 
         downstream = new TcpClientSession(this.remoteAddress, this.remotePort, protocol);
         disableSrvResolving();
@@ -1098,39 +1100,6 @@ public class GeyserSession implements CommandSender {
     }
 
     /**
-     * Adds a new inventory task.
-     * Inventory tasks are executed one at a time, in order.
-     *
-     * @param task the task to run
-     */
-    public void addInventoryTask(Runnable task) {
-        synchronized (inventoryLock) {
-            inventoryFuture = inventoryFuture.thenRun(task).exceptionally(throwable -> {
-                GeyserConnector.getInstance().getLogger().error("Error processing inventory task", throwable.getCause());
-                return null;
-            });
-        }
-    }
-
-    /**
-     * Adds a new inventory task with a delay.
-     * The delay is achieved by scheduling with the Geyser general thread pool.
-     * Inventory tasks are executed one at a time, in order.
-     *
-     * @param task the delayed task to run
-     * @param delayMillis delay in milliseconds
-     */
-    public void addInventoryTask(Runnable task, long delayMillis) {
-        synchronized (inventoryLock) {
-            Executor delayedExecutor = command -> GeyserConnector.getInstance().getGeneralThreadPool().schedule(command, delayMillis, TimeUnit.MILLISECONDS);
-            inventoryFuture = inventoryFuture.thenRunAsync(task, delayedExecutor).exceptionally(throwable -> {
-                GeyserConnector.getInstance().getLogger().error("Error processing inventory task", throwable.getCause());
-                return null;
-            });
-        }
-    }
-
-    /**
      * @return the next Bedrock item network ID to use for a new item
      */
     public int getNextItemNetId() {
@@ -1231,10 +1200,14 @@ public class GeyserSession implements CommandSender {
      * @param packet the java edition packet from MCProtocolLib
      */
     public void sendDownstreamPacket(Packet packet) {
-        if (downstream != null && (protocol.getSubProtocol().equals(SubProtocol.GAME) || packet.getClass() == LoginPluginResponsePacket.class)) {
-            downstream.send(packet);
-        } else {
-            connector.getLogger().debug("Tried to send downstream packet " + packet.getClass().getSimpleName() + " before connected to the server");
+        if (!closed && this.downstream != null) {
+            this.downstream.getChannel().eventLoop().execute(() -> {
+                if (protocol.getSubProtocol().equals(SubProtocol.GAME) || packet.getClass() == LoginPluginResponsePacket.class) {
+                    downstream.send(packet);
+                } else {
+                    connector.getLogger().debug("Tried to send downstream packet " + packet.getClass().getSimpleName() + " before connected to the server");
+                }
+            });
         }
     }
 

--- a/connector/src/main/java/org/geysermc/connector/network/session/cache/EntityCache.java
+++ b/connector/src/main/java/org/geysermc/connector/network/session/cache/EntityCache.java
@@ -26,6 +26,8 @@
 package org.geysermc.connector.network.session.cache;
 
 import it.unimi.dsi.fastutil.longs.*;
+import it.unimi.dsi.fastutil.objects.Object2ObjectOpenHashMap;
+import it.unimi.dsi.fastutil.objects.ObjectArrayList;
 import it.unimi.dsi.fastutil.objects.ObjectOpenHashSet;
 import lombok.Getter;
 import org.geysermc.connector.entity.Tickable;
@@ -44,15 +46,15 @@ public class EntityCache {
     private final GeyserSession session;
 
     @Getter
-    private Long2ObjectMap<Entity> entities = Long2ObjectMaps.synchronize(new Long2ObjectOpenHashMap<>());
+    private final Long2ObjectMap<Entity> entities = new Long2ObjectOpenHashMap<>();
     /**
      * A list of all entities that must be ticked.
      */
-    private final List<Tickable> tickableEntities = Collections.synchronizedList(new ArrayList<>());
-    private Long2LongMap entityIdTranslations = Long2LongMaps.synchronize(new Long2LongOpenHashMap());
-    private Map<UUID, PlayerEntity> playerEntities = Collections.synchronizedMap(new HashMap<>());
-    private Map<UUID, BossBar> bossBars = Collections.synchronizedMap(new HashMap<>());
-    private final Long2LongMap cachedPlayerEntityLinks = Long2LongMaps.synchronize(new Long2LongOpenHashMap());
+    private final List<Tickable> tickableEntities = new ObjectArrayList<>();
+    private final Long2LongMap entityIdTranslations = new Long2LongOpenHashMap();
+    private final Map<UUID, PlayerEntity> playerEntities = new Object2ObjectOpenHashMap<>();
+    private final Map<UUID, BossBar> bossBars = new Object2ObjectOpenHashMap<>();
+    private final Long2LongMap cachedPlayerEntityLinks = new Long2LongOpenHashMap();
 
     @Getter
     private final AtomicLong nextEntityId = new AtomicLong(2L);
@@ -154,13 +156,6 @@ public class EntityCache {
 
     public void updateBossBars() {
         bossBars.values().forEach(BossBar::updateBossBar);
-    }
-
-    public void clear() {
-        entities = null;
-        entityIdTranslations = null;
-        playerEntities = null;
-        bossBars = null;
     }
 
     public long getCachedPlayerEntityLink(long playerId) {

--- a/connector/src/main/java/org/geysermc/connector/network/translators/PacketTranslatorRegistry.java
+++ b/connector/src/main/java/org/geysermc/connector/network/translators/PacketTranslatorRegistry.java
@@ -89,7 +89,7 @@ public class PacketTranslatorRegistry<T> {
             try {
                 PacketTranslator<P> translator = (PacketTranslator<P>) translators.get(clazz);
                 if (translator != null) {
-                    translator.translate(packet, session);
+                    session.getEventLoop().execute(() -> translator.translate(packet, session));
                     return true;
                 } else {
                     if ((GeyserConnector.getInstance().getPlatformType() != PlatformType.STANDALONE || !(packet instanceof BedrockPacket)) && !IGNORED_PACKETS.contains(clazz)) {

--- a/connector/src/main/java/org/geysermc/connector/network/translators/PacketTranslatorRegistry.java
+++ b/connector/src/main/java/org/geysermc/connector/network/translators/PacketTranslatorRegistry.java
@@ -29,6 +29,7 @@ import com.github.steveice10.mc.protocol.packet.ingame.server.ServerPlayerListDa
 import com.github.steveice10.mc.protocol.packet.ingame.server.world.ServerUpdateLightPacket;
 import com.github.steveice10.packetlib.packet.Packet;
 import com.nukkitx.protocol.bedrock.BedrockPacket;
+import io.netty.channel.EventLoop;
 import it.unimi.dsi.fastutil.objects.ObjectArrayList;
 import org.geysermc.common.PlatformType;
 import org.geysermc.connector.GeyserConnector;
@@ -89,10 +90,11 @@ public class PacketTranslatorRegistry<T> {
             try {
                 PacketTranslator<P> translator = (PacketTranslator<P>) translators.get(clazz);
                 if (translator != null) {
-                    if (session.getEventLoop().inEventLoop()) {
+                    EventLoop eventLoop = session.getEventLoop();
+                    if (eventLoop.inEventLoop()) {
                         translator.translate(packet, session);
                     } else {
-                        session.getEventLoop().execute(() -> translator.translate(packet, session));
+                        eventLoop.execute(() -> translator.translate(packet, session));
                     }
                     return true;
                 } else {

--- a/connector/src/main/java/org/geysermc/connector/network/translators/PacketTranslatorRegistry.java
+++ b/connector/src/main/java/org/geysermc/connector/network/translators/PacketTranslatorRegistry.java
@@ -89,7 +89,11 @@ public class PacketTranslatorRegistry<T> {
             try {
                 PacketTranslator<P> translator = (PacketTranslator<P>) translators.get(clazz);
                 if (translator != null) {
-                    session.getEventLoop().execute(() -> translator.translate(packet, session));
+                    if (session.getEventLoop().inEventLoop()) {
+                        translator.translate(packet, session);
+                    } else {
+                        session.getEventLoop().execute(() -> translator.translate(packet, session));
+                    }
                     return true;
                 } else {
                     if ((GeyserConnector.getInstance().getPlatformType() != PlatformType.STANDALONE || !(packet instanceof BedrockPacket)) && !IGNORED_PACKETS.contains(clazz)) {

--- a/connector/src/main/java/org/geysermc/connector/network/translators/bedrock/BedrockAnimateTranslator.java
+++ b/connector/src/main/java/org/geysermc/connector/network/translators/bedrock/BedrockAnimateTranslator.java
@@ -48,7 +48,7 @@ public class BedrockAnimateTranslator extends PacketTranslator<AnimatePacket> {
         switch (packet.getAction()) {
             case SWING_ARM:
                 // Delay so entity damage can be processed first
-                session.getConnector().getGeneralThreadPool().schedule(() ->
+                session.getEventLoop().schedule(() ->
                         session.sendDownstreamPacket(new ClientPlayerSwingArmPacket(Hand.MAIN_HAND)),
                         25,
                         TimeUnit.MILLISECONDS

--- a/connector/src/main/java/org/geysermc/connector/network/translators/bedrock/BedrockInventoryTransactionTranslator.java
+++ b/connector/src/main/java/org/geysermc/connector/network/translators/bedrock/BedrockInventoryTransactionTranslator.java
@@ -83,26 +83,24 @@ public class BedrockInventoryTransactionTranslator extends PacketTranslator<Inve
                     InventoryActionData containerAction = packet.getActions().get(1);
                     if (worldAction.getSource().getType() == InventorySource.Type.WORLD_INTERACTION
                             && worldAction.getSource().getFlag() == InventorySource.Flag.DROP_ITEM) {
-                        session.addInventoryTask(() -> {
-                            if (session.getPlayerInventory().getHeldItemSlot() != containerAction.getSlot() ||
-                                    session.getPlayerInventory().getItemInHand().isEmpty()) {
-                                return;
-                            }
+                        if (session.getPlayerInventory().getHeldItemSlot() != containerAction.getSlot() ||
+                                session.getPlayerInventory().getItemInHand().isEmpty()) {
+                            return;
+                        }
 
-                            boolean dropAll = worldAction.getToItem().getCount() > 1;
-                            ClientPlayerActionPacket dropAllPacket = new ClientPlayerActionPacket(
-                                    dropAll ? PlayerAction.DROP_ITEM_STACK : PlayerAction.DROP_ITEM,
-                                    BlockUtils.POSITION_ZERO,
-                                    BlockFace.DOWN
-                            );
-                            session.sendDownstreamPacket(dropAllPacket);
+                        boolean dropAll = worldAction.getToItem().getCount() > 1;
+                        ClientPlayerActionPacket dropAllPacket = new ClientPlayerActionPacket(
+                                dropAll ? PlayerAction.DROP_ITEM_STACK : PlayerAction.DROP_ITEM,
+                                BlockUtils.POSITION_ZERO,
+                                BlockFace.DOWN
+                        );
+                        session.sendDownstreamPacket(dropAllPacket);
 
-                            if (dropAll) {
-                                session.getPlayerInventory().setItemInHand(GeyserItemStack.EMPTY);
-                            } else {
-                                session.getPlayerInventory().getItemInHand().sub(1);
-                            }
-                        });
+                        if (dropAll) {
+                            session.getPlayerInventory().setItemInHand(GeyserItemStack.EMPTY);
+                        } else {
+                            session.getPlayerInventory().getItemInHand().sub(1);
+                        }
                     }
                 }
                 break;
@@ -222,7 +220,7 @@ public class BedrockInventoryTransactionTranslator extends PacketTranslator<Inve
                                     if (session.isSneaking() || blockState != BlockRegistries.JAVA_IDENTIFIERS.get("minecraft:crafting_table")) {
                                         // Delay the interaction in case the client doesn't intend to actually use the bucket
                                         // See BedrockActionTranslator.java
-                                        session.setBucketScheduledFuture(session.getConnector().getGeneralThreadPool().schedule(() -> {
+                                        session.setBucketScheduledFuture(session.getEventLoop().schedule(() -> {
                                             ClientPlayerUseItemPacket itemPacket = new ClientPlayerUseItemPacket(Hand.MAIN_HAND);
                                             session.sendDownstreamPacket(itemPacket);
                                         }, 5, TimeUnit.MILLISECONDS));

--- a/connector/src/main/java/org/geysermc/connector/network/translators/bedrock/BedrockItemStackRequestTranslator.java
+++ b/connector/src/main/java/org/geysermc/connector/network/translators/bedrock/BedrockItemStackRequestTranslator.java
@@ -45,6 +45,6 @@ public class BedrockItemStackRequestTranslator extends PacketTranslator<ItemStac
             return;
 
         InventoryTranslator translator = session.getInventoryTranslator();
-        session.addInventoryTask(() -> translator.translateRequests(session, inventory, packet.getRequests()));
+        translator.translateRequests(session, inventory, packet.getRequests());
     }
 }

--- a/connector/src/main/java/org/geysermc/connector/network/translators/bedrock/entity/BedrockEntityEventTranslator.java
+++ b/connector/src/main/java/org/geysermc/connector/network/translators/bedrock/entity/BedrockEntityEventTranslator.java
@@ -37,6 +37,8 @@ import org.geysermc.connector.network.session.GeyserSession;
 import org.geysermc.connector.network.translators.PacketTranslator;
 import org.geysermc.connector.network.translators.Translator;
 
+import java.util.concurrent.TimeUnit;
+
 @Translator(packet = EntityEventPacket.class)
 public class BedrockEntityEventTranslator extends PacketTranslator<EntityEventPacket> {
 
@@ -48,12 +50,10 @@ public class BedrockEntityEventTranslator extends PacketTranslator<EntityEventPa
                 session.sendUpstreamPacket(packet);
                 return;
             case COMPLETE_TRADE:
-                session.addInventoryTask(() -> {
-                    ClientSelectTradePacket selectTradePacket = new ClientSelectTradePacket(packet.getData());
-                    session.sendDownstreamPacket(selectTradePacket);
-                });
+                ClientSelectTradePacket selectTradePacket = new ClientSelectTradePacket(packet.getData());
+                session.sendDownstreamPacket(selectTradePacket);
 
-                session.addInventoryTask(() -> {
+                session.getEventLoop().schedule(() -> {
                     Entity villager = session.getPlayerEntity();
                     Inventory openInventory = session.getOpenInventory();
                     if (openInventory instanceof MerchantContainer) {
@@ -66,7 +66,7 @@ public class BedrockEntityEventTranslator extends PacketTranslator<EntityEventPa
                             villager.updateBedrockMetadata(session);
                         }
                     }
-                }, 100);
+                }, 100, TimeUnit.MILLISECONDS);
                 return;
         }
         session.getConnector().getLogger().debug("Did not translate incoming EntityEventPacket: " + packet.toString());

--- a/connector/src/main/java/org/geysermc/connector/network/translators/java/JavaLoginSuccessTranslator.java
+++ b/connector/src/main/java/org/geysermc/connector/network/translators/java/JavaLoginSuccessTranslator.java
@@ -1,0 +1,61 @@
+/*
+ * Copyright (c) 2019-2021 GeyserMC. http://geysermc.org
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ *
+ * @author GeyserMC
+ * @link https://github.com/GeyserMC/Geyser
+ */
+
+package org.geysermc.connector.network.translators.java;
+
+import com.github.steveice10.mc.auth.data.GameProfile;
+import com.github.steveice10.mc.protocol.packet.login.server.LoginSuccessPacket;
+import org.geysermc.connector.common.AuthType;
+import org.geysermc.connector.entity.player.PlayerEntity;
+import org.geysermc.connector.network.session.GeyserSession;
+import org.geysermc.connector.network.translators.PacketTranslator;
+import org.geysermc.connector.network.translators.Translator;
+import org.geysermc.connector.skin.SkinManager;
+
+@Translator(packet = LoginSuccessPacket.class)
+public class JavaLoginSuccessTranslator extends PacketTranslator<LoginSuccessPacket> {
+
+    @Override
+    public void translate(LoginSuccessPacket packet, GeyserSession session) {
+        PlayerEntity playerEntity = session.getPlayerEntity();
+        AuthType remoteAuthType = session.getRemoteAuthType();
+
+        // Required, or else Floodgate players break with Spigot chunk caching
+        GameProfile profile = packet.getProfile();
+        playerEntity.setUsername(profile.getName());
+        playerEntity.setUuid(profile.getId());
+
+        // Check if they are not using a linked account
+        if (remoteAuthType == AuthType.OFFLINE || playerEntity.getUuid().getMostSignificantBits() == 0) {
+            SkinManager.handleBedrockSkin(playerEntity, session.getClientData());
+        }
+
+        if (remoteAuthType == AuthType.FLOODGATE) {
+            // We'll send the skin upload a bit after the handshake packet (aka this packet),
+            // because otherwise the global server returns the data too fast.
+            session.getAuthData().upload(session.getConnector());
+        }
+    }
+}

--- a/connector/src/main/java/org/geysermc/connector/network/translators/java/JavaRespawnTranslator.java
+++ b/connector/src/main/java/org/geysermc/connector/network/translators/java/JavaRespawnTranslator.java
@@ -49,11 +49,9 @@ public class JavaRespawnTranslator extends PacketTranslator<ServerRespawnPacket>
         entity.setHealth(entity.getMaxHealth());
         entity.getAttributes().put(GeyserAttributeType.HEALTH, entity.createHealthAttribute());
 
-        session.addInventoryTask(() -> {
-            session.setInventoryTranslator(InventoryTranslator.PLAYER_INVENTORY_TRANSLATOR);
-            session.setOpenInventory(null);
-            session.setClosingInventory(false);
-        });
+        session.setInventoryTranslator(InventoryTranslator.PLAYER_INVENTORY_TRANSLATOR);
+        session.setOpenInventory(null);
+        session.setClosingInventory(false);
 
         SetPlayerGameTypePacket playerGameTypePacket = new SetPlayerGameTypePacket();
         playerGameTypePacket.setGamemode(packet.getGamemode().ordinal());

--- a/connector/src/main/java/org/geysermc/connector/network/translators/java/entity/player/JavaPlayerChangeHeldItemTranslator.java
+++ b/connector/src/main/java/org/geysermc/connector/network/translators/java/entity/player/JavaPlayerChangeHeldItemTranslator.java
@@ -36,14 +36,12 @@ public class JavaPlayerChangeHeldItemTranslator extends PacketTranslator<ServerP
 
     @Override
     public void translate(ServerPlayerChangeHeldItemPacket packet, GeyserSession session) {
-        session.addInventoryTask(() -> {
-            PlayerHotbarPacket hotbarPacket = new PlayerHotbarPacket();
-            hotbarPacket.setContainerId(0);
-            hotbarPacket.setSelectedHotbarSlot(packet.getSlot());
-            hotbarPacket.setSelectHotbarSlot(true);
-            session.sendUpstreamPacket(hotbarPacket);
+        PlayerHotbarPacket hotbarPacket = new PlayerHotbarPacket();
+        hotbarPacket.setContainerId(0);
+        hotbarPacket.setSelectedHotbarSlot(packet.getSlot());
+        hotbarPacket.setSelectHotbarSlot(true);
+        session.sendUpstreamPacket(hotbarPacket);
 
-            session.getPlayerInventory().setHeldItemSlot(packet.getSlot());
-        });
+        session.getPlayerInventory().setHeldItemSlot(packet.getSlot());
     }
 }

--- a/connector/src/main/java/org/geysermc/connector/network/translators/java/window/JavaCloseWindowTranslator.java
+++ b/connector/src/main/java/org/geysermc/connector/network/translators/java/window/JavaCloseWindowTranslator.java
@@ -36,9 +36,8 @@ public class JavaCloseWindowTranslator extends PacketTranslator<ServerCloseWindo
 
     @Override
     public void translate(ServerCloseWindowPacket packet, GeyserSession session) {
-        session.addInventoryTask(() ->
-                // Sometimes the server can request a window close of ID 0... when the window isn't even open
-                // Don't confirm in this instance
-                InventoryUtils.closeInventory(session, packet.getWindowId(), (session.getOpenInventory() != null && session.getOpenInventory().getId() == packet.getWindowId())));
+        // Sometimes the server can request a window close of ID 0... when the window isn't even open
+        // Don't confirm in this instance
+        InventoryUtils.closeInventory(session, packet.getWindowId(), (session.getOpenInventory() != null && session.getOpenInventory().getId() == packet.getWindowId()));
     }
 }

--- a/connector/src/main/java/org/geysermc/connector/network/translators/java/window/JavaOpenWindowTranslator.java
+++ b/connector/src/main/java/org/geysermc/connector/network/translators/java/window/JavaOpenWindowTranslator.java
@@ -31,48 +31,46 @@ import org.geysermc.connector.inventory.Inventory;
 import org.geysermc.connector.network.session.GeyserSession;
 import org.geysermc.connector.network.translators.PacketTranslator;
 import org.geysermc.connector.network.translators.Translator;
+import org.geysermc.connector.network.translators.chat.MessageTranslator;
 import org.geysermc.connector.network.translators.inventory.InventoryTranslator;
 import org.geysermc.connector.utils.InventoryUtils;
 import org.geysermc.connector.utils.LocaleUtils;
-import org.geysermc.connector.network.translators.chat.MessageTranslator;
 
 @Translator(packet = ServerOpenWindowPacket.class)
 public class JavaOpenWindowTranslator extends PacketTranslator<ServerOpenWindowPacket> {
 
     @Override
     public void translate(ServerOpenWindowPacket packet, GeyserSession session) {
-        session.addInventoryTask(() -> {
-            if (packet.getWindowId() == 0) {
-                return;
-            }
+        if (packet.getWindowId() == 0) {
+            return;
+        }
 
-            InventoryTranslator newTranslator = InventoryTranslator.INVENTORY_TRANSLATORS.get(packet.getType());
-            Inventory openInventory = session.getOpenInventory();
-            //No translator exists for this window type. Close all windows and return.
-            if (newTranslator == null) {
-                if (openInventory != null) {
-                    InventoryUtils.closeInventory(session, openInventory.getId(), true);
-                }
-                ClientCloseWindowPacket closeWindowPacket = new ClientCloseWindowPacket(packet.getWindowId());
-                session.sendDownstreamPacket(closeWindowPacket);
-                return;
-            }
-
-            String name = MessageTranslator.convertMessageLenient(packet.getName(), session.getLocale());
-            name = LocaleUtils.getLocaleString(name, session.getLocale());
-
-            Inventory newInventory = newTranslator.createInventory(name, packet.getWindowId(), packet.getType(), session.getPlayerInventory());
+        InventoryTranslator newTranslator = InventoryTranslator.INVENTORY_TRANSLATORS.get(packet.getType());
+        Inventory openInventory = session.getOpenInventory();
+        //No translator exists for this window type. Close all windows and return.
+        if (newTranslator == null) {
             if (openInventory != null) {
-                // If the window type is the same, don't close.
-                // In rare cases, inventories can do funny things where it keeps the same window type up but change the contents.
-                if (openInventory.getWindowType() != packet.getType()) {
-                    // Sometimes the server can double-open an inventory with the same ID - don't confirm in that instance.
-                    InventoryUtils.closeInventory(session, openInventory.getId(), openInventory.getId() != packet.getWindowId());
-                }
+                InventoryUtils.closeInventory(session, openInventory.getId(), true);
             }
+            ClientCloseWindowPacket closeWindowPacket = new ClientCloseWindowPacket(packet.getWindowId());
+            session.sendDownstreamPacket(closeWindowPacket);
+            return;
+        }
 
-            session.setInventoryTranslator(newTranslator);
-            InventoryUtils.openInventory(session, newInventory);
-        });
+        String name = MessageTranslator.convertMessageLenient(packet.getName(), session.getLocale());
+        name = LocaleUtils.getLocaleString(name, session.getLocale());
+
+        Inventory newInventory = newTranslator.createInventory(name, packet.getWindowId(), packet.getType(), session.getPlayerInventory());
+        if (openInventory != null) {
+            // If the window type is the same, don't close.
+            // In rare cases, inventories can do funny things where it keeps the same window type up but change the contents.
+            if (openInventory.getWindowType() != packet.getType()) {
+                // Sometimes the server can double-open an inventory with the same ID - don't confirm in that instance.
+                InventoryUtils.closeInventory(session, openInventory.getId(), openInventory.getId() != packet.getWindowId());
+            }
+        }
+
+        session.setInventoryTranslator(newTranslator);
+        InventoryUtils.openInventory(session, newInventory);
     }
 }

--- a/connector/src/main/java/org/geysermc/connector/network/translators/java/window/JavaSetSlotTranslator.java
+++ b/connector/src/main/java/org/geysermc/connector/network/translators/java/window/JavaSetSlotTranslator.java
@@ -59,39 +59,37 @@ public class JavaSetSlotTranslator extends PacketTranslator<ServerSetSlotPacket>
 
     @Override
     public void translate(ServerSetSlotPacket packet, GeyserSession session) {
-        session.addInventoryTask(() -> {
-            if (packet.getWindowId() == 255) { //cursor
-                GeyserItemStack newItem = GeyserItemStack.from(packet.getItem());
-                session.getPlayerInventory().setCursor(newItem, session);
-                InventoryUtils.updateCursor(session);
-                return;
+        if (packet.getWindowId() == 255) { //cursor
+            GeyserItemStack newItem = GeyserItemStack.from(packet.getItem());
+            session.getPlayerInventory().setCursor(newItem, session);
+            InventoryUtils.updateCursor(session);
+            return;
+        }
+
+        //TODO: support window id -2, should update player inventory
+        Inventory inventory = InventoryUtils.getInventory(session, packet.getWindowId());
+        if (inventory == null)
+            return;
+
+        inventory.setStateId(packet.getStateId());
+
+        InventoryTranslator translator = session.getInventoryTranslator();
+        if (translator != null) {
+            if (session.getCraftingGridFuture() != null) {
+                session.getCraftingGridFuture().cancel(false);
             }
+            session.setCraftingGridFuture(session.getEventLoop().schedule(() -> updateCraftingGrid(session, packet, inventory, translator), 150, TimeUnit.MILLISECONDS));
 
-            //TODO: support window id -2, should update player inventory
-            Inventory inventory = InventoryUtils.getInventory(session, packet.getWindowId());
-            if (inventory == null)
-                return;
-
-            inventory.setStateId(packet.getStateId());
-
-            InventoryTranslator translator = session.getInventoryTranslator();
-            if (translator != null) {
-                if (session.getCraftingGridFuture() != null) {
-                    session.getCraftingGridFuture().cancel(false);
-                }
-                session.setCraftingGridFuture(session.getConnector().getGeneralThreadPool().schedule(() -> session.addInventoryTask(() -> updateCraftingGrid(session, packet, inventory, translator)), 150, TimeUnit.MILLISECONDS));
-
-                GeyserItemStack newItem = GeyserItemStack.from(packet.getItem());
-                if (packet.getWindowId() == 0 && !(translator instanceof PlayerInventoryTranslator)) {
-                    // In rare cases, the window ID can still be 0 but Java treats it as valid
-                    session.getPlayerInventory().setItem(packet.getSlot(), newItem, session);
-                    InventoryTranslator.PLAYER_INVENTORY_TRANSLATOR.updateSlot(session, session.getPlayerInventory(), packet.getSlot());
-                } else {
-                    inventory.setItem(packet.getSlot(), newItem, session);
-                    translator.updateSlot(session, inventory, packet.getSlot());
-                }
+            GeyserItemStack newItem = GeyserItemStack.from(packet.getItem());
+            if (packet.getWindowId() == 0 && !(translator instanceof PlayerInventoryTranslator)) {
+                // In rare cases, the window ID can still be 0 but Java treats it as valid
+                session.getPlayerInventory().setItem(packet.getSlot(), newItem, session);
+                InventoryTranslator.PLAYER_INVENTORY_TRANSLATOR.updateSlot(session, session.getPlayerInventory(), packet.getSlot());
+            } else {
+                inventory.setItem(packet.getSlot(), newItem, session);
+                translator.updateSlot(session, inventory, packet.getSlot());
             }
-        });
+        }
     }
 
     private static void updateCraftingGrid(GeyserSession session, ServerSetSlotPacket packet, Inventory inventory, InventoryTranslator translator) {

--- a/connector/src/main/java/org/geysermc/connector/network/translators/java/window/JavaWindowItemsTranslator.java
+++ b/connector/src/main/java/org/geysermc/connector/network/translators/java/window/JavaWindowItemsTranslator.java
@@ -39,25 +39,23 @@ public class JavaWindowItemsTranslator extends PacketTranslator<ServerWindowItem
 
     @Override
     public void translate(ServerWindowItemsPacket packet, GeyserSession session) {
-        session.addInventoryTask(() -> {
-            Inventory inventory = InventoryUtils.getInventory(session, packet.getWindowId());
-            if (inventory == null)
-                return;
+        Inventory inventory = InventoryUtils.getInventory(session, packet.getWindowId());
+        if (inventory == null)
+            return;
 
-            inventory.setStateId(packet.getStateId());
+        inventory.setStateId(packet.getStateId());
 
-            for (int i = 0; i < packet.getItems().length; i++) {
-                GeyserItemStack newItem = GeyserItemStack.from(packet.getItems()[i]);
-                inventory.setItem(i, newItem, session);
-            }
+        for (int i = 0; i < packet.getItems().length; i++) {
+            GeyserItemStack newItem = GeyserItemStack.from(packet.getItems()[i]);
+            inventory.setItem(i, newItem, session);
+        }
 
-            InventoryTranslator translator = session.getInventoryTranslator();
-            if (translator != null) {
-                translator.updateInventory(session, inventory);
-            }
+        InventoryTranslator translator = session.getInventoryTranslator();
+        if (translator != null) {
+            translator.updateInventory(session, inventory);
+        }
 
-            session.getPlayerInventory().setCursor(GeyserItemStack.from(packet.getCarriedItem()), session);
-            InventoryUtils.updateCursor(session);
-        });
+        session.getPlayerInventory().setCursor(GeyserItemStack.from(packet.getCarriedItem()), session);
+        InventoryUtils.updateCursor(session);
     }
 }

--- a/connector/src/main/java/org/geysermc/connector/network/translators/java/window/JavaWindowPropertyTranslator.java
+++ b/connector/src/main/java/org/geysermc/connector/network/translators/java/window/JavaWindowPropertyTranslator.java
@@ -38,15 +38,13 @@ public class JavaWindowPropertyTranslator extends PacketTranslator<ServerWindowP
 
     @Override
     public void translate(ServerWindowPropertyPacket packet, GeyserSession session) {
-        session.addInventoryTask(() -> {
-            Inventory inventory = InventoryUtils.getInventory(session, packet.getWindowId());
-            if (inventory == null)
-                return;
+        Inventory inventory = InventoryUtils.getInventory(session, packet.getWindowId());
+        if (inventory == null)
+            return;
 
-            InventoryTranslator translator = session.getInventoryTranslator();
-            if (translator != null) {
-                translator.updateProperty(session, inventory, packet.getRawProperty(), packet.getValue());
-            }
-        });
+        InventoryTranslator translator = session.getInventoryTranslator();
+        if (translator != null) {
+            translator.updateProperty(session, inventory, packet.getRawProperty(), packet.getValue());
+        }
     }
 }

--- a/connector/src/main/java/org/geysermc/connector/network/translators/world/block/entity/SkullBlockEntityTranslator.java
+++ b/connector/src/main/java/org/geysermc/connector/network/translators/world/block/entity/SkullBlockEntityTranslator.java
@@ -147,7 +147,7 @@ public class SkullBlockEntityTranslator extends BlockEntityTranslator implements
             if (session.getUpstream().isInitialized()) {
                 player.spawnEntity(session);
 
-                SkullSkinManager.requestAndHandleSkin(player, session, (skin -> session.getConnector().getGeneralThreadPool().schedule(() -> {
+                SkullSkinManager.requestAndHandleSkin(player, session, (skin -> session.getEventLoop().schedule(() -> {
                     // Delay to minimize split-second "player" pop-in
                     player.getMetadata().getFlags().setFlag(EntityFlag.INVISIBLE, false);
                     player.updateBedrockMetadata(session);

--- a/connector/src/main/java/org/geysermc/connector/utils/InventoryUtils.java
+++ b/connector/src/main/java/org/geysermc/connector/utils/InventoryUtils.java
@@ -37,7 +37,6 @@ import com.nukkitx.protocol.bedrock.data.inventory.ContainerId;
 import com.nukkitx.protocol.bedrock.data.inventory.ItemData;
 import com.nukkitx.protocol.bedrock.packet.InventorySlotPacket;
 import com.nukkitx.protocol.bedrock.packet.PlayerHotbarPacket;
-import org.geysermc.connector.GeyserConnector;
 import org.geysermc.connector.common.ChatColor;
 import org.geysermc.connector.inventory.Container;
 import org.geysermc.connector.inventory.GeyserItemStack;
@@ -80,17 +79,16 @@ public class InventoryUtils {
         if (translator != null) {
             translator.prepareInventory(session, inventory);
             if (translator instanceof DoubleChestInventoryTranslator && !((Container) inventory).isUsingRealBlock()) {
-                GeyserConnector.getInstance().getGeneralThreadPool().schedule(() ->
-                    session.addInventoryTask(() -> {
-                        Inventory openInv = session.getOpenInventory();
-                        if (openInv != null && openInv.getId() == inventory.getId()) {
-                            translator.openInventory(session, inventory);
-                            translator.updateInventory(session, inventory);
-                        } else if (openInv != null && openInv.isPending()) {
-                            // Presumably, this inventory is no longer relevant, and the client doesn't care about it
-                            displayInventory(session, openInv);
-                        }
-                }), 200, TimeUnit.MILLISECONDS);
+                session.getEventLoop().schedule(() -> {
+                    Inventory openInv = session.getOpenInventory();
+                    if (openInv != null && openInv.getId() == inventory.getId()) {
+                        translator.openInventory(session, inventory);
+                        translator.updateInventory(session, inventory);
+                    } else if (openInv != null && openInv.isPending()) {
+                        // Presumably, this inventory is no longer relevant, and the client doesn't care about it
+                        displayInventory(session, openInv);
+                    }
+                }, 200, TimeUnit.MILLISECONDS);
             } else {
                 translator.openInventory(session, inventory);
                 translator.updateInventory(session, inventory);


### PR DESCRIPTION
This removes a lot of concurrency checking that needs to be done, because there should be no way two packets can be handled at the same time.