### PR TITLE
Fix custom merchant inventory not opening

### DIFF
--- a/core/src/main/java/org/geysermc/geyser/inventory/MerchantContainer.java
+++ b/core/src/main/java/org/geysermc/geyser/inventory/MerchantContainer.java
@@ -27,6 +27,7 @@ package org.geysermc.geyser.inventory;
 
 import com.github.steveice10.mc.protocol.data.game.inventory.VillagerTrade;
 import com.github.steveice10.mc.protocol.data.game.inventory.ContainerType;
+import com.github.steveice10.mc.protocol.packet.ingame.clientbound.inventory.ClientboundMerchantOffersPacket;
 import lombok.Getter;
 import lombok.Setter;
 import org.geysermc.geyser.entity.type.Entity;
@@ -36,6 +37,7 @@ import org.geysermc.geyser.entity.type.Entity;
 public class MerchantContainer extends Container {
     private Entity villager;
     private VillagerTrade[] villagerTrades;
+    private ClientboundMerchantOffersPacket pendingOffersPacket;
 
     public MerchantContainer(String title, int id, int size, ContainerType containerType, PlayerInventory playerInventory) {
         super(title, id, size, containerType, playerInventory);

--- a/core/src/main/java/org/geysermc/geyser/translator/protocol/bedrock/BedrockContainerCloseTranslator.java
+++ b/core/src/main/java/org/geysermc/geyser/translator/protocol/bedrock/BedrockContainerCloseTranslator.java
@@ -61,7 +61,7 @@ public class BedrockContainerCloseTranslator extends PacketTranslator<ContainerC
                 InventoryUtils.displayInventory(session, openInventory);
                 openInventory.setPending(false);
 
-                if(openInventory instanceof MerchantContainer merchantContainer && merchantContainer.getPendingOffersPacket() != null) {
+                if (openInventory instanceof MerchantContainer merchantContainer && merchantContainer.getPendingOffersPacket() != null) {
                     JavaMerchantOffersTranslator.openMerchant(session, merchantContainer.getPendingOffersPacket(), merchantContainer);
                 }
             }

--- a/core/src/main/java/org/geysermc/geyser/translator/protocol/bedrock/BedrockContainerCloseTranslator.java
+++ b/core/src/main/java/org/geysermc/geyser/translator/protocol/bedrock/BedrockContainerCloseTranslator.java
@@ -61,11 +61,8 @@ public class BedrockContainerCloseTranslator extends PacketTranslator<ContainerC
                 InventoryUtils.displayInventory(session, openInventory);
                 openInventory.setPending(false);
 
-                if(openInventory instanceof MerchantContainer) {
-                    Runnable runnable = JavaMerchantOffersTranslator.QUEUED_ACTIONS.getIfPresent(openInventory.getId());
-                    if(runnable == null)
-                        return;
-                    runnable.run();
+                if(openInventory instanceof MerchantContainer merchantContainer && merchantContainer.getPendingOffersPacket() != null) {
+                    JavaMerchantOffersTranslator.openMerchant(session, merchantContainer.getPendingOffersPacket(), merchantContainer);
                 }
             }
         }

--- a/core/src/main/java/org/geysermc/geyser/translator/protocol/bedrock/BedrockContainerCloseTranslator.java
+++ b/core/src/main/java/org/geysermc/geyser/translator/protocol/bedrock/BedrockContainerCloseTranslator.java
@@ -32,6 +32,7 @@ import org.geysermc.geyser.inventory.MerchantContainer;
 import org.geysermc.geyser.session.GeyserSession;
 import org.geysermc.geyser.translator.protocol.PacketTranslator;
 import org.geysermc.geyser.translator.protocol.Translator;
+import org.geysermc.geyser.translator.protocol.java.inventory.JavaMerchantOffersTranslator;
 import org.geysermc.geyser.util.InventoryUtils;
 
 @Translator(packet = ContainerClosePacket.class)
@@ -59,6 +60,13 @@ public class BedrockContainerCloseTranslator extends PacketTranslator<ContainerC
             } else if (openInventory.isPending()) {
                 InventoryUtils.displayInventory(session, openInventory);
                 openInventory.setPending(false);
+
+                if(openInventory instanceof MerchantContainer) {
+                    Runnable runnable = JavaMerchantOffersTranslator.QUEUED_ACTIONS.getIfPresent(openInventory.getId());
+                    if(runnable == null)
+                        return;
+                    runnable.run();
+                }
             }
         }
     }

