### PR TITLE
Fix help command

### DIFF
--- a/bootstrap/bungeecord/src/main/java/org/geysermc/platform/bungeecord/command/GeyserBungeeCommandExecutor.java
+++ b/bootstrap/bungeecord/src/main/java/org/geysermc/platform/bungeecord/command/GeyserBungeeCommandExecutor.java
@@ -35,6 +35,7 @@ import org.geysermc.connector.command.GeyserCommand;
 import org.geysermc.connector.network.session.GeyserSession;
 import org.geysermc.connector.utils.LanguageUtils;
 
+import javax.annotation.Nullable;
 import java.util.Arrays;
 import java.util.Collections;
 
@@ -52,30 +53,27 @@ public class GeyserBungeeCommandExecutor extends Command implements TabExecutor 
 
     @Override
     public void execute(CommandSender sender, String[] args) {
+        BungeeCommandSender commandSender = new BungeeCommandSender(sender);
+        @Nullable GeyserSession session = this.commandExecutor.getGeyserSession(commandSender);
         if (args.length > 0) {
             GeyserCommand command = this.commandExecutor.getCommand(args[0]);
             if (command != null) {
-                BungeeCommandSender commandSender = new BungeeCommandSender(sender);
                 if (!sender.hasPermission(command.getPermission())) {
                     String message = LanguageUtils.getPlayerLocaleString("geyser.bootstrap.command.permission_fail", commandSender.getLocale());
 
                     commandSender.sendMessage(ChatColor.RED + message);
                     return;
                 }
-                GeyserSession session = null;
-                if (command.isBedrockOnly()) {
-                    session = this.commandExecutor.getGeyserSession(commandSender);
-                    if (session == null) {
-                        String message = LanguageUtils.getPlayerLocaleString("geyser.bootstrap.command.bedrock_only", commandSender.getLocale());
+                if (command.isBedrockOnly() && session == null) {
+                    String message = LanguageUtils.getPlayerLocaleString("geyser.bootstrap.command.bedrock_only", commandSender.getLocale());
 
-                        commandSender.sendMessage(ChatColor.RED + message);
-                        return;
-                    }
+                    commandSender.sendMessage(ChatColor.RED + message);
+                    return;
                 }
                 command.execute(session, commandSender, args.length > 1 ? Arrays.copyOfRange(args, 1, args.length) : new String[0]);
             }
         } else {
-            this.commandExecutor.getCommand("help").execute(null, new BungeeCommandSender(sender), new String[0]);
+            this.commandExecutor.getCommand("help").execute(session, commandSender, new String[0]);
         }
     }
 

--- a/bootstrap/bungeecord/src/main/java/org/geysermc/platform/bungeecord/command/GeyserBungeeCommandExecutor.java
+++ b/bootstrap/bungeecord/src/main/java/org/geysermc/platform/bungeecord/command/GeyserBungeeCommandExecutor.java
@@ -54,7 +54,8 @@ public class GeyserBungeeCommandExecutor extends Command implements TabExecutor 
     @Override
     public void execute(CommandSender sender, String[] args) {
         BungeeCommandSender commandSender = new BungeeCommandSender(sender);
-        @Nullable GeyserSession session = this.commandExecutor.getGeyserSession(commandSender);
+        GeyserSession session = this.commandExecutor.getGeyserSession(commandSender);
+
         if (args.length > 0) {
             GeyserCommand command = this.commandExecutor.getCommand(args[0]);
             if (command != null) {

--- a/bootstrap/spigot/src/main/java/org/geysermc/platform/spigot/command/GeyserSpigotCommandExecutor.java
+++ b/bootstrap/spigot/src/main/java/org/geysermc/platform/spigot/command/GeyserSpigotCommandExecutor.java
@@ -49,6 +49,7 @@ public class GeyserSpigotCommandExecutor extends CommandExecutor implements TabE
     public boolean onCommand(CommandSender sender, Command command, String label, String[] args) {
         SpigotCommandSender commandSender = new SpigotCommandSender(sender);
         GeyserSession session = getGeyserSession(commandSender);
+
         if (args.length > 0) {
             GeyserCommand geyserCommand = getCommand(args[0]);
             if (geyserCommand != null) {

--- a/bootstrap/spigot/src/main/java/org/geysermc/platform/spigot/command/GeyserSpigotCommandExecutor.java
+++ b/bootstrap/spigot/src/main/java/org/geysermc/platform/spigot/command/GeyserSpigotCommandExecutor.java
@@ -47,29 +47,26 @@ public class GeyserSpigotCommandExecutor extends CommandExecutor implements TabE
 
     @Override
     public boolean onCommand(CommandSender sender, Command command, String label, String[] args) {
+        SpigotCommandSender commandSender = new SpigotCommandSender(sender);
+        GeyserSession session = getGeyserSession(commandSender);
         if (args.length > 0) {
             GeyserCommand geyserCommand = getCommand(args[0]);
             if (geyserCommand != null) {
-                SpigotCommandSender commandSender = new SpigotCommandSender(sender);
                 if (!sender.hasPermission(geyserCommand.getPermission())) {
                     String message = LanguageUtils.getPlayerLocaleString("geyser.bootstrap.command.permission_fail", commandSender.getLocale());
 
                     commandSender.sendMessage(ChatColor.RED + message);
                     return true;
                 }
-                GeyserSession session = null;
-                if (geyserCommand.isBedrockOnly()) {
-                    session = getGeyserSession(commandSender);
-                    if (session == null) {
-                        sender.sendMessage(ChatColor.RED + LanguageUtils.getPlayerLocaleString("geyser.bootstrap.command.bedrock_only", commandSender.getLocale()));
-                        return true;
-                    }
+                if (geyserCommand.isBedrockOnly() && session == null) {
+                    sender.sendMessage(ChatColor.RED + LanguageUtils.getPlayerLocaleString("geyser.bootstrap.command.bedrock_only", commandSender.getLocale()));
+                    return true;
                 }
                 geyserCommand.execute(session, commandSender, args.length > 1 ? Arrays.copyOfRange(args, 1, args.length) : new String[0]);
                 return true;
             }
         } else {
-            getCommand("help").execute(null, new SpigotCommandSender(sender), new String[0]);
+            getCommand("help").execute(session, commandSender, new String[0]);
             return true;
         }
         return true;

--- a/bootstrap/sponge/src/main/java/org/geysermc/platform/sponge/command/GeyserSpongeCommandExecutor.java
+++ b/bootstrap/sponge/src/main/java/org/geysermc/platform/sponge/command/GeyserSpongeCommandExecutor.java
@@ -53,28 +53,26 @@ public class GeyserSpongeCommandExecutor extends CommandExecutor implements Comm
 
     @Override
     public CommandResult process(CommandSource source, String arguments) {
+        CommandSender commandSender = new SpongeCommandSender(source);
+        GeyserSession session = getGeyserSession(commandSender);
+
         String[] args = arguments.split(" ");
         if (args.length > 0) {
             GeyserCommand command = getCommand(args[0]);
             if (command != null) {
-                CommandSender commandSender = new SpongeCommandSender(source);
                 if (!source.hasPermission(command.getPermission())) {
                     // Not ideal to use log here but we dont get a session
                     source.sendMessage(Text.of(ChatColor.RED + LanguageUtils.getLocaleStringLog("geyser.bootstrap.command.permission_fail")));
                     return CommandResult.success();
                 }
-                GeyserSession session = null;
-                if (command.isBedrockOnly()) {
-                    session = getGeyserSession(commandSender);
-                    if (session == null) {
-                        source.sendMessage(Text.of(ChatColor.RED + LanguageUtils.getLocaleStringLog("geyser.bootstrap.command.bedrock_only")));
-                        return CommandResult.success();
-                    }
+                if (command.isBedrockOnly() && session == null) {
+                    source.sendMessage(Text.of(ChatColor.RED + LanguageUtils.getLocaleStringLog("geyser.bootstrap.command.bedrock_only")));
+                    return CommandResult.success();
                 }
                 getCommand(args[0]).execute(session, commandSender, args.length > 1 ? Arrays.copyOfRange(args, 1, args.length) : new String[0]);
             }
         } else {
-            getCommand("help").execute(null, new SpongeCommandSender(source), new String[0]);
+            getCommand("help").execute(session, commandSender, new String[0]);
         }
         return CommandResult.success();
     }

--- a/bootstrap/velocity/src/main/java/org/geysermc/platform/velocity/command/GeyserVelocityCommandExecutor.java
+++ b/bootstrap/velocity/src/main/java/org/geysermc/platform/velocity/command/GeyserVelocityCommandExecutor.java
@@ -48,6 +48,7 @@ public class GeyserVelocityCommandExecutor extends CommandExecutor implements Si
     public void execute(Invocation invocation) {
         CommandSender sender = new VelocityCommandSender(invocation.source());
         GeyserSession session = getGeyserSession(sender);
+
         if (invocation.arguments().length > 0) {
             GeyserCommand command = getCommand(invocation.arguments()[0]);
             if (command != null) {

--- a/bootstrap/velocity/src/main/java/org/geysermc/platform/velocity/command/GeyserVelocityCommandExecutor.java
+++ b/bootstrap/velocity/src/main/java/org/geysermc/platform/velocity/command/GeyserVelocityCommandExecutor.java
@@ -46,26 +46,23 @@ public class GeyserVelocityCommandExecutor extends CommandExecutor implements Si
 
     @Override
     public void execute(Invocation invocation) {
+        CommandSender sender = new VelocityCommandSender(invocation.source());
+        GeyserSession session = getGeyserSession(sender);
         if (invocation.arguments().length > 0) {
             GeyserCommand command = getCommand(invocation.arguments()[0]);
             if (command != null) {
-                CommandSender sender = new VelocityCommandSender(invocation.source());
                 if (!invocation.source().hasPermission(getCommand(invocation.arguments()[0]).getPermission())) {
                     sender.sendMessage(ChatColor.RED + LanguageUtils.getPlayerLocaleString("geyser.bootstrap.command.permission_fail", sender.getLocale()));
                     return;
                 }
-                GeyserSession session = null;
-                if (command.isBedrockOnly()) {
-                    session = getGeyserSession(sender);
-                    if (session == null) {
-                        sender.sendMessage(ChatColor.RED + LanguageUtils.getPlayerLocaleString("geyser.bootstrap.command.bedrock_only", sender.getLocale()));
-                        return;
-                    }
+                if (command.isBedrockOnly() && session == null) {
+                    sender.sendMessage(ChatColor.RED + LanguageUtils.getPlayerLocaleString("geyser.bootstrap.command.bedrock_only", sender.getLocale()));
+                    return;
                 }
                 command.execute(session, sender, invocation.arguments().length > 1 ? Arrays.copyOfRange(invocation.arguments(), 1, invocation.arguments().length) : new String[0]);
             }
         } else {
-            getCommand("help").execute(null, new VelocityCommandSender(invocation.source()), new String[0]);
+            getCommand("help").execute(session, sender, new String[0]);
         }
     }
 

--- a/connector/src/main/java/org/geysermc/connector/command/CommandExecutor.java
+++ b/connector/src/main/java/org/geysermc/connector/command/CommandExecutor.java
@@ -29,6 +29,7 @@ import lombok.AllArgsConstructor;
 import org.geysermc.connector.GeyserConnector;
 import org.geysermc.connector.network.session.GeyserSession;
 
+import javax.annotation.Nullable;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
@@ -46,6 +47,7 @@ public class CommandExecutor {
         return connector.getCommandManager().getCommands().get(label);
     }
 
+    @Nullable
     public GeyserSession getGeyserSession(CommandSender sender) {
         if (sender.isConsole()) {
             return null;


### PR DESCRIPTION
GeyserSession is now always passed to GeyserCommand.execute() if the command sender is a bedrock player.

It wasn't passed if it was not a bedrock-only command. The help command is not a bedrock-only command, so session was not passed to it, so the help command treated bedrock players as not bedrock players.