### PR TITLE
Generate velocity-plugins.json and relocate fastutil

### DIFF
--- a/bootstrap/velocity/build.gradle.kts
+++ b/bootstrap/velocity/build.gradle.kts
@@ -1,11 +1,12 @@
 val velocityVersion = "3.0.0"
 
 dependencies {
+    annotationProcessor("com.velocitypowered", "velocity-api", velocityVersion)
     api(projects.core)
 }
 
 platformRelocate("com.fasterxml.jackson")
-platformRelocate("it.unimi.fastutil")
+platformRelocate("it.unimi.dsi.fastutil")
 platformRelocate("net.kyori.adventure.text.serializer.gson.legacyimpl")
 
 exclude("com.google.*:*")

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -10,6 +10,10 @@ allprojects {
     group = "org.geysermc"
     version = "2.1.0-SNAPSHOT"
     description = "Allows for players from Minecraft: Bedrock Edition to join Minecraft: Java Edition servers."
+
+    tasks.withType<JavaCompile> {
+        options.encoding = "UTF-8"
+    }
 }
 
 val platforms = setOf(


### PR DESCRIPTION
I'm pretty sure that the resource processing [here](https://github.com/GeyserMC/Geyser/blob/feature/extensions/build-logic/src/main/kotlin/geyser.base-conventions.gradle.kts#L12) won't actually apply to velocity-plugins.json. But that's fine because the plugin annotations in the velocity plugin class pulls version/build data from GeyserImpl, which Blossom handles.

Compared to master, `epoll` and `kqueue` within `netty-channel` are being shaded even though Velocity provides both. I tried excluding with `exclude("io.netty:netty-channel:*")` but it still persisted.