### PR TITLE
Add support for a custom shutdown message

### DIFF
--- a/core/src/main/java/org/geysermc/geyser/GeyserImpl.java
+++ b/core/src/main/java/org/geysermc/geyser/GeyserImpl.java
@@ -495,12 +495,13 @@ public class GeyserImpl implements GeyserApi {
 
     @Override
     public void shutdown() {
+		 GeyserConfiguration config = bootstrap.getGeyserConfig();
         bootstrap.getGeyserLogger().info(GeyserLocale.getLocaleStringLog("geyser.core.shutdown"));
         shuttingDown = true;
 
         if (sessionManager.size() >= 1) {
             bootstrap.getGeyserLogger().info(GeyserLocale.getLocaleStringLog("geyser.core.shutdown.kick.log", sessionManager.size()));
-            sessionManager.disconnectAll("geyser.core.shutdown.kick.message");
+            sessionManager.disconnectAll(config.getBedrock().getShutdownMessage());
             bootstrap.getGeyserLogger().info(GeyserLocale.getLocaleStringLog("geyser.core.shutdown.kick.done"));
         }
 

--- a/core/src/main/java/org/geysermc/geyser/GeyserImpl.java
+++ b/core/src/main/java/org/geysermc/geyser/GeyserImpl.java
@@ -495,7 +495,7 @@ public class GeyserImpl implements GeyserApi {
 
     @Override
     public void shutdown() {
-		 GeyserConfiguration config = bootstrap.getGeyserConfig();
+		GeyserConfiguration config = bootstrap.getGeyserConfig();
         bootstrap.getGeyserLogger().info(GeyserLocale.getLocaleStringLog("geyser.core.shutdown"));
         shuttingDown = true;
 

--- a/core/src/main/java/org/geysermc/geyser/GeyserImpl.java
+++ b/core/src/main/java/org/geysermc/geyser/GeyserImpl.java
@@ -501,7 +501,11 @@ public class GeyserImpl implements GeyserApi {
 
         if (sessionManager.size() >= 1) {
             bootstrap.getGeyserLogger().info(GeyserLocale.getLocaleStringLog("geyser.core.shutdown.kick.log", sessionManager.size()));
-            sessionManager.disconnectAll(config.getBedrock().getShutdownMessage());
+            if (config.getBedrock().getShutdownMessage().isBlank()) {
+                sessionManager.disconnectAll("geyser.core.shutdown.kick.message");
+            } else {
+                sessionManager.disconnectAll(config.getBedrock().getShutdownMessage());
+            }
             bootstrap.getGeyserLogger().info(GeyserLocale.getLocaleStringLog("geyser.core.shutdown.kick.done"));
         }
 

--- a/core/src/main/java/org/geysermc/geyser/configuration/GeyserConfiguration.java
+++ b/core/src/main/java/org/geysermc/geyser/configuration/GeyserConfiguration.java
@@ -118,6 +118,8 @@ public interface GeyserConfiguration {
         String getMotd2();
 
         String getServerName();
+		
+		 String getShutdownMessage();
 
         int getCompressionLevel();
 

--- a/core/src/main/java/org/geysermc/geyser/configuration/GeyserConfiguration.java
+++ b/core/src/main/java/org/geysermc/geyser/configuration/GeyserConfiguration.java
@@ -119,7 +119,7 @@ public interface GeyserConfiguration {
 
         String getServerName();
 		
-		 String getShutdownMessage();
+        String getShutdownMessage();
 
         int getCompressionLevel();
 

--- a/core/src/main/java/org/geysermc/geyser/configuration/GeyserJacksonConfiguration.java
+++ b/core/src/main/java/org/geysermc/geyser/configuration/GeyserJacksonConfiguration.java
@@ -164,6 +164,9 @@ public abstract class GeyserJacksonConfiguration implements GeyserConfiguration 
 
         @JsonProperty("server-name")
         private String serverName = GeyserImpl.NAME;
+		
+		 @JsonProperty("shutdown-message")
+        private String shutdownMessage = "Geyser Proxy shutting down";
 
         @JsonProperty("compression-level")
         private int compressionLevel = 6;

--- a/core/src/main/java/org/geysermc/geyser/configuration/GeyserJacksonConfiguration.java
+++ b/core/src/main/java/org/geysermc/geyser/configuration/GeyserJacksonConfiguration.java
@@ -165,7 +165,7 @@ public abstract class GeyserJacksonConfiguration implements GeyserConfiguration 
         @JsonProperty("server-name")
         private String serverName = GeyserImpl.NAME;
 		
-		 @JsonProperty("shutdown-message")
+        @JsonProperty("shutdown-message")
         private String shutdownMessage = "Geyser Proxy shutting down";
 
         @JsonProperty("compression-level")

--- a/core/src/main/java/org/geysermc/geyser/network/UpstreamPacketHandler.java
+++ b/core/src/main/java/org/geysermc/geyser/network/UpstreamPacketHandler.java
@@ -69,7 +69,11 @@ public class UpstreamPacketHandler extends LoggingPacketHandler {
         if (geyser.isShuttingDown()) {
             // Don't allow new players in if we're no longer operating
             GeyserConfiguration config = bootstrap.getGeyserConfig();
-            session.disconnect(config.getBedrock().getShutdownMessage());
+            if (config.getBedrock().getShutdownMessage().isBlank()) {
+                session.disconnect("geyser.core.shutdown.kick.message");
+            } else {
+                session.disconnect(config.getBedrock().getShutdownMessage());
+            }
             return true;
         }
 

--- a/core/src/main/java/org/geysermc/geyser/network/UpstreamPacketHandler.java
+++ b/core/src/main/java/org/geysermc/geyser/network/UpstreamPacketHandler.java
@@ -30,6 +30,7 @@ import com.nukkitx.protocol.bedrock.BedrockPacketCodec;
 import com.nukkitx.protocol.bedrock.data.ExperimentData;
 import com.nukkitx.protocol.bedrock.data.ResourcePackType;
 import com.nukkitx.protocol.bedrock.packet.*;
+import org.geysermc.geyser.GeyserBootstrap;
 import org.geysermc.geyser.GeyserImpl;
 import org.geysermc.geyser.configuration.GeyserConfiguration;
 import org.geysermc.geyser.pack.ResourcePack;
@@ -56,6 +57,8 @@ public class UpstreamPacketHandler extends LoggingPacketHandler {
         return Registries.BEDROCK_PACKET_TRANSLATORS.translate(packet.getClass(), packet, session);
     }
 
+    private GeyserBootstrap bootstrap;
+
     @Override
     boolean defaultHandler(BedrockPacket packet) {
         return translateAndDefault(packet);
@@ -65,7 +68,8 @@ public class UpstreamPacketHandler extends LoggingPacketHandler {
     public boolean handle(LoginPacket loginPacket) {
         if (geyser.isShuttingDown()) {
             // Don't allow new players in if we're no longer operating
-            session.disconnect(GeyserLocale.getLocaleStringLog("geyser.core.shutdown.kick.message"));
+            GeyserConfiguration config = bootstrap.getGeyserConfig();
+            session.disconnect(config.getBedrock().getShutdownMessage());
             return true;
         }
 

--- a/core/src/main/resources/config.yml
+++ b/core/src/main/resources/config.yml
@@ -23,6 +23,8 @@ bedrock:
   motd2: "Another Geyser server."
   # The Server Name that will be sent to Minecraft: Bedrock Edition clients. This is visible in both the pause menu and the settings menu.
   server-name: "Geyser"
+  # The message that will be displayed to Minecraft: Bedrock Edition clients when Geyser shuts down.
+  shutdown-message: "Geyser Proxy shutting down"
   # How much to compress network traffic to the Bedrock client. The higher the number, the more CPU usage used, but
   # the smaller the bandwidth used. Does not have any effect below -1 or above 9. Set to -1 to disable.
   compression-level: 6


### PR DESCRIPTION
This PR allows setting a custom message to be shown to bedrock clients when Geyser shuts down.

It also adds a new config option called ``shutdown-message`` with a comment explaining its function. This does make the locale ``geyser.core.shutdown.kick.message`` no longer have a purpose.