### PR TITLE
Remove commands from autocomplete/help list that cannot be run

### DIFF
--- a/bootstrap/bungeecord/src/main/java/org/geysermc/platform/bungeecord/command/BungeeCommandSender.java
+++ b/bootstrap/bungeecord/src/main/java/org/geysermc/platform/bungeecord/command/BungeeCommandSender.java
@@ -63,4 +63,9 @@ public class BungeeCommandSender implements CommandSender {
         }
         return LanguageUtils.getDefaultLocale();
     }
+
+    @Override
+    public boolean hasPermission(String permission) {
+        return handle.hasPermission(permission);
+    }
 }

--- a/bootstrap/bungeecord/src/main/java/org/geysermc/platform/bungeecord/command/GeyserBungeeCommandExecutor.java
+++ b/bootstrap/bungeecord/src/main/java/org/geysermc/platform/bungeecord/command/GeyserBungeeCommandExecutor.java
@@ -86,10 +86,20 @@ public class GeyserBungeeCommandExecutor extends Command implements TabExecutor 
         List<String> availableCommands = new ArrayList<>();
 
         if (args.length == 1) {
-            // Only show commands they have permission to use
             Map<String, GeyserCommand> commands = connector.getCommandManager().getCommands();
+
+            // Need to know for the commands that are bedrock only
+            boolean isBedrockPlayer = this.commandExecutor.getGeyserSession(new BungeeCommandSender(sender)) != null;
+
+            // Only show commands they have permission to use
             for (String name : commands.keySet()) {
-                if (sender.hasPermission(commands.get(name).getPermission())) {
+                GeyserCommand command = commands.get(name);
+                if (sender.hasPermission(command.getPermission())) {
+
+                    if (command.isBedrockOnly() && !isBedrockPlayer) {
+                        continue;
+                    }
+
                     availableCommands.add(name);
                 }
             }

--- a/bootstrap/bungeecord/src/main/java/org/geysermc/platform/bungeecord/command/GeyserBungeeCommandExecutor.java
+++ b/bootstrap/bungeecord/src/main/java/org/geysermc/platform/bungeecord/command/GeyserBungeeCommandExecutor.java
@@ -35,10 +35,8 @@ import org.geysermc.connector.command.GeyserCommand;
 import org.geysermc.connector.network.session.GeyserSession;
 import org.geysermc.connector.utils.LanguageUtils;
 
-import java.util.ArrayList;
 import java.util.Arrays;
-import java.util.List;
-import java.util.Map;
+import java.util.Collections;
 
 public class GeyserBungeeCommandExecutor extends Command implements TabExecutor {
 
@@ -83,28 +81,10 @@ public class GeyserBungeeCommandExecutor extends Command implements TabExecutor 
 
     @Override
     public Iterable<String> onTabComplete(CommandSender sender, String[] args) {
-        List<String> availableCommands = new ArrayList<>();
-
         if (args.length == 1) {
-            Map<String, GeyserCommand> commands = connector.getCommandManager().getCommands();
-
-            // Need to know for the commands that are bedrock only
-            boolean isBedrockPlayer = this.commandExecutor.getGeyserSession(new BungeeCommandSender(sender)) != null;
-
-            // Only show commands they have permission to use
-            for (String name : commands.keySet()) {
-                GeyserCommand command = commands.get(name);
-                if (sender.hasPermission(command.getPermission())) {
-
-                    if (command.isBedrockOnly() && !isBedrockPlayer) {
-                        continue;
-                    }
-
-                    availableCommands.add(name);
-                }
-            }
+            return commandExecutor.tabComplete(new BungeeCommandSender(sender));
+        } else {
+            return Collections.emptyList();
         }
-
-        return availableCommands;
     }
 }

--- a/bootstrap/bungeecord/src/main/java/org/geysermc/platform/bungeecord/command/GeyserBungeeCommandExecutor.java
+++ b/bootstrap/bungeecord/src/main/java/org/geysermc/platform/bungeecord/command/GeyserBungeeCommandExecutor.java
@@ -37,6 +37,8 @@ import org.geysermc.connector.utils.LanguageUtils;
 
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.List;
+import java.util.Map;
 
 public class GeyserBungeeCommandExecutor extends Command implements TabExecutor {
 
@@ -81,9 +83,18 @@ public class GeyserBungeeCommandExecutor extends Command implements TabExecutor 
 
     @Override
     public Iterable<String> onTabComplete(CommandSender sender, String[] args) {
+        List<String> availableCommands = new ArrayList<>();
+
         if (args.length == 1) {
-            return connector.getCommandManager().getCommandNames();
+            // Only show commands they have permission to use
+            Map<String, GeyserCommand> commands = connector.getCommandManager().getCommands();
+            for (String name : commands.keySet()) {
+                if (sender.hasPermission(commands.get(name).getPermission())) {
+                    availableCommands.add(name);
+                }
+            }
         }
-        return new ArrayList<>();
+
+        return availableCommands;
     }
 }

--- a/bootstrap/spigot/src/main/java/org/geysermc/platform/spigot/command/GeyserSpigotCommandExecutor.java
+++ b/bootstrap/spigot/src/main/java/org/geysermc/platform/spigot/command/GeyserSpigotCommandExecutor.java
@@ -35,10 +35,9 @@ import org.geysermc.connector.command.GeyserCommand;
 import org.geysermc.connector.network.session.GeyserSession;
 import org.geysermc.connector.utils.LanguageUtils;
 
-import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.List;
-import java.util.Map;
 
 public class GeyserSpigotCommandExecutor extends CommandExecutor implements TabExecutor {
 
@@ -78,28 +77,9 @@ public class GeyserSpigotCommandExecutor extends CommandExecutor implements TabE
 
     @Override
     public List<String> onTabComplete(CommandSender sender, Command command, String label, String[] args) {
-        List<String> availableCommands = new ArrayList<>();
-
         if (args.length == 1) {
-            Map<String, GeyserCommand> commands = connector.getCommandManager().getCommands();
-
-            // Need to know for the commands that are bedrock only
-            boolean isBedrockPlayer = getGeyserSession(new SpigotCommandSender(sender)) != null;
-
-            // Only show commands they have permission to use
-            for (String name : commands.keySet()) {
-                GeyserCommand geyserCommand = commands.get(name);
-                if (sender.hasPermission(geyserCommand.getPermission())) {
-
-                    if (geyserCommand.isBedrockOnly() && !isBedrockPlayer) {
-                        continue;
-                    }
-
-                    availableCommands.add(name);
-                }
-            }
+            return tabComplete(new SpigotCommandSender(sender));
         }
-
-        return availableCommands;
+        return Collections.emptyList();
     }
 }

--- a/bootstrap/spigot/src/main/java/org/geysermc/platform/spigot/command/GeyserSpigotCommandExecutor.java
+++ b/bootstrap/spigot/src/main/java/org/geysermc/platform/spigot/command/GeyserSpigotCommandExecutor.java
@@ -81,10 +81,20 @@ public class GeyserSpigotCommandExecutor extends CommandExecutor implements TabE
         List<String> availableCommands = new ArrayList<>();
 
         if (args.length == 1) {
-            // Only show commands they have permission to use
             Map<String, GeyserCommand> commands = connector.getCommandManager().getCommands();
+
+            // Need to know for the commands that are bedrock only
+            boolean isBedrockPlayer = getGeyserSession(new SpigotCommandSender(sender)) != null;
+
+            // Only show commands they have permission to use
             for (String name : commands.keySet()) {
-                if (sender.hasPermission(commands.get(name).getPermission())) {
+                GeyserCommand geyserCommand = commands.get(name);
+                if (sender.hasPermission(geyserCommand.getPermission())) {
+
+                    if (geyserCommand.isBedrockOnly() && !isBedrockPlayer) {
+                        continue;
+                    }
+
                     availableCommands.add(name);
                 }
             }

--- a/bootstrap/spigot/src/main/java/org/geysermc/platform/spigot/command/GeyserSpigotCommandExecutor.java
+++ b/bootstrap/spigot/src/main/java/org/geysermc/platform/spigot/command/GeyserSpigotCommandExecutor.java
@@ -38,6 +38,7 @@ import org.geysermc.connector.utils.LanguageUtils;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
+import java.util.Map;
 
 public class GeyserSpigotCommandExecutor extends CommandExecutor implements TabExecutor {
 
@@ -77,9 +78,18 @@ public class GeyserSpigotCommandExecutor extends CommandExecutor implements TabE
 
     @Override
     public List<String> onTabComplete(CommandSender sender, Command command, String label, String[] args) {
+        List<String> availableCommands = new ArrayList<>();
+
         if (args.length == 1) {
-            return connector.getCommandManager().getCommandNames();
+            // Only show commands they have permission to use
+            Map<String, GeyserCommand> commands = connector.getCommandManager().getCommands();
+            for (String name : commands.keySet()) {
+                if (sender.hasPermission(commands.get(name).getPermission())) {
+                    availableCommands.add(name);
+                }
+            }
         }
-        return new ArrayList<>();
+
+        return availableCommands;
     }
 }

--- a/bootstrap/spigot/src/main/java/org/geysermc/platform/spigot/command/SpigotCommandSender.java
+++ b/bootstrap/spigot/src/main/java/org/geysermc/platform/spigot/command/SpigotCommandSender.java
@@ -73,6 +73,11 @@ public class SpigotCommandSender implements CommandSender {
         return locale;
     }
 
+    @Override
+    public boolean hasPermission(String permission) {
+        return handle.hasPermission(permission);
+    }
+
     /**
      * Set if we are on pre-1.12, and therefore {@code player.getLocale()} doesn't exist and we have to get
      * {@code player.spigot().getLocale()}.

--- a/bootstrap/spigot/src/main/resources/plugin.yml
+++ b/bootstrap/spigot/src/main/resources/plugin.yml
@@ -8,7 +8,7 @@ api-version: 1.13
 commands:
   geyser:
     description: The main command for Geyser.
-    usage: /geyser help
+    usage: /geyser <subcommand>
 permissions:
   geyser.command.help:
     description: Shows help for all registered commands.

--- a/bootstrap/spigot/src/main/resources/plugin.yml
+++ b/bootstrap/spigot/src/main/resources/plugin.yml
@@ -13,24 +13,27 @@ permissions:
   geyser.command.help:
     description: Shows help for all registered commands.
     default: true
-  geyser.command.advancement:
-    description: Shows the advancements of the player on the server.
-    default: true
-  geyser.command.dump:
-    description: Dumps Geyser debug information for bug reports.
-    default: false
-  geyser.command.list:
-    description: List all players connected through Geyser.
-    default: false
   geyser.command.offhand:
     description: Puts an items in your offhand.
     default: true
-  geyser.command.reload:
-    description: Reloads the Geyser configurations. Kicks all players when used!
-    default: false
+  geyser.command.advancements:
+    description: Shows the advancements of the player on the server.
+    default: true
   geyser.command.statistics:
     description: Shows the statistics of the player on the server.
     default: true
+  geyser.command.settings:
+    description: Modify user settings
+    default: true
+  geyser.command.list:
+    description: List all players connected through Geyser.
+    default: false
+  geyser.command.dump:
+    description: Dumps Geyser debug information for bug reports.
+    default: false
+  geyser.command.reload:
+    description: Reloads the Geyser configurations. Kicks all players when used!
+    default: false
   geyser.command.version:
     description: Shows the current Geyser version and checks for updates.
     default: false

--- a/bootstrap/spigot/src/main/resources/plugin.yml
+++ b/bootstrap/spigot/src/main/resources/plugin.yml
@@ -12,17 +12,25 @@ commands:
 permissions:
   geyser.command.help:
     description: Shows help for all registered commands.
+    default: true
   geyser.command.advancement:
     description: Shows the advancements of the player on the server.
+    default: true
   geyser.command.dump:
     description: Dumps Geyser debug information for bug reports.
+    default: false
   geyser.command.list:
     description: List all players connected through Geyser.
+    default: false
   geyser.command.offhand:
     description: Puts an items in your offhand.
+    default: true
   geyser.command.reload:
     description: Reloads the Geyser configurations. Kicks all players when used!
+    default: false
   geyser.command.statistics:
     description: Shows the statistics of the player on the server.
+    default: true
   geyser.command.version:
     description: Shows the current Geyser version and checks for updates.
+    default: false

--- a/bootstrap/spigot/src/main/resources/plugin.yml
+++ b/bootstrap/spigot/src/main/resources/plugin.yml
@@ -27,13 +27,13 @@ permissions:
     default: true
   geyser.command.list:
     description: List all players connected through Geyser.
-    default: false
+    default: op
   geyser.command.dump:
     description: Dumps Geyser debug information for bug reports.
-    default: false
+    default: op
   geyser.command.reload:
     description: Reloads the Geyser configurations. Kicks all players when used!
     default: false
   geyser.command.version:
     description: Shows the current Geyser version and checks for updates.
-    default: false
+    default: op

--- a/bootstrap/sponge/src/main/java/org/geysermc/platform/sponge/command/GeyserSpongeCommandExecutor.java
+++ b/bootstrap/sponge/src/main/java/org/geysermc/platform/sponge/command/GeyserSpongeCommandExecutor.java
@@ -43,6 +43,7 @@ import javax.annotation.Nullable;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
+import java.util.Map;
 import java.util.Optional;
 
 public class GeyserSpongeCommandExecutor extends CommandExecutor implements CommandCallable {
@@ -81,10 +82,19 @@ public class GeyserSpongeCommandExecutor extends CommandExecutor implements Comm
 
     @Override
     public List<String> getSuggestions(CommandSource source, String arguments, @Nullable Location<World> targetPosition) {
+        List<String> availableCommands = new ArrayList<>();
+
         if (arguments.split(" ").length == 1) {
-            return connector.getCommandManager().getCommandNames();
+            // Only show commands they have permission to use
+            Map<String, GeyserCommand> commands = connector.getCommandManager().getCommands();
+            for (String name : commands.keySet()) {
+                if (source.hasPermission(commands.get(name).getPermission())) {
+                    availableCommands.add(name);
+                }
+            }
         }
-        return new ArrayList<>();
+
+        return availableCommands;
     }
 
     @Override

--- a/bootstrap/sponge/src/main/java/org/geysermc/platform/sponge/command/GeyserSpongeCommandExecutor.java
+++ b/bootstrap/sponge/src/main/java/org/geysermc/platform/sponge/command/GeyserSpongeCommandExecutor.java
@@ -85,10 +85,20 @@ public class GeyserSpongeCommandExecutor extends CommandExecutor implements Comm
         List<String> availableCommands = new ArrayList<>();
 
         if (arguments.split(" ").length == 1) {
-            // Only show commands they have permission to use
             Map<String, GeyserCommand> commands = connector.getCommandManager().getCommands();
+
+            // Need to know for the commands that are bedrock only
+            boolean isBedrockPlayer = getGeyserSession(new SpongeCommandSender(source)) != null;
+
+            // Only show commands they have permission to use
             for (String name : commands.keySet()) {
-                if (source.hasPermission(commands.get(name).getPermission())) {
+                GeyserCommand command = commands.get(name);
+                if (source.hasPermission(command.getPermission())) {
+
+                    if (command.isBedrockOnly() && !isBedrockPlayer) {
+                        continue;
+                    }
+
                     availableCommands.add(name);
                 }
             }

--- a/bootstrap/sponge/src/main/java/org/geysermc/platform/sponge/command/GeyserSpongeCommandExecutor.java
+++ b/bootstrap/sponge/src/main/java/org/geysermc/platform/sponge/command/GeyserSpongeCommandExecutor.java
@@ -40,10 +40,9 @@ import org.spongepowered.api.world.Location;
 import org.spongepowered.api.world.World;
 
 import javax.annotation.Nullable;
-import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.List;
-import java.util.Map;
 import java.util.Optional;
 
 public class GeyserSpongeCommandExecutor extends CommandExecutor implements CommandCallable {
@@ -82,29 +81,10 @@ public class GeyserSpongeCommandExecutor extends CommandExecutor implements Comm
 
     @Override
     public List<String> getSuggestions(CommandSource source, String arguments, @Nullable Location<World> targetPosition) {
-        List<String> availableCommands = new ArrayList<>();
-
         if (arguments.split(" ").length == 1) {
-            Map<String, GeyserCommand> commands = connector.getCommandManager().getCommands();
-
-            // Need to know for the commands that are bedrock only
-            boolean isBedrockPlayer = getGeyserSession(new SpongeCommandSender(source)) != null;
-
-            // Only show commands they have permission to use
-            for (String name : commands.keySet()) {
-                GeyserCommand command = commands.get(name);
-                if (source.hasPermission(command.getPermission())) {
-
-                    if (command.isBedrockOnly() && !isBedrockPlayer) {
-                        continue;
-                    }
-
-                    availableCommands.add(name);
-                }
-            }
+            return tabComplete(new SpongeCommandSender(source));
         }
-
-        return availableCommands;
+        return Collections.emptyList();
     }
 
     @Override

--- a/bootstrap/sponge/src/main/java/org/geysermc/platform/sponge/command/SpongeCommandSender.java
+++ b/bootstrap/sponge/src/main/java/org/geysermc/platform/sponge/command/SpongeCommandSender.java
@@ -51,4 +51,9 @@ public class SpongeCommandSender implements CommandSender {
     public boolean isConsole() {
         return handle instanceof ConsoleSource;
     }
+
+    @Override
+    public boolean hasPermission(String permission) {
+        return handle.hasPermission(permission);
+    }
 }

--- a/bootstrap/standalone/src/main/java/org/geysermc/platform/standalone/GeyserStandaloneLogger.java
+++ b/bootstrap/standalone/src/main/java/org/geysermc/platform/standalone/GeyserStandaloneLogger.java
@@ -110,4 +110,9 @@ public class GeyserStandaloneLogger extends SimpleTerminalConsole implements Gey
     public boolean isConsole() {
         return true;
     }
+
+    @Override
+    public boolean hasPermission(String permission) {
+        return true;
+    }
 }

--- a/bootstrap/velocity/src/main/java/org/geysermc/platform/velocity/command/GeyserVelocityCommandExecutor.java
+++ b/bootstrap/velocity/src/main/java/org/geysermc/platform/velocity/command/GeyserVelocityCommandExecutor.java
@@ -37,6 +37,7 @@ import org.geysermc.connector.utils.LanguageUtils;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
+import java.util.Map;
 
 public class GeyserVelocityCommandExecutor extends CommandExecutor implements SimpleCommand {
 
@@ -71,9 +72,18 @@ public class GeyserVelocityCommandExecutor extends CommandExecutor implements Si
 
     @Override
     public List<String> suggest(Invocation invocation) {
-        if (invocation.arguments().length == 0) {
-            return connector.getCommandManager().getCommandNames();
+        List<String> availableCommands = new ArrayList<>();
+
+        if (invocation.arguments().length == 1) {
+            // Only show commands they have permission to use
+            Map<String, GeyserCommand> commands = connector.getCommandManager().getCommands();
+            for (String name : commands.keySet()) {
+                if (invocation.source().hasPermission(commands.get(name).getPermission())) {
+                    availableCommands.add(name);
+                }
+            }
         }
-        return new ArrayList<>();
+
+        return availableCommands;
     }
 }

--- a/bootstrap/velocity/src/main/java/org/geysermc/platform/velocity/command/GeyserVelocityCommandExecutor.java
+++ b/bootstrap/velocity/src/main/java/org/geysermc/platform/velocity/command/GeyserVelocityCommandExecutor.java
@@ -34,10 +34,9 @@ import org.geysermc.connector.common.ChatColor;
 import org.geysermc.connector.network.session.GeyserSession;
 import org.geysermc.connector.utils.LanguageUtils;
 
-import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.List;
-import java.util.Map;
 
 public class GeyserVelocityCommandExecutor extends CommandExecutor implements SimpleCommand {
 
@@ -72,29 +71,10 @@ public class GeyserVelocityCommandExecutor extends CommandExecutor implements Si
 
     @Override
     public List<String> suggest(Invocation invocation) {
-        List<String> availableCommands = new ArrayList<>();
-
-        // Both length 1 and 2 result in the suggestion still showing while the arg is being typed in
+        // Velocity seems to do the splitting a bit differently. This results in the same behaviour in bungeecord/spigot.
         if (invocation.arguments().length == 0 || invocation.arguments().length == 1) {
-            Map<String, GeyserCommand> commands = connector.getCommandManager().getCommands();
-
-            // Need to know for the commands that are bedrock only
-            boolean isBedrockPlayer = getGeyserSession(new VelocityCommandSender(invocation.source())) != null;
-
-            // Only show commands they have permission to use
-            for (String name : commands.keySet()) {
-                GeyserCommand command = commands.get(name);
-                if (invocation.source().hasPermission(command.getPermission())) {
-
-                    if (command.isBedrockOnly() && !isBedrockPlayer) {
-                        continue;
-                    }
-
-                    availableCommands.add(name);
-                }
-            }
+            return tabComplete(new VelocityCommandSender(invocation.source()));
         }
-
-        return availableCommands;
+        return Collections.emptyList();
     }
 }

--- a/bootstrap/velocity/src/main/java/org/geysermc/platform/velocity/command/GeyserVelocityCommandExecutor.java
+++ b/bootstrap/velocity/src/main/java/org/geysermc/platform/velocity/command/GeyserVelocityCommandExecutor.java
@@ -73,14 +73,23 @@ public class GeyserVelocityCommandExecutor extends CommandExecutor implements Si
     @Override
     public List<String> suggest(Invocation invocation) {
         List<String> availableCommands = new ArrayList<>();
-        GeyserConnector.getInstance().getLogger().info("arguments length: " + invocation.arguments().length);
 
         // Both length 1 and 2 result in the suggestion still showing while the arg is being typed in
         if (invocation.arguments().length == 0 || invocation.arguments().length == 1) {
-            // Only show commands they have permission to use
             Map<String, GeyserCommand> commands = connector.getCommandManager().getCommands();
+
+            // Need to know for the commands that are bedrock only
+            boolean isBedrockPlayer = getGeyserSession(new VelocityCommandSender(invocation.source())) != null;
+
+            // Only show commands they have permission to use
             for (String name : commands.keySet()) {
-                if (invocation.source().hasPermission(commands.get(name).getPermission())) {
+                GeyserCommand command = commands.get(name);
+                if (invocation.source().hasPermission(command.getPermission())) {
+
+                    if (command.isBedrockOnly() && !isBedrockPlayer) {
+                        continue;
+                    }
+
                     availableCommands.add(name);
                 }
             }

--- a/bootstrap/velocity/src/main/java/org/geysermc/platform/velocity/command/GeyserVelocityCommandExecutor.java
+++ b/bootstrap/velocity/src/main/java/org/geysermc/platform/velocity/command/GeyserVelocityCommandExecutor.java
@@ -73,8 +73,10 @@ public class GeyserVelocityCommandExecutor extends CommandExecutor implements Si
     @Override
     public List<String> suggest(Invocation invocation) {
         List<String> availableCommands = new ArrayList<>();
+        GeyserConnector.getInstance().getLogger().info("arguments length: " + invocation.arguments().length);
 
-        if (invocation.arguments().length == 1) {
+        // Both length 1 and 2 result in the suggestion still showing while the arg is being typed in
+        if (invocation.arguments().length == 0 || invocation.arguments().length == 1) {
             // Only show commands they have permission to use
             Map<String, GeyserCommand> commands = connector.getCommandManager().getCommands();
             for (String name : commands.keySet()) {

--- a/bootstrap/velocity/src/main/java/org/geysermc/platform/velocity/command/VelocityCommandSender.java
+++ b/bootstrap/velocity/src/main/java/org/geysermc/platform/velocity/command/VelocityCommandSender.java
@@ -72,4 +72,9 @@ public class VelocityCommandSender implements CommandSender {
         }
         return LanguageUtils.getDefaultLocale();
     }
+
+    @Override
+    public boolean hasPermission(String permission) {
+        return handle.hasPermission(permission);
+    }
 }

--- a/connector/src/main/java/org/geysermc/connector/command/CommandExecutor.java
+++ b/connector/src/main/java/org/geysermc/connector/command/CommandExecutor.java
@@ -29,6 +29,10 @@ import lombok.AllArgsConstructor;
 import org.geysermc.connector.GeyserConnector;
 import org.geysermc.connector.network.session.GeyserSession;
 
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+
 /**
  * Represents helper functions for listening to {@code /geyser} commands.
  */
@@ -52,5 +56,35 @@ public class CommandExecutor {
             }
         }
         return null;
+    }
+
+    /**
+     * Determine which subcommands to suggest in the tab complete for the main /geyser command by a given command sender.
+     *
+     * @param sender The command sender to receive the tab complete suggestions. If the command sender is not a bedrock player, bedrock commands will not be shown.
+     *               If the command sender does not have the permission for a given command, the command will not be shown.
+     * @return A list of command names to include in the tab complete
+     */
+    public List<String> tabComplete(CommandSender sender) {
+        List<String> availableCommands = new ArrayList<>();
+        Map<String, GeyserCommand> commands = connector.getCommandManager().getCommands();
+
+        // Need to know for the commands that are bedrock only
+        boolean isBedrockPlayer = getGeyserSession(sender) != null;
+
+        // Only show commands they have permission to use
+        for (String name : commands.keySet()) {
+            GeyserCommand geyserCommand = commands.get(name);
+            if (sender.hasPermission(geyserCommand.getPermission())) {
+
+                if (geyserCommand.isBedrockOnly() && !isBedrockPlayer) {
+                    continue;
+                }
+
+                availableCommands.add(name);
+            }
+        }
+
+        return availableCommands;
     }
 }

--- a/connector/src/main/java/org/geysermc/connector/command/CommandExecutor.java
+++ b/connector/src/main/java/org/geysermc/connector/command/CommandExecutor.java
@@ -30,6 +30,7 @@ import org.geysermc.connector.GeyserConnector;
 import org.geysermc.connector.network.session.GeyserSession;
 
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 
@@ -61,23 +62,28 @@ public class CommandExecutor {
     /**
      * Determine which subcommands to suggest in the tab complete for the main /geyser command by a given command sender.
      *
-     * @param sender The command sender to receive the tab complete suggestions. If the command sender is not a bedrock player, bedrock commands will not be shown.
+     * @param sender The command sender to receive the tab complete suggestions.
+     *               If the command sender is a bedrock player, an empty list will be returned as bedrock players do not get command argument suggestions.
+     *               If the command sender is not a bedrock player, bedrock commands will not be shown.
      *               If the command sender does not have the permission for a given command, the command will not be shown.
      * @return A list of command names to include in the tab complete
      */
     public List<String> tabComplete(CommandSender sender) {
+        if (getGeyserSession(sender) != null) {
+            // Bedrock doesn't get tab completions or argument suggestions
+            return Collections.emptyList();
+        }
+
         List<String> availableCommands = new ArrayList<>();
         Map<String, GeyserCommand> commands = connector.getCommandManager().getCommands();
-
-        // Need to know for the commands that are bedrock only
-        boolean isBedrockPlayer = getGeyserSession(sender) != null;
 
         // Only show commands they have permission to use
         for (String name : commands.keySet()) {
             GeyserCommand geyserCommand = commands.get(name);
             if (sender.hasPermission(geyserCommand.getPermission())) {
 
-                if (geyserCommand.isBedrockOnly() && !isBedrockPlayer) {
+                if (geyserCommand.isBedrockOnly()) {
+                    // Don't show commands the JE player can't run
                     continue;
                 }
 

--- a/connector/src/main/java/org/geysermc/connector/command/CommandSender.java
+++ b/connector/src/main/java/org/geysermc/connector/command/CommandSender.java
@@ -56,4 +56,12 @@ public interface CommandSender {
     default String getLocale() {
         return LanguageUtils.getDefaultLocale();
     }
+
+    /**
+     * Checks if the CommandSender has a permission
+     *
+     * @param permission The permission node to check
+     * @return true if the CommandSender has the requested permission, false if not
+     */
+    boolean hasPermission(String permission);
 }

--- a/connector/src/main/java/org/geysermc/connector/network/session/GeyserSession.java
+++ b/connector/src/main/java/org/geysermc/connector/network/session/GeyserSession.java
@@ -1381,7 +1381,8 @@ public class GeyserSession implements CommandSender {
      * @param permission The permission node to check
      * @return true if the player has the requested permission, false if not
      */
-    public Boolean hasPermission(String permission) {
+    @Override
+    public boolean hasPermission(String permission) {
         return connector.getWorldManager().hasPermission(this, permission);
     }
 


### PR DESCRIPTION
For tab complete (i.e. argument suggestions) and the /geyser help command:
- Don't show commands the command sender doesn't have permission for
- Don't show bedrock-only commands if the sender is not bedrock

Other stuff:
- Add permission defaults to spigot's plugin.yml so that basic perms are not false by default
- Fix the advancements perm in spigot's plugin.yml and add the statistics command perm
- Improve velocity's command argument suggestions so that it matches other platforms