### PR TITLE
Added Advanced Tooltips

### DIFF
--- a/bootstrap/spigot/src/main/resources/plugin.yml
+++ b/bootstrap/spigot/src/main/resources/plugin.yml
@@ -19,6 +19,9 @@ permissions:
   geyser.command.advancements:
     description: Shows the advancements of the player on the server.
     default: true
+  geyser.command.advancedtooltips:
+    description: Toggles showing advanced tooltips on your items.
+    default: true
   geyser.command.statistics:
     description: Shows the statistics of the player on the server.
     default: true

--- a/bootstrap/spigot/src/main/resources/plugin.yml
+++ b/bootstrap/spigot/src/main/resources/plugin.yml
@@ -19,7 +19,7 @@ permissions:
   geyser.command.advancements:
     description: Shows the advancements of the player on the server.
     default: true
-  geyser.command.advancedtooltips:
+  geyser.command.tooltips:
     description: Toggles showing advanced tooltips on your items.
     default: true
   geyser.command.statistics:

--- a/connector/src/main/java/org/geysermc/connector/command/CommandManager.java
+++ b/connector/src/main/java/org/geysermc/connector/command/CommandManager.java
@@ -54,6 +54,7 @@ public abstract class CommandManager {
         registerCommand(new SettingsCommand(connector, "settings", "geyser.commands.settings.desc", "geyser.command.settings"));
         registerCommand(new StatisticsCommand(connector, "statistics", "geyser.commands.statistics.desc", "geyser.command.statistics"));
         registerCommand(new AdvancementsCommand("advancements", "geyser.commands.advancements.desc", "geyser.command.advancements"));
+        registerCommand(new AdvancedTooltipsCommand("tooltips", "geyser.commands.advancedtooltips.desc", "geyser.command.tooltips"));
         if (GeyserConnector.getInstance().getPlatformType() == PlatformType.STANDALONE) {
             registerCommand(new StopCommand(connector, "stop", "geyser.commands.stop.desc", "geyser.command.stop"));
         }

--- a/connector/src/main/java/org/geysermc/connector/command/defaults/AdvancedTooltipsCommand.java
+++ b/connector/src/main/java/org/geysermc/connector/command/defaults/AdvancedTooltipsCommand.java
@@ -38,7 +38,7 @@ public class AdvancedTooltipsCommand extends GeyserCommand {
     @Override
     public void execute(GeyserSession session, CommandSender sender, String[] args) {
         if (session != null) {
-            String onOrOff = session.isAdvancedTooltips() ? "on" : "off";
+            String onOrOff = session.isAdvancedTooltips() ? "off" : "on";
             session.setAdvancedTooltips(!session.isAdvancedTooltips());
             session.sendMessage("§l§e" + LocaleUtils.getLocaleString("debug.prefix", session.getLocale()) + " §r" + LocaleUtils.getLocaleString("debug.advanced_tooltips." + onOrOff, session.getLocale()));
             session.getInventoryTranslator().updateInventory(session, session.getPlayerInventory());

--- a/connector/src/main/java/org/geysermc/connector/command/defaults/AdvancedTooltipsCommand.java
+++ b/connector/src/main/java/org/geysermc/connector/command/defaults/AdvancedTooltipsCommand.java
@@ -27,10 +27,7 @@ package org.geysermc.connector.command.defaults;
 
 import org.geysermc.connector.command.CommandSender;
 import org.geysermc.connector.command.GeyserCommand;
-import org.geysermc.connector.inventory.Inventory;
 import org.geysermc.connector.network.session.GeyserSession;
-import org.geysermc.connector.network.translators.inventory.InventoryTranslator;
-import org.geysermc.connector.network.translators.inventory.updater.InventoryUpdater;
 import org.geysermc.connector.utils.LocaleUtils;
 
 public class AdvancedTooltipsCommand extends GeyserCommand {

--- a/connector/src/main/java/org/geysermc/connector/command/defaults/AdvancedTooltipsCommand.java
+++ b/connector/src/main/java/org/geysermc/connector/command/defaults/AdvancedTooltipsCommand.java
@@ -1,0 +1,60 @@
+/*
+ * Copyright (c) 2019-2021 GeyserMC. http://geysermc.org
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ *
+ * @author GeyserMC
+ * @link https://github.com/GeyserMC/Geyser
+ */
+
+package org.geysermc.connector.command.defaults;
+
+import org.geysermc.connector.command.CommandSender;
+import org.geysermc.connector.command.GeyserCommand;
+import org.geysermc.connector.network.session.GeyserSession;
+import org.geysermc.connector.utils.LocaleUtils;
+
+public class AdvancedTooltipsCommand extends GeyserCommand {
+    public AdvancedTooltipsCommand(String name, String description, String permission) {
+        super(name, description, permission);
+    }
+
+    @Override
+    public void execute(GeyserSession session, CommandSender sender, String[] args) {
+        if (session != null) {
+            if (session.isAdvancedTooltips()) {
+                session.sendMessage("§l§e" + LocaleUtils.getLocaleString("debug.prefix", session.getLocale() + " §r" + LocaleUtils.getLocaleString("debug.advanced_tooltips.off", session.getLocale())));
+                session.setAdvancedTooltips(false);
+            } else {
+                session.sendMessage("§l§e" + LocaleUtils.getLocaleString("debug.prefix", session.getLocale() + " §r" + LocaleUtils.getLocaleString("debug.advanced_tooltips.on", session.getLocale())));
+                session.setAdvancedTooltips(true);
+            }
+        }
+    }
+
+    @Override
+    public boolean isExecutableOnConsole() {
+        return false;
+    }
+
+    @Override
+    public boolean isBedrockOnly() {
+        return true;
+    }
+}

--- a/connector/src/main/java/org/geysermc/connector/command/defaults/AdvancedTooltipsCommand.java
+++ b/connector/src/main/java/org/geysermc/connector/command/defaults/AdvancedTooltipsCommand.java
@@ -28,6 +28,8 @@ package org.geysermc.connector.command.defaults;
 import org.geysermc.connector.command.CommandSender;
 import org.geysermc.connector.command.GeyserCommand;
 import org.geysermc.connector.network.session.GeyserSession;
+import org.geysermc.connector.network.translators.inventory.InventoryTranslator;
+import org.geysermc.connector.network.translators.inventory.updater.InventoryUpdater;
 import org.geysermc.connector.utils.LocaleUtils;
 
 public class AdvancedTooltipsCommand extends GeyserCommand {
@@ -38,13 +40,10 @@ public class AdvancedTooltipsCommand extends GeyserCommand {
     @Override
     public void execute(GeyserSession session, CommandSender sender, String[] args) {
         if (session != null) {
-            if (session.isAdvancedTooltips()) {
-                session.sendMessage("§l§e" + LocaleUtils.getLocaleString("debug.prefix", session.getLocale() + " §r" + LocaleUtils.getLocaleString("debug.advanced_tooltips.off", session.getLocale())));
-                session.setAdvancedTooltips(false);
-            } else {
-                session.sendMessage("§l§e" + LocaleUtils.getLocaleString("debug.prefix", session.getLocale() + " §r" + LocaleUtils.getLocaleString("debug.advanced_tooltips.on", session.getLocale())));
-                session.setAdvancedTooltips(true);
-            }
+            String onOrOff = session.isAdvancedTooltips() ? "on" : "off";
+            session.setAdvancedTooltips(!session.isAdvancedTooltips());
+            session.sendMessage("§l§e" + LocaleUtils.getLocaleString("debug.prefix", session.getLocale()) + " §r" + LocaleUtils.getLocaleString("debug.advanced_tooltips." + onOrOff, session.getLocale()));
+            new InventoryUpdater().updateInventory(InventoryTranslator.PLAYER_INVENTORY_TRANSLATOR, session, session.getPlayerInventory());
         }
     }
 

--- a/connector/src/main/java/org/geysermc/connector/command/defaults/AdvancedTooltipsCommand.java
+++ b/connector/src/main/java/org/geysermc/connector/command/defaults/AdvancedTooltipsCommand.java
@@ -27,6 +27,7 @@ package org.geysermc.connector.command.defaults;
 
 import org.geysermc.connector.command.CommandSender;
 import org.geysermc.connector.command.GeyserCommand;
+import org.geysermc.connector.inventory.Inventory;
 import org.geysermc.connector.network.session.GeyserSession;
 import org.geysermc.connector.network.translators.inventory.InventoryTranslator;
 import org.geysermc.connector.network.translators.inventory.updater.InventoryUpdater;
@@ -43,7 +44,7 @@ public class AdvancedTooltipsCommand extends GeyserCommand {
             String onOrOff = session.isAdvancedTooltips() ? "on" : "off";
             session.setAdvancedTooltips(!session.isAdvancedTooltips());
             session.sendMessage("§l§e" + LocaleUtils.getLocaleString("debug.prefix", session.getLocale()) + " §r" + LocaleUtils.getLocaleString("debug.advanced_tooltips." + onOrOff, session.getLocale()));
-            new InventoryUpdater().updateInventory(InventoryTranslator.PLAYER_INVENTORY_TRANSLATOR, session, session.getPlayerInventory());
+            session.getInventoryTranslator().updateInventory(session, session.getPlayerInventory());
         }
     }
 

--- a/connector/src/main/java/org/geysermc/connector/network/session/GeyserSession.java
+++ b/connector/src/main/java/org/geysermc/connector/network/session/GeyserSession.java
@@ -444,6 +444,12 @@ public class GeyserSession implements CommandSender {
 
     private MinecraftProtocol protocol;
 
+    /**
+     * Whether advanced tooltips will be added to the player's items.
+     */
+    @Setter
+    private boolean advancedTooltips = false;
+
     public GeyserSession(GeyserConnector connector, BedrockServerSession bedrockServerSession, EventLoop eventLoop) {
         this.connector = connector;
         this.upstream = new UpstreamSession(bedrockServerSession);

--- a/connector/src/main/java/org/geysermc/connector/network/translators/item/ItemTranslator.java
+++ b/connector/src/main/java/org/geysermc/connector/network/translators/item/ItemTranslator.java
@@ -209,13 +209,13 @@ public abstract class ItemTranslator {
         if (maxDurability != 0) {
             int durability = maxDurability - ((IntTag) newNbt.get("Damage")).getValue();
             if (durability != maxDurability) {
-                listTag.add(new StringTag("AdvancedTooltipDurability", "§r§f" + String.format(MessageTranslator.convertMessage("item.durability", language), durability, maxDurability)));
+                listTag.add(new StringTag("", "§r§f" + String.format(MessageTranslator.convertMessage("item.durability", language), durability, maxDurability)));
             }
         }
 
-        listTag.add(new StringTag("AdvancedTooltipItemId", "§r§8" + mapping.getJavaIdentifier()));
+        listTag.add(new StringTag("", "§r§8" + mapping.getJavaIdentifier()));
         if (nbt != null) {
-            listTag.add(new StringTag("AdvancedTooltipNBTTagCount", "§r§8" + String.format(MessageTranslator.convertMessage("item.nbt_tags", language), nbt.size())));
+            listTag.add(new StringTag("", "§r§8" + String.format(MessageTranslator.convertMessage("item.nbt_tags", language), nbt.size())));
         }
         compoundTag.put(listTag);
         newNbt.put(compoundTag);

--- a/connector/src/main/java/org/geysermc/connector/network/translators/item/ItemTranslator.java
+++ b/connector/src/main/java/org/geysermc/connector/network/translators/item/ItemTranslator.java
@@ -156,7 +156,7 @@ public abstract class ItemTranslator {
 
         nbt = translateDisplayProperties(session, nbt, bedrockItem);
         if (session.isAdvancedTooltips()) {
-            nbt = addAdvancedTooltips(nbt, session.getItemMappings().getMapping(stack));
+            nbt = addAdvancedTooltips(nbt, session.getItemMappings().getMapping(stack), session.getLocale());
         }
 
         ItemStack itemStack = new ItemStack(stack.getId(), stack.getAmount(), nbt);
@@ -187,7 +187,7 @@ public abstract class ItemTranslator {
         return builder.build();
     }
 
-    private static CompoundTag addAdvancedTooltips(CompoundTag nbt, ItemMapping mapping) {
+    private static CompoundTag addAdvancedTooltips(CompoundTag nbt, ItemMapping mapping, String language) {
         CompoundTag newNbt = nbt;
         if (newNbt == null) {
             newNbt = new CompoundTag("nbt");
@@ -209,7 +209,7 @@ public abstract class ItemTranslator {
         if (maxDurability != 0) {
             int durability = maxDurability - ((IntTag) newNbt.get("Damage")).getValue();
             if (durability != maxDurability) {
-                listTag.add(new StringTag("AdvancedTooltipDurability", "§r§fDurability: " + durability + "/" + maxDurability));
+                listTag.add(new StringTag("AdvancedTooltipDurability", "§r§f" + String.format(MessageTranslator.convertMessage("item.durability", language), durability, maxDurability)));
             }
         }
 

--- a/connector/src/main/java/org/geysermc/connector/network/translators/item/ItemTranslator.java
+++ b/connector/src/main/java/org/geysermc/connector/network/translators/item/ItemTranslator.java
@@ -155,6 +155,9 @@ public abstract class ItemTranslator {
         }
 
         nbt = translateDisplayProperties(session, nbt, bedrockItem);
+        if (session.isAdvancedTooltips()) {
+            nbt = addAdvancedTooltips(nbt, session.getItemMappings().getMapping(stack));
+        }
 
         ItemStack itemStack = new ItemStack(stack.getId(), stack.getAmount(), nbt);
 
@@ -182,6 +185,41 @@ public abstract class ItemTranslator {
         }
 
         return builder.build();
+    }
+
+    private static CompoundTag addAdvancedTooltips(CompoundTag nbt, ItemMapping mapping) {
+        CompoundTag newNbt = nbt;
+        if (newNbt == null) {
+            newNbt = new CompoundTag("nbt");
+            CompoundTag display = new CompoundTag("display");
+            display.put(new ListTag("Lore"));
+            newNbt.put(display);
+        }
+        CompoundTag compoundTag = newNbt.get("display");
+        if (compoundTag == null) {
+            compoundTag = new CompoundTag("display");
+        }
+        ListTag listTag = compoundTag.get("Lore");
+
+        if (listTag == null) {
+            listTag = new ListTag("Lore");
+        }
+        int maxDurability = mapping.getMaxDamage();
+
+        if (maxDurability != 0) {
+            int durability = maxDurability - ((IntTag) newNbt.get("Damage")).getValue();
+            if (durability != maxDurability) {
+                listTag.add(new StringTag("AdvancedTooltipDurability", "§r§fDurability: " + durability + "/" + maxDurability));
+            }
+        }
+
+        listTag.add(new StringTag("AdvancedTooltipItemId", "§r§8" + mapping.getJavaIdentifier()));
+        if (nbt != null) {
+            listTag.add(new StringTag("AdvancedTooltipNBTTagCount", "§r§8" + "NBT: " + nbt.size() + " tag(s)"));
+        }
+        compoundTag.put(listTag);
+        newNbt.put(compoundTag);
+        return newNbt;
     }
 
     /**

--- a/connector/src/main/java/org/geysermc/connector/network/translators/item/ItemTranslator.java
+++ b/connector/src/main/java/org/geysermc/connector/network/translators/item/ItemTranslator.java
@@ -215,7 +215,7 @@ public abstract class ItemTranslator {
 
         listTag.add(new StringTag("AdvancedTooltipItemId", "§r§8" + mapping.getJavaIdentifier()));
         if (nbt != null) {
-            listTag.add(new StringTag("AdvancedTooltipNBTTagCount", "§r§8" + "NBT: " + nbt.size() + " tag(s)"));
+            listTag.add(new StringTag("AdvancedTooltipNBTTagCount", "§r§8" + String.format(MessageTranslator.convertMessage("item.nbt_tags", language), nbt.size())));
         }
         compoundTag.put(listTag);
         newNbt.put(compoundTag);


### PR DESCRIPTION
Added an advanced tooltip command (the equivalent of F3 + H on Java) that you can run to toggle showing advanced tooltips.
Command: /geyser tooltips

Adds feature of issue #1684

Requires language PR https://github.com/GeyserMC/languages/pull/87

Fixed #1684
Closes #1684
Idk chew told me to do that