### PR TITLE
Fix java style queries responding incorrectly

### DIFF
--- a/core/src/main/java/org/geysermc/geyser/network/QueryPacketHandler.java
+++ b/core/src/main/java/org/geysermc/geyser/network/QueryPacketHandler.java
@@ -91,8 +91,10 @@ public class QueryPacketHandler {
         switch (type) {
             case HANDSHAKE:
                 sendToken();
+                break;
             case STATISTICS:
                 sendQueryData();
+                break;
         }
     }
 


### PR DESCRIPTION
Adds some much-needed missing break statements

Before: (Just asking for challenge and getting both)
![2022-06-15_00-25-57](https://user-images.githubusercontent.com/5401186/173707121-a7e60e81-8eb4-4bd9-b4be-7a2117e39458.png)


After: (Full challenge response as expected and documented)
![image](https://user-images.githubusercontent.com/5401186/173707106-15b24257-63ee-42c7-a9c0-b26059afdeb9.png)

I'm amazed we missed this when adding the feature.
