### PR TITLE
Update Config Warning

### DIFF
--- a/connector/src/main/resources/config.yml
+++ b/connector/src/main/resources/config.yml
@@ -59,7 +59,6 @@ remote:
   forward-hostname: false
 
 # Allows the overworld world height to be extended from 0 - 255 to -64 - 319. This option cannot be changed during a reload.
-# 1.17.0-1.17.2 Bedrock clients cannot connect with this option enabled.
 # Performance issues and/or additional bugs may occur for Bedrock clients as this is an experimental toggle on their end.
 extended-world-height: false
 


### PR DESCRIPTION
Since Bedrock Clients Below 1.17.10 are no longer supported anyway, this warning should be removed. For the Extended World Height Option
# 1.17.0-1.17.2 Bedrock clients cannot connect with this option enabled.