### PR TITLE
Update Inventory.java to not throw error

### DIFF
--- a/connector/src/main/java/org/geysermc/connector/inventory/Inventory.java
+++ b/connector/src/main/java/org/geysermc/connector/inventory/Inventory.java
@@ -95,7 +95,7 @@ public class Inventory {
     }
 
     public GeyserItemStack getItem(int slot) {
-        if (slot > this.size) {
+        if (slot >= this.size) {
             GeyserConnector.getInstance().getLogger().debug("Tried to get an item out of bounds! " + this);
             return GeyserItemStack.EMPTY;
         }


### PR DESCRIPTION
This change prevents an ArrayIndexOutOfBoundsException from being thrown on line 102.