### PR TITLE
Ability to change NTP server from config

### DIFF
--- a/connector/src/main/java/org/geysermc/connector/GeyserConnector.java
+++ b/connector/src/main/java/org/geysermc/connector/GeyserConnector.java
@@ -191,7 +191,7 @@ public class GeyserConnector {
 
         TimeSyncer timeSyncer = null;
         if (config.getRemote().getAuthType() == AuthType.FLOODGATE) {
-            timeSyncer = new TimeSyncer(Constants.NTP_SERVER);
+            timeSyncer = new TimeSyncer(config.getNtpServer());
             try {
                 Key key = new AesKeyProducer().produceFrom(config.getFloodgateKeyPath());
                 cipher = new AesCipher(new Base64Topping());

--- a/connector/src/main/java/org/geysermc/connector/configuration/GeyserConfiguration.java
+++ b/connector/src/main/java/org/geysermc/connector/configuration/GeyserConfiguration.java
@@ -38,7 +38,7 @@ import java.util.Map;
 public interface GeyserConfiguration {
 
     // Modify this when you introduce breaking changes into the config
-    int CURRENT_CONFIG_VERSION = 4;
+    int CURRENT_CONFIG_VERSION = 5;
 
     IBedrockConfiguration getBedrock();
 
@@ -172,6 +172,8 @@ public interface GeyserConfiguration {
     int getMtu();
 
     boolean isUseDirectConnection();
+
+    String getNtpServer();
 
     int getConfigVersion();
 

--- a/connector/src/main/java/org/geysermc/connector/configuration/GeyserConfiguration.java
+++ b/connector/src/main/java/org/geysermc/connector/configuration/GeyserConfiguration.java
@@ -38,7 +38,7 @@ import java.util.Map;
 public interface GeyserConfiguration {
 
     // Modify this when you introduce breaking changes into the config
-    int CURRENT_CONFIG_VERSION = 5;
+    int CURRENT_CONFIG_VERSION = 4;
 
     IBedrockConfiguration getBedrock();
 

--- a/connector/src/main/java/org/geysermc/connector/configuration/GeyserJacksonConfiguration.java
+++ b/connector/src/main/java/org/geysermc/connector/configuration/GeyserJacksonConfiguration.java
@@ -250,6 +250,9 @@ public abstract class GeyserJacksonConfiguration implements GeyserConfiguration 
     @JsonProperty("use-direct-connection")
     private boolean useDirectConnection = true;
 
+    @JsonProperty("ntp-server")
+    private String ntpServer = "time.cloudflare.com";
+
     @JsonProperty("config-version")
     private int configVersion = 0;
 

--- a/connector/src/main/java/org/geysermc/connector/utils/Constants.java
+++ b/connector/src/main/java/org/geysermc/connector/utils/Constants.java
@@ -30,7 +30,6 @@ import java.net.URISyntaxException;
 
 public final class Constants {
     public static final URI GLOBAL_API_WS_URI;
-    public static final String NTP_SERVER = "time.cloudflare.com";
 
     public static final String NEWS_OVERVIEW_URL = "https://api.geysermc.org/v1/news";
     public static final String NEWS_PROJECT_NAME = "geyser";

--- a/connector/src/main/resources/config.yml
+++ b/connector/src/main/resources/config.yml
@@ -80,7 +80,7 @@ floodgate-key-file: key.pem
 #    microsoft-account: true # Whether the account is a Mojang or Microsoft account.
 #
 #  bluerkelp2:
-#    email: not_really_my_email_address_mr_minecrafter53267@gmail.com
+#    email: not_really_my_email_address_mr_minecrafter53267@gmail.com 
 #    password: "this isn't really my password"
 #    microsoft-account: false
 

--- a/connector/src/main/resources/config.yml
+++ b/connector/src/main/resources/config.yml
@@ -204,4 +204,4 @@ use-direct-connection: true
 # NTP server used to synchronize time
 ntp-server: time.cloudflare.com
 
-config-version: 5
+config-version: 4

--- a/connector/src/main/resources/config.yml
+++ b/connector/src/main/resources/config.yml
@@ -79,8 +79,8 @@ floodgate-key-file: key.pem
 #    password: javaccountpassword123 # Your Minecraft: Java Edition password
 #    microsoft-account: true # Whether the account is a Mojang or Microsoft account.
 #
-#  bluerkelp2: 
-#    email: not_really_my_email_address_mr_minecrafter53267@gmail.com 
+#  bluerkelp2:
+#    email: not_really_my_email_address_mr_minecrafter53267@gmail.com
 #    password: "this isn't really my password"
 #    microsoft-account: false
 
@@ -201,4 +201,7 @@ enable-proxy-connections: false
 # If disabled on plugin versions, expect performance decrease and latency increase
 use-direct-connection: true
 
-config-version: 4
+# NTP server used to synchronize time
+ntp-server: time.cloudflare.com
+
+config-version: 5

--- a/connector/src/main/resources/config.yml
+++ b/connector/src/main/resources/config.yml
@@ -79,7 +79,7 @@ floodgate-key-file: key.pem
 #    password: javaccountpassword123 # Your Minecraft: Java Edition password
 #    microsoft-account: true # Whether the account is a Mojang or Microsoft account.
 #
-#  bluerkelp2:
+#  bluerkelp2: 
 #    email: not_really_my_email_address_mr_minecrafter53267@gmail.com 
 #    password: "this isn't really my password"
 #    microsoft-account: false


### PR DESCRIPTION
I added ability to change NTP server used to sync time into config, so you are able to use different server in case you cannot use cloudflare's `time.cloudflare.com`. I personally cannot use it, because my hosting blocks it and not willing to unblock it...
Discussed on https://github.com/GeyserMC/Geyser/issues/2330