### PR TITLE
Automatically add 'Needs Triage' label to new issues

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,5 +1,6 @@
 name: Bug report
 description: Create a report to help us improve
+labels: Needs Triage
 body:
 - type: markdown
   attributes:

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,6 +1,6 @@
 name: Feature request
 description: Suggest an idea for this project
-labels: "Feature Request"
+labels: "Feature Request,Needs Triage"
 body:
 - type: markdown
   attributes:


### PR DESCRIPTION
### Brief
This PR makes a small change to the issue templates to automatically add the 'Needs Triage' label to newly created issues.

### Rationale
While currently we have been simply leaving new bug reports unlabelled and feature requests automatically get given the "Feature Request" label, I feel like this can make it more difficult to sort through issues that we need to attend to.

We have over 200 issues (which is a lot to keep track of) and I'd like to start adding labels such as priority to better help with prioritizing our time and helping contributors, especially new ones, in finding the issues they should be working on.

------

When an issue has been properly looked over please remove this label, if you just have a quick glance and don't reply or just add another label then it should stay.

I'll manually add the label to existing issues. Please squash and merge. 