### PR TITLE
Add client option to hide custom skulls

### DIFF
--- a/connector/src/main/java/org/geysermc/connector/GeyserConnector.java
+++ b/connector/src/main/java/org/geysermc/connector/GeyserConnector.java
@@ -231,7 +231,6 @@ public class GeyserConnector {
 
         CooldownUtils.setDefaultShowCooldown(config.getShowCooldown());
         DimensionUtils.changeBedrockNetherId(config.isAboveBedrockNetherBuilding()); // Apply End dimension ID workaround to Nether
-        SkullBlockEntityTranslator.ALLOW_CUSTOM_SKULLS = config.isAllowCustomSkulls();
 
         // https://github.com/GeyserMC/Geyser/issues/957
         RakNetConstants.MAXIMUM_MTU_SIZE = (short) config.getMtu();

--- a/connector/src/main/java/org/geysermc/connector/network/session/cache/PreferencesCache.java
+++ b/connector/src/main/java/org/geysermc/connector/network/session/cache/PreferencesCache.java
@@ -41,10 +41,17 @@ public class PreferencesCache {
      */
     @Setter
     private boolean prefersShowCoordinates = true;
+
     /**
      * If the client's preference will be ignored, this will return false.
      */
     private boolean allowShowCoordinates;
+
+    /**
+     * If the session wants custom skulls to be shown.
+     */
+    @Setter
+    private boolean prefersCustomSkulls;
 
     /**
      * Which CooldownType the client prefers. Initially set to {@link CooldownUtils#getDefaultShowCooldown()}.
@@ -54,6 +61,8 @@ public class PreferencesCache {
 
     public PreferencesCache(GeyserSession session) {
         this.session = session;
+
+        prefersCustomSkulls = session.getConnector().getConfig().isAllowCustomSkulls();
     }
 
     /**
@@ -67,5 +76,12 @@ public class PreferencesCache {
     public void updateShowCoordinates() {
         allowShowCoordinates = !session.isReducedDebugInfo() && session.getConnector().getConfig().isShowCoordinates();
         session.sendGameRule("showcoordinates", allowShowCoordinates && prefersShowCoordinates);
+    }
+
+    /**
+     * @return true if the session prefers custom skulls, and the config allows them.
+     */
+    public boolean showCustomSkulls() {
+        return prefersCustomSkulls && session.getConnector().getConfig().isAllowCustomSkulls();
     }
 }

--- a/connector/src/main/java/org/geysermc/connector/network/translators/java/world/JavaUpdateTileEntityTranslator.java
+++ b/connector/src/main/java/org/geysermc/connector/network/translators/java/world/JavaUpdateTileEntityTranslator.java
@@ -63,7 +63,7 @@ public class JavaUpdateTileEntityTranslator extends PacketTranslator<ServerUpdat
         }
         BlockEntityUtils.updateBlockEntity(session, translator.getBlockEntityTag(id, packet.getNbt(), blockState), packet.getPosition());
         // Check for custom skulls.
-        if (SkullBlockEntityTranslator.ALLOW_CUSTOM_SKULLS && packet.getNbt().contains("SkullOwner")) {
+        if (session.getPreferencesCache().showCustomSkulls() && packet.getNbt().contains("SkullOwner")) {
             SkullBlockEntityTranslator.spawnPlayer(session, packet.getNbt(), blockState);
         }
 

--- a/connector/src/main/java/org/geysermc/connector/utils/ChunkUtils.java
+++ b/connector/src/main/java/org/geysermc/connector/utils/ChunkUtils.java
@@ -294,7 +294,7 @@ public class ChunkUtils {
             bedrockBlockEntities[i] = blockEntityTranslator.getBlockEntityTag(tagName, tag, blockState);
 
             // Check for custom skulls
-            if (SkullBlockEntityTranslator.ALLOW_CUSTOM_SKULLS && tag.contains("SkullOwner")) {
+            if (session.getPreferencesCache().showCustomSkulls() && tag.contains("SkullOwner")) {
                 SkullBlockEntityTranslator.spawnPlayer(session, tag, blockState);
             }
             i++;

--- a/connector/src/main/java/org/geysermc/connector/utils/SettingsUtils.java
+++ b/connector/src/main/java/org/geysermc/connector/utils/SettingsUtils.java
@@ -50,7 +50,10 @@ public class SettingsUtils {
                 .iconPath("textures/ui/settings_glyph_color_2x.png");
 
         // Only show the client title if any of the client settings are available
-        boolean showClientSettings = session.getPreferencesCache().isAllowShowCoordinates() || CooldownUtils.getDefaultShowCooldown() != CooldownUtils.CooldownType.DISABLED;
+        boolean showClientSettings = session.getPreferencesCache().isAllowShowCoordinates()
+                || CooldownUtils.getDefaultShowCooldown() != CooldownUtils.CooldownType.DISABLED
+                || session.getConnector().getConfig().isAllowCustomSkulls();
+
         if (showClientSettings) {
             builder.label("geyser.settings.title.client");
 
@@ -65,6 +68,10 @@ public class SettingsUtils {
                 cooldownDropdown.option("options.attack.hotbar", session.getPreferencesCache().getCooldownPreference() == CooldownUtils.CooldownType.ACTIONBAR);
                 cooldownDropdown.option("options.off", session.getPreferencesCache().getCooldownPreference() == CooldownUtils.CooldownType.DISABLED);
                 builder.dropdown(cooldownDropdown);
+            }
+
+            if (session.getConnector().getConfig().isAllowCustomSkulls()) {
+                builder.toggle("geyser.settings.option.customSkulls", session.getPreferencesCache().isPrefersCustomSkulls());
             }
         }
 
@@ -121,6 +128,10 @@ public class SettingsUtils {
                 if (CooldownUtils.getDefaultShowCooldown() != CooldownUtils.CooldownType.DISABLED) {
                     CooldownUtils.CooldownType cooldownType = CooldownUtils.CooldownType.VALUES[(int) response.next()];
                     session.getPreferencesCache().setCooldownPreference(cooldownType);
+                }
+
+                if (session.getConnector().getConfig().isAllowCustomSkulls()) {
+                    session.getPreferencesCache().setPrefersCustomSkulls(response.next());
                 }
             }
 


### PR DESCRIPTION
I looked into making a more elegant preference system but it was a bit of a wormhole which I don't have the time for right now.

Allows the user to enable/disable the new renderings of heads, if the config option is enabled. Might help with lower end devices. Resolves https://github.com/GeyserMC/Geyser/issues/2392

Depends on https://github.com/GeyserMC/languages/pull/85 for the title in the settings form