### PR TITLE
Add method in Connection API for transferring connections

### DIFF
--- a/api/base/src/main/java/org/geysermc/api/session/Connection.java
+++ b/api/base/src/main/java/org/geysermc/api/session/Connection.java
@@ -55,5 +55,11 @@ public interface Connection {
      */
     String xuid();
 
-
+    /**
+     * Transfer the connection to a server. The current server is a valid target.
+     *
+     * @param address The address of the server
+     * @param port The port of the server
+     */
+    void transferConnection(@NonNull String address, int port);
 }

--- a/api/base/src/main/java/org/geysermc/api/session/Connection.java
+++ b/api/base/src/main/java/org/geysermc/api/session/Connection.java
@@ -26,6 +26,7 @@
 package org.geysermc.api.session;
 
 import org.checkerframework.checker.nullness.qual.NonNull;
+import org.checkerframework.common.value.qual.IntRange;
 
 import java.util.UUID;
 
@@ -56,11 +57,12 @@ public interface Connection {
     String xuid();
 
     /**
-     * Transfer the connection to a server. The current server is a valid target.
+     * Transfer the connection to a server. A Bedrock player can successfully transfer to the same server they are
+     * currently playing on.
      *
      * @param address The address of the server
      * @param port The port of the server
      * @return true if the transfer was a success
      */
-    boolean transfer(@NonNull String address, int port);
+    boolean transfer(@NonNull String address, @IntRange(from = 0, to = 65535) int port);
 }

--- a/api/base/src/main/java/org/geysermc/api/session/Connection.java
+++ b/api/base/src/main/java/org/geysermc/api/session/Connection.java
@@ -60,6 +60,7 @@ public interface Connection {
      *
      * @param address The address of the server
      * @param port The port of the server
+     * @return true if the transfer was a success
      */
-    void transfer(@NonNull String address, int port);
+    boolean transfer(@NonNull String address, int port);
 }

--- a/api/base/src/main/java/org/geysermc/api/session/Connection.java
+++ b/api/base/src/main/java/org/geysermc/api/session/Connection.java
@@ -61,5 +61,5 @@ public interface Connection {
      * @param address The address of the server
      * @param port The port of the server
      */
-    void transferConnection(@NonNull String address, int port);
+    void transfer(@NonNull String address, int port);
 }

--- a/core/src/main/java/org/geysermc/geyser/session/GeyserSession.java
+++ b/core/src/main/java/org/geysermc/geyser/session/GeyserSession.java
@@ -1326,6 +1326,15 @@ public class GeyserSession implements GeyserConnection, CommandSender {
     }
 
     @Override
+    public void transferConnection(@NonNull String address, int port) {
+        Objects.requireNonNull(address);
+        TransferPacket transferPacket = new TransferPacket();
+        transferPacket.setAddress(address);
+        transferPacket.setPort(port);
+        sendUpstreamPacket(transferPacket);
+    }
+
+    @Override
     public void sendMessage(String message) {
         TextPacket textPacket = new TextPacket();
         textPacket.setPlatformChatId("");

--- a/core/src/main/java/org/geysermc/geyser/session/GeyserSession.java
+++ b/core/src/main/java/org/geysermc/geyser/session/GeyserSession.java
@@ -78,6 +78,7 @@ import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NonNull;
 import lombok.Setter;
+import org.checkerframework.common.value.qual.IntRange;
 import org.geysermc.common.PlatformType;
 import org.geysermc.cumulus.Form;
 import org.geysermc.cumulus.util.FormBuilder;
@@ -1325,9 +1326,14 @@ public class GeyserSession implements GeyserConnection, CommandSender {
         return authData.xuid();
     }
 
+    @SuppressWarnings("ConstantConditions") // Need to enforce the parameter annotations
     @Override
-    public boolean transfer(@NonNull String address, int port) {
-        Objects.requireNonNull(address);
+    public boolean transfer(@NonNull String address, @IntRange(from = 0, to = 65535) int port) {
+        if (address == null || address.isBlank()) {
+            throw new IllegalArgumentException("Server address cannot be null or blank");
+        } else if (port < 0 || port > 65535) {
+            throw new IllegalArgumentException("Server port must be between 0 and 65535, was " + port);
+        }
         TransferPacket transferPacket = new TransferPacket();
         transferPacket.setAddress(address);
         transferPacket.setPort(port);

--- a/core/src/main/java/org/geysermc/geyser/session/GeyserSession.java
+++ b/core/src/main/java/org/geysermc/geyser/session/GeyserSession.java
@@ -1326,12 +1326,13 @@ public class GeyserSession implements GeyserConnection, CommandSender {
     }
 
     @Override
-    public void transfer(@NonNull String address, int port) {
+    public boolean transfer(@NonNull String address, int port) {
         Objects.requireNonNull(address);
         TransferPacket transferPacket = new TransferPacket();
         transferPacket.setAddress(address);
         transferPacket.setPort(port);
         sendUpstreamPacket(transferPacket);
+        return true;
     }
 
     @Override

--- a/core/src/main/java/org/geysermc/geyser/session/GeyserSession.java
+++ b/core/src/main/java/org/geysermc/geyser/session/GeyserSession.java
@@ -1326,7 +1326,7 @@ public class GeyserSession implements GeyserConnection, CommandSender {
     }
 
     @Override
-    public void transferConnection(@NonNull String address, int port) {
+    public void transfer(@NonNull String address, int port) {
         Objects.requireNonNull(address);
         TransferPacket transferPacket = new TransferPacket();
         transferPacket.setAddress(address);


### PR DESCRIPTION
As described.

Should we throw an illegal argument exception if the address is blank or the port is not in range 0 - 65535 ?