### PR TITLE
Handle a string possibly being null

### DIFF
--- a/connector/src/main/java/org/geysermc/connector/network/translators/chat/MessageTranslator.java
+++ b/connector/src/main/java/org/geysermc/connector/network/translators/chat/MessageTranslator.java
@@ -147,6 +147,9 @@ public class MessageTranslator {
      * @return Bedrock formatted message
      */
     public static String convertMessageLenient(String message, String locale) {
+        if (message == null) {
+            return "";
+        }
         if (message.isBlank()) {
             return message;
         }


### PR DESCRIPTION
An NPE can be thrown if message is null and message.isBlank() is called, so this handles that possibility (which has happened in the past).