### PR TITLE
Integrate two ribbons of sonarqube on the README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,8 @@
 
 [![License: MIT](https://img.shields.io/badge/license-MIT-blue.svg)](LICENSE)
 [![Build Status](https://ci.opencollab.dev/job/Geyser/job/master/badge/icon)](https://ci.opencollab.dev/job/GeyserMC/job/Geyser/job/master/)
+[![Quality Gate Status](https://sonarcloud.io/api/project_badges/measure?project=GeyserMC_Geyser&metric=alert_status)](https://sonarcloud.io/summary/new_code?id=GeyserMC_Geyser)
+[![Lines of Code](https://sonarcloud.io/api/project_badges/measure?project=GeyserMC_Geyser&metric=ncloc)](https://sonarcloud.io/summary/new_code?id=GeyserMC_Geyser)
 [![Discord](https://img.shields.io/discord/613163671870242838.svg?color=%237289da&label=discord)](https://discord.gg/geysermc)
 [![Crowdin](https://badges.crowdin.net/geyser/localized.svg)](https://translate.geysermc.org/)
 


### PR DESCRIPTION
That way we can see how much line of code has the project and if the sonarqube quality gate pass or fail.

I intentionally didn't integrate bugs, code smells counters ribbons as I think we should first clean the project (I will work on PRs for that) and then when it's good we can add this visually. I think it brings more this way)

What do you think ?


Cheers,
Seb