--- a/core/src/main/java/org/geysermc/geyser/translator/protocol/java/inventory/JavaMerchantOffersTranslator.java
+++ b/core/src/main/java/org/geysermc/geyser/translator/protocol/java/inventory/JavaMerchantOffersTranslator.java
@@ -58,7 +58,7 @@ public class JavaMerchantOffersTranslator extends PacketTranslator<ClientboundMe
         }
 
         // No previous inventory was closed -> no need of queuing the merchant inventory
-        if(!openInventory.isPending()) {
+        if (!openInventory.isPending()) {
             openMerchant(session, packet, merchantInventory);
             return;
         }

--- a/core/src/main/java/org/geysermc/geyser/translator/protocol/java/inventory/JavaMerchantOffersTranslator.java
+++ b/core/src/main/java/org/geysermc/geyser/translator/protocol/java/inventory/JavaMerchantOffersTranslator.java
@@ -39,6 +39,7 @@ import org.geysermc.geyser.entity.type.Entity;
 import org.geysermc.geyser.inventory.Inventory;
 import org.geysermc.geyser.inventory.MerchantContainer;
 import org.geysermc.geyser.session.GeyserSession;
+import org.geysermc.geyser.translator.inventory.InventoryTranslator;
 import org.geysermc.geyser.translator.protocol.PacketTranslator;
 import org.geysermc.geyser.translator.protocol.Translator;
 import org.geysermc.geyser.translator.inventory.item.ItemTranslator;
@@ -46,6 +47,7 @@ import org.geysermc.geyser.registry.type.ItemMapping;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.concurrent.TimeUnit;
 
 @Translator(packet = ClientboundMerchantOffersPacket.class)
 public class JavaMerchantOffersTranslator extends PacketTranslator<ClientboundMerchantOffersPacket> {
@@ -57,79 +59,90 @@ public class JavaMerchantOffersTranslator extends PacketTranslator<ClientboundMe
             return;
         }
 
-        // Retrieve the fake villager involved in the trade, and update its metadata to match with the window information
-        merchantInventory.setVillagerTrades(packet.getTrades());
-        Entity villager = merchantInventory.getVillager();
-        villager.getDirtyMetadata().put(EntityData.TRADE_TIER, packet.getVillagerLevel() - 1);
-        villager.getDirtyMetadata().put(EntityData.MAX_TRADE_TIER, 4);
-        villager.getDirtyMetadata().put(EntityData.TRADE_XP, packet.getExperience());
-        villager.updateBedrockMetadata();
+        // Prepare inventory in such a way that a villager is assigned to the merchant inventory if it does not exist
+        // As it could be, that the inventory is declared as pending due to previous closing inventory -> leads to an incorrect
+        // order of execution, which the delay in combination should handle
+        InventoryTranslator inventoryTranslator = InventoryTranslator
+                .inventoryTranslator(com.github.steveice10.mc.protocol.data.game.inventory.ContainerType.MERCHANT);
 
-        // Construct the packet that opens the trading window
-        UpdateTradePacket updateTradePacket = new UpdateTradePacket();
-        updateTradePacket.setTradeTier(packet.getVillagerLevel() - 1);
-        updateTradePacket.setContainerId((short) packet.getContainerId());
-        updateTradePacket.setContainerType(ContainerType.TRADE);
-        updateTradePacket.setDisplayName(openInventory.getTitle());
-        updateTradePacket.setSize(0);
-        updateTradePacket.setNewTradingUi(true);
-        updateTradePacket.setUsingEconomyTrade(true);
-        updateTradePacket.setPlayerUniqueEntityId(session.getPlayerEntity().getGeyserId());
-        updateTradePacket.setTraderUniqueEntityId(villager.getGeyserId());
+        assert inventoryTranslator != null;
+        inventoryTranslator.prepareInventory(session, merchantInventory);
 
-        NbtMapBuilder builder = NbtMap.builder();
-        boolean addExtraTrade = packet.isRegularVillager() && packet.getVillagerLevel() < 5;
-        List<NbtMap> tags = new ArrayList<>(addExtraTrade ? packet.getTrades().length + 1 : packet.getTrades().length);
-        for (int i = 0; i < packet.getTrades().length; i++) {
-            VillagerTrade trade = packet.getTrades()[i];
-            NbtMapBuilder recipe = NbtMap.builder();
-            recipe.putInt("netId", i + 1);
-            recipe.putInt("maxUses", trade.isTradeDisabled() ? 0 : trade.getMaxUses());
-            recipe.putInt("traderExp", trade.getXp());
-            recipe.putFloat("priceMultiplierA", trade.getPriceMultiplier());
-            recipe.put("sell", getItemTag(session, trade.getOutput(), 0));
-            recipe.putFloat("priceMultiplierB", 0.0f);
-            recipe.putInt("buyCountB", trade.getSecondInput() != null ? trade.getSecondInput().getAmount() : 0);
-            recipe.putInt("buyCountA", trade.getFirstInput().getAmount());
-            recipe.putInt("demand", trade.getDemand());
-            recipe.putInt("tier", packet.getVillagerLevel() > 0 ? packet.getVillagerLevel() - 1 : 0); // -1 crashes client
-            recipe.put("buyA", getItemTag(session, trade.getFirstInput(), trade.getSpecialPrice()));
-            if (trade.getSecondInput() != null) {
-                recipe.put("buyB", getItemTag(session, trade.getSecondInput(), 0));
+        session.scheduleInEventLoop(() -> {
+            // Retrieve the fake villager involved in the trade, and update its metadata to match with the window information
+            merchantInventory.setVillagerTrades(packet.getTrades());
+            Entity villager = merchantInventory.getVillager();
+            villager.getDirtyMetadata().put(EntityData.TRADE_TIER, packet.getVillagerLevel() - 1);
+            villager.getDirtyMetadata().put(EntityData.MAX_TRADE_TIER, 4);
+            villager.getDirtyMetadata().put(EntityData.TRADE_XP, packet.getExperience());
+            villager.updateBedrockMetadata();
+
+            // Construct the packet that opens the trading window
+            UpdateTradePacket updateTradePacket = new UpdateTradePacket();
+            updateTradePacket.setTradeTier(packet.getVillagerLevel() - 1);
+            updateTradePacket.setContainerId((short) packet.getContainerId());
+            updateTradePacket.setContainerType(ContainerType.TRADE);
+            updateTradePacket.setDisplayName(openInventory.getTitle());
+            updateTradePacket.setSize(0);
+            updateTradePacket.setNewTradingUi(true);
+            updateTradePacket.setUsingEconomyTrade(true);
+            updateTradePacket.setPlayerUniqueEntityId(session.getPlayerEntity().getGeyserId());
+            updateTradePacket.setTraderUniqueEntityId(villager.getGeyserId());
+
+            NbtMapBuilder builder = NbtMap.builder();
+            boolean addExtraTrade = packet.isRegularVillager() && packet.getVillagerLevel() < 5;
+            List<NbtMap> tags = new ArrayList<>(addExtraTrade ? packet.getTrades().length + 1 : packet.getTrades().length);
+            for (int i = 0; i < packet.getTrades().length; i++) {
+                VillagerTrade trade = packet.getTrades()[i];
+                NbtMapBuilder recipe = NbtMap.builder();
+                recipe.putInt("netId", i + 1);
+                recipe.putInt("maxUses", trade.isTradeDisabled() ? 0 : trade.getMaxUses());
+                recipe.putInt("traderExp", trade.getXp());
+                recipe.putFloat("priceMultiplierA", trade.getPriceMultiplier());
+                recipe.put("sell", getItemTag(session, trade.getOutput(), 0));
+                recipe.putFloat("priceMultiplierB", 0.0f);
+                recipe.putInt("buyCountB", trade.getSecondInput() != null ? trade.getSecondInput().getAmount() : 0);
+                recipe.putInt("buyCountA", trade.getFirstInput().getAmount());
+                recipe.putInt("demand", trade.getDemand());
+                recipe.putInt("tier", packet.getVillagerLevel() > 0 ? packet.getVillagerLevel() - 1 : 0); // -1 crashes client
+                recipe.put("buyA", getItemTag(session, trade.getFirstInput(), trade.getSpecialPrice()));
+                if (trade.getSecondInput() != null) {
+                    recipe.put("buyB", getItemTag(session, trade.getSecondInput(), 0));
+                }
+                recipe.putInt("uses", trade.getNumUses());
+                recipe.putByte("rewardExp", (byte) 1);
+                tags.add(recipe.build());
             }
-            recipe.putInt("uses", trade.getNumUses());
-            recipe.putByte("rewardExp", (byte) 1);
-            tags.add(recipe.build());
-        }
 
-        //Hidden trade to fix visual experience bug
-        if (addExtraTrade) {
-            tags.add(NbtMap.builder()
-                    .putInt("maxUses", 0)
-                    .putInt("traderExp", 0)
-                    .putFloat("priceMultiplierA", 0.0f)
-                    .putFloat("priceMultiplierB", 0.0f)
-                    .putInt("buyCountB", 0)
-                    .putInt("buyCountA", 0)
-                    .putInt("demand", 0)
-                    .putInt("tier", 5)
-                    .putInt("uses", 0)
-                    .putByte("rewardExp", (byte) 0)
-                    .build());
-        }
+            //Hidden trade to fix visual experience bug
+            if (addExtraTrade) {
+                tags.add(NbtMap.builder()
+                        .putInt("maxUses", 0)
+                        .putInt("traderExp", 0)
+                        .putFloat("priceMultiplierA", 0.0f)
+                        .putFloat("priceMultiplierB", 0.0f)
+                        .putInt("buyCountB", 0)
+                        .putInt("buyCountA", 0)
+                        .putInt("demand", 0)
+                        .putInt("tier", 5)
+                        .putInt("uses", 0)
+                        .putByte("rewardExp", (byte) 0)
+                        .build());
+            }
 
-        builder.putList("Recipes", NbtType.COMPOUND, tags);
+            builder.putList("Recipes", NbtType.COMPOUND, tags);
 
-        List<NbtMap> expTags = new ArrayList<>(5);
-        expTags.add(NbtMap.builder().putInt("0", 0).build());
-        expTags.add(NbtMap.builder().putInt("1", 10).build());
-        expTags.add(NbtMap.builder().putInt("2", 70).build());
-        expTags.add(NbtMap.builder().putInt("3", 150).build());
-        expTags.add(NbtMap.builder().putInt("4", 250).build());
-        builder.putList("TierExpRequirements", NbtType.COMPOUND, expTags);
+            List<NbtMap> expTags = new ArrayList<>(5);
+            expTags.add(NbtMap.builder().putInt("0", 0).build());
+            expTags.add(NbtMap.builder().putInt("1", 10).build());
+            expTags.add(NbtMap.builder().putInt("2", 70).build());
+            expTags.add(NbtMap.builder().putInt("3", 150).build());
+            expTags.add(NbtMap.builder().putInt("4", 250).build());
+            builder.putList("TierExpRequirements", NbtType.COMPOUND, expTags);
 
-        updateTradePacket.setOffers(builder.build());
-        session.sendUpstreamPacket(updateTradePacket);
+            updateTradePacket.setOffers(builder.build());
+            session.sendUpstreamPacket(updateTradePacket);
+        }, 200, TimeUnit.MILLISECONDS);
     }
 
     private NbtMap getItemTag(GeyserSession session, ItemStack stack, int specialPrice) {

--- a/core/src/main/java/org/geysermc/geyser/translator/protocol/java/inventory/JavaMerchantOffersTranslator.java
+++ b/core/src/main/java/org/geysermc/geyser/translator/protocol/java/inventory/JavaMerchantOffersTranslator.java
@@ -30,7 +30,6 @@ import com.github.steveice10.mc.protocol.data.game.inventory.VillagerTrade;
 import com.github.steveice10.mc.protocol.packet.ingame.clientbound.inventory.ClientboundMerchantOffersPacket;
 import com.google.common.cache.Cache;
 import com.google.common.cache.CacheBuilder;
-import com.google.common.collect.Queues;
 import com.nukkitx.nbt.NbtMap;
 import com.nukkitx.nbt.NbtMapBuilder;
 import com.nukkitx.nbt.NbtType;
@@ -41,14 +40,14 @@ import com.nukkitx.protocol.bedrock.packet.UpdateTradePacket;
 import org.geysermc.geyser.entity.type.Entity;
 import org.geysermc.geyser.inventory.Inventory;
 import org.geysermc.geyser.inventory.MerchantContainer;
+import org.geysermc.geyser.registry.type.ItemMapping;
 import org.geysermc.geyser.session.GeyserSession;
-import org.geysermc.geyser.translator.inventory.InventoryTranslator;
+import org.geysermc.geyser.translator.inventory.item.ItemTranslator;
 import org.geysermc.geyser.translator.protocol.PacketTranslator;
 import org.geysermc.geyser.translator.protocol.Translator;
-import org.geysermc.geyser.translator.inventory.item.ItemTranslator;
-import org.geysermc.geyser.registry.type.ItemMapping;
 
-import java.util.*;
+import java.util.ArrayList;
+import java.util.List;
 import java.util.concurrent.TimeUnit;
 
 @Translator(packet = ClientboundMerchantOffersPacket.class)

--- a/core/src/main/java/org/geysermc/geyser/translator/protocol/java/inventory/JavaMerchantOffersTranslator.java
+++ b/core/src/main/java/org/geysermc/geyser/translator/protocol/java/inventory/JavaMerchantOffersTranslator.java
@@ -28,6 +28,9 @@ package org.geysermc.geyser.translator.protocol.java.inventory;
 import com.github.steveice10.mc.protocol.data.game.entity.metadata.ItemStack;
 import com.github.steveice10.mc.protocol.data.game.inventory.VillagerTrade;
 import com.github.steveice10.mc.protocol.packet.ingame.clientbound.inventory.ClientboundMerchantOffersPacket;
+import com.google.common.cache.Cache;
+import com.google.common.cache.CacheBuilder;
+import com.google.common.collect.Queues;
 import com.nukkitx.nbt.NbtMap;
 import com.nukkitx.nbt.NbtMapBuilder;
 import com.nukkitx.nbt.NbtType;
@@ -45,12 +48,15 @@ import org.geysermc.geyser.translator.protocol.Translator;
 import org.geysermc.geyser.translator.inventory.item.ItemTranslator;
 import org.geysermc.geyser.registry.type.ItemMapping;
 
-import java.util.ArrayList;
-import java.util.List;
+import java.util.*;
 import java.util.concurrent.TimeUnit;
 
 @Translator(packet = ClientboundMerchantOffersPacket.class)
 public class JavaMerchantOffersTranslator extends PacketTranslator<ClientboundMerchantOffersPacket> {
+
+    public static Cache<Integer, Runnable> QUEUED_ACTIONS = CacheBuilder.newBuilder()
+            .expireAfterWrite(5, TimeUnit.SECONDS)
+            .build();
 
     @Override
     public void translate(GeyserSession session, ClientboundMerchantOffersPacket packet) {
@@ -59,90 +65,91 @@ public class JavaMerchantOffersTranslator extends PacketTranslator<ClientboundMe
             return;
         }
 
-        // Prepare inventory in such a way that a villager is assigned to the merchant inventory if it does not exist
-        // As it could be, that the inventory is declared as pending due to previous closing inventory -> leads to an incorrect
-        // order of execution, which the delay in combination should handle
-        InventoryTranslator inventoryTranslator = InventoryTranslator
-                .inventoryTranslator(com.github.steveice10.mc.protocol.data.game.inventory.ContainerType.MERCHANT);
+        // No previous inventory was closed -> no need of queuing the merchant inventory
+        if(!openInventory.isPending()) {
+            this.openMerchant(session, packet, merchantInventory);
+            return;
+        }
 
-        assert inventoryTranslator != null;
-        inventoryTranslator.prepareInventory(session, merchantInventory);
+        // The inventory is declared as pending due to previous closing inventory -> leads to an incorrect order of execution
+        // Handled in BedrockContainerCloseTranslator
+        QUEUED_ACTIONS.put(openInventory.getId(), () -> this.openMerchant(session, packet, merchantInventory));
+    }
 
-        session.scheduleInEventLoop(() -> {
-            // Retrieve the fake villager involved in the trade, and update its metadata to match with the window information
-            merchantInventory.setVillagerTrades(packet.getTrades());
-            Entity villager = merchantInventory.getVillager();
-            villager.getDirtyMetadata().put(EntityData.TRADE_TIER, packet.getVillagerLevel() - 1);
-            villager.getDirtyMetadata().put(EntityData.MAX_TRADE_TIER, 4);
-            villager.getDirtyMetadata().put(EntityData.TRADE_XP, packet.getExperience());
-            villager.updateBedrockMetadata();
+    private void openMerchant(GeyserSession session, ClientboundMerchantOffersPacket packet, MerchantContainer merchantInventory) {
+        // Retrieve the fake villager involved in the trade, and update its metadata to match with the window information
+        merchantInventory.setVillagerTrades(packet.getTrades());
+        Entity villager = merchantInventory.getVillager();
+        villager.getDirtyMetadata().put(EntityData.TRADE_TIER, packet.getVillagerLevel() - 1);
+        villager.getDirtyMetadata().put(EntityData.MAX_TRADE_TIER, 4);
+        villager.getDirtyMetadata().put(EntityData.TRADE_XP, packet.getExperience());
+        villager.updateBedrockMetadata();
 
-            // Construct the packet that opens the trading window
-            UpdateTradePacket updateTradePacket = new UpdateTradePacket();
-            updateTradePacket.setTradeTier(packet.getVillagerLevel() - 1);
-            updateTradePacket.setContainerId((short) packet.getContainerId());
-            updateTradePacket.setContainerType(ContainerType.TRADE);
-            updateTradePacket.setDisplayName(openInventory.getTitle());
-            updateTradePacket.setSize(0);
-            updateTradePacket.setNewTradingUi(true);
-            updateTradePacket.setUsingEconomyTrade(true);
-            updateTradePacket.setPlayerUniqueEntityId(session.getPlayerEntity().getGeyserId());
-            updateTradePacket.setTraderUniqueEntityId(villager.getGeyserId());
+        // Construct the packet that opens the trading window
+        UpdateTradePacket updateTradePacket = new UpdateTradePacket();
+        updateTradePacket.setTradeTier(packet.getVillagerLevel() - 1);
+        updateTradePacket.setContainerId((short) packet.getContainerId());
+        updateTradePacket.setContainerType(ContainerType.TRADE);
+        updateTradePacket.setDisplayName(session.getOpenInventory().getTitle());
+        updateTradePacket.setSize(0);
+        updateTradePacket.setNewTradingUi(true);
+        updateTradePacket.setUsingEconomyTrade(true);
+        updateTradePacket.setPlayerUniqueEntityId(session.getPlayerEntity().getGeyserId());
+        updateTradePacket.setTraderUniqueEntityId(villager.getGeyserId());
 
-            NbtMapBuilder builder = NbtMap.builder();
-            boolean addExtraTrade = packet.isRegularVillager() && packet.getVillagerLevel() < 5;
-            List<NbtMap> tags = new ArrayList<>(addExtraTrade ? packet.getTrades().length + 1 : packet.getTrades().length);
-            for (int i = 0; i < packet.getTrades().length; i++) {
-                VillagerTrade trade = packet.getTrades()[i];
-                NbtMapBuilder recipe = NbtMap.builder();
-                recipe.putInt("netId", i + 1);
-                recipe.putInt("maxUses", trade.isTradeDisabled() ? 0 : trade.getMaxUses());
-                recipe.putInt("traderExp", trade.getXp());
-                recipe.putFloat("priceMultiplierA", trade.getPriceMultiplier());
-                recipe.put("sell", getItemTag(session, trade.getOutput(), 0));
-                recipe.putFloat("priceMultiplierB", 0.0f);
-                recipe.putInt("buyCountB", trade.getSecondInput() != null ? trade.getSecondInput().getAmount() : 0);
-                recipe.putInt("buyCountA", trade.getFirstInput().getAmount());
-                recipe.putInt("demand", trade.getDemand());
-                recipe.putInt("tier", packet.getVillagerLevel() > 0 ? packet.getVillagerLevel() - 1 : 0); // -1 crashes client
-                recipe.put("buyA", getItemTag(session, trade.getFirstInput(), trade.getSpecialPrice()));
-                if (trade.getSecondInput() != null) {
-                    recipe.put("buyB", getItemTag(session, trade.getSecondInput(), 0));
-                }
-                recipe.putInt("uses", trade.getNumUses());
-                recipe.putByte("rewardExp", (byte) 1);
-                tags.add(recipe.build());
+        NbtMapBuilder builder = NbtMap.builder();
+        boolean addExtraTrade = packet.isRegularVillager() && packet.getVillagerLevel() < 5;
+        List<NbtMap> tags = new ArrayList<>(addExtraTrade ? packet.getTrades().length + 1 : packet.getTrades().length);
+        for (int i = 0; i < packet.getTrades().length; i++) {
+            VillagerTrade trade = packet.getTrades()[i];
+            NbtMapBuilder recipe = NbtMap.builder();
+            recipe.putInt("netId", i + 1);
+            recipe.putInt("maxUses", trade.isTradeDisabled() ? 0 : trade.getMaxUses());
+            recipe.putInt("traderExp", trade.getXp());
+            recipe.putFloat("priceMultiplierA", trade.getPriceMultiplier());
+            recipe.put("sell", getItemTag(session, trade.getOutput(), 0));
+            recipe.putFloat("priceMultiplierB", 0.0f);
+            recipe.putInt("buyCountB", trade.getSecondInput() != null ? trade.getSecondInput().getAmount() : 0);
+            recipe.putInt("buyCountA", trade.getFirstInput().getAmount());
+            recipe.putInt("demand", trade.getDemand());
+            recipe.putInt("tier", packet.getVillagerLevel() > 0 ? packet.getVillagerLevel() - 1 : 0); // -1 crashes client
+            recipe.put("buyA", getItemTag(session, trade.getFirstInput(), trade.getSpecialPrice()));
+            if (trade.getSecondInput() != null) {
+                recipe.put("buyB", getItemTag(session, trade.getSecondInput(), 0));
             }
+            recipe.putInt("uses", trade.getNumUses());
+            recipe.putByte("rewardExp", (byte) 1);
+            tags.add(recipe.build());
+        }
 
-            //Hidden trade to fix visual experience bug
-            if (addExtraTrade) {
-                tags.add(NbtMap.builder()
-                        .putInt("maxUses", 0)
-                        .putInt("traderExp", 0)
-                        .putFloat("priceMultiplierA", 0.0f)
-                        .putFloat("priceMultiplierB", 0.0f)
-                        .putInt("buyCountB", 0)
-                        .putInt("buyCountA", 0)
-                        .putInt("demand", 0)
-                        .putInt("tier", 5)
-                        .putInt("uses", 0)
-                        .putByte("rewardExp", (byte) 0)
-                        .build());
-            }
+        //Hidden trade to fix visual experience bug
+        if (addExtraTrade) {
+            tags.add(NbtMap.builder()
+                    .putInt("maxUses", 0)
+                    .putInt("traderExp", 0)
+                    .putFloat("priceMultiplierA", 0.0f)
+                    .putFloat("priceMultiplierB", 0.0f)
+                    .putInt("buyCountB", 0)
+                    .putInt("buyCountA", 0)
+                    .putInt("demand", 0)
+                    .putInt("tier", 5)
+                    .putInt("uses", 0)
+                    .putByte("rewardExp", (byte) 0)
+                    .build());
+        }
 
-            builder.putList("Recipes", NbtType.COMPOUND, tags);
+        builder.putList("Recipes", NbtType.COMPOUND, tags);
 
-            List<NbtMap> expTags = new ArrayList<>(5);
-            expTags.add(NbtMap.builder().putInt("0", 0).build());
-            expTags.add(NbtMap.builder().putInt("1", 10).build());
-            expTags.add(NbtMap.builder().putInt("2", 70).build());
-            expTags.add(NbtMap.builder().putInt("3", 150).build());
-            expTags.add(NbtMap.builder().putInt("4", 250).build());
-            builder.putList("TierExpRequirements", NbtType.COMPOUND, expTags);
+        List<NbtMap> expTags = new ArrayList<>(5);
+        expTags.add(NbtMap.builder().putInt("0", 0).build());
+        expTags.add(NbtMap.builder().putInt("1", 10).build());
+        expTags.add(NbtMap.builder().putInt("2", 70).build());
+        expTags.add(NbtMap.builder().putInt("3", 150).build());
+        expTags.add(NbtMap.builder().putInt("4", 250).build());
+        builder.putList("TierExpRequirements", NbtType.COMPOUND, expTags);
 
-            updateTradePacket.setOffers(builder.build());
-            session.sendUpstreamPacket(updateTradePacket);
-        }, 200, TimeUnit.MILLISECONDS);
+        updateTradePacket.setOffers(builder.build());
+        session.sendUpstreamPacket(updateTradePacket);
     }
 
     private NbtMap getItemTag(GeyserSession session, ItemStack stack, int specialPrice) {


### PR DESCRIPTION
**Hello!**

During development of a plugin using custom merchant inventories for our server, I noticed that it partially doesn't work for Bedrock/PE players.

**Custom Merchants cannot be opened because the Villager is null. Full exception:** 

```
java.lang.NullPointerException: Cannot invoke "org.geysermc.geyser.entity.type.Entity.getDirtyMetadata()" because "villager" is null
        at org.geysermc.geyser.translator.protocol.java.inventory.JavaMerchantOffersTranslator.translate(JavaMerchantOffersTranslator.java:63) ~[Geyser.jar:?]
        at org.geysermc.geyser.translator.protocol.java.inventory.JavaMerchantOffersTranslator.translate(JavaMerchantOffersTranslator.java:50) ~[Geyser.jar:?]
        at org.geysermc.geyser.registry.PacketTranslatorRegistry.translate0(PacketTranslatorRegistry.java:86) ~[Geyser.jar:?]
        at org.geysermc.geyser.registry.PacketTranslatorRegistry.lambda$translate$0(PacketTranslatorRegistry.java:67) ~[Geyser.jar:?]
        at io.netty.channel.DefaultEventLoop.run(DefaultEventLoop.java:54) [Geyser.jar:?]
        at io.netty.util.concurrent.SingleThreadEventExecutor$4.run(SingleThreadEventExecutor.java:986) [Geyser.jar:?]
        at io.netty.util.internal.ThreadExecutorMap$2.run(ThreadExecutorMap.java:74) [Geyser.jar:?]
        at io.netty.util.concurrent.FastThreadLocalRunnable.run(FastThreadLocalRunnable.java:30) [Geyser.jar:?]
        at java.lang.Thread.run(Thread.java:831) [?:?]
> java.lang.NullPointerException: Cannot invoke "org.geysermc.geyser.entity.type.Entity.getDirtyMetadata()" because "villager" is null
        at org.geysermc.geyser.translator.protocol.java.inventory.JavaMerchantOffersTranslator.translate(JavaMerchantOffersTranslator.java:63)
        at org.geysermc.geyser.translator.protocol.java.inventory.JavaMerchantOffersTranslator.translate(JavaMerchantOffersTranslator.java:50)
        at org.geysermc.geyser.registry.PacketTranslatorRegistry.translate0(PacketTranslatorRegistry.java:86)
        at org.geysermc.geyser.registry.PacketTranslatorRegistry.lambda$translate$0(PacketTranslatorRegistry.java:67)
        at io.netty.channel.DefaultEventLoop.run(DefaultEventLoop.java:54)
        at io.netty.util.concurrent.SingleThreadEventExecutor$4.run(SingleThreadEventExecutor.java:986)
        at io.netty.util.internal.ThreadExecutorMap$2.run(ThreadExecutorMap.java:74)
        at io.netty.util.concurrent.FastThreadLocalRunnable.run(FastThreadLocalRunnable.java:30)
        at java.base/java.lang.Thread.run(Thread.java:831)

```

_I assume that this is only the case if an inventory is closed directly before (e.g. you switch from an inventory to the merchant inventory). Workaround would be to open the merchant inventory some ticks later_ 

<img width="828" alt="grafik" src="https://user-images.githubusercontent.com/12764339/144763434-801994ca-96f3-4eba-a3d9-da9c15dae901.png">


This is because the opening of the merchant inventory is set to `Pending` status (due to the previous closing inventory - [can be seen here](https://github.com/GeyserMC/Geyser/blob/master/core/src/main/java/org/geysermc/geyser/util/InventoryUtils.java#L72)), which causes `JavaMerchantOffersTranslator#translate` to be called before `MerchantInventoryTranslator#prepareInventory`. This results in an incorrect order of execution, since the `JavaMerchantOffersTranslator` depends on `MerchantInventoryTranslator#prepareInventory` (because that's where the fake villager of the merchant inventory is set - which in turn is needed). In this case, we queue all requests for a merchant inventory when a previous inventory has been closed. This request is executed immediately after the merchant inventory is opened.

Issues that would be completely fixed (also tested):

- https://github.com/GeyserMC/Geyser/issues/1256
- https://github.com/GeyserMC/Geyser/issues/2543

