### PR TITLE
Add additional check for finished editing sign (fix #1063)

### DIFF
--- a/core/src/main/java/org/geysermc/geyser/session/GeyserSession.java
+++ b/core/src/main/java/org/geysermc/geyser/session/GeyserSession.java
@@ -554,6 +554,7 @@ public class GeyserSession implements GeyserConnection, CommandSender {
         bedrockServerSession.addDisconnectHandler(disconnectReason -> {
             InetAddress address = bedrockServerSession.getRealAddress().getAddress();
             geyser.getLogger().info(GeyserLocale.getLocaleStringLog("geyser.network.disconnect", address, disconnectReason));
+
             disconnect(disconnectReason.name());
             geyser.getSessionManager().removeSession(this);
         });

--- a/core/src/main/java/org/geysermc/geyser/session/GeyserSession.java
+++ b/core/src/main/java/org/geysermc/geyser/session/GeyserSession.java
@@ -554,7 +554,14 @@ public class GeyserSession implements GeyserConnection, CommandSender {
         bedrockServerSession.addDisconnectHandler(disconnectReason -> {
             InetAddress address = bedrockServerSession.getRealAddress().getAddress();
             geyser.getLogger().info(GeyserLocale.getLocaleStringLog("geyser.network.disconnect", address, disconnectReason));
-
+            // Check if there is undetermined sign update packet
+            if (this.getLastSignUpdatePacket() != null) {
+                // We send the packet to the server
+                this.sendDownstreamPacket(this.getLastSignUpdatePacket());
+                // We set the sign text&packet cached in the session to null to indicate there is no work-in-progress sign
+                this.setLastSignMessage(null);
+                this.setLastSignUpdatePacket(null);
+            }
             disconnect(disconnectReason.name());
             geyser.getSessionManager().removeSession(this);
         });

--- a/core/src/main/java/org/geysermc/geyser/session/GeyserSession.java
+++ b/core/src/main/java/org/geysermc/geyser/session/GeyserSession.java
@@ -46,6 +46,7 @@ import com.github.steveice10.mc.protocol.data.game.statistic.CustomStatistic;
 import com.github.steveice10.mc.protocol.data.game.statistic.Statistic;
 import com.github.steveice10.mc.protocol.packet.handshake.serverbound.ClientIntentionPacket;
 import com.github.steveice10.mc.protocol.packet.ingame.serverbound.ServerboundClientInformationPacket;
+import com.github.steveice10.mc.protocol.packet.ingame.serverbound.level.ServerboundSignUpdatePacket;
 import com.github.steveice10.mc.protocol.packet.ingame.serverbound.player.ServerboundMovePlayerPosPacket;
 import com.github.steveice10.mc.protocol.packet.ingame.serverbound.player.ServerboundPlayerAbilitiesPacket;
 import com.github.steveice10.mc.protocol.packet.login.serverbound.ServerboundCustomQueryPacket;
@@ -464,6 +465,15 @@ public class GeyserSession implements GeyserConnection, CommandSender {
      */
     @Setter
     private String lastSignMessage;
+
+    /**
+     * Stores the last sign update packet.
+     * Bedrock sends packets every time you update the sign, sometimes even sends duplicated packets,
+     * while Java only wants the final packet.
+     * Until determine that the user has finished editing(started moving/interacting), we send the packet to the server.
+     */
+    @Setter
+    private ServerboundSignUpdatePacket lastSignUpdatePacket;
 
     /**
      * Stores a map of all statistics sent from the server.

--- a/core/src/main/java/org/geysermc/geyser/session/GeyserSession.java
+++ b/core/src/main/java/org/geysermc/geyser/session/GeyserSession.java
@@ -554,14 +554,6 @@ public class GeyserSession implements GeyserConnection, CommandSender {
         bedrockServerSession.addDisconnectHandler(disconnectReason -> {
             InetAddress address = bedrockServerSession.getRealAddress().getAddress();
             geyser.getLogger().info(GeyserLocale.getLocaleStringLog("geyser.network.disconnect", address, disconnectReason));
-            // Check if there is undetermined sign update packet
-            if (this.getLastSignUpdatePacket() != null) {
-                // We send the packet to the server
-                this.sendDownstreamPacket(this.getLastSignUpdatePacket());
-                // We set the sign text&packet cached in the session to null to indicate there is no work-in-progress sign
-                this.setLastSignMessage(null);
-                this.setLastSignUpdatePacket(null);
-            }
             disconnect(disconnectReason.name());
             geyser.getSessionManager().removeSession(this);
         });
@@ -971,6 +963,14 @@ public class GeyserSession implements GeyserConnection, CommandSender {
     }
 
     public void disconnect(String reason) {
+        // Check if there is undetermined sign update packet
+        if (this.getLastSignUpdatePacket() != null) {
+            // We send the packet to the server
+            this.sendDownstreamPacket(this.getLastSignUpdatePacket());
+            // We set the sign text&packet cached in the session to null to indicate there is no work-in-progress sign
+            this.setLastSignMessage(null);
+            this.setLastSignUpdatePacket(null);
+        }
         if (!closed) {
             loggedIn = false;
             if (downstream != null) {

--- a/core/src/main/java/org/geysermc/geyser/session/cache/SignUpdateCache.java
+++ b/core/src/main/java/org/geysermc/geyser/session/cache/SignUpdateCache.java
@@ -1,0 +1,60 @@
+/*
+ * Copyright (c) 2019-2022 GeyserMC. http://geysermc.org
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ *
+ * @author GeyserMC
+ * @link https://github.com/GeyserMC/Geyser
+ */
+
+package org.geysermc.geyser.session.cache;
+
+import com.github.steveice10.mc.protocol.packet.ingame.serverbound.level.ServerboundSignUpdatePacket;
+import lombok.Getter;
+import lombok.Setter;
+import org.geysermc.geyser.session.GeyserSession;
+
+/**
+ * Manages updating the current created sign.
+ *
+ * Java only sends sign update when player finishes editing, while Bedrock sends updates more frequently.
+ * This can cause 'change non-editable sign' on spigot servers.
+ */
+public class SignUpdateCache {
+    private final GeyserSession session;
+    @Setter
+    @Getter
+    private ServerboundSignUpdatePacket packet;
+
+    public SignUpdateCache(GeyserSession session) {
+        this.session = session;
+    }
+
+    /**
+     * Check to see if there is a sign update to send, and if so, send it.
+     */
+    public void checkForSend() {
+        if (packet == null) {
+            // No new packet has to be sent
+            return;
+        }
+        session.sendDownstreamPacket(packet);
+        packet = null;
+    }
+}

--- a/core/src/main/java/org/geysermc/geyser/translator/protocol/bedrock/BedrockBlockEntityDataTranslator.java
+++ b/core/src/main/java/org/geysermc/geyser/translator/protocol/bedrock/BedrockBlockEntityDataTranslator.java
@@ -108,11 +108,7 @@ public class BedrockBlockEntityDataTranslator extends PacketTranslator<BlockEnti
             if (iterator < lines.length) lines[iterator] = newMessage.toString();
             Position pos = new Position(tag.getInt("x"), tag.getInt("y"), tag.getInt("z"));
             ServerboundSignUpdatePacket signUpdatePacket = new ServerboundSignUpdatePacket(pos, lines);
-            session.sendDownstreamPacket(signUpdatePacket);
-
-            // We set the sign text cached in the session to null to indicate there is no work-in-progress sign
-            session.setLastSignMessage(null);
-
+            session.setLastSignUpdatePacket(signUpdatePacket);
         } else if (id.equals("JigsawBlock")) {
             // Client has just sent a jigsaw block update
             Position pos = new Position(tag.getInt("x"), tag.getInt("y"), tag.getInt("z"));

--- a/core/src/main/java/org/geysermc/geyser/translator/protocol/bedrock/BedrockBlockEntityDataTranslator.java
+++ b/core/src/main/java/org/geysermc/geyser/translator/protocol/bedrock/BedrockBlockEntityDataTranslator.java
@@ -44,23 +44,6 @@ public class BedrockBlockEntityDataTranslator extends PacketTranslator<BlockEnti
         String id = tag.getString("id");
         if (id.equals("Sign")) {
             String text = tag.getString("Text");
-            Position pos = new Position(tag.getInt("x"), tag.getInt("y"), tag.getInt("z"));
-            // Check if there is undetermined sign update packet
-            if (session.getLastSignUpdatePacket() != null && !session.getLastSignUpdatePacket().getPosition().equals(pos)) {
-                // We send the packet to the server
-                session.sendDownstreamPacket(session.getLastSignUpdatePacket());
-                // We set the sign text&packet cached in the session to null to indicate there is no work-in-progress sign
-                session.setLastSignMessage(null);
-                session.setLastSignUpdatePacket(null);
-            }
-            // This is the reason why this all works - Bedrock sends packets every time you update the sign, Java only wants the final packet
-            // But Bedrock sends one final packet when you're done editing the sign, which should be equal to the last message since there's no edits
-            // So if the latest update does not match the last cached update then it's still being edited
-            if (!text.equals(session.getLastSignMessage())) {
-                session.setLastSignMessage(text);
-                return;
-            }
-            // Otherwise the two messages are identical and we can get to work deconstructing
             StringBuilder newMessage = new StringBuilder();
             // While Bedrock's sign lines are one string, Java's is an array of each line
             // (Initialized all with empty strings because it complains about null)
@@ -115,8 +98,8 @@ public class BedrockBlockEntityDataTranslator extends PacketTranslator<BlockEnti
             }
             // Put the final line on since it isn't done in the for loop
             if (iterator < lines.length) lines[iterator] = newMessage.toString();
-            ServerboundSignUpdatePacket signUpdatePacket = new ServerboundSignUpdatePacket(pos, lines);
-            session.setLastSignUpdatePacket(signUpdatePacket);
+            Position pos = new Position(tag.getInt("x"), tag.getInt("y"), tag.getInt("z"));
+            session.getSignUpdateCache().setPacket(new ServerboundSignUpdatePacket(pos, lines));
         } else if (id.equals("JigsawBlock")) {
             // Client has just sent a jigsaw block update
             Position pos = new Position(tag.getInt("x"), tag.getInt("y"), tag.getInt("z"));

--- a/core/src/main/java/org/geysermc/geyser/translator/protocol/bedrock/BedrockInventoryTransactionTranslator.java
+++ b/core/src/main/java/org/geysermc/geyser/translator/protocol/bedrock/BedrockInventoryTransactionTranslator.java
@@ -79,8 +79,9 @@ public class BedrockInventoryTransactionTranslator extends PacketTranslator<Inve
 
     @Override
     public void translate(GeyserSession session, InventoryTransactionPacket packet) {
-        // Send book updates before opening inventories
+        // Send book & sign updates before opening inventories
         session.getBookEditCache().checkForSend();
+        session.getSignUpdateCache().checkForSend();
 
         ItemMappings mappings = session.getItemMappings();
 

--- a/core/src/main/java/org/geysermc/geyser/translator/protocol/bedrock/BedrockMobEquipmentTranslator.java
+++ b/core/src/main/java/org/geysermc/geyser/translator/protocol/bedrock/BedrockMobEquipmentTranslator.java
@@ -49,8 +49,9 @@ public class BedrockMobEquipmentTranslator extends PacketTranslator<MobEquipment
             return;
         }
 
-        // Send book update before switching hotbar slot
+        // Send book & sign update before switching hotbar slot
         session.getBookEditCache().checkForSend();
+        session.getSignUpdateCache().checkForSend();
 
         session.getPlayerInventory().setHeldItemSlot(packet.getHotbarSlot());
 

--- a/core/src/main/java/org/geysermc/geyser/translator/protocol/bedrock/entity/player/BedrockActionTranslator.java
+++ b/core/src/main/java/org/geysermc/geyser/translator/protocol/bedrock/entity/player/BedrockActionTranslator.java
@@ -55,18 +55,10 @@ public class BedrockActionTranslator extends PacketTranslator<PlayerActionPacket
     public void translate(GeyserSession session, PlayerActionPacket packet) {
         SessionPlayerEntity entity = session.getPlayerEntity();
 
-        // Send book update before any player action
+        // Send book & sign update before any player action
         if (packet.getAction() != PlayerActionType.RESPAWN) {
             session.getBookEditCache().checkForSend();
-        }
-
-        // Check if there is undetermined sign update packet
-        if (session.getLastSignUpdatePacket() != null) {
-            // We send the packet to the server
-            session.sendDownstreamPacket(session.getLastSignUpdatePacket());
-            // We set the sign text&packet cached in the session to null to indicate there is no work-in-progress sign
-            session.setLastSignMessage(null);
-            session.setLastSignUpdatePacket(null);
+            session.getSignUpdateCache().checkForSend();
         }
 
         Vector3i vector = packet.getBlockPosition();

--- a/core/src/main/java/org/geysermc/geyser/translator/protocol/bedrock/entity/player/BedrockActionTranslator.java
+++ b/core/src/main/java/org/geysermc/geyser/translator/protocol/bedrock/entity/player/BedrockActionTranslator.java
@@ -60,6 +60,15 @@ public class BedrockActionTranslator extends PacketTranslator<PlayerActionPacket
             session.getBookEditCache().checkForSend();
         }
 
+        // Check if there is undetermined sign update packet
+        if (session.getLastSignUpdatePacket() != null) {
+            // We send the packet to the server
+            session.sendDownstreamPacket(session.getLastSignUpdatePacket());
+            // We set the sign text&packet cached in the session to null to indicate there is no work-in-progress sign
+            session.setLastSignMessage(null);
+            session.setLastSignUpdatePacket(null);
+        }
+
         Vector3i vector = packet.getBlockPosition();
 
         switch (packet.getAction()) {

--- a/core/src/main/java/org/geysermc/geyser/translator/protocol/bedrock/entity/player/BedrockMovePlayerTranslator.java
+++ b/core/src/main/java/org/geysermc/geyser/translator/protocol/bedrock/entity/player/BedrockMovePlayerTranslator.java
@@ -64,8 +64,9 @@ public class BedrockMovePlayerTranslator extends PacketTranslator<MovePlayerPack
 
         session.setLastMovementTimestamp(System.currentTimeMillis());
 
-        // Send book update before the player moves
+        // Send book & sign update before the player moves
         session.getBookEditCache().checkForSend();
+        session.getSignUpdateCache().checkForSend();
 
         // Ignore movement packets until Bedrock's position matches the teleported position
         if (session.getUnconfirmedTeleport() != null) {
@@ -155,15 +156,6 @@ public class BedrockMovePlayerTranslator extends PacketTranslator<MovePlayerPack
         }
         if (entity.getRightParrot() != null) {
             entity.getRightParrot().moveAbsolute(entity.getPosition(), entity.getYaw(), entity.getPitch(), entity.getHeadYaw(), true, false);
-        }
-
-        // Check if there is undetermined sign update packet
-        if (session.getLastSignUpdatePacket() != null && (positionChanged || rotationChanged)) {
-            // We send the packet to the server
-            session.sendDownstreamPacket(session.getLastSignUpdatePacket());
-            // We set the sign text&packet cached in the session to null to indicate there is no work-in-progress sign
-            session.setLastSignMessage(null);
-            session.setLastSignUpdatePacket(null);
         }
     }
 

--- a/core/src/main/java/org/geysermc/geyser/translator/protocol/bedrock/entity/player/BedrockMovePlayerTranslator.java
+++ b/core/src/main/java/org/geysermc/geyser/translator/protocol/bedrock/entity/player/BedrockMovePlayerTranslator.java
@@ -156,6 +156,15 @@ public class BedrockMovePlayerTranslator extends PacketTranslator<MovePlayerPack
         if (entity.getRightParrot() != null) {
             entity.getRightParrot().moveAbsolute(entity.getPosition(), entity.getYaw(), entity.getPitch(), entity.getHeadYaw(), true, false);
         }
+
+        // Check if there is undetermined sign update packet
+        if (session.getLastSignUpdatePacket() != null && (positionChanged || rotationChanged)) {
+            // We send the packet to the server
+            session.sendDownstreamPacket(session.getLastSignUpdatePacket());
+            // We set the sign text&packet cached in the session to null to indicate there is no work-in-progress sign
+            session.setLastSignMessage(null);
+            session.setLastSignUpdatePacket(null);
+        }
     }
 
     private boolean isInvalidNumber(float val) {


### PR DESCRIPTION
In #1063, some bedrock clients are unable to write the sign, throwing 'change non-editable sign'. It's probably caused by duplicated packets from the client which corrupts the original finishing check.

Though there's no direct field in the packet that indicates the user finishes editing, I'm only able to use some tricky way to determine when should we send the packet. In this PR, I delay the sign update packet until when player moving, doing action, editing another sign or disconnecting. Hope it helps and not causes more problem.

And if there's better(or less tricky) way to solve this, I'd love to hear from you.😄