### PR TITLE
Register `floodgate:transfer` plugin channel

### DIFF
--- a/common/src/main/java/org/geysermc/floodgate/pluginmessage/PluginMessageChannels.java
+++ b/common/src/main/java/org/geysermc/floodgate/pluginmessage/PluginMessageChannels.java
@@ -1,0 +1,45 @@
+/*
+ * Copyright (c) 2019-2022 GeyserMC. http://geysermc.org
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ *
+ * @author GeyserMC
+ * @link https://github.com/GeyserMC/Geyser
+ */
+
+package org.geysermc.floodgate.pluginmessage;
+
+import com.google.common.base.Charsets;
+
+public final class PluginMessageChannels {
+    public static final String SKIN = "floodgate:skin";
+    public static final String FORM = "floodgate:form";
+    public static final String TRANSFER = "floodgate:transfer";
+
+    private static final byte[] FLOODGATE_REGISTER_DATA = String.join("\0", SKIN, FORM, TRANSFER).getBytes(Charsets.UTF_8);
+
+    /**
+     * Get the prebuilt register data as a byte array
+     *
+     * @return the register data of the Floodgate channels
+     */
+    public static byte[] getFloodgateRegisterData() {
+        return FLOODGATE_REGISTER_DATA;
+    }
+}

--- a/core/src/main/java/org/geysermc/geyser/skin/FloodgateSkinUploader.java
+++ b/core/src/main/java/org/geysermc/geyser/skin/FloodgateSkinUploader.java
@@ -30,6 +30,7 @@ import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.node.ObjectNode;
 import lombok.Getter;
+import org.geysermc.floodgate.pluginmessage.PluginMessageChannels;
 import org.geysermc.geyser.GeyserImpl;
 import org.geysermc.geyser.GeyserLogger;
 import org.geysermc.geyser.session.GeyserSession;
@@ -47,8 +48,6 @@ import java.util.Iterator;
 import java.util.List;
 import java.util.concurrent.ThreadLocalRandom;
 import java.util.concurrent.TimeUnit;
-
-import static org.geysermc.geyser.util.PluginMessageUtils.getSkinChannel;
 
 public final class FloodgateSkinUploader {
     private final ObjectMapper JACKSON = new ObjectMapper();
@@ -126,7 +125,7 @@ public final class FloodgateSkinUploader {
 
                                 byte[] bytes = (value + '\0' + signature)
                                         .getBytes(StandardCharsets.UTF_8);
-                                PluginMessageUtils.sendMessage(session, getSkinChannel(), bytes);
+                                PluginMessageUtils.sendMessage(session, PluginMessageChannels.SKIN, bytes);
                             }
                             break;
                         case LOG_MESSAGE:

--- a/core/src/main/java/org/geysermc/geyser/translator/protocol/java/JavaCustomPayloadTranslator.java
+++ b/core/src/main/java/org/geysermc/geyser/translator/protocol/java/JavaCustomPayloadTranslator.java
@@ -102,8 +102,6 @@ public class JavaCustomPayloadTranslator extends PacketTranslator<ClientboundCus
             transferPacket.setAddress(address);
             transferPacket.setPort(port);
             session.sendUpstreamPacket(transferPacket);
-        } else {
-            logger.warning("Unknown plugin message channel: " + channel);
         }
     }
 }

--- a/core/src/main/java/org/geysermc/geyser/translator/protocol/java/JavaCustomPayloadTranslator.java
+++ b/core/src/main/java/org/geysermc/geyser/translator/protocol/java/JavaCustomPayloadTranslator.java
@@ -29,6 +29,7 @@ import com.github.steveice10.mc.protocol.packet.ingame.serverbound.ServerboundCu
 import com.github.steveice10.mc.protocol.packet.ingame.clientbound.ClientboundCustomPayloadPacket;
 import com.google.common.base.Charsets;
 import com.nukkitx.protocol.bedrock.packet.TransferPacket;
+import org.geysermc.floodgate.pluginmessage.PluginMessageChannels;
 import org.geysermc.geyser.GeyserImpl;
 import org.geysermc.geyser.GeyserLogger;
 import org.geysermc.geyser.session.auth.AuthType;
@@ -54,7 +55,7 @@ public class JavaCustomPayloadTranslator extends PacketTranslator<ClientboundCus
 
         String channel = packet.getChannel();
 
-        if (channel.equals("floodgate:form")) {
+        if (channel.equals(PluginMessageChannels.FORM)) {
             byte[] data = packet.getData();
 
             // receive: first byte is form type, second and third are the id, remaining is the form data
@@ -81,7 +82,7 @@ public class JavaCustomPayloadTranslator extends PacketTranslator<ClientboundCus
             });
             session.sendForm(form);
 
-        } else if (channel.equals("floodgate:transfer")) {
+        } else if (channel.equals(PluginMessageChannels.TRANSFER)) {
             byte[] data = packet.getData();
 
             // port, 4 bytes. remaining data, address.
@@ -101,6 +102,8 @@ public class JavaCustomPayloadTranslator extends PacketTranslator<ClientboundCus
             transferPacket.setAddress(address);
             transferPacket.setPort(port);
             session.sendUpstreamPacket(transferPacket);
+        } else {
+            logger.warning("Unknown plugin message channel: " + channel);
         }
     }
 }

--- a/core/src/main/java/org/geysermc/geyser/translator/protocol/java/JavaLoginTranslator.java
+++ b/core/src/main/java/org/geysermc/geyser/translator/protocol/java/JavaLoginTranslator.java
@@ -32,6 +32,7 @@ import com.nukkitx.protocol.bedrock.data.PlayerPermission;
 import com.nukkitx.protocol.bedrock.packet.AdventureSettingsPacket;
 import com.nukkitx.protocol.bedrock.packet.GameRulesChangedPacket;
 import com.nukkitx.protocol.bedrock.packet.SetPlayerGameTypePacket;
+import org.geysermc.floodgate.pluginmessage.PluginMessageChannels;
 import org.geysermc.geyser.entity.type.player.PlayerEntity;
 import org.geysermc.geyser.session.GeyserSession;
 import org.geysermc.geyser.session.auth.AuthType;
@@ -102,7 +103,7 @@ public class JavaLoginTranslator extends PacketTranslator<ClientboundLoginPacket
 
         // register the plugin messaging channels used in Floodgate
         if (session.getRemoteAuthType() == AuthType.FLOODGATE) {
-            session.sendDownstreamPacket(new ServerboundCustomPayloadPacket("minecraft:register", PluginMessageUtils.getFloodgateRegisterData()));
+            session.sendDownstreamPacket(new ServerboundCustomPayloadPacket("minecraft:register", PluginMessageChannels.getFloodgateRegisterData()));
         }
 
         if (!newDimension.equals(session.getDimension())) {

--- a/core/src/main/java/org/geysermc/geyser/util/PluginMessageUtils.java
+++ b/core/src/main/java/org/geysermc/geyser/util/PluginMessageUtils.java
@@ -33,9 +33,7 @@ import org.geysermc.geyser.session.GeyserSession;
 import java.nio.ByteBuffer;
 
 public class PluginMessageUtils {
-    private static final String SKIN_CHANNEL = "floodgate:skin";
     private static final byte[] GEYSER_BRAND_DATA;
-    private static final byte[] FLOODGATE_REGISTER_DATA;
 
     static {
         byte[] data = GeyserImpl.NAME.getBytes(Charsets.UTF_8);
@@ -44,8 +42,6 @@ public class PluginMessageUtils {
                         .put(writeVarInt(data.length))
                         .put(data)
                         .array();
-
-        FLOODGATE_REGISTER_DATA = (SKIN_CHANNEL + "\0floodgate:form").getBytes(Charsets.UTF_8);
     }
 
     /**
@@ -55,22 +51,6 @@ public class PluginMessageUtils {
      */
     public static byte[] getGeyserBrandData() {
         return GEYSER_BRAND_DATA;
-    }
-
-    /**
-     * Get the prebuilt register data as a byte array
-     *
-     * @return the register data of the Floodgate channels
-     */
-    public static byte[] getFloodgateRegisterData() {
-        return FLOODGATE_REGISTER_DATA;
-    }
-
-    /**
-     * Returns the skin channel used in Floodgate
-     */
-    public static String getSkinChannel() {
-        return SKIN_CHANNEL;
     }
 
     public static void sendMessage(GeyserSession session, String channel, byte[] data) {


### PR DESCRIPTION
Geyser currently doesn't do this, so the transfer method in Floodgate's API just... does nothing.

Before:
<img src="https://cdn.discordapp.com/attachments/613170125696270357/954889099112775680/unknown.png">

After: https://mclo.gs/u6v2RWI

Moved the channel definitions to common so that floodgate can use the constants as well.