### PR TITLE
Fix some mount offsets and strange behaviors with GSit

### DIFF
--- a/core/src/main/java/org/geysermc/geyser/entity/type/AreaEffectCloudEntity.java
+++ b/core/src/main/java/org/geysermc/geyser/entity/type/AreaEffectCloudEntity.java
@@ -58,9 +58,8 @@ public class AreaEffectCloudEntity extends Entity {
     }
 
     public void setRadius(FloatEntityMetadata entityMetadata) {
-        float value = entityMetadata.getPrimitiveValue();
         // Anything less than 0.5 will cause the cloud to despawn
-        value = Math.max(value, 0.5f);
+        float value = Math.max(entityMetadata.getPrimitiveValue(), 0.5f);
         dirtyMetadata.put(EntityData.AREA_EFFECT_CLOUD_RADIUS, value);
         dirtyMetadata.put(EntityData.BOUNDING_BOX_WIDTH, 2.0f * value);
     }

--- a/core/src/main/java/org/geysermc/geyser/entity/type/AreaEffectCloudEntity.java
+++ b/core/src/main/java/org/geysermc/geyser/entity/type/AreaEffectCloudEntity.java
@@ -47,18 +47,20 @@ public class AreaEffectCloudEntity extends Entity {
     protected void initializeMetadata() {
         super.initializeMetadata();
         // Without this the cloud doesn't appear,
-        dirtyMetadata.put(EntityData.AREA_EFFECT_CLOUD_DURATION, 600);
+        dirtyMetadata.put(EntityData.AREA_EFFECT_CLOUD_DURATION, Integer.MAX_VALUE);
 
         // This disabled client side shrink of the cloud
         dirtyMetadata.put(EntityData.AREA_EFFECT_CLOUD_RADIUS, 0.0f);
-        dirtyMetadata.put(EntityData.AREA_EFFECT_CLOUD_CHANGE_RATE, -0.005f);
-        dirtyMetadata.put(EntityData.AREA_EFFECT_CLOUD_CHANGE_ON_PICKUP, -0.5f);
+        dirtyMetadata.put(EntityData.AREA_EFFECT_CLOUD_CHANGE_RATE, Float.MIN_VALUE);
+        dirtyMetadata.put(EntityData.AREA_EFFECT_CLOUD_CHANGE_ON_PICKUP, Float.MIN_VALUE);
 
         setFlag(EntityFlag.FIRE_IMMUNE, true);
     }
 
     public void setRadius(FloatEntityMetadata entityMetadata) {
         float value = entityMetadata.getPrimitiveValue();
+        // Anything less than 0.5 will cause the cloud to despawn
+        value = Math.max(value, 0.5f);
         dirtyMetadata.put(EntityData.AREA_EFFECT_CLOUD_RADIUS, value);
         dirtyMetadata.put(EntityData.BOUNDING_BOX_WIDTH, 2.0f * value);
     }

--- a/core/src/main/java/org/geysermc/geyser/entity/type/BoatEntity.java
+++ b/core/src/main/java/org/geysermc/geyser/entity/type/BoatEntity.java
@@ -84,8 +84,12 @@ public class BoatEntity extends Entity {
 
         MoveEntityAbsolutePacket moveEntityPacket = new MoveEntityAbsolutePacket();
         moveEntityPacket.setRuntimeEntityId(geyserId);
-        // Minimal glitching when ClientboundMoveVehiclePacket is sent
-        moveEntityPacket.setPosition(session.getRidingVehicleEntity() == this ? position.up(EntityDefinitions.PLAYER.offset() - this.definition.offset()) : this.position);
+        if (session.getRidingVehicleEntity() == this && session.getPlayerEntity().isRidingInFront()) {
+            // Minimal glitching when ClientboundMoveVehiclePacket is sent
+            moveEntityPacket.setPosition(position.up(EntityDefinitions.PLAYER.offset() - this.definition.offset()));
+        } else {
+            moveEntityPacket.setPosition(this.position);
+        }
         moveEntityPacket.setRotation(getBedrockRotation());
         moveEntityPacket.setOnGround(isOnGround);
         moveEntityPacket.setTeleported(teleported);

--- a/core/src/main/java/org/geysermc/geyser/entity/type/BoatEntity.java
+++ b/core/src/main/java/org/geysermc/geyser/entity/type/BoatEntity.java
@@ -84,7 +84,7 @@ public class BoatEntity extends Entity {
 
         MoveEntityAbsolutePacket moveEntityPacket = new MoveEntityAbsolutePacket();
         moveEntityPacket.setRuntimeEntityId(geyserId);
-        if (session.getRidingVehicleEntity() == this && session.getPlayerEntity().isRidingInFront()) {
+        if (session.getPlayerEntity().getVehicle() == this && session.getPlayerEntity().isRidingInFront()) {
             // Minimal glitching when ClientboundMoveVehiclePacket is sent
             moveEntityPacket.setPosition(position.up(EntityDefinitions.PLAYER.offset() - this.definition.offset()));
         } else {

--- a/core/src/main/java/org/geysermc/geyser/entity/type/BoatEntity.java
+++ b/core/src/main/java/org/geysermc/geyser/entity/type/BoatEntity.java
@@ -132,7 +132,7 @@ public class BoatEntity extends Entity {
             paddleTimeLeft = 0f;
             if (!this.passengers.isEmpty()) {
                 // Get the entity by the first stored passenger and convey motion in this manner
-                Entity entity = session.getEntityCache().getEntityByJavaId(this.passengers.getInt(0));
+                Entity entity = this.passengers.get(0);
                 if (entity != null) {
                     updateLeftPaddle(session, entity);
                 }
@@ -148,7 +148,7 @@ public class BoatEntity extends Entity {
         if (isPaddlingRight) {
             paddleTimeRight = 0f;
             if (!this.passengers.isEmpty()) {
-                Entity entity = session.getEntityCache().getEntityByJavaId(this.passengers.getInt(0));
+                Entity entity = this.passengers.get(0);
                 if (entity != null) {
                     updateRightPaddle(session, entity);
                 }

--- a/core/src/main/java/org/geysermc/geyser/entity/type/BoatEntity.java
+++ b/core/src/main/java/org/geysermc/geyser/entity/type/BoatEntity.java
@@ -132,7 +132,7 @@ public class BoatEntity extends Entity {
             paddleTimeLeft = 0f;
             if (!this.passengers.isEmpty()) {
                 // Get the entity by the first stored passenger and convey motion in this manner
-                Entity entity = session.getEntityCache().getEntityByJavaId(this.passengers.iterator().nextLong());
+                Entity entity = session.getEntityCache().getEntityByJavaId(this.passengers.getInt(0));
                 if (entity != null) {
                     updateLeftPaddle(session, entity);
                 }
@@ -148,7 +148,7 @@ public class BoatEntity extends Entity {
         if (isPaddlingRight) {
             paddleTimeRight = 0f;
             if (!this.passengers.isEmpty()) {
-                Entity entity = session.getEntityCache().getEntityByJavaId(this.passengers.iterator().nextLong());
+                Entity entity = session.getEntityCache().getEntityByJavaId(this.passengers.getInt(0));
                 if (entity != null) {
                     updateRightPaddle(session, entity);
                 }

--- a/core/src/main/java/org/geysermc/geyser/entity/type/Entity.java
+++ b/core/src/main/java/org/geysermc/geyser/entity/type/Entity.java
@@ -39,7 +39,8 @@ import com.nukkitx.protocol.bedrock.packet.AddEntityPacket;
 import com.nukkitx.protocol.bedrock.packet.MoveEntityAbsolutePacket;
 import com.nukkitx.protocol.bedrock.packet.RemoveEntityPacket;
 import com.nukkitx.protocol.bedrock.packet.SetEntityDataPacket;
-import it.unimi.dsi.fastutil.longs.LongOpenHashSet;
+import it.unimi.dsi.fastutil.ints.IntArrayList;
+import it.unimi.dsi.fastutil.ints.IntList;
 import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.Setter;
@@ -90,7 +91,7 @@ public class Entity {
     protected String nametag = "";
     /* Metadata end */
 
-    protected LongOpenHashSet passengers = new LongOpenHashSet();
+    protected IntList passengers = new IntArrayList();
     /**
      * A container to store temporary metadata before it's sent to Bedrock.
      */
@@ -181,7 +182,7 @@ public class Entity {
     public boolean despawnEntity() {
         if (!valid) return true;
 
-        for (long passenger : passengers) { // Make sure all passengers on the despawned entity are updated
+        for (int passenger : passengers) { // Make sure all passengers on the despawned entity are updated
             Entity entity = session.getEntityCache().getEntityByJavaId(passenger);
             if (entity == null) continue;
             entity.setFlag(EntityFlag.RIDING, false);

--- a/core/src/main/java/org/geysermc/geyser/entity/type/Entity.java
+++ b/core/src/main/java/org/geysermc/geyser/entity/type/Entity.java
@@ -93,7 +93,7 @@ public class Entity {
     /* Metadata end */
 
     protected IntList passengers = new IntArrayList();
-    protected int vehicleId = -1;
+    protected Entity vehicle;
     /**
      * A container to store temporary metadata before it's sent to Bedrock.
      */
@@ -187,7 +187,7 @@ public class Entity {
         for (int passenger : passengers) { // Make sure all passengers on the despawned entity are updated
             Entity entity = session.getEntityCache().getEntityByJavaId(passenger);
             if (entity == null) continue;
-            entity.setVehicleId(-1);
+            entity.setVehicle(null);
             entity.setFlag(EntityFlag.RIDING, false);
             entity.updateBedrockMetadata();
         }
@@ -459,7 +459,6 @@ public class Entity {
      * Update this entity's mount offset
      */
     protected void updateMountOffset() {
-        Entity vehicle = session.getEntityCache().getEntityByJavaId(vehicleId);
         if (vehicle != null) {
             boolean rider = vehicle.getPassengers().getInt(0) == entityId;
             EntityUtils.updateMountOffset(this, vehicle, rider, true, vehicle.getPassengers().size() > 1);

--- a/core/src/main/java/org/geysermc/geyser/entity/type/Entity.java
+++ b/core/src/main/java/org/geysermc/geyser/entity/type/Entity.java
@@ -187,6 +187,7 @@ public class Entity {
         for (int passenger : passengers) { // Make sure all passengers on the despawned entity are updated
             Entity entity = session.getEntityCache().getEntityByJavaId(passenger);
             if (entity == null) continue;
+            entity.setVehicleId(-1);
             entity.setFlag(EntityFlag.RIDING, false);
             entity.updateBedrockMetadata();
         }

--- a/core/src/main/java/org/geysermc/geyser/entity/type/FishingHookEntity.java
+++ b/core/src/main/java/org/geysermc/geyser/entity/type/FishingHookEntity.java
@@ -78,13 +78,7 @@ public class FishingHookEntity extends ThrowableEntity {
 
     public void setHookedEntity(IntEntityMetadata entityMetadata) {
         int hookedEntityId = entityMetadata.getPrimitiveValue() - 1;
-        Entity entity;
-        if (session.getPlayerEntity().getEntityId() == hookedEntityId) {
-            entity = session.getPlayerEntity();
-        } else {
-            entity = session.getEntityCache().getEntityByJavaId(hookedEntityId);
-        }
-
+        Entity entity = session.getEntityCache().getEntityByJavaId(hookedEntityId);
         if (entity != null) {
             bedrockTargetId = entity.getGeyserId();
             dirtyMetadata.put(EntityData.TARGET_EID, bedrockTargetId);

--- a/core/src/main/java/org/geysermc/geyser/entity/type/living/ArmorStandEntity.java
+++ b/core/src/main/java/org/geysermc/geyser/entity/type/living/ArmorStandEntity.java
@@ -148,6 +148,7 @@ public class ArmorStandEntity extends LivingEntity {
             if (isMarker) {
                 setBoundingBoxWidth(0.0f);
                 setBoundingBoxHeight(0.0f);
+                dirtyMetadata.put(EntityData.SCALE, 0f);
             } else {
                 toggleSmallStatus();
             }

--- a/core/src/main/java/org/geysermc/geyser/entity/type/living/ArmorStandEntity.java
+++ b/core/src/main/java/org/geysermc/geyser/entity/type/living/ArmorStandEntity.java
@@ -146,8 +146,8 @@ public class ArmorStandEntity extends LivingEntity {
         isMarker = (xd & 0x10) == 0x10;
         if (oldIsMarker != isMarker) {
             if (isMarker) {
-                dirtyMetadata.put(EntityData.BOUNDING_BOX_WIDTH, 0.0f);
-                dirtyMetadata.put(EntityData.BOUNDING_BOX_HEIGHT, 0.0f);
+                setBoundingBoxWidth(0.0f);
+                setBoundingBoxHeight(0.0f);
                 dirtyMetadata.put(EntityData.SCALE, 0f);
             } else {
                 toggleSmallStatus();
@@ -376,8 +376,8 @@ public class ArmorStandEntity extends LivingEntity {
      * If this armor stand is not a marker, set its bounding box size and scale.
      */
     private void toggleSmallStatus() {
-        dirtyMetadata.put(EntityData.BOUNDING_BOX_WIDTH, isSmall ? 0.25f : definition.width());
-        dirtyMetadata.put(EntityData.BOUNDING_BOX_HEIGHT, isSmall ? 0.9875f : definition.height());
+        setBoundingBoxWidth(isSmall ? 0.25f : definition.width());
+        setBoundingBoxHeight(isSmall ? 0.9875f : definition.height());
         dirtyMetadata.put(EntityData.SCALE, isSmall ? 0.55f : 1f);
     }
 

--- a/core/src/main/java/org/geysermc/geyser/entity/type/living/ArmorStandEntity.java
+++ b/core/src/main/java/org/geysermc/geyser/entity/type/living/ArmorStandEntity.java
@@ -148,12 +148,11 @@ public class ArmorStandEntity extends LivingEntity {
             if (isMarker) {
                 setBoundingBoxWidth(0.0f);
                 setBoundingBoxHeight(0.0f);
-                dirtyMetadata.put(EntityData.SCALE, 0f);
             } else {
                 toggleSmallStatus();
             }
 
-            updatePassengerOffsets();
+            updateMountOffset();
             updateSecondEntityStatus(false);
         }
 

--- a/core/src/main/java/org/geysermc/geyser/entity/type/living/ArmorStandEntity.java
+++ b/core/src/main/java/org/geysermc/geyser/entity/type/living/ArmorStandEntity.java
@@ -153,6 +153,7 @@ public class ArmorStandEntity extends LivingEntity {
                 toggleSmallStatus();
             }
 
+            updatePassengerOffsets();
             updateSecondEntityStatus(false);
         }
 

--- a/core/src/main/java/org/geysermc/geyser/entity/type/living/animal/StriderEntity.java
+++ b/core/src/main/java/org/geysermc/geyser/entity/type/living/animal/StriderEntity.java
@@ -62,7 +62,7 @@ public class StriderEntity extends AnimalEntity {
             boolean parentShaking = false;
             //TODO optimize
             for (Entity ent : session.getEntityCache().getEntities().values()) {
-                if (ent.getPassengers().contains(entityId) && ent instanceof StriderEntity) {
+                if (ent.getPassengers().contains((int) entityId) && ent instanceof StriderEntity) {
                     parentShaking = ent.getFlag(EntityFlag.SHAKING);
                     break;
                 }
@@ -76,7 +76,7 @@ public class StriderEntity extends AnimalEntity {
         }
 
         // Update the passengers if we have any
-        for (long passenger : passengers) {
+        for (int passenger : passengers) {
             Entity passengerEntity = session.getEntityCache().getEntityByJavaId(passenger);
             if (passengerEntity != null) {
                 passengerEntity.updateBedrockMetadata();

--- a/core/src/main/java/org/geysermc/geyser/entity/type/living/animal/StriderEntity.java
+++ b/core/src/main/java/org/geysermc/geyser/entity/type/living/animal/StriderEntity.java
@@ -72,10 +72,9 @@ public class StriderEntity extends AnimalEntity {
         }
 
         // Update the passengers if we have any
-        for (int passenger : passengers) {
-            Entity passengerEntity = session.getEntityCache().getEntityByJavaId(passenger);
-            if (passengerEntity != null) {
-                passengerEntity.updateBedrockMetadata();
+        for (Entity passenger : passengers) {
+            if (passenger != null) {
+                passenger.updateBedrockMetadata();
             }
         }
 

--- a/core/src/main/java/org/geysermc/geyser/entity/type/living/animal/StriderEntity.java
+++ b/core/src/main/java/org/geysermc/geyser/entity/type/living/animal/StriderEntity.java
@@ -60,7 +60,6 @@ public class StriderEntity extends AnimalEntity {
         // Needs to copy the parent state
         if (getFlag(EntityFlag.RIDING)) {
             boolean parentShaking = false;
-            Entity vehicle = session.getEntityCache().getEntityByJavaId(vehicleId);
             if (vehicle instanceof StriderEntity) {
                 parentShaking = vehicle.getFlag(EntityFlag.SHAKING);
             }

--- a/core/src/main/java/org/geysermc/geyser/entity/type/living/animal/StriderEntity.java
+++ b/core/src/main/java/org/geysermc/geyser/entity/type/living/animal/StriderEntity.java
@@ -60,12 +60,9 @@ public class StriderEntity extends AnimalEntity {
         // Needs to copy the parent state
         if (getFlag(EntityFlag.RIDING)) {
             boolean parentShaking = false;
-            //TODO optimize
-            for (Entity ent : session.getEntityCache().getEntities().values()) {
-                if (ent.getPassengers().contains((int) entityId) && ent instanceof StriderEntity) {
-                    parentShaking = ent.getFlag(EntityFlag.SHAKING);
-                    break;
-                }
+            Entity vehicle = session.getEntityCache().getEntityByJavaId(vehicleId);
+            if (vehicle instanceof StriderEntity) {
+                parentShaking = vehicle.getFlag(EntityFlag.SHAKING);
             }
     
             setFlag(EntityFlag.BREATHING, !parentShaking);

--- a/core/src/main/java/org/geysermc/geyser/entity/type/living/monster/GuardianEntity.java
+++ b/core/src/main/java/org/geysermc/geyser/entity/type/living/monster/GuardianEntity.java
@@ -42,13 +42,7 @@ public class GuardianEntity extends MonsterEntity {
 
     public void setGuardianTarget(IntEntityMetadata entityMetadata) {
         int entityId = entityMetadata.getPrimitiveValue();
-        Entity entity;
-        if (session.getPlayerEntity().getEntityId() == entityId) {
-            entity = session.getPlayerEntity();
-        } else {
-            entity = session.getEntityCache().getEntityByJavaId(entityId);
-        }
-
+        Entity entity = session.getEntityCache().getEntityByJavaId(entityId);
         if (entity != null) {
             dirtyMetadata.put(EntityData.TARGET_EID, entity.getGeyserId());
         } else {

--- a/core/src/main/java/org/geysermc/geyser/entity/type/living/monster/PiglinEntity.java
+++ b/core/src/main/java/org/geysermc/geyser/entity/type/living/monster/PiglinEntity.java
@@ -44,6 +44,8 @@ public class PiglinEntity extends BasePiglinEntity {
         boolean isBaby = entityMetadata.getPrimitiveValue();
         dirtyMetadata.put(EntityData.SCALE, isBaby? .55f : 1f);
         setFlag(EntityFlag.BABY, isBaby);
+
+        updatePassengerOffsets();
     }
 
     public void setChargingCrossbow(BooleanEntityMetadata entityMetadata) {

--- a/core/src/main/java/org/geysermc/geyser/entity/type/living/monster/PiglinEntity.java
+++ b/core/src/main/java/org/geysermc/geyser/entity/type/living/monster/PiglinEntity.java
@@ -45,7 +45,7 @@ public class PiglinEntity extends BasePiglinEntity {
         dirtyMetadata.put(EntityData.SCALE, isBaby? .55f : 1f);
         setFlag(EntityFlag.BABY, isBaby);
 
-        updatePassengerOffsets();
+        updateMountOffset();
     }
 
     public void setChargingCrossbow(BooleanEntityMetadata entityMetadata) {

--- a/core/src/main/java/org/geysermc/geyser/entity/type/living/monster/WitherEntity.java
+++ b/core/src/main/java/org/geysermc/geyser/entity/type/living/monster/WitherEntity.java
@@ -60,15 +60,11 @@ public class WitherEntity extends MonsterEntity {
 
     private void setTargetId(EntityData entityData, IntEntityMetadata entityMetadata) {
         int entityId = entityMetadata.getPrimitiveValue();
-        Entity entity;
-        if (session.getPlayerEntity().getEntityId() == entityId) {
-            entity = session.getPlayerEntity();
-        } else {
-            entity = session.getEntityCache().getEntityByJavaId(entityId);
-        }
-
+        Entity entity = session.getEntityCache().getEntityByJavaId(entityId);
         if (entity != null) {
             dirtyMetadata.put(entityData, entity.getGeyserId());
+        } else {
+            dirtyMetadata.put(entityData, (long) 0);
         }
     }
 

--- a/core/src/main/java/org/geysermc/geyser/entity/type/living/monster/ZoglinEntity.java
+++ b/core/src/main/java/org/geysermc/geyser/entity/type/living/monster/ZoglinEntity.java
@@ -42,7 +42,11 @@ public class ZoglinEntity extends MonsterEntity {
 
     public void setBaby(BooleanEntityMetadata entityMetadata) {
         boolean isBaby = entityMetadata.getPrimitiveValue();
-        dirtyMetadata.put(EntityData.SCALE, isBaby? .55f : 1f);
-        setFlag(EntityFlag.BABY, isBaby);
+        if (isBaby != getFlag(EntityFlag.BABY)) {
+            dirtyMetadata.put(EntityData.SCALE, isBaby ? .55f : 1f);
+            setFlag(EntityFlag.BABY, isBaby);
+
+            updatePassengerOffsets();
+        }
     }
 }

--- a/core/src/main/java/org/geysermc/geyser/entity/type/living/monster/ZoglinEntity.java
+++ b/core/src/main/java/org/geysermc/geyser/entity/type/living/monster/ZoglinEntity.java
@@ -49,4 +49,10 @@ public class ZoglinEntity extends MonsterEntity {
             updatePassengerOffsets();
         }
     }
+
+    @Override
+    public float getBoundingBoxHeight() {
+        float scale = getFlag(EntityFlag.BABY) ? 0.55f : 1f;
+        return scale * definition.height();
+    }
 }

--- a/core/src/main/java/org/geysermc/geyser/entity/type/living/monster/ZombieEntity.java
+++ b/core/src/main/java/org/geysermc/geyser/entity/type/living/monster/ZombieEntity.java
@@ -45,6 +45,8 @@ public class ZombieEntity extends MonsterEntity {
         boolean isBaby = entityMetadata.getPrimitiveValue();
         dirtyMetadata.put(EntityData.SCALE, isBaby ? .55f : 1.0f);
         setFlag(EntityFlag.BABY, isBaby);
+
+        updateMountOffset();
     }
 
     public void setConvertingToDrowned(BooleanEntityMetadata entityMetadata) {

--- a/core/src/main/java/org/geysermc/geyser/entity/type/player/PlayerEntity.java
+++ b/core/src/main/java/org/geysermc/geyser/entity/type/player/PlayerEntity.java
@@ -123,14 +123,6 @@ public class PlayerEntity extends LivingEntity {
 
         setFlagsDirty(false);
 
-        long linkedEntityId = session.getEntityCache().getCachedPlayerEntityLink(entityId);
-        if (linkedEntityId != -1) {
-            Entity linkedEntity = session.getEntityCache().getEntityByJavaId(linkedEntityId);
-            if (linkedEntity != null) {
-                addPlayerPacket.getEntityLinks().add(new EntityLinkData(linkedEntity.getGeyserId(), geyserId, EntityLinkData.Type.RIDER, false, false));
-            }
-        }
-
         valid = true;
         session.sendUpstreamPacket(addPlayerPacket);
     }

--- a/core/src/main/java/org/geysermc/geyser/entity/type/player/SessionPlayerEntity.java
+++ b/core/src/main/java/org/geysermc/geyser/entity/type/player/SessionPlayerEntity.java
@@ -93,31 +93,6 @@ public class SessionPlayerEntity extends PlayerEntity {
         session.getCollisionManager().updatePlayerBoundingBox(this.position.down(definition.offset()));
     }
 
-    public void respawn(float x, float y, float z, float yaw, float pitch) {
-        setPosition(Vector3f.from(x, y, z));
-        setYaw(yaw);
-        setPitch(pitch);
-        setHeadYaw(yaw);
-
-        RespawnPacket respawnPacket = new RespawnPacket();
-        respawnPacket.setRuntimeEntityId(0); // Bedrock server behavior
-        respawnPacket.setPosition(position);
-        respawnPacket.setState(RespawnPacket.State.SERVER_READY);
-        session.sendUpstreamPacket(respawnPacket);
-
-        updateBedrockMetadata();
-
-        MovePlayerPacket movePlayerPacket = new MovePlayerPacket();
-        movePlayerPacket.setRuntimeEntityId(geyserId);
-        movePlayerPacket.setPosition(position);
-        movePlayerPacket.setRotation(getBedrockRotation());
-        movePlayerPacket.setMode(MovePlayerPacket.Mode.RESPAWN);
-
-        session.sendUpstreamPacket(movePlayerPacket);
-
-        session.getGeyser().getLogger().debug(GeyserLocale.getLocaleStringLog("geyser.entity.player.spawn", x, y, z));
-    }
-
     @Override
     public void setPosition(Vector3f position) {
         if (session != null) { // null during entity initialization

--- a/core/src/main/java/org/geysermc/geyser/entity/type/player/SessionPlayerEntity.java
+++ b/core/src/main/java/org/geysermc/geyser/entity/type/player/SessionPlayerEntity.java
@@ -35,11 +35,14 @@ import com.nukkitx.math.vector.Vector3f;
 import com.nukkitx.protocol.bedrock.data.AttributeData;
 import com.nukkitx.protocol.bedrock.data.entity.EntityData;
 import com.nukkitx.protocol.bedrock.data.entity.EntityFlag;
+import com.nukkitx.protocol.bedrock.packet.MovePlayerPacket;
+import com.nukkitx.protocol.bedrock.packet.RespawnPacket;
 import com.nukkitx.protocol.bedrock.packet.UpdateAttributesPacket;
 import it.unimi.dsi.fastutil.objects.Object2ObjectOpenHashMap;
 import lombok.Getter;
 import org.geysermc.geyser.entity.attribute.GeyserAttributeType;
 import org.geysermc.geyser.session.GeyserSession;
+import org.geysermc.geyser.text.GeyserLocale;
 import org.geysermc.geyser.util.AttributeUtils;
 
 import java.util.Collections;
@@ -88,6 +91,31 @@ public class SessionPlayerEntity extends PlayerEntity {
     public void moveRelative(double relX, double relY, double relZ, float yaw, float pitch, float headYaw, boolean isOnGround) {
         super.moveRelative(relX, relY, relZ, yaw, pitch, headYaw, isOnGround);
         session.getCollisionManager().updatePlayerBoundingBox(this.position.down(definition.offset()));
+    }
+
+    public void respawn(float x, float y, float z, float yaw, float pitch) {
+        setPosition(Vector3f.from(x, y, z));
+        setYaw(yaw);
+        setPitch(pitch);
+        setHeadYaw(yaw);
+
+        RespawnPacket respawnPacket = new RespawnPacket();
+        respawnPacket.setRuntimeEntityId(0); // Bedrock server behavior
+        respawnPacket.setPosition(position);
+        respawnPacket.setState(RespawnPacket.State.SERVER_READY);
+        session.sendUpstreamPacket(respawnPacket);
+
+        updateBedrockMetadata();
+
+        MovePlayerPacket movePlayerPacket = new MovePlayerPacket();
+        movePlayerPacket.setRuntimeEntityId(geyserId);
+        movePlayerPacket.setPosition(position);
+        movePlayerPacket.setRotation(getBedrockRotation());
+        movePlayerPacket.setMode(MovePlayerPacket.Mode.RESPAWN);
+
+        session.sendUpstreamPacket(movePlayerPacket);
+
+        session.getGeyser().getLogger().debug(GeyserLocale.getLocaleStringLog("geyser.entity.player.spawn", x, y, z));
     }
 
     @Override

--- a/core/src/main/java/org/geysermc/geyser/entity/type/player/SessionPlayerEntity.java
+++ b/core/src/main/java/org/geysermc/geyser/entity/type/player/SessionPlayerEntity.java
@@ -140,7 +140,10 @@ public class SessionPlayerEntity extends PlayerEntity {
     @Override
     public void setFlags(ByteEntityMetadata entityMetadata) {
         super.setFlags(entityMetadata);
-        session.setSwimmingInWater((entityMetadata.getPrimitiveValue() & 0x10) == 0x10 && getFlag(EntityFlag.SPRINTING));
+        // Swimming/crawling is controlled by the Java server
+        boolean swimming = (entityMetadata.getPrimitiveValue() & 0x10) == 0x10;
+        session.setSwimming(swimming);
+        session.setSwimmingInWater(swimming && getFlag(EntityFlag.SPRINTING));
         refreshSpeed = true;
     }
 

--- a/core/src/main/java/org/geysermc/geyser/entity/type/player/SessionPlayerEntity.java
+++ b/core/src/main/java/org/geysermc/geyser/entity/type/player/SessionPlayerEntity.java
@@ -73,7 +73,7 @@ public class SessionPlayerEntity extends PlayerEntity {
     private final GeyserSession session;
 
     public SessionPlayerEntity(GeyserSession session) {
-        super(session, 1, 1, new GameProfile(UUID.randomUUID(), "unknown"), Vector3f.ZERO, Vector3f.ZERO, 0, 0, 0);
+        super(session, -1, 1, new GameProfile(UUID.randomUUID(), "unknown"), Vector3f.ZERO, Vector3f.ZERO, 0, 0, 0);
 
         valid = true;
         this.session = session;

--- a/core/src/main/java/org/geysermc/geyser/session/GeyserSession.java
+++ b/core/src/main/java/org/geysermc/geyser/session/GeyserSession.java
@@ -331,9 +331,6 @@ public class GeyserSession implements GeyserConnection, CommandSender {
     @Setter
     private Vector3f lastInteractionPlayerPosition = Vector3f.ZERO;
 
-    @Setter
-    private Entity ridingVehicleEntity;
-
     /**
      * The entity that the client is currently looking at.
      */

--- a/core/src/main/java/org/geysermc/geyser/session/cache/EntityCache.java
+++ b/core/src/main/java/org/geysermc/geyser/session/cache/EntityCache.java
@@ -56,15 +56,12 @@ public class EntityCache {
     private final Long2LongMap entityIdTranslations = new Long2LongOpenHashMap();
     private final Map<UUID, PlayerEntity> playerEntities = new Object2ObjectOpenHashMap<>();
     private final Map<UUID, BossBar> bossBars = new Object2ObjectOpenHashMap<>();
-    private final Long2LongMap cachedPlayerEntityLinks = new Long2LongOpenHashMap();
 
     @Getter
     private final AtomicLong nextEntityId = new AtomicLong(2L);
 
     public EntityCache(GeyserSession session) {
         this.session = session;
-
-        cachedPlayerEntityLinks.defaultReturnValue(-1L);
     }
 
     public void spawnEntity(Entity entity) {
@@ -112,8 +109,6 @@ public class EntityCache {
         }
 
         session.getPlayerWithCustomHeads().clear();
-        // As a precaution
-        cachedPlayerEntityLinks.clear();
     }
 
     public Entity getEntityByGeyserId(long geyserId) {
@@ -161,14 +156,6 @@ public class EntityCache {
 
     public void updateBossBars() {
         bossBars.values().forEach(BossBar::updateBossBar);
-    }
-
-    public long getCachedPlayerEntityLink(long playerId) {
-        return cachedPlayerEntityLinks.remove(playerId);
-    }
-
-    public void addCachedPlayerEntityLink(long playerId, long linkedEntityId) {
-        cachedPlayerEntityLinks.put(playerId, linkedEntityId);
     }
 
     public List<Tickable> getTickableEntities() {

--- a/core/src/main/java/org/geysermc/geyser/session/cache/EntityCache.java
+++ b/core/src/main/java/org/geysermc/geyser/session/cache/EntityCache.java
@@ -121,6 +121,9 @@ public class EntityCache {
     }
 
     public Entity getEntityByJavaId(long javaId) {
+        if (javaId == session.getPlayerEntity().getEntityId()) {
+            return session.getPlayerEntity();
+        }
         return entities.get(entityIdTranslations.get(javaId));
     }
 

--- a/core/src/main/java/org/geysermc/geyser/session/cache/TeleportCache.java
+++ b/core/src/main/java/org/geysermc/geyser/session/cache/TeleportCache.java
@@ -66,6 +66,10 @@ public class TeleportCache {
         unconfirmedFor++;
     }
 
+    public void resetUnconfirmedFor() {
+        unconfirmedFor = 0;
+    }
+
     public boolean shouldResend() {
         return unconfirmedFor >= RESEND_THRESHOLD;
     }

--- a/core/src/main/java/org/geysermc/geyser/session/cache/WorldBorder.java
+++ b/core/src/main/java/org/geysermc/geyser/session/cache/WorldBorder.java
@@ -151,7 +151,7 @@ public class WorldBorder {
             // Move the player back, but allow gravity to take place
             // Teleported = true makes going back better, but disconnects the player from their mounted entity
             playerEntity.moveAbsolute(Vector3f.from(playerEntity.getPosition().getX(), (newPosition.getY() - EntityDefinitions.PLAYER.offset()), playerEntity.getPosition().getZ()),
-                    playerEntity.getYaw(), playerEntity.getPitch(), playerEntity.getHeadYaw(), playerEntity.isOnGround(), session.getPlayerEntity().getVehicle() == null);
+                    playerEntity.getYaw(), playerEntity.getPitch(), playerEntity.getHeadYaw(), playerEntity.isOnGround(), playerEntity.getVehicle() == null);
         }
         return isInWorldBorder;
     }

--- a/core/src/main/java/org/geysermc/geyser/session/cache/WorldBorder.java
+++ b/core/src/main/java/org/geysermc/geyser/session/cache/WorldBorder.java
@@ -151,7 +151,7 @@ public class WorldBorder {
             // Move the player back, but allow gravity to take place
             // Teleported = true makes going back better, but disconnects the player from their mounted entity
             playerEntity.moveAbsolute(Vector3f.from(playerEntity.getPosition().getX(), (newPosition.getY() - EntityDefinitions.PLAYER.offset()), playerEntity.getPosition().getZ()),
-                    playerEntity.getYaw(), playerEntity.getPitch(), playerEntity.getHeadYaw(), playerEntity.isOnGround(), session.getRidingVehicleEntity() == null);
+                    playerEntity.getYaw(), playerEntity.getPitch(), playerEntity.getHeadYaw(), playerEntity.isOnGround(), session.getPlayerEntity().getVehicle() == null);
         }
         return isInWorldBorder;
     }

--- a/core/src/main/java/org/geysermc/geyser/translator/protocol/bedrock/BedrockMoveEntityAbsoluteTranslator.java
+++ b/core/src/main/java/org/geysermc/geyser/translator/protocol/bedrock/BedrockMoveEntityAbsoluteTranslator.java
@@ -45,7 +45,7 @@ public class BedrockMoveEntityAbsoluteTranslator extends PacketTranslator<MoveEn
     public void translate(GeyserSession session, MoveEntityAbsolutePacket packet) {
         session.setLastVehicleMoveTimestamp(System.currentTimeMillis());
 
-        Entity ridingEntity = session.getRidingVehicleEntity();
+        Entity ridingEntity = session.getPlayerEntity().getVehicle();
         if (ridingEntity != null && session.getWorldBorder().isPassingIntoBorderBoundaries(packet.getPosition(), false)) {
             Vector3f position = Vector3f.from(ridingEntity.getPosition().getX(), packet.getPosition().getY(),
                     ridingEntity.getPosition().getZ());

--- a/core/src/main/java/org/geysermc/geyser/translator/protocol/bedrock/BedrockPlayerInputTranslator.java
+++ b/core/src/main/java/org/geysermc/geyser/translator/protocol/bedrock/BedrockPlayerInputTranslator.java
@@ -54,7 +54,7 @@ public class BedrockPlayerInputTranslator extends PacketTranslator<PlayerInputPa
 
         // Bedrock only sends movement vehicle packets while moving
         // This allows horses to take damage while standing on magma
-        Entity vehicle = session.getRidingVehicleEntity();
+        Entity vehicle = session.getPlayerEntity().getVehicle();
         boolean sendMovement = false;
         if (vehicle instanceof AbstractHorseEntity && !(vehicle instanceof LlamaEntity)) {
             sendMovement = vehicle.isOnGround();

--- a/core/src/main/java/org/geysermc/geyser/translator/protocol/bedrock/entity/player/BedrockActionTranslator.java
+++ b/core/src/main/java/org/geysermc/geyser/translator/protocol/bedrock/entity/player/BedrockActionTranslator.java
@@ -77,16 +77,17 @@ public class BedrockActionTranslator extends PacketTranslator<PlayerActionPacket
                 session.sendUpstreamPacket(attributesPacket);
                 break;
             case START_SWIMMING:
-                ServerboundPlayerCommandPacket startSwimPacket = new ServerboundPlayerCommandPacket((int) entity.getEntityId(), PlayerState.START_SPRINTING);
-                session.sendDownstreamPacket(startSwimPacket);
-
-                session.setSwimming(true);
+                if (!session.getPlayerEntity().getFlag(EntityFlag.SWIMMING)) {
+                    ServerboundPlayerCommandPacket startSwimPacket = new ServerboundPlayerCommandPacket((int) entity.getEntityId(), PlayerState.START_SPRINTING);
+                    session.sendDownstreamPacket(startSwimPacket);
+                }
                 break;
             case STOP_SWIMMING:
-                ServerboundPlayerCommandPacket stopSwimPacket = new ServerboundPlayerCommandPacket((int) entity.getEntityId(), PlayerState.STOP_SPRINTING);
-                session.sendDownstreamPacket(stopSwimPacket);
-
-                session.setSwimming(false);
+                // Prevent packet spam when Bedrock players are crawling near the edge of a block
+                if (session.isSwimmingInWater()) {
+                    ServerboundPlayerCommandPacket stopSwimPacket = new ServerboundPlayerCommandPacket((int) entity.getEntityId(), PlayerState.STOP_SPRINTING);
+                    session.sendDownstreamPacket(stopSwimPacket);
+                }
                 break;
             case START_GLIDE:
                 // Otherwise gliding will not work in creative
@@ -134,13 +135,17 @@ public class BedrockActionTranslator extends PacketTranslator<PlayerActionPacket
                 session.setSneaking(false);
                 break;
             case START_SPRINT:
-                ServerboundPlayerCommandPacket startSprintPacket = new ServerboundPlayerCommandPacket((int) entity.getEntityId(), PlayerState.START_SPRINTING);
-                session.sendDownstreamPacket(startSprintPacket);
-                session.setSprinting(true);
+                if (!session.getPlayerEntity().getFlag(EntityFlag.SWIMMING)) {
+                    ServerboundPlayerCommandPacket startSprintPacket = new ServerboundPlayerCommandPacket((int) entity.getEntityId(), PlayerState.START_SPRINTING);
+                    session.sendDownstreamPacket(startSprintPacket);
+                    session.setSprinting(true);
+                }
                 break;
             case STOP_SPRINT:
-                ServerboundPlayerCommandPacket stopSprintPacket = new ServerboundPlayerCommandPacket((int) entity.getEntityId(), PlayerState.STOP_SPRINTING);
-                session.sendDownstreamPacket(stopSprintPacket);
+                if (!session.getPlayerEntity().getFlag(EntityFlag.SWIMMING)) {
+                    ServerboundPlayerCommandPacket stopSprintPacket = new ServerboundPlayerCommandPacket((int) entity.getEntityId(), PlayerState.STOP_SPRINTING);
+                    session.sendDownstreamPacket(stopSprintPacket);
+                }
                 session.setSprinting(false);
                 break;
             case DROP_ITEM:

--- a/core/src/main/java/org/geysermc/geyser/translator/protocol/bedrock/entity/player/BedrockInteractTranslator.java
+++ b/core/src/main/java/org/geysermc/geyser/translator/protocol/bedrock/entity/player/BedrockInteractTranslator.java
@@ -74,7 +74,6 @@ public class BedrockInteractTranslator extends PacketTranslator<InteractPacket> 
             case LEAVE_VEHICLE:
                 ServerboundPlayerCommandPacket sneakPacket = new ServerboundPlayerCommandPacket((int) entity.getEntityId(), PlayerState.START_SNEAKING);
                 session.sendDownstreamPacket(sneakPacket);
-                session.getPlayerEntity().setVehicle(null);
                 break;
             case MOUSEOVER:
                 // Handle the buttons for mobile - "Mount", etc; and the suggestions for console - "ZL: Mount", etc

--- a/core/src/main/java/org/geysermc/geyser/translator/protocol/bedrock/entity/player/BedrockInteractTranslator.java
+++ b/core/src/main/java/org/geysermc/geyser/translator/protocol/bedrock/entity/player/BedrockInteractTranslator.java
@@ -74,7 +74,7 @@ public class BedrockInteractTranslator extends PacketTranslator<InteractPacket> 
             case LEAVE_VEHICLE:
                 ServerboundPlayerCommandPacket sneakPacket = new ServerboundPlayerCommandPacket((int) entity.getEntityId(), PlayerState.START_SNEAKING);
                 session.sendDownstreamPacket(sneakPacket);
-                session.setRidingVehicleEntity(null);
+                session.getPlayerEntity().setVehicle(null);
                 break;
             case MOUSEOVER:
                 // Handle the buttons for mobile - "Mount", etc; and the suggestions for console - "ZL: Mount", etc
@@ -97,7 +97,7 @@ public class BedrockInteractTranslator extends PacketTranslator<InteractPacket> 
                 break;
             case OPEN_INVENTORY:
                 if (session.getOpenInventory() == null) {
-                    Entity ridingEntity = session.getRidingVehicleEntity();
+                    Entity ridingEntity = session.getPlayerEntity().getVehicle();
                     if (ridingEntity instanceof AbstractHorseEntity) {
                         if (ridingEntity.getFlag(EntityFlag.TAMED)) {
                             // We should request to open the horse inventory instead

--- a/core/src/main/java/org/geysermc/geyser/translator/protocol/bedrock/entity/player/BedrockMovePlayerTranslator.java
+++ b/core/src/main/java/org/geysermc/geyser/translator/protocol/bedrock/entity/player/BedrockMovePlayerTranslator.java
@@ -67,7 +67,8 @@ public class BedrockMovePlayerTranslator extends PacketTranslator<MovePlayerPack
         // Send book update before the player moves
         session.getBookEditCache().checkForSend();
 
-        if (!session.getUnconfirmedTeleports().isEmpty()) {
+        // Ignore movement packets until Bedrock's position matches the teleported position
+        if (session.getUnconfirmedTeleport() != null) {
             session.confirmTeleport(packet.getPosition().toDouble().sub(0, EntityDefinitions.PLAYER.offset(), 0));
             return;
         }

--- a/core/src/main/java/org/geysermc/geyser/translator/protocol/bedrock/entity/player/BedrockMovePlayerTranslator.java
+++ b/core/src/main/java/org/geysermc/geyser/translator/protocol/bedrock/entity/player/BedrockMovePlayerTranslator.java
@@ -67,7 +67,7 @@ public class BedrockMovePlayerTranslator extends PacketTranslator<MovePlayerPack
         // Send book update before the player moves
         session.getBookEditCache().checkForSend();
 
-        if (!session.getTeleportMap().isEmpty()) {
+        if (!session.getUnconfirmedTeleports().isEmpty()) {
             session.confirmTeleport(packet.getPosition().toDouble().sub(0, EntityDefinitions.PLAYER.offset(), 0));
             return;
         }

--- a/core/src/main/java/org/geysermc/geyser/translator/protocol/bedrock/entity/player/BedrockRiderJumpTranslator.java
+++ b/core/src/main/java/org/geysermc/geyser/translator/protocol/bedrock/entity/player/BedrockRiderJumpTranslator.java
@@ -38,7 +38,7 @@ import org.geysermc.geyser.translator.protocol.Translator;
 public class BedrockRiderJumpTranslator extends PacketTranslator<RiderJumpPacket> {
     @Override
     public void translate(GeyserSession session, RiderJumpPacket packet) {
-        Entity vehicle = session.getRidingVehicleEntity();
+        Entity vehicle = session.getPlayerEntity().getVehicle();
         if (vehicle instanceof AbstractHorseEntity) {
             ServerboundPlayerCommandPacket playerCommandPacket = new ServerboundPlayerCommandPacket((int) vehicle.getEntityId(),  PlayerState.START_HORSE_JUMP, packet.getJumpStrength());
             session.sendDownstreamPacket(playerCommandPacket);

--- a/core/src/main/java/org/geysermc/geyser/translator/protocol/java/entity/JavaAnimateTranslator.java
+++ b/core/src/main/java/org/geysermc/geyser/translator/protocol/java/entity/JavaAnimateTranslator.java
@@ -41,12 +41,7 @@ public class JavaAnimateTranslator extends PacketTranslator<ClientboundAnimatePa
 
     @Override
     public void translate(GeyserSession session, ClientboundAnimatePacket packet) {
-        Entity entity;
-        if (packet.getEntityId() == session.getPlayerEntity().getEntityId()) {
-            entity = session.getPlayerEntity();
-        } else {
-            entity = session.getEntityCache().getEntityByJavaId(packet.getEntityId());
-        }
+        Entity entity = session.getEntityCache().getEntityByJavaId(packet.getEntityId());
         if (entity == null)
             return;
 

--- a/core/src/main/java/org/geysermc/geyser/translator/protocol/java/entity/JavaEntityEventTranslator.java
+++ b/core/src/main/java/org/geysermc/geyser/translator/protocol/java/entity/JavaEntityEventTranslator.java
@@ -47,12 +47,7 @@ public class JavaEntityEventTranslator extends PacketTranslator<ClientboundEntit
 
     @Override
     public void translate(GeyserSession session, ClientboundEntityEventPacket packet) {
-        Entity entity;
-        if (packet.getEntityId() == session.getPlayerEntity().getEntityId()) {
-            entity = session.getPlayerEntity();
-        } else {
-            entity = session.getEntityCache().getEntityByJavaId(packet.getEntityId());
-        }
+        Entity entity = session.getEntityCache().getEntityByJavaId(packet.getEntityId());
         if (entity == null)
             return;
 

--- a/core/src/main/java/org/geysermc/geyser/translator/protocol/java/entity/JavaMoveEntityPosRotTranslator.java
+++ b/core/src/main/java/org/geysermc/geyser/translator/protocol/java/entity/JavaMoveEntityPosRotTranslator.java
@@ -37,9 +37,6 @@ public class JavaMoveEntityPosRotTranslator extends PacketTranslator<Clientbound
     @Override
     public void translate(GeyserSession session, ClientboundMoveEntityPosRotPacket packet) {
         Entity entity = session.getEntityCache().getEntityByJavaId(packet.getEntityId());
-        if (packet.getEntityId() == session.getPlayerEntity().getEntityId()) {
-            entity = session.getPlayerEntity();
-        }
         if (entity == null) return;
 
         entity.updatePositionAndRotation(packet.getMoveX(), packet.getMoveY(), packet.getMoveZ(), packet.getYaw(), packet.getPitch(), packet.isOnGround());

--- a/core/src/main/java/org/geysermc/geyser/translator/protocol/java/entity/JavaMoveEntityPosTranslator.java
+++ b/core/src/main/java/org/geysermc/geyser/translator/protocol/java/entity/JavaMoveEntityPosTranslator.java
@@ -36,12 +36,7 @@ public class JavaMoveEntityPosTranslator extends PacketTranslator<ClientboundMov
 
     @Override
     public void translate(GeyserSession session, ClientboundMoveEntityPosPacket packet) {
-        Entity entity;
-        if (packet.getEntityId() == session.getPlayerEntity().getEntityId()) {
-            entity = session.getPlayerEntity();
-        } else {
-            entity = session.getEntityCache().getEntityByJavaId(packet.getEntityId());
-        }
+        Entity entity = session.getEntityCache().getEntityByJavaId(packet.getEntityId());
         if (entity == null) return;
 
         entity.moveRelative(packet.getMoveX(), packet.getMoveY(), packet.getMoveZ(), entity.getYaw(), entity.getPitch(), entity.getHeadYaw(), packet.isOnGround());

--- a/core/src/main/java/org/geysermc/geyser/translator/protocol/java/entity/JavaMoveEntityRotTranslator.java
+++ b/core/src/main/java/org/geysermc/geyser/translator/protocol/java/entity/JavaMoveEntityRotTranslator.java
@@ -37,9 +37,6 @@ public class JavaMoveEntityRotTranslator extends PacketTranslator<ClientboundMov
     @Override
     public void translate(GeyserSession session, ClientboundMoveEntityRotPacket packet) {
         Entity entity = session.getEntityCache().getEntityByJavaId(packet.getEntityId());
-        if (packet.getEntityId() == session.getPlayerEntity().getEntityId()) {
-            entity = session.getPlayerEntity();
-        }
         if (entity == null) return;
 
         entity.updateRotation(packet.getYaw(), packet.getPitch(), packet.isOnGround());

--- a/core/src/main/java/org/geysermc/geyser/translator/protocol/java/entity/JavaMoveVehicleTranslator.java
+++ b/core/src/main/java/org/geysermc/geyser/translator/protocol/java/entity/JavaMoveVehicleTranslator.java
@@ -37,7 +37,7 @@ public class JavaMoveVehicleTranslator extends PacketTranslator<ClientboundMoveV
 
     @Override
     public void translate(GeyserSession session, ClientboundMoveVehiclePacket packet) {
-        Entity entity = session.getRidingVehicleEntity();
+        Entity entity = session.getPlayerEntity().getVehicle();
         if (entity == null) return;
 
         entity.moveAbsolute(Vector3f.from(packet.getX(), packet.getY(), packet.getZ()), packet.getYaw(), packet.getPitch(), false, true);

--- a/core/src/main/java/org/geysermc/geyser/translator/protocol/java/entity/JavaRemoveMobEffectTranslator.java
+++ b/core/src/main/java/org/geysermc/geyser/translator/protocol/java/entity/JavaRemoveMobEffectTranslator.java
@@ -38,12 +38,9 @@ public class JavaRemoveMobEffectTranslator extends PacketTranslator<ClientboundR
 
     @Override
     public void translate(GeyserSession session, ClientboundRemoveMobEffectPacket packet) {
-        Entity entity;
-        if (packet.getEntityId() == session.getPlayerEntity().getEntityId()) {
-            entity = session.getPlayerEntity();
+        Entity entity  = session.getEntityCache().getEntityByJavaId(packet.getEntityId());
+        if (entity == session.getPlayerEntity()) {
             session.getEffectCache().removeEffect(packet.getEffect());
-        } else {
-            entity = session.getEntityCache().getEntityByJavaId(packet.getEntityId());
         }
         if (entity == null)
             return;

--- a/core/src/main/java/org/geysermc/geyser/translator/protocol/java/entity/JavaRotateHeadTranslator.java
+++ b/core/src/main/java/org/geysermc/geyser/translator/protocol/java/entity/JavaRotateHeadTranslator.java
@@ -36,13 +36,7 @@ public class JavaRotateHeadTranslator extends PacketTranslator<ClientboundRotate
 
     @Override
     public void translate(GeyserSession session, ClientboundRotateHeadPacket packet) {
-        Entity entity;
-        if (packet.getEntityId() == session.getPlayerEntity().getEntityId()) {
-            entity = session.getPlayerEntity();
-        } else {
-            entity = session.getEntityCache().getEntityByJavaId(packet.getEntityId());
-        }
-
+        Entity entity = session.getEntityCache().getEntityByJavaId(packet.getEntityId());
         if (entity == null) return;
 
         entity.updateHeadLookRotation(packet.getHeadYaw());

--- a/core/src/main/java/org/geysermc/geyser/translator/protocol/java/entity/JavaSetEntityDataTranslator.java
+++ b/core/src/main/java/org/geysermc/geyser/translator/protocol/java/entity/JavaSetEntityDataTranslator.java
@@ -40,12 +40,7 @@ public class JavaSetEntityDataTranslator extends PacketTranslator<ClientboundSet
     @SuppressWarnings({"rawtypes", "unchecked"})
     @Override
     public void translate(GeyserSession session, ClientboundSetEntityDataPacket packet) {
-        Entity entity;
-        if (packet.getEntityId() == session.getPlayerEntity().getEntityId()) {
-            entity = session.getPlayerEntity();
-        } else {
-            entity = session.getEntityCache().getEntityByJavaId(packet.getEntityId());
-        }
+        Entity entity = session.getEntityCache().getEntityByJavaId(packet.getEntityId());
         if (entity == null) return;
 
         EntityDefinition<?> definition = entity.getDefinition();

--- a/core/src/main/java/org/geysermc/geyser/translator/protocol/java/entity/JavaSetEntityLinkTranslator.java
+++ b/core/src/main/java/org/geysermc/geyser/translator/protocol/java/entity/JavaSetEntityLinkTranslator.java
@@ -43,33 +43,23 @@ public class JavaSetEntityLinkTranslator extends PacketTranslator<ClientboundSet
 
     @Override
     public void translate(GeyserSession session, ClientboundSetEntityLinkPacket packet) {
-        Entity holderId;
-        if (packet.getEntityId() == session.getPlayerEntity().getEntityId()) {
-            holderId = session.getPlayerEntity();
-        } else {
-            holderId = session.getEntityCache().getEntityByJavaId(packet.getEntityId());
-        }
+        Entity holderId = session.getEntityCache().getEntityByJavaId(packet.getEntityId());
         if (!(holderId instanceof MobEntity mobEntity)) {
             return;
         }
 
-        Entity attachedToId;
-        if (packet.getAttachedToId() == session.getPlayerEntity().getEntityId()) {
-            attachedToId = session.getPlayerEntity();
-        } else {
-            attachedToId = session.getEntityCache().getEntityByJavaId(packet.getAttachedToId());
-            if ((attachedToId == null || packet.getAttachedToId() == 0)) {
-                // Is not being leashed
-                mobEntity.setFlag(EntityFlag.LEASHED, false);
-                mobEntity.setLeashHolderBedrockId(-1L);
-                mobEntity.updateBedrockMetadata();
-                EntityEventPacket eventPacket = new EntityEventPacket();
-                eventPacket.setRuntimeEntityId(holderId.getGeyserId());
-                eventPacket.setType(EntityEventType.REMOVE_LEASH);
-                eventPacket.setData(0);
-                session.sendUpstreamPacket(eventPacket);
-                return;
-            }
+        Entity attachedToId = session.getEntityCache().getEntityByJavaId(packet.getAttachedToId());
+        if (attachedToId == null || packet.getAttachedToId() == 0) {
+            // Is not being leashed
+            mobEntity.setFlag(EntityFlag.LEASHED, false);
+            mobEntity.setLeashHolderBedrockId(-1L);
+            mobEntity.updateBedrockMetadata();
+            EntityEventPacket eventPacket = new EntityEventPacket();
+            eventPacket.setRuntimeEntityId(holderId.getGeyserId());
+            eventPacket.setType(EntityEventType.REMOVE_LEASH);
+            eventPacket.setData(0);
+            session.sendUpstreamPacket(eventPacket);
+            return;
         }
 
         mobEntity.setFlag(EntityFlag.LEASHED, true);

--- a/core/src/main/java/org/geysermc/geyser/translator/protocol/java/entity/JavaSetEntityMotionTranslator.java
+++ b/core/src/main/java/org/geysermc/geyser/translator/protocol/java/entity/JavaSetEntityMotionTranslator.java
@@ -41,12 +41,7 @@ public class JavaSetEntityMotionTranslator extends PacketTranslator<ClientboundS
 
     @Override
     public void translate(GeyserSession session, ClientboundSetEntityMotionPacket packet) {
-        Entity entity;
-        if (packet.getEntityId() == session.getPlayerEntity().getEntityId()) {
-            entity = session.getPlayerEntity();
-        } else {
-            entity = session.getEntityCache().getEntityByJavaId(packet.getEntityId());
-        }
+        Entity entity = session.getEntityCache().getEntityByJavaId(packet.getEntityId());
         if (entity == null) return;
 
         entity.setMotion(Vector3f.from(packet.getMotionX(), packet.getMotionY(), packet.getMotionZ()));

--- a/core/src/main/java/org/geysermc/geyser/translator/protocol/java/entity/JavaSetEntityMotionTranslator.java
+++ b/core/src/main/java/org/geysermc/geyser/translator/protocol/java/entity/JavaSetEntityMotionTranslator.java
@@ -46,7 +46,7 @@ public class JavaSetEntityMotionTranslator extends PacketTranslator<ClientboundS
 
         entity.setMotion(Vector3f.from(packet.getMotionX(), packet.getMotionY(), packet.getMotionZ()));
 
-        if (entity == session.getRidingVehicleEntity() && entity instanceof AbstractHorseEntity) {
+        if (entity == session.getPlayerEntity().getVehicle() && entity instanceof AbstractHorseEntity) {
             // Horses for some reason teleport back when a SetEntityMotionPacket is sent while
             // a player is riding on them. Java clients seem to ignore it anyways.
             return;

--- a/core/src/main/java/org/geysermc/geyser/translator/protocol/java/entity/JavaSetEquipmentTranslator.java
+++ b/core/src/main/java/org/geysermc/geyser/translator/protocol/java/entity/JavaSetEquipmentTranslator.java
@@ -44,13 +44,7 @@ public class JavaSetEquipmentTranslator extends PacketTranslator<ClientboundSetE
 
     @Override
     public void translate(GeyserSession session, ClientboundSetEquipmentPacket packet) {
-        Entity entity;
-        if (packet.getEntityId() == session.getPlayerEntity().getEntityId()) {
-            entity = session.getPlayerEntity();
-        } else {
-            entity = session.getEntityCache().getEntityByJavaId(packet.getEntityId());
-        }
-
+        Entity entity = session.getEntityCache().getEntityByJavaId(packet.getEntityId());
         if (entity == null)
             return;
 

--- a/core/src/main/java/org/geysermc/geyser/translator/protocol/java/entity/JavaSetPassengersTranslator.java
+++ b/core/src/main/java/org/geysermc/geyser/translator/protocol/java/entity/JavaSetPassengersTranslator.java
@@ -69,7 +69,7 @@ public class JavaSetPassengersTranslator extends PacketTranslator<ClientboundSet
             linkPacket.setEntityLink(new EntityLinkData(entity.getGeyserId(), passenger.getGeyserId(), type, false, false));
             session.sendUpstreamPacket(linkPacket);
 
-            passenger.setVehicleId(packet.getEntityId());
+            passenger.setVehicle(entity);
             EntityUtils.updateRiderRotationLock(passenger, entity, true);
             EntityUtils.updateMountOffset(passenger, entity, rider, true, (packet.getPassengerIds().length > 1));
             // Force an update to the passenger metadata
@@ -88,7 +88,7 @@ public class JavaSetPassengersTranslator extends PacketTranslator<ClientboundSet
                 linkPacket.setEntityLink(new EntityLinkData(entity.getGeyserId(), passenger.getGeyserId(), EntityLinkData.Type.REMOVE, false, false));
                 session.sendUpstreamPacket(linkPacket);
 
-                passenger.setVehicleId(-1);
+                passenger.setVehicle(null);
                 EntityUtils.updateRiderRotationLock(passenger, entity, false);
                 EntityUtils.updateMountOffset(passenger, entity, false, false, (packet.getPassengerIds().length > 1));
                 // Force an update to the passenger metadata

--- a/core/src/main/java/org/geysermc/geyser/translator/protocol/java/entity/JavaSetPassengersTranslator.java
+++ b/core/src/main/java/org/geysermc/geyser/translator/protocol/java/entity/JavaSetPassengersTranslator.java
@@ -69,6 +69,7 @@ public class JavaSetPassengersTranslator extends PacketTranslator<ClientboundSet
             linkPacket.setEntityLink(new EntityLinkData(entity.getGeyserId(), passenger.getGeyserId(), type, false, false));
             session.sendUpstreamPacket(linkPacket);
 
+            passenger.setVehicleId(packet.getEntityId());
             EntityUtils.updateRiderRotationLock(passenger, entity, true);
             EntityUtils.updateMountOffset(passenger, entity, rider, true, (packet.getPassengerIds().length > 1));
             // Force an update to the passenger metadata
@@ -87,6 +88,7 @@ public class JavaSetPassengersTranslator extends PacketTranslator<ClientboundSet
                 linkPacket.setEntityLink(new EntityLinkData(entity.getGeyserId(), passenger.getGeyserId(), EntityLinkData.Type.REMOVE, false, false));
                 session.sendUpstreamPacket(linkPacket);
 
+                passenger.setVehicleId(-1);
                 EntityUtils.updateRiderRotationLock(passenger, entity, false);
                 EntityUtils.updateMountOffset(passenger, entity, false, false, (packet.getPassengerIds().length > 1));
                 // Force an update to the passenger metadata

--- a/core/src/main/java/org/geysermc/geyser/translator/protocol/java/entity/JavaSetPassengersTranslator.java
+++ b/core/src/main/java/org/geysermc/geyser/translator/protocol/java/entity/JavaSetPassengersTranslator.java
@@ -43,20 +43,13 @@ public class JavaSetPassengersTranslator extends PacketTranslator<ClientboundSet
 
     @Override
     public void translate(GeyserSession session, ClientboundSetPassengersPacket packet) {
-        Entity entity;
-        if (packet.getEntityId() == session.getPlayerEntity().getEntityId()) {
-            entity = session.getPlayerEntity();
-        } else {
-            entity = session.getEntityCache().getEntityByJavaId(packet.getEntityId());
-        }
-
+        Entity entity = session.getEntityCache().getEntityByJavaId(packet.getEntityId());
         if (entity == null) return;
 
         // Handle new/existing passengers
         for (long passengerId : packet.getPassengerIds()) {
             Entity passenger = session.getEntityCache().getEntityByJavaId(passengerId);
-            if (passengerId == session.getPlayerEntity().getEntityId()) {
-                passenger = session.getPlayerEntity();
+            if (passenger == session.getPlayerEntity()) {
                 session.setRidingVehicleEntity(entity);
                 // We need to confirm teleports before entering a vehicle, or else we will likely exit right out
                 session.confirmTeleport(passenger.getPosition().sub(0, EntityDefinitions.PLAYER.offset(), 0).toDouble());
@@ -86,9 +79,6 @@ public class JavaSetPassengersTranslator extends PacketTranslator<ClientboundSet
         IntList newPassengers = new IntArrayList(packet.getPassengerIds());
         for (int passengerId : entity.getPassengers()) {
             Entity passenger = session.getEntityCache().getEntityByJavaId(passengerId);
-            if (passengerId == session.getPlayerEntity().getEntityId()) {
-                passenger = session.getPlayerEntity();
-            }
             if (passenger == null) {
                 continue;
             }

--- a/core/src/main/java/org/geysermc/geyser/translator/protocol/java/entity/JavaSetPassengersTranslator.java
+++ b/core/src/main/java/org/geysermc/geyser/translator/protocol/java/entity/JavaSetPassengersTranslator.java
@@ -50,7 +50,7 @@ public class JavaSetPassengersTranslator extends PacketTranslator<ClientboundSet
         for (long passengerId : packet.getPassengerIds()) {
             Entity passenger = session.getEntityCache().getEntityByJavaId(passengerId);
             if (passenger == session.getPlayerEntity()) {
-                session.setRidingVehicleEntity(entity);
+                session.getPlayerEntity().setVehicle(entity);
                 // We need to confirm teleports before entering a vehicle, or else we will likely exit right out
                 session.confirmTeleport(passenger.getPosition().sub(0, EntityDefinitions.PLAYER.offset(), 0).toDouble());
             }

--- a/core/src/main/java/org/geysermc/geyser/translator/protocol/java/entity/JavaTakeItemEntityTranslator.java
+++ b/core/src/main/java/org/geysermc/geyser/translator/protocol/java/entity/JavaTakeItemEntityTranslator.java
@@ -49,12 +49,7 @@ public class JavaTakeItemEntityTranslator extends PacketTranslator<ClientboundTa
         Entity collectedEntity = session.getEntityCache().getEntityByJavaId(packet.getCollectedEntityId());
         if (collectedEntity == null) return;
         // Collector is the entity 'picking up' the item
-        Entity collectorEntity;
-        if (packet.getCollectorEntityId() == session.getPlayerEntity().getEntityId()) {
-            collectorEntity = session.getPlayerEntity();
-        } else {
-            collectorEntity = session.getEntityCache().getEntityByJavaId(packet.getCollectorEntityId());
-        }
+        Entity collectorEntity = session.getEntityCache().getEntityByJavaId(packet.getCollectorEntityId());
         if (collectorEntity == null) return;
         if (collectedEntity instanceof ExpOrbEntity) {
             // Player just picked up an experience orb

--- a/core/src/main/java/org/geysermc/geyser/translator/protocol/java/entity/JavaTeleportEntityTranslator.java
+++ b/core/src/main/java/org/geysermc/geyser/translator/protocol/java/entity/JavaTeleportEntityTranslator.java
@@ -38,9 +38,6 @@ public class JavaTeleportEntityTranslator extends PacketTranslator<ClientboundTe
     @Override
     public void translate(GeyserSession session, ClientboundTeleportEntityPacket packet) {
         Entity entity = session.getEntityCache().getEntityByJavaId(packet.getEntityId());
-        if (packet.getEntityId() == session.getPlayerEntity().getEntityId()) {
-            entity = session.getPlayerEntity();
-        }
         if (entity == null) return;
 
         entity.teleport(Vector3f.from(packet.getX(), packet.getY(), packet.getZ()), packet.getYaw(), packet.getPitch(), packet.isOnGround());

--- a/core/src/main/java/org/geysermc/geyser/translator/protocol/java/entity/JavaUpdateAttributesTranslator.java
+++ b/core/src/main/java/org/geysermc/geyser/translator/protocol/java/entity/JavaUpdateAttributesTranslator.java
@@ -37,12 +37,7 @@ public class JavaUpdateAttributesTranslator extends PacketTranslator<Clientbound
 
     @Override
     public void translate(GeyserSession session, ClientboundUpdateAttributesPacket packet) {
-        Entity entity;
-        if (packet.getEntityId() == session.getPlayerEntity().getEntityId()) {
-            entity = session.getPlayerEntity();
-        } else {
-            entity = session.getEntityCache().getEntityByJavaId(packet.getEntityId());
-        }
+        Entity entity = session.getEntityCache().getEntityByJavaId(packet.getEntityId());
         if (!(entity instanceof LivingEntity livingEntity)) return;
 
         livingEntity.updateBedrockAttributes(session, packet.getAttributes());

--- a/core/src/main/java/org/geysermc/geyser/translator/protocol/java/entity/JavaUpdateMobEffectTranslator.java
+++ b/core/src/main/java/org/geysermc/geyser/translator/protocol/java/entity/JavaUpdateMobEffectTranslator.java
@@ -38,12 +38,9 @@ public class JavaUpdateMobEffectTranslator extends PacketTranslator<ClientboundU
 
     @Override
     public void translate(GeyserSession session, ClientboundUpdateMobEffectPacket packet) {
-        Entity entity;
-        if (packet.getEntityId() == session.getPlayerEntity().getEntityId()) {
-            entity = session.getPlayerEntity();
+        Entity entity = session.getEntityCache().getEntityByJavaId(packet.getEntityId());
+        if (entity == session.getPlayerEntity()) {
             session.getEffectCache().setEffect(packet.getEffect(), packet.getAmplifier());
-        } else {
-            entity = session.getEntityCache().getEntityByJavaId(packet.getEntityId());
         }
         if (entity == null)
             return;

--- a/core/src/main/java/org/geysermc/geyser/translator/protocol/java/entity/player/JavaPlayerPositionTranslator.java
+++ b/core/src/main/java/org/geysermc/geyser/translator/protocol/java/entity/player/JavaPlayerPositionTranslator.java
@@ -28,22 +28,19 @@ package org.geysermc.geyser.translator.protocol.java.entity.player;
 import com.github.steveice10.mc.protocol.data.game.entity.player.PositionElement;
 import com.github.steveice10.mc.protocol.packet.ingame.clientbound.entity.player.ClientboundPlayerPositionPacket;
 import com.github.steveice10.mc.protocol.packet.ingame.serverbound.level.ServerboundAcceptTeleportationPacket;
+import com.github.steveice10.mc.protocol.packet.ingame.serverbound.player.ServerboundMovePlayerPosRotPacket;
 import com.nukkitx.math.vector.Vector3f;
-import com.nukkitx.protocol.bedrock.data.entity.EntityData;
 import com.nukkitx.protocol.bedrock.data.entity.EntityLinkData;
-import com.nukkitx.protocol.bedrock.packet.MovePlayerPacket;
-import com.nukkitx.protocol.bedrock.packet.RespawnPacket;
 import com.nukkitx.protocol.bedrock.packet.SetEntityLinkPacket;
-import org.geysermc.geyser.entity.type.Entity;
 import org.geysermc.geyser.entity.EntityDefinitions;
-import org.geysermc.geyser.entity.type.player.PlayerEntity;
+import org.geysermc.geyser.entity.type.Entity;
+import org.geysermc.geyser.entity.type.player.SessionPlayerEntity;
 import org.geysermc.geyser.session.GeyserSession;
 import org.geysermc.geyser.session.cache.TeleportCache;
 import org.geysermc.geyser.translator.protocol.PacketTranslator;
 import org.geysermc.geyser.translator.protocol.Translator;
 import org.geysermc.geyser.util.ChunkUtils;
 import org.geysermc.geyser.util.EntityUtils;
-import org.geysermc.geyser.text.GeyserLocale;
 
 @Translator(packet = ClientboundPlayerPositionPacket.class)
 public class JavaPlayerPositionTranslator extends PacketTranslator<ClientboundPlayerPositionPacket> {
@@ -53,57 +50,33 @@ public class JavaPlayerPositionTranslator extends PacketTranslator<ClientboundPl
         if (!session.isLoggedIn())
             return;
 
-        PlayerEntity entity = session.getPlayerEntity();
+        SessionPlayerEntity entity = session.getPlayerEntity();
 
         if (!session.isSpawned()) {
-            Vector3f pos = Vector3f.from(packet.getX(), packet.getY(), packet.getZ());
-            entity.setPosition(pos);
-            entity.setYaw(packet.getYaw());
-            entity.setPitch(packet.getPitch());
-            entity.setHeadYaw(packet.getYaw());
-
-            RespawnPacket respawnPacket = new RespawnPacket();
-            respawnPacket.setRuntimeEntityId(0); // Bedrock server behavior
-            respawnPacket.setPosition(entity.getPosition());
-            respawnPacket.setState(RespawnPacket.State.SERVER_READY);
-            session.sendUpstreamPacket(respawnPacket);
-
-            entity.updateBedrockMetadata();
-
-            MovePlayerPacket movePlayerPacket = new MovePlayerPacket();
-            movePlayerPacket.setRuntimeEntityId(entity.getGeyserId());
-            movePlayerPacket.setPosition(entity.getPosition());
-            movePlayerPacket.setRotation(Vector3f.from(packet.getPitch(), packet.getYaw(), 0));
-            movePlayerPacket.setMode(MovePlayerPacket.Mode.RESPAWN);
-
-            session.sendUpstreamPacket(movePlayerPacket);
+            // The server sends an absolute teleport everytime the player is respawned
+            entity.respawn((float) packet.getX(), (float) packet.getY(), (float) packet.getZ(), packet.getYaw(), packet.getPitch());
             session.setSpawned(true);
+            // Make sure the player moves away from (0, 32767, 0) before accepting movement packets
+            session.setUnconfirmedTeleport(new TeleportCache(packet.getX(), packet.getY(), packet.getZ(), packet.getPitch(), packet.getYaw(), packet.getTeleportId()));
 
-            ServerboundAcceptTeleportationPacket teleportConfirmPacket = new ServerboundAcceptTeleportationPacket(packet.getTeleportId());
-            session.sendDownstreamPacket(teleportConfirmPacket);
+            acceptTeleport(session, packet.getX(), packet.getY(), packet.getZ(), packet.getYaw(), packet.getPitch(), packet.getTeleportId());
 
-            ChunkUtils.updateChunkPosition(session, pos.toInt());
-
-            session.getGeyser().getLogger().debug(GeyserLocale.getLocaleStringLog("geyser.entity.player.spawn", packet.getX(), packet.getY(), packet.getZ()));
+            ChunkUtils.updateChunkPosition(session, entity.getPosition().toInt());
             return;
         }
 
-        session.setSpawned(true);
-
         if (packet.isDismountVehicle() && session.getRidingVehicleEntity() != null) {
             Entity vehicle = session.getRidingVehicleEntity();
+
             SetEntityLinkPacket linkPacket = new SetEntityLinkPacket();
             linkPacket.setEntityLink(new EntityLinkData(vehicle.getGeyserId(), entity.getGeyserId(), EntityLinkData.Type.REMOVE, false, false));
             session.sendUpstreamPacket(linkPacket);
-            vehicle.getPassengers().rem((int) entity.getEntityId());
-            entity.getDirtyMetadata().put(EntityData.RIDER_ROTATION_LOCKED, (byte) 0);
-            entity.getDirtyMetadata().put(EntityData.RIDER_MAX_ROTATION, 0f);
-            entity.getDirtyMetadata().put(EntityData.RIDER_MIN_ROTATION, 0f);
-            entity.getDirtyMetadata().put(EntityData.RIDER_ROTATION_OFFSET, 0f);
-            session.setRidingVehicleEntity(null);
-            entity.updateBedrockMetadata();
 
-            EntityUtils.updateMountOffset(entity, vehicle, false, false, entity.getPassengers().size() > 1);
+            vehicle.getPassengers().rem((int) entity.getEntityId());
+            session.setRidingVehicleEntity(null);
+
+            EntityUtils.updateRiderRotationLock(entity, null, false);
+            EntityUtils.updateMountOffset(entity, null, false, false, entity.getPassengers().size() > 1);
             entity.updateBedrockMetadata();
         }
 
@@ -120,9 +93,9 @@ public class JavaPlayerPositionTranslator extends PacketTranslator<ClientboundPl
         float newYaw = packet.getYaw() +
                 (packet.getRelative().contains(PositionElement.YAW) ? entity.getBedrockRotation().getY() : 0);
 
-        session.getGeyser().getLogger().debug("Teleport from " + entity.getPosition().getX() + " " + (entity.getPosition().getY() - EntityDefinitions.PLAYER.offset()) + " " + entity.getPosition().getZ());
+        int id = packet.getTeleportId();
 
-        session.addTeleport(new TeleportCache(newX, newY, newZ, newPitch, newYaw, packet.getTeleportId()));
+        session.getGeyser().getLogger().debug("Teleport (" + id + ") from " + entity.getPosition().getX() + " " + (entity.getPosition().getY() - EntityDefinitions.PLAYER.offset()) + " " + entity.getPosition().getZ());
 
         Vector3f lastPlayerPosition = entity.getPosition().down(EntityDefinitions.PLAYER.offset());
         float lastPlayerPitch = entity.getBedrockRotation().getX();
@@ -132,9 +105,22 @@ public class JavaPlayerPositionTranslator extends PacketTranslator<ClientboundPl
         session.getGeyser().getLogger().debug("to " + entity.getPosition().getX() + " " + (entity.getPosition().getY() - EntityDefinitions.PLAYER.offset()) + " " + entity.getPosition().getZ());
 
         // Bedrock ignores teleports that are extremely close to the player's original position and orientation,
-        // so check if we can immediately confirm the teleport
+        // so check if we need to cache the teleport
         if (lastPlayerPosition.distanceSquared(teleportDestination) < 0.001 && Math.abs(newPitch - lastPlayerPitch) < 5) {
-            session.confirmTeleport(lastPlayerPosition.toDouble());
+            session.setUnconfirmedTeleport(null);
+        } else {
+            session.setUnconfirmedTeleport(new TeleportCache(newX, newY, newZ, newPitch, newYaw, id));
         }
+
+        acceptTeleport(session, newX, newY, newZ, newYaw, newPitch, id);
+    }
+
+    private void acceptTeleport(GeyserSession session, double x, double y, double z, float yaw, float pitch, int id) {
+        // Confirm the teleport when we receive it to match Java edition
+        ServerboundAcceptTeleportationPacket teleportConfirmPacket = new ServerboundAcceptTeleportationPacket(id);
+        session.sendDownstreamPacket(teleportConfirmPacket);
+        // Servers (especially ones like Hypixel) expect exact coordinates given back to them.
+        ServerboundMovePlayerPosRotPacket positionPacket = new ServerboundMovePlayerPosRotPacket(false, x, y, z, yaw, pitch);
+        session.sendDownstreamPacket(positionPacket);
     }
 }

--- a/core/src/main/java/org/geysermc/geyser/translator/protocol/java/entity/player/JavaPlayerPositionTranslator.java
+++ b/core/src/main/java/org/geysermc/geyser/translator/protocol/java/entity/player/JavaPlayerPositionTranslator.java
@@ -97,7 +97,7 @@ public class JavaPlayerPositionTranslator extends PacketTranslator<ClientboundPl
             linkPacket.setEntityLink(new EntityLinkData(vehicle.getGeyserId(), entity.getGeyserId(), EntityLinkData.Type.REMOVE, false, false));
             session.sendUpstreamPacket(linkPacket);
 
-            vehicle.getPassengers().rem((int) entity.getEntityId());
+            vehicle.getPassengers().remove(entity);
             session.getPlayerEntity().setVehicle(null);
 
             EntityUtils.updateRiderRotationLock(entity, null, false);

--- a/core/src/main/java/org/geysermc/geyser/translator/protocol/java/entity/player/JavaPlayerPositionTranslator.java
+++ b/core/src/main/java/org/geysermc/geyser/translator/protocol/java/entity/player/JavaPlayerPositionTranslator.java
@@ -95,7 +95,7 @@ public class JavaPlayerPositionTranslator extends PacketTranslator<ClientboundPl
             SetEntityLinkPacket linkPacket = new SetEntityLinkPacket();
             linkPacket.setEntityLink(new EntityLinkData(vehicle.getGeyserId(), entity.getGeyserId(), EntityLinkData.Type.REMOVE, false, false));
             session.sendUpstreamPacket(linkPacket);
-            vehicle.getPassengers().remove(entity.getEntityId());
+            vehicle.getPassengers().rem((int) entity.getEntityId());
             entity.getDirtyMetadata().put(EntityData.RIDER_ROTATION_LOCKED, (byte) 0);
             entity.getDirtyMetadata().put(EntityData.RIDER_MAX_ROTATION, 0f);
             entity.getDirtyMetadata().put(EntityData.RIDER_MIN_ROTATION, 0f);
@@ -104,6 +104,7 @@ public class JavaPlayerPositionTranslator extends PacketTranslator<ClientboundPl
             entity.updateBedrockMetadata();
 
             EntityUtils.updateMountOffset(entity, vehicle, false, false, entity.getPassengers().size() > 1);
+            entity.updateBedrockMetadata();
         }
 
         // If coordinates are relative, then add to the existing coordinate

--- a/core/src/main/java/org/geysermc/geyser/translator/protocol/java/entity/player/JavaPlayerPositionTranslator.java
+++ b/core/src/main/java/org/geysermc/geyser/translator/protocol/java/entity/player/JavaPlayerPositionTranslator.java
@@ -90,15 +90,15 @@ public class JavaPlayerPositionTranslator extends PacketTranslator<ClientboundPl
             return;
         }
 
-        if (packet.isDismountVehicle() && session.getRidingVehicleEntity() != null) {
-            Entity vehicle = session.getRidingVehicleEntity();
+        Entity vehicle = session.getPlayerEntity().getVehicle();
+        if (packet.isDismountVehicle() && vehicle != null) {
 
             SetEntityLinkPacket linkPacket = new SetEntityLinkPacket();
             linkPacket.setEntityLink(new EntityLinkData(vehicle.getGeyserId(), entity.getGeyserId(), EntityLinkData.Type.REMOVE, false, false));
             session.sendUpstreamPacket(linkPacket);
 
             vehicle.getPassengers().rem((int) entity.getEntityId());
-            session.setRidingVehicleEntity(null);
+            session.getPlayerEntity().setVehicle(null);
 
             EntityUtils.updateRiderRotationLock(entity, null, false);
             EntityUtils.updateMountOffset(entity, null, false, false, entity.getPassengers().size() > 1);

--- a/core/src/main/java/org/geysermc/geyser/translator/protocol/java/entity/spawn/JavaAddEntityTranslator.java
+++ b/core/src/main/java/org/geysermc/geyser/translator/protocol/java/entity/spawn/JavaAddEntityTranslator.java
@@ -71,12 +71,7 @@ public class JavaAddEntityTranslator extends PacketTranslator<ClientboundAddEnti
         } else if (packet.getType() == EntityType.FISHING_BOBBER) {
             // Fishing bobbers need the owner for the line
             int ownerEntityId = ((ProjectileData) packet.getData()).getOwnerId();
-            Entity owner;
-            if (session.getPlayerEntity().getEntityId() == ownerEntityId) {
-                owner = session.getPlayerEntity();
-            } else {
-                owner = session.getEntityCache().getEntityByJavaId(ownerEntityId);
-            }
+            Entity owner = session.getEntityCache().getEntityByJavaId(ownerEntityId);
             // Java clients only spawn fishing hooks with a player as its owner
             if (owner instanceof PlayerEntity) {
                 entity = new FishingHookEntity(session, packet.getEntityId(), session.getEntityCache().getNextEntityId().incrementAndGet(), packet.getUuid(),

--- a/core/src/main/java/org/geysermc/geyser/util/EntityUtils.java
+++ b/core/src/main/java/org/geysermc/geyser/util/EntityUtils.java
@@ -160,7 +160,6 @@ public final class EntityUtils {
                 switch (mount.getDefinition().entityType()) {
                     case MINECART, HOPPER_MINECART, TNT_MINECART, CHEST_MINECART, FURNACE_MINECART, SPAWNER_MINECART,
                             COMMAND_BLOCK_MINECART, BOAT -> yOffset = 0.1875f;
-                    default -> yOffset += 0.3125f;
                 }
             }
             /*

--- a/core/src/main/java/org/geysermc/geyser/util/EntityUtils.java
+++ b/core/src/main/java/org/geysermc/geyser/util/EntityUtils.java
@@ -74,7 +74,7 @@ public final class EntityUtils {
         switch (mount.getDefinition().entityType()) {
             case CHICKEN, SPIDER -> mountedHeightOffset = height * 0.5f;
             case DONKEY, MULE -> mountedHeightOffset -= 0.25f;
-            case LLAMA -> mountedHeightOffset = height * 0.67f;
+            case LLAMA -> mountedHeightOffset = height * 0.6f;
             case MINECART, HOPPER_MINECART, TNT_MINECART, CHEST_MINECART, FURNACE_MINECART, SPAWNER_MINECART,
                     COMMAND_BLOCK_MINECART -> mountedHeightOffset = 0;
             case BOAT -> mountedHeightOffset = -0.1f;
@@ -158,6 +158,13 @@ public final class EntityUtils {
                 case LLAMA:
                     zOffset = -0.3f;
                     break;
+            }
+            if (passenger.getDefinition().entityType() == EntityType.SHULKER) {
+                switch (mount.getDefinition().entityType()) {
+                    case MINECART, HOPPER_MINECART, TNT_MINECART, CHEST_MINECART, FURNACE_MINECART, SPAWNER_MINECART,
+                            COMMAND_BLOCK_MINECART, BOAT -> yOffset = 0.1875f;
+                    default -> yOffset += 0.3125f;
+                }
             }
             /*
              * Bedrock Differences

--- a/core/src/main/java/org/geysermc/geyser/util/EntityUtils.java
+++ b/core/src/main/java/org/geysermc/geyser/util/EntityUtils.java
@@ -28,6 +28,7 @@ package org.geysermc.geyser.util;
 import com.github.steveice10.mc.protocol.data.game.entity.Effect;
 import com.github.steveice10.mc.protocol.data.game.entity.type.EntityType;
 import com.nukkitx.math.vector.Vector3f;
+import com.nukkitx.protocol.bedrock.data.entity.EntityData;
 import com.nukkitx.protocol.bedrock.data.entity.EntityFlag;
 import org.geysermc.geyser.entity.type.Entity;
 import org.geysermc.geyser.entity.EntityDefinitions;
@@ -178,7 +179,21 @@ public final class EntityUtils {
             Vector3f offset = Vector3f.from(xOffset, yOffset, zOffset);
             passenger.setRiderSeatPosition(offset);
         }
-        passenger.updateBedrockMetadata();
+    }
+
+    public static void updateRiderRotationLock(Entity passenger, Entity mount, boolean isRiding) {
+        if (isRiding && mount.getDefinition() == EntityDefinitions.BOAT) {
+            // Head rotation is locked while riding in a boat
+            passenger.getDirtyMetadata().put(EntityData.RIDER_ROTATION_LOCKED, (byte) 1);
+            passenger.getDirtyMetadata().put(EntityData.RIDER_MAX_ROTATION, 90f);
+            passenger.getDirtyMetadata().put(EntityData.RIDER_MIN_ROTATION, 1f);
+            passenger.getDirtyMetadata().put(EntityData.RIDER_ROTATION_OFFSET, -90f);
+        } else {
+            passenger.getDirtyMetadata().put(EntityData.RIDER_ROTATION_LOCKED, (byte) 0);
+            passenger.getDirtyMetadata().put(EntityData.RIDER_MAX_ROTATION, 0f);
+            passenger.getDirtyMetadata().put(EntityData.RIDER_MIN_ROTATION, 0f);
+            passenger.getDirtyMetadata().put(EntityData.RIDER_ROTATION_OFFSET, 0f);
+        }
     }
 
     private EntityUtils() {

--- a/core/src/main/java/org/geysermc/geyser/util/EntityUtils.java
+++ b/core/src/main/java/org/geysermc/geyser/util/EntityUtils.java
@@ -74,7 +74,7 @@ public final class EntityUtils {
         switch (mount.getDefinition().entityType()) {
             case CHICKEN, SPIDER -> mountedHeightOffset = height * 0.5f;
             case DONKEY, MULE -> mountedHeightOffset -= 0.25f;
-            case LLAMA -> mountedHeightOffset = height * 0.6f;
+            case TRADER_LLAMA, LLAMA -> mountedHeightOffset = height * 0.6f;
             case MINECART, HOPPER_MINECART, TNT_MINECART, CHEST_MINECART, FURNACE_MINECART, SPAWNER_MINECART,
                     COMMAND_BLOCK_MINECART -> mountedHeightOffset = 0;
             case BOAT -> mountedHeightOffset = -0.1f;
@@ -144,20 +144,16 @@ public final class EntityUtils {
             float yOffset = mountedHeightOffset + heightOffset;
             float zOffset = 0;
             switch (mount.getDefinition().entityType()) {
-                case BOAT:
+                case BOAT -> {
                     // Without the X offset, more than one entity on a boat is stacked on top of each other
                     if (rider && moreThanOneEntity) {
                         xOffset = 0.2f;
                     } else if (moreThanOneEntity) {
                         xOffset = -0.6f;
                     }
-                    break;
-                case CHICKEN:
-                    zOffset = -0.1f;
-                    break;
-                case LLAMA:
-                    zOffset = -0.3f;
-                    break;
+                }
+                case CHICKEN -> zOffset = -0.1f;
+                case TRADER_LLAMA, LLAMA -> zOffset = -0.3f;
             }
             if (passenger.getDefinition().entityType() == EntityType.SHULKER) {
                 switch (mount.getDefinition().entityType()) {

--- a/core/src/main/java/org/geysermc/geyser/util/EntityUtils.java
+++ b/core/src/main/java/org/geysermc/geyser/util/EntityUtils.java
@@ -169,8 +169,10 @@ public final class EntityUtils {
              * Horses are tinier
              * Players, Minecarts, and Boats have different origins
              */
-            if (passenger.getDefinition().entityType() == EntityType.PLAYER && mount.getDefinition().entityType() != EntityType.PLAYER) {
-                yOffset += EntityDefinitions.PLAYER.offset();
+            if (passenger.getDefinition().entityType() == EntityType.PLAYER) {
+                if (mount.getDefinition().entityType() != EntityType.PLAYER && mount.getDefinition().entityType() != EntityType.AREA_EFFECT_CLOUD) {
+                    yOffset += EntityDefinitions.PLAYER.offset();
+                }
             }
             switch (mount.getDefinition().entityType()) {
                 case MINECART, HOPPER_MINECART, TNT_MINECART, CHEST_MINECART, FURNACE_MINECART, SPAWNER_MINECART,


### PR DESCRIPTION
List of changes:
- Change EntityCache.getEntityByJavaId to return the session's player entity to reduce repetition in multiple translator classes
- Prevent boats from floating when a Bedrock player rides in the back
- Fix mount offset for passengers riding llama, trader llamas, and baby zoglins
- Fix mount offset for shulkers riding boats and minecarts
- Fix mount offset when riding on armor stands (fixes bug 1 of GeyserMC#2180)
- Prevent area effect clouds from despawning when given a radius of 0 (fixes bug 3, 3.1, and 4 of GeyserMC#2180)
- Update mount offset on metadata changes (Fixes GeyserMC#1515)
- Confirm teleports in the order received. This allows Bedrock players to move after GSit sends a teleport with an id of 0.
- Fix players not crawling with GSit (Fixes bug 2 of GeyserMC#2180)