### PR TITLE
Re-arrange groups and artefacts when publishing

### DIFF
--- a/api/geyser/build.gradle.kts
+++ b/api/geyser/build.gradle.kts
@@ -1,3 +1,10 @@
 dependencies {
     api(projects.api)
 }
+
+publishing {
+    publications.named<MavenPublication>("mavenJava") {
+        groupId = rootProject.group as String + ".geyser"
+        artifactId = "api"
+    }
+}

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -32,7 +32,6 @@ subprojects {
     val relativePath = projectDir.relativeTo(rootProject.projectDir).path
 
     if (relativePath.contains("api")) {
-        group = rootProject.group as String + ".api"
         plugins.apply("geyser.api-conventions")
     } else {
         group = rootProject.group as String + ".geyser"

--- a/core/build.gradle.kts
+++ b/core/build.gradle.kts
@@ -77,6 +77,13 @@ dependencies {
     annotationProcessor(projects.ap)
 }
 
+publishing {
+    publications.named<MavenPublication>("mavenJava") {
+        artifact(tasks["jar"])
+        artifact(tasks["sourcesJar"])
+    }
+}
+
 configure<BlossomExtension> {
     val indra = the<IndraGitExtension>()
 


### PR DESCRIPTION
Packages are now published under these formats:
- `org.geysermc:api`
- `org.geysermc.geyser:core`
- `org.geysermc.geyser:spigot`
- `org.geysermc.geyser:api`