### PR TITLE
Prevent async task pool from being full (fix #2883)

### DIFF
--- a/core/src/main/java/org/geysermc/geyser/skin/SkinProvider.java
+++ b/core/src/main/java/org/geysermc/geyser/skin/SkinProvider.java
@@ -601,6 +601,8 @@ public class SkinProvider {
 
         HttpURLConnection con = (HttpURLConnection) new URL(imageUrl).openConnection();
         con.setRequestProperty("User-Agent", "Geyser-" + GeyserImpl.getInstance().getPlatformType().toString() + "/" + GeyserImpl.VERSION);
+        con.setConnectTimeout(10000);
+        con.setReadTimeout(10000);
 
         BufferedImage image = ImageIO.read(con.getInputStream());
         if (image == null) throw new NullPointerException();

--- a/core/src/main/java/org/geysermc/geyser/util/WebUtils.java
+++ b/core/src/main/java/org/geysermc/geyser/util/WebUtils.java
@@ -52,6 +52,8 @@ public class WebUtils {
             HttpURLConnection con = (HttpURLConnection) url.openConnection();
             con.setRequestMethod("GET");
             con.setRequestProperty("User-Agent", "Geyser-" + GeyserImpl.getInstance().getPlatformType().toString() + "/" + GeyserImpl.VERSION); // Otherwise Java 8 fails on checking updates
+            con.setConnectTimeout(10000);
+            con.setReadTimeout(10000);
 
             return connectionToString(con);
         } catch (Exception e) {


### PR DESCRIPTION
This PR will fix https://github.com/GeyserMC/Geyser/issues/2883

HttpURLConnection has no timeout by default. If your country's internet is bad, in the worst case, the async pool will be full forever. So Geyser will not be able to handle the auth requests.

Setting the connect and read timeout, #2883 could be fixed.