### PR TITLE
Cleanup some ping passthrough stuff

### DIFF
--- a/bootstrap/bungeecord/src/main/java/org/geysermc/geyser/platform/bungeecord/GeyserBungeePingPassthrough.java
+++ b/bootstrap/bungeecord/src/main/java/org/geysermc/geyser/platform/bungeecord/GeyserBungeePingPassthrough.java
@@ -29,6 +29,7 @@ import lombok.AllArgsConstructor;
 import net.md_5.bungee.api.ProxyServer;
 import net.md_5.bungee.api.ServerPing;
 import net.md_5.bungee.api.chat.BaseComponent;
+import net.md_5.bungee.api.chat.TextComponent;
 import net.md_5.bungee.api.config.ListenerInfo;
 import net.md_5.bungee.api.connection.PendingConnection;
 import net.md_5.bungee.api.event.ProxyPingEvent;
@@ -52,8 +53,11 @@ public class GeyserBungeePingPassthrough implements IGeyserPingPassthrough, List
     public GeyserPingInfo getPingInformation(InetSocketAddress inetSocketAddress) {
         CompletableFuture<ProxyPingEvent> future = new CompletableFuture<>();
         proxyServer.getPluginManager().callEvent(new ProxyPingEvent(new GeyserPendingConnection(inetSocketAddress), getPingInfo(), (event, throwable) -> {
-            if (throwable != null) future.completeExceptionally(throwable);
-            else future.complete(event);
+            if (throwable != null) {
+                future.completeExceptionally(throwable);
+            } else {
+                future.complete(event);
+            }
         }));
         ProxyPingEvent event = future.join();
         ServerPing response = event.getResponse();
@@ -76,9 +80,12 @@ public class GeyserBungeePingPassthrough implements IGeyserPingPassthrough, List
 
     private ServerPing getPingInfo() {
         return new ServerPing(
-                new ServerPing.Protocol(proxyServer.getName() + " " + proxyServer.getGameVersion(), ProtocolConstants.SUPPORTED_VERSION_IDS.get(ProtocolConstants.SUPPORTED_VERSION_IDS.size() - 1)),
+                new ServerPing.Protocol(
+                        proxyServer.getName() + " " + ProtocolConstants.SUPPORTED_VERSIONS.get(0) + "-" + ProtocolConstants.SUPPORTED_VERSIONS.get(ProtocolConstants.SUPPORTED_VERSIONS.size() - 1),
+                        ProtocolConstants.SUPPORTED_VERSION_IDS.get(ProtocolConstants.SUPPORTED_VERSION_IDS.size() - 1)),
                 new ServerPing.Players(getDefaultListener().getMaxPlayers(), proxyServer.getOnlineCount(), null),
-                getDefaultListener().getMotd(), proxyServer.getConfig().getFaviconObject()
+                TextComponent.fromLegacyText(getDefaultListener().getMotd())[0],
+                proxyServer.getConfig().getFaviconObject()
         );
     }
 

--- a/bootstrap/spigot/src/main/java/org/geysermc/geyser/platform/spigot/GeyserSpigotPingPassthrough.java
+++ b/bootstrap/spigot/src/main/java/org/geysermc/geyser/platform/spigot/GeyserSpigotPingPassthrough.java
@@ -57,8 +57,8 @@ public class GeyserSpigotPingPassthrough implements IGeyserPingPassthrough {
             Bukkit.getOnlinePlayers().stream().map(Player::getName).forEach(geyserPingInfo.getPlayerList()::add);
             return geyserPingInfo;
         } catch (Exception e) {
-            logger.debug("Error while getting Bukkit ping passthrough: " + e.toString());
-            return new GeyserPingInfo(null, null, null);
+            logger.debug("Error while getting Bukkit ping passthrough: " + e);
+            return null;
         }
     }
 
@@ -79,5 +79,4 @@ public class GeyserSpigotPingPassthrough implements IGeyserPingPassthrough {
             return Collections.emptyIterator();
         }
     }
-
 }

--- a/core/src/main/java/org/geysermc/geyser/ping/IGeyserPingPassthrough.java
+++ b/core/src/main/java/org/geysermc/geyser/ping/IGeyserPingPassthrough.java
@@ -25,6 +25,7 @@
 
 package org.geysermc.geyser.ping;
 
+import javax.annotation.Nullable;
 import java.net.Inet4Address;
 import java.net.InetSocketAddress;
 
@@ -38,6 +39,7 @@ public interface IGeyserPingPassthrough {
      *
      * @return string of the MOTD
      */
+    @Nullable
     default GeyserPingInfo getPingInformation() {
         return this.getPingInformation(new InetSocketAddress(Inet4Address.getLoopbackAddress(), 69));
     }
@@ -48,6 +50,7 @@ public interface IGeyserPingPassthrough {
      * @param inetSocketAddress the ip address of the client pinging the server
      * @return string of the MOTD
      */
+    @Nullable
     GeyserPingInfo getPingInformation(InetSocketAddress inetSocketAddress);
 
 }


### PR DESCRIPTION
Mostly just some deprecated usage on BungeeCord
- Replaced ServerPing constructor with BaseComponent instead of String for motd
- Replaced usage of ProxyServer#getGameVersion()

On Spigot, decided to return a null GeyserPingInfo instead of one with empty data, since Geyser seems to always check for null GeyserPingInfo, but not always its data components.

Only tested BungeeCord to make sure motd and version passthrough were still the same.