### PR TITLE
supports unofficial yggdrasil (authlib-injector)

### DIFF
--- a/core/pom.xml
+++ b/core/pom.xml
@@ -149,7 +149,7 @@
         <dependency>
             <groupId>com.github.GeyserMC</groupId>
             <artifactId>MCAuthLib</artifactId>
-            <version>d9d773e</version>
+            <version>1374241</version>
             <scope>compile</scope>
         </dependency>
         <dependency>

--- a/core/src/main/java/org/geysermc/geyser/GeyserImpl.java
+++ b/core/src/main/java/org/geysermc/geyser/GeyserImpl.java
@@ -81,6 +81,7 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.net.InetAddress;
 import java.net.InetSocketAddress;
+import java.net.URI;
 import java.net.UnknownHostException;
 import java.security.Key;
 import java.text.DecimalFormat;
@@ -210,6 +211,14 @@ public class GeyserImpl implements GeyserApi {
         SkinProvider.registerCacheImageTask(this);
 
         ResourcePack.loadPacks();
+
+        if (config.getRemote().getAuthType() == AuthType.ONLINE && !config.getRemote().getAuthServer().equals("offline")) {
+            String rootUri = config.getRemote().getAuthServer();
+            StringBuilder rootUriBuilder = new StringBuilder(rootUri);
+            if (!rootUri.endsWith("/"))
+                rootUriBuilder.append("/");
+            ServiceRoot.registerYggdrasilServiceRoot(URI.create(rootUriBuilder.toString()));
+        }
 
         if (platformType != PlatformType.STANDALONE && config.getRemote().getAddress().equals("auto")) {
             // Set the remote address to localhost since that is where we are always connecting

--- a/core/src/main/java/org/geysermc/geyser/configuration/GeyserConfiguration.java
+++ b/core/src/main/java/org/geysermc/geyser/configuration/GeyserConfiguration.java
@@ -147,6 +147,8 @@ public interface GeyserConfiguration {
 
         AuthType getAuthType();
 
+        String getAuthServer();
+
         boolean isPasswordAuthentication();
 
         boolean isUseProxyProtocol();

--- a/core/src/main/java/org/geysermc/geyser/configuration/GeyserJacksonConfiguration.java
+++ b/core/src/main/java/org/geysermc/geyser/configuration/GeyserJacksonConfiguration.java
@@ -218,6 +218,10 @@ public abstract class GeyserJacksonConfiguration implements GeyserConfiguration 
         @JsonProperty("auth-type")
         private AuthType authType = AuthType.ONLINE;
 
+        @Setter
+        @JsonProperty("auth-server")
+        private String authServer = "official";
+
         @JsonProperty("allow-password-authentication")
         private boolean passwordAuthentication = true;
 

--- a/core/src/main/resources/config.yml
+++ b/core/src/main/resources/config.yml
@@ -47,6 +47,10 @@ remote:
   # For plugin versions, it's recommended to keep the `address` field to "auto" so Floodgate support is automatically configured.
   # If Floodgate is installed and `address:` is set to "auto", then "auth-type: floodgate" will automatically be used.
   auth-type: online
+  # Yggdrasil server's api root. If the java server started with authlib-injector (see https://github.com/yushijinhun/authlib-injector) and has switched on `online-mode`, you should paste the yggdrasil api root here.
+  # For servers using official mojang authlib, keep this field to "official".
+  # Only meaningful when `auth-type` is set to "online".
+  auth-server: official
   # Allow for password-based authentication methods through Geyser. Only useful in online mode.
   # If this is false, users must authenticate to Microsoft using a code provided by Geyser on their desktop.
   allow-password-authentication: true


### PR DESCRIPTION
[This PR](https://github.com/GeyserMC/MCAuthLib/pull/26) needs accepting.

It allows servers with [authlib-injector](https://github.com/yushijinhun/authlib-injector) and online-mode to use Geyser correctly.

Fill the `auth-server` field in `config.yml` with yggdrasil api root and (re)start the server.

**CURRENTLY NOT TESTED!!!**