### PR TITLE
Prevent max health from being set below 0

### DIFF
--- a/core/src/main/java/org/geysermc/geyser/entity/type/LivingEntity.java
+++ b/core/src/main/java/org/geysermc/geyser/entity/type/LivingEntity.java
@@ -300,7 +300,8 @@ public class LivingEntity extends Entity {
         if (javaAttribute.getType() instanceof AttributeType.Builtin type) {
             switch (type) {
                 case GENERIC_MAX_HEALTH -> {
-                    this.maxHealth = (float) AttributeUtils.calculateValue(javaAttribute);
+                    // Setting max health to 0 or below causes the entity to die on Bedrock but not on Java
+                    this.maxHealth = Math.max((float) AttributeUtils.calculateValue(javaAttribute), 1f);
                     newAttributes.add(createHealthAttribute());
                 }
                 case GENERIC_ATTACK_DAMAGE -> newAttributes.add(calculateAttribute(javaAttribute, GeyserAttributeType.ATTACK_DAMAGE));

--- a/core/src/main/java/org/geysermc/geyser/entity/type/LivingEntity.java
+++ b/core/src/main/java/org/geysermc/geyser/entity/type/LivingEntity.java
@@ -300,7 +300,8 @@ public class LivingEntity extends Entity {
         if (javaAttribute.getType() instanceof AttributeType.Builtin type) {
             switch (type) {
                 case GENERIC_MAX_HEALTH -> {
-                    // Setting max health to 0 or below causes the entity to die on Bedrock but not on Java
+                    // Since 1.18.0, setting the max health to 0 or below causes the entity to die on Bedrock but not on Java
+                    // See https://github.com/GeyserMC/Geyser/issues/2971
                     this.maxHealth = Math.max((float) AttributeUtils.calculateValue(javaAttribute), 1f);
                     newAttributes.add(createHealthAttribute());
                 }


### PR DESCRIPTION
Fixes https://github.com/GeyserMC/Geyser/issues/2971

TrainCarts and BKCommonLib sets the mount's max health to 0 to hide the mount's health bar however this causes the entity to die on Bedrock. Setting the max health to 1 seems to do the same thing without any issues.
[Reference](https://github.com/bergerhealer/BKCommonLib/blob/e337b94d4f8af502d8417d86b92b347d5889d18f/src/main/java/com/bergerkiller/bukkit/common/map/MapPlayerInput.java#L570)