### PR TITLE
Fix some item interactions

### DIFF
--- a/core/src/main/java/org/geysermc/geyser/inventory/item/StoredItemMappings.java
+++ b/core/src/main/java/org/geysermc/geyser/inventory/item/StoredItemMappings.java
@@ -48,10 +48,12 @@ public class StoredItemMappings {
     private final ItemMapping enchantedBook;
     private final ItemMapping fishingRod;
     private final int flintAndSteel;
+    private final int frogspawn;
     private final int goldenApple;
     private final int goldIngot;
     private final int ironIngot;
     private final int lead;
+    private final int lilyPad;
     private final ItemMapping milkBucket;
     private final int nameTag;
     private final ItemMapping powderSnowBucket;
@@ -76,10 +78,12 @@ public class StoredItemMappings {
         this.enchantedBook = load(itemMappings, "enchanted_book");
         this.fishingRod = load(itemMappings, "fishing_rod");
         this.flintAndSteel = load(itemMappings, "flint_and_steel").getJavaId();
+        this.frogspawn = load(itemMappings, "frogspawn").getBedrockId();
         this.goldenApple = load(itemMappings, "golden_apple").getJavaId();
         this.goldIngot = load(itemMappings, "gold_ingot").getJavaId();
         this.ironIngot = load(itemMappings, "iron_ingot").getJavaId();
         this.lead = load(itemMappings, "lead").getJavaId();
+        this.lilyPad = load(itemMappings, "lily_pad").getBedrockId();
         this.milkBucket = load(itemMappings, "milk_bucket");
         this.nameTag = load(itemMappings, "name_tag").getJavaId();
         this.powderSnowBucket = load(itemMappings, "powder_snow_bucket");

--- a/core/src/main/java/org/geysermc/geyser/inventory/item/StoredItemMappings.java
+++ b/core/src/main/java/org/geysermc/geyser/inventory/item/StoredItemMappings.java
@@ -49,6 +49,7 @@ public class StoredItemMappings {
     private final ItemMapping fishingRod;
     private final int flintAndSteel;
     private final int frogspawn;
+    private final int glassBottle;
     private final int goldenApple;
     private final int goldIngot;
     private final int ironIngot;
@@ -79,6 +80,7 @@ public class StoredItemMappings {
         this.fishingRod = load(itemMappings, "fishing_rod");
         this.flintAndSteel = load(itemMappings, "flint_and_steel").getJavaId();
         this.frogspawn = load(itemMappings, "frogspawn").getBedrockId();
+        this.glassBottle = load(itemMappings, "glass_bottle").getBedrockId();
         this.goldenApple = load(itemMappings, "golden_apple").getJavaId();
         this.goldIngot = load(itemMappings, "gold_ingot").getJavaId();
         this.ironIngot = load(itemMappings, "iron_ingot").getJavaId();

--- a/core/src/main/java/org/geysermc/geyser/inventory/item/StoredItemMappings.java
+++ b/core/src/main/java/org/geysermc/geyser/inventory/item/StoredItemMappings.java
@@ -42,6 +42,7 @@ public class StoredItemMappings {
     private final ItemMapping banner;
     private final ItemMapping barrier;
     private final int bowl;
+    private final int bucket;
     private final int chest;
     private final ItemMapping compass;
     private final ItemMapping crossbow;
@@ -73,6 +74,7 @@ public class StoredItemMappings {
         this.banner = load(itemMappings, "white_banner"); // As of 1.17.10, all banners have the same Bedrock ID
         this.barrier = load(itemMappings, "barrier");
         this.bowl = load(itemMappings, "bowl").getJavaId();
+        this.bucket = load(itemMappings, "bucket").getBedrockId();
         this.chest = load(itemMappings, "chest").getJavaId();
         this.compass = load(itemMappings, "compass");
         this.crossbow = load(itemMappings, "crossbow");

--- a/core/src/main/java/org/geysermc/geyser/level/block/BlockStateValues.java
+++ b/core/src/main/java/org/geysermc/geyser/level/block/BlockStateValues.java
@@ -34,7 +34,6 @@ import org.geysermc.geyser.registry.BlockRegistries;
 import org.geysermc.geyser.registry.type.BlockMapping;
 import org.geysermc.geyser.level.physics.Direction;
 import org.geysermc.geyser.level.physics.PistonBehavior;
-import org.geysermc.geyser.util.BlockUtils;
 import org.geysermc.geyser.util.collection.FixedInt2ByteMap;
 import org.geysermc.geyser.util.collection.FixedInt2IntMap;
 import org.geysermc.geyser.util.collection.LecternHasBookMap;
@@ -52,7 +51,6 @@ public final class BlockStateValues {
     private static final Int2ObjectMap<DoubleChestValue> DOUBLE_CHEST_VALUES = new Int2ObjectOpenHashMap<>();
     private static final Int2ObjectMap<String> FLOWER_POT_VALUES = new Int2ObjectOpenHashMap<>();
     private static final IntSet HORIZONTAL_FACING_JIGSAWS = new IntOpenHashSet();
-    private static final IntSet INTERACTABLE_BLOCKS = new IntOpenHashSet();
     private static final LecternHasBookMap LECTERN_BOOK_STATES = new LecternHasBookMap();
     private static final IntSet NON_WATER_CAULDRONS = new IntOpenHashSet();
     private static final Int2IntMap NOTEBLOCK_PITCHES = new FixedInt2IntMap();
@@ -87,55 +85,6 @@ public final class BlockStateValues {
      * @param blockData      JsonNode of info about the block from blocks.json
      */
     public static void storeBlockStateValues(String javaId, int javaBlockState, JsonNode blockData) {
-        String cleanJavaId = BlockUtils.getCleanIdentifier(javaId);
-        switch (cleanJavaId) {
-            case "minecraft:anvil":
-            case "minecraft:barrel":
-            case "minecraft:beacon":
-            case "minecraft:brewing_stand":
-            case "minecraft:cartography_table":
-            case "minecraft:crafting_table":
-            case "minecraft:dispenser":
-            case "minecraft:dragon_egg":
-            case "minecraft:dropper":
-            case "minecraft:enchanting_table":
-            case "minecraft:grindstone":
-            case "minecraft:hopper":
-            case "minecraft:lever":
-            case "minecraft:loom":
-            case "minecraft:note_block":
-            case "minecraft:smithing_table":
-            case "minecraft:smoker":
-            case "minecraft:stonecutter":
-                INTERACTABLE_BLOCKS.add(javaBlockState);
-                break;
-            default:
-                if (cleanJavaId.contains("furnace")) { // Furnace and Blast furnaces
-                    INTERACTABLE_BLOCKS.add(javaBlockState);
-                } else if (cleanJavaId.endsWith("_bed")) {
-                    INTERACTABLE_BLOCKS.add(javaBlockState);
-                } else if (cleanJavaId.endsWith("_button")) {
-                    INTERACTABLE_BLOCKS.add(javaBlockState);
-                } else if (cleanJavaId.startsWith("minecraft:cave_vines") && javaId.contains("berries=true")) { // cave_vines and cave_vines_plant
-                    INTERACTABLE_BLOCKS.add(javaBlockState);
-                } else if (cleanJavaId.endsWith("chest")) { // chest, ender_chest, and trapped_chest
-                    INTERACTABLE_BLOCKS.add(javaBlockState);
-                } else if (cleanJavaId.endsWith("door") && !cleanJavaId.contains("iron")) { // All wooden doors and wooden trapdoors
-                    INTERACTABLE_BLOCKS.add(javaBlockState);
-                } else if (cleanJavaId.endsWith("fence_gate")) {
-                    INTERACTABLE_BLOCKS.add(javaBlockState);
-                } else if (cleanJavaId.startsWith("minecraft:potted_")) {
-                    INTERACTABLE_BLOCKS.add(javaBlockState);
-                } else if (javaId.equals("minecraft:jukebox[has_record=true]")) {
-                    INTERACTABLE_BLOCKS.add(javaBlockState);
-                } else if (cleanJavaId.endsWith("shulker_box")) {
-                    INTERACTABLE_BLOCKS.add(javaBlockState);
-                } else if (cleanJavaId.endsWith("_sign")) {
-                    INTERACTABLE_BLOCKS.add(javaBlockState);
-                }
-        }
-
-
         JsonNode bannerColor = blockData.get("banner_color");
         if (bannerColor != null) {
             BANNER_COLORS.put(javaBlockState, (byte) bannerColor.intValue());
@@ -291,16 +240,6 @@ public final class BlockStateValues {
      */
     public static boolean isCauldron(int state) {
         return ALL_CAULDRONS.contains(state);
-    }
-
-    /**
-     * Blocks that are interactable will unconditionally do some action and should block ServerboundUseItemPacket from
-     * being sent.
-     *
-     * @return if this Java block state is interactable
-     */
-    public static boolean isInteractableBlock(int state) {
-        return INTERACTABLE_BLOCKS.contains(state);
     }
 
     /**

--- a/core/src/main/java/org/geysermc/geyser/level/block/BlockStateValues.java
+++ b/core/src/main/java/org/geysermc/geyser/level/block/BlockStateValues.java
@@ -34,6 +34,7 @@ import org.geysermc.geyser.registry.BlockRegistries;
 import org.geysermc.geyser.registry.type.BlockMapping;
 import org.geysermc.geyser.level.physics.Direction;
 import org.geysermc.geyser.level.physics.PistonBehavior;
+import org.geysermc.geyser.util.BlockUtils;
 import org.geysermc.geyser.util.collection.FixedInt2ByteMap;
 import org.geysermc.geyser.util.collection.FixedInt2IntMap;
 import org.geysermc.geyser.util.collection.LecternHasBookMap;
@@ -44,12 +45,14 @@ import java.util.Locale;
  * Used for block entities if the Java block state contains Bedrock block information.
  */
 public final class BlockStateValues {
+    private static final IntSet ALL_CAULDRONS = new IntOpenHashSet();
     private static final Int2IntMap BANNER_COLORS = new FixedInt2IntMap();
     private static final Int2ByteMap BED_COLORS = new FixedInt2ByteMap();
     private static final Int2ByteMap COMMAND_BLOCK_VALUES = new Int2ByteOpenHashMap();
     private static final Int2ObjectMap<DoubleChestValue> DOUBLE_CHEST_VALUES = new Int2ObjectOpenHashMap<>();
     private static final Int2ObjectMap<String> FLOWER_POT_VALUES = new Int2ObjectOpenHashMap<>();
     private static final IntSet HORIZONTAL_FACING_JIGSAWS = new IntOpenHashSet();
+    public static final IntSet INTERACTABLE_BLOCKS = new IntOpenHashSet();
     private static final LecternHasBookMap LECTERN_BOOK_STATES = new LecternHasBookMap();
     private static final IntSet NON_WATER_CAULDRONS = new IntOpenHashSet();
     private static final Int2IntMap NOTEBLOCK_PITCHES = new FixedInt2IntMap();
@@ -84,6 +87,55 @@ public final class BlockStateValues {
      * @param blockData      JsonNode of info about the block from blocks.json
      */
     public static void storeBlockStateValues(String javaId, int javaBlockState, JsonNode blockData) {
+        String cleanJavaId = BlockUtils.getCleanIdentifier(javaId);
+        switch (cleanJavaId) {
+            case "minecraft:anvil":
+            case "minecraft:barrel":
+            case "minecraft:beacon":
+            case "minecraft:brewing_stand":
+            case "minecraft:cartography_table":
+            case "minecraft:crafting_table":
+            case "minecraft:dispenser":
+            case "minecraft:dragon_egg":
+            case "minecraft:dropper":
+            case "minecraft:enchanting_table":
+            case "minecraft:grindstone":
+            case "minecraft:hopper":
+            case "minecraft:lever":
+            case "minecraft:loom":
+            case "minecraft:note_block":
+            case "minecraft:smithing_table":
+            case "minecraft:smoker":
+            case "minecraft:stonecutter":
+                INTERACTABLE_BLOCKS.add(javaBlockState);
+                break;
+            default:
+                if (cleanJavaId.contains("furnace")) { // Furnace and Blast furnaces
+                    INTERACTABLE_BLOCKS.add(javaBlockState);
+                } else if (cleanJavaId.endsWith("_bed")) {
+                    INTERACTABLE_BLOCKS.add(javaBlockState);
+                } else if (cleanJavaId.endsWith("_button")) {
+                    INTERACTABLE_BLOCKS.add(javaBlockState);
+                } else if (cleanJavaId.startsWith("minecraft:cave_vines") && javaId.contains("berries=true")) { // cave_vines and cave_vines_plant
+                    INTERACTABLE_BLOCKS.add(javaBlockState);
+                } else if (cleanJavaId.endsWith("chest")) { // chest, ender_chest, and trapped_chest
+                    INTERACTABLE_BLOCKS.add(javaBlockState);
+                } else if (cleanJavaId.endsWith("door") && !cleanJavaId.contains("iron")) { // All wooden doors and wooden trapdoors
+                    INTERACTABLE_BLOCKS.add(javaBlockState);
+                } else if (cleanJavaId.endsWith("fence_gate")) {
+                    INTERACTABLE_BLOCKS.add(javaBlockState);
+                } else if (cleanJavaId.startsWith("minecraft:potted_")) {
+                    INTERACTABLE_BLOCKS.add(javaBlockState);
+                } else if (javaId.equals("minecraft:jukebox[has_record=true]")) {
+                    INTERACTABLE_BLOCKS.add(javaBlockState);
+                } else if (cleanJavaId.endsWith("shulker_box")) {
+                    INTERACTABLE_BLOCKS.add(javaBlockState);
+                } else if (cleanJavaId.endsWith("_sign")) {
+                    INTERACTABLE_BLOCKS.add(javaBlockState);
+                }
+        }
+
+
         JsonNode bannerColor = blockData.get("banner_color");
         if (bannerColor != null) {
             BANNER_COLORS.put(javaBlockState, (byte) bannerColor.intValue());
@@ -193,6 +245,9 @@ public final class BlockStateValues {
             return;
         }
 
+        if (javaId.contains("cauldron")) {
+            ALL_CAULDRONS.add(javaBlockState);
+        }
         if (javaId.contains("_cauldron") && !javaId.contains("water_")) {
              NON_WATER_CAULDRONS.add(javaBlockState);
         }
@@ -225,8 +280,28 @@ public final class BlockStateValues {
      *
      * @return if this Java block state is a non-empty non-water cauldron
      */
-    public static boolean isCauldron(int state) {
+    public static boolean isNonWaterCauldron(int state) {
         return NON_WATER_CAULDRONS.contains(state);
+    }
+
+    /**
+     * Interacting with a cauldron with a bucket must only send ServerboundUseItemOnPacket and not ServerboundUseItemPacket
+     * as otherwise it can result in the liquid being placed.
+     *
+     * @return if this Java block state is a cauldron
+     */
+    public static boolean isCauldron(int state) {
+        return ALL_CAULDRONS.contains(state);
+    }
+
+    /**
+     * Blocks that are interactable will unconditionally do some action and should block ServerboundUseItemPacket from
+     * being sent.
+     *
+     * @return if this Java block state is interactable
+     */
+    public static boolean isInteractableBlock(int state) {
+        return INTERACTABLE_BLOCKS.contains(state);
     }
 
     /**

--- a/core/src/main/java/org/geysermc/geyser/level/block/BlockStateValues.java
+++ b/core/src/main/java/org/geysermc/geyser/level/block/BlockStateValues.java
@@ -52,7 +52,7 @@ public final class BlockStateValues {
     private static final Int2ObjectMap<DoubleChestValue> DOUBLE_CHEST_VALUES = new Int2ObjectOpenHashMap<>();
     private static final Int2ObjectMap<String> FLOWER_POT_VALUES = new Int2ObjectOpenHashMap<>();
     private static final IntSet HORIZONTAL_FACING_JIGSAWS = new IntOpenHashSet();
-    public static final IntSet INTERACTABLE_BLOCKS = new IntOpenHashSet();
+    private static final IntSet INTERACTABLE_BLOCKS = new IntOpenHashSet();
     private static final LecternHasBookMap LECTERN_BOOK_STATES = new LecternHasBookMap();
     private static final IntSet NON_WATER_CAULDRONS = new IntOpenHashSet();
     private static final Int2IntMap NOTEBLOCK_PITCHES = new FixedInt2IntMap();
@@ -285,8 +285,7 @@ public final class BlockStateValues {
     }
 
     /**
-     * Interacting with a cauldron with a bucket must only send ServerboundUseItemOnPacket and not ServerboundUseItemPacket
-     * as otherwise it can result in the liquid being placed.
+     * When using a bucket on a cauldron sending a ServerboundUseItemPacket can result in the liquid being placed.
      *
      * @return if this Java block state is a cauldron
      */

--- a/core/src/main/java/org/geysermc/geyser/registry/BlockRegistries.java
+++ b/core/src/main/java/org/geysermc/geyser/registry/BlockRegistries.java
@@ -72,6 +72,16 @@ public class BlockRegistries {
      */
     public static final SimpleRegistry<IntSet> WATERLOGGED = SimpleRegistry.create(RegistryLoaders.empty(IntOpenHashSet::new));
 
+    /**
+     * A registry containing all blockstates which are always interactive.
+     */
+    public static final SimpleRegistry<IntSet> INTERACTIVE = SimpleRegistry.create(RegistryLoaders.empty(IntOpenHashSet::new));
+
+    /**
+     * A registry containing all blockstates which are interactive if the player has the may build permission.
+     */
+    public static final SimpleRegistry<IntSet> INTERACTIVE_MAY_BUILD = SimpleRegistry.create(RegistryLoaders.empty(IntOpenHashSet::new));
+
     static {
         BlockRegistryPopulator.populate();
     }

--- a/core/src/main/java/org/geysermc/geyser/registry/populator/ItemRegistryPopulator.java
+++ b/core/src/main/java/org/geysermc/geyser/registry/populator/ItemRegistryPopulator.java
@@ -164,6 +164,9 @@ public class ItemRegistryPopulator {
                 } else if (identifier.equals("minecraft:empty_map") && damage == 2) {
                     // Bedrock-only as its own item
                     continue;
+                } else if (identifier.equals("minecraft:bordure_indented_banner_pattern") || identifier.equals("minecraft:field_masoned_banner_pattern")) {
+                    // Bedrock-only banner patterns
+                    continue;
                 }
                 StartGamePacket.ItemEntry entry = entries.get(identifier);
                 int id = -1;

--- a/core/src/main/java/org/geysermc/geyser/session/GeyserSession.java
+++ b/core/src/main/java/org/geysermc/geyser/session/GeyserSession.java
@@ -524,6 +524,12 @@ public class GeyserSession implements GeyserConnection, CommandSender {
      */
     private ScheduledFuture<?> tickThread = null;
 
+    /**
+     * Used to return the player to their original rotation after using an item in BedrockInventoryTransactionTranslator
+     */
+    @Setter
+    private ScheduledFuture<?> lookBackScheduledFuture = null;
+
     private MinecraftProtocol protocol;
 
     public GeyserSession(GeyserImpl geyser, BedrockServerSession bedrockServerSession, EventLoop eventLoop) {

--- a/core/src/main/java/org/geysermc/geyser/session/GeyserSession.java
+++ b/core/src/main/java/org/geysermc/geyser/session/GeyserSession.java
@@ -433,11 +433,10 @@ public class GeyserSession implements GeyserConnection, CommandSender {
     private long lastInteractionTime;
 
     /**
-     * Stores a future interaction to place a bucket. Will be cancelled if the client instead intended to
-     * interact with a block.
+     * Stores whether the player intended to place a bucket.
      */
     @Setter
-    private ScheduledFuture<?> bucketScheduledFuture;
+    private boolean placedBucket;
 
     /**
      * Used to send a movement packet every three seconds if the player hasn't moved. Prevents timeouts when AFK in certain instances.

--- a/core/src/main/java/org/geysermc/geyser/translator/level/block/entity/BedrockOnlyBlockEntity.java
+++ b/core/src/main/java/org/geysermc/geyser/translator/level/block/entity/BedrockOnlyBlockEntity.java
@@ -62,7 +62,7 @@ public interface BedrockOnlyBlockEntity extends RequiresBlockState {
             return FlowerPotBlockEntityTranslator.getTag(session, blockState, position);
         } else if (PistonBlockEntityTranslator.isBlock(blockState)) {
             return PistonBlockEntityTranslator.getTag(blockState, position);
-        } else if (BlockStateValues.isCauldron(blockState)) {
+        } else if (BlockStateValues.isNonWaterCauldron(blockState)) {
             // As of 1.18.30: this is required to make rendering not look weird on chunk load (lava and snow cauldrons look dim)
             return NbtMap.builder()
                     .putString("id", "Cauldron")

--- a/core/src/main/java/org/geysermc/geyser/translator/protocol/bedrock/BedrockInventoryTransactionTranslator.java
+++ b/core/src/main/java/org/geysermc/geyser/translator/protocol/bedrock/BedrockInventoryTransactionTranslator.java
@@ -334,6 +334,9 @@ public class BedrockInventoryTransactionTranslator extends PacketTranslator<Inve
                             } else if (session.getItemMappings().getSpawnEggIds().contains(packet.getItemInHand().getId())) {
                                 // Handled in case 0
                                 break;
+                            } else if (packet.getItemInHand().getId() == session.getItemMappings().getStoredItems().glassBottle()) {
+                                // Handled in case 0
+                                break;
                             }
                         }
 
@@ -537,8 +540,8 @@ public class BedrockInventoryTransactionTranslator extends PacketTranslator<Inve
     }
 
     private boolean useItem(GeyserSession session, InventoryTransactionPacket packet, int blockState) {
-        // Let the server decide if the item should change, not the client, and revert the changes the client made
-        InventoryTranslator.PLAYER_INVENTORY_TRANSLATOR.updateSlot(session, session.getPlayerInventory(), session.getPlayerInventory().getOffsetForHotbar(packet.getHotbarSlot()));
+        // Update the player's inventory to remove any items added by the client itself
+        InventoryTranslator.PLAYER_INVENTORY_TRANSLATOR.updateInventory(session, session.getPlayerInventory());
         // Check if the player is interacting with a block
         if (!session.isSneaking()) {
             if (BlockRegistries.INTERACTIVE.get().contains(blockState)) {

--- a/core/src/main/java/org/geysermc/geyser/translator/protocol/bedrock/BedrockInventoryTransactionTranslator.java
+++ b/core/src/main/java/org/geysermc/geyser/translator/protocol/bedrock/BedrockInventoryTransactionTranslator.java
@@ -541,7 +541,12 @@ public class BedrockInventoryTransactionTranslator extends PacketTranslator<Inve
         InventoryTranslator.PLAYER_INVENTORY_TRANSLATOR.updateSlot(session, session.getPlayerInventory(), session.getPlayerInventory().getOffsetForHotbar(packet.getHotbarSlot()));
         // Check if the player is interacting with a block
         if (!session.isSneaking()) {
-            if (BlockStateValues.isInteractableBlock(blockState)) {
+            if (BlockRegistries.INTERACTIVE.get().contains(blockState)) {
+                return false;
+            }
+
+            boolean mayBuild = session.getGameMode() == GameMode.SURVIVAL || session.getGameMode() == GameMode.CREATIVE;
+            if (mayBuild && BlockRegistries.INTERACTIVE_MAY_BUILD.get().contains(blockState)) {
                 return false;
             }
         }

--- a/core/src/main/java/org/geysermc/geyser/translator/protocol/bedrock/BedrockInventoryTransactionTranslator.java
+++ b/core/src/main/java/org/geysermc/geyser/translator/protocol/bedrock/BedrockInventoryTransactionTranslator.java
@@ -578,13 +578,15 @@ public class BedrockInventoryTransactionTranslator extends PacketTranslator<Inve
         if (session.getLookBackScheduledFuture() != null) {
             session.getLookBackScheduledFuture().cancel(false);
         }
-        session.setLookBackScheduledFuture(session.scheduleInEventLoop(() -> {
-            Vector3d newPlayerPosition = session.getCollisionManager().getPlayerBoundingBox().getBottomCenter();
-            if (!newPlayerPosition.equals(playerPosition) || entity.getYaw() != returnPacket.getYaw() || entity.getPitch() != returnPacket.getPitch()) {
-                // The player moved/rotated so there is no need to change their rotation back
-                return;
-            }
-            session.sendDownstreamPacket(returnPacket);
-        }, 150, TimeUnit.MILLISECONDS));
+        if (Math.abs(entity.getYaw() - yaw) > 1f || Math.abs(entity.getPitch() - pitch) > 1f) {
+            session.setLookBackScheduledFuture(session.scheduleInEventLoop(() -> {
+                Vector3d newPlayerPosition = session.getCollisionManager().getPlayerBoundingBox().getBottomCenter();
+                if (!newPlayerPosition.equals(playerPosition) || entity.getYaw() != returnPacket.getYaw() || entity.getPitch() != returnPacket.getPitch()) {
+                    // The player moved/rotated so there is no need to change their rotation back
+                    return;
+                }
+                session.sendDownstreamPacket(returnPacket);
+            }, 150, TimeUnit.MILLISECONDS));
+        }
     }
 }

--- a/core/src/main/java/org/geysermc/geyser/translator/protocol/bedrock/BedrockInventoryTransactionTranslator.java
+++ b/core/src/main/java/org/geysermc/geyser/translator/protocol/bedrock/BedrockInventoryTransactionTranslator.java
@@ -542,8 +542,9 @@ public class BedrockInventoryTransactionTranslator extends PacketTranslator<Inve
     private boolean useItem(GeyserSession session, InventoryTransactionPacket packet, int blockState) {
         // Update the player's inventory to remove any items added by the client itself
         Inventory playerInventory = session.getPlayerInventory();
-        InventoryTranslator.PLAYER_INVENTORY_TRANSLATOR.updateSlot(session, playerInventory, playerInventory.getOffsetForHotbar(packet.getHotbarSlot()));
-        if (packet.getItemInHand().getCount() > 1) {
+        int heldItemSlot = playerInventory.getOffsetForHotbar(packet.getHotbarSlot());
+        InventoryTranslator.PLAYER_INVENTORY_TRANSLATOR.updateSlot(session, playerInventory, heldItemSlot);
+        if (playerInventory.getItem(heldItemSlot).getAmount() > 1) {
             if (packet.getItemInHand().getId() == session.getItemMappings().getStoredItems().bucket() ||
                 packet.getItemInHand().getId() == session.getItemMappings().getStoredItems().glassBottle()) {
                 // Using a stack of buckets or glass bottles will result in an item being added to the first empty slot.

--- a/core/src/main/java/org/geysermc/geyser/translator/protocol/bedrock/BedrockInventoryTransactionTranslator.java
+++ b/core/src/main/java/org/geysermc/geyser/translator/protocol/bedrock/BedrockInventoryTransactionTranslator.java
@@ -518,11 +518,7 @@ public class BedrockInventoryTransactionTranslator extends PacketTranslator<Inve
         session.sendUpstreamPacket(updateWaterPacket);
 
         // Reset the item in hand to prevent "missing" blocks
-        InventorySlotPacket slotPacket = new InventorySlotPacket();
-        slotPacket.setContainerId(ContainerId.INVENTORY);
-        slotPacket.setSlot(packet.getHotbarSlot());
-        slotPacket.setItem(packet.getItemInHand());
-        session.sendUpstreamPacket(slotPacket);
+        InventoryTranslator.PLAYER_INVENTORY_TRANSLATOR.updateSlot(session, session.getPlayerInventory(), packet.getHotbarSlot() + 36);
     }
 
     private boolean useItem(GeyserSession session, InventoryTransactionPacket packet) {

--- a/core/src/main/java/org/geysermc/geyser/translator/protocol/bedrock/BedrockInventoryTransactionTranslator.java
+++ b/core/src/main/java/org/geysermc/geyser/translator/protocol/bedrock/BedrockInventoryTransactionTranslator.java
@@ -56,6 +56,7 @@ import org.geysermc.geyser.registry.type.ItemMapping;
 import org.geysermc.geyser.registry.type.ItemMappings;
 import org.geysermc.geyser.session.GeyserSession;
 import org.geysermc.geyser.translator.inventory.InventoryTranslator;
+import org.geysermc.geyser.translator.inventory.item.ItemTranslator;
 import org.geysermc.geyser.translator.protocol.PacketTranslator;
 import org.geysermc.geyser.translator.protocol.Translator;
 import org.geysermc.geyser.util.BlockUtils;
@@ -527,12 +528,12 @@ public class BedrockInventoryTransactionTranslator extends PacketTranslator<Inve
     }
 
     private boolean isIncorrectHeldItem(GeyserSession session, InventoryTransactionPacket packet) {
-        int heldItemId = packet.getItemInHand() == null ? ItemData.AIR.getId() : packet.getItemInHand().getId();
         int javaSlot = session.getPlayerInventory().getOffsetForHotbar(packet.getHotbarSlot());
-        ItemData expectedItemData = session.getPlayerInventory().getItem(javaSlot).getItemData(session);
+        int expectedItemId = ItemTranslator.getBedrockItemMapping(session, session.getPlayerInventory().getItem(javaSlot)).getBedrockId();
+        int heldItemId = packet.getItemInHand() == null ? ItemData.AIR.getId() : packet.getItemInHand().getId();
 
-        if (expectedItemData.getId() != heldItemId) {
-            session.getGeyser().getLogger().debug(session.name() + "'s held item has desynced! Expected: " + expectedItemData.getId() + " Received: " + heldItemId);
+        if (expectedItemId != heldItemId) {
+            session.getGeyser().getLogger().debug(session.name() + "'s held item has desynced! Expected: " + expectedItemId + " Received: " + heldItemId);
             session.getGeyser().getLogger().debug("Packet: " + packet);
             return true;
         }

--- a/core/src/main/java/org/geysermc/geyser/translator/protocol/bedrock/BedrockInventoryTransactionTranslator.java
+++ b/core/src/main/java/org/geysermc/geyser/translator/protocol/bedrock/BedrockInventoryTransactionTranslator.java
@@ -337,7 +337,8 @@ public class BedrockInventoryTransactionTranslator extends PacketTranslator<Inve
                             }
                         }
 
-                        useItem(session, packet);
+                        ServerboundUseItemPacket useItemPacket = new ServerboundUseItemPacket(Hand.MAIN_HAND, session.getNextSequence());
+                        session.sendDownstreamPacket(useItemPacket);
 
                         List<LegacySetItemSlotData> legacySlots = packet.getLegacySlots();
                         if (packet.getActions().size() == 1 && legacySlots.size() > 0) {
@@ -584,6 +585,6 @@ public class BedrockInventoryTransactionTranslator extends PacketTranslator<Inve
                 return;
             }
             session.sendDownstreamPacket(returnPacket);
-        }, 50, TimeUnit.MILLISECONDS));
+        }, 150, TimeUnit.MILLISECONDS));
     }
 }

--- a/core/src/main/java/org/geysermc/geyser/translator/protocol/bedrock/BedrockInventoryTransactionTranslator.java
+++ b/core/src/main/java/org/geysermc/geyser/translator/protocol/bedrock/BedrockInventoryTransactionTranslator.java
@@ -272,11 +272,15 @@ public class BedrockInventoryTransactionTranslator extends PacketTranslator<Inve
                         session.sendDownstreamPacket(blockPacket);
 
                         if (packet.getItemInHand() != null) {
-                            // Otherwise boats will not be able to be placed in survival and buckets won't work on mobile
-                            if (session.getItemMappings().getBoatIds().contains(packet.getItemInHand().getId())) {
+                            int itemId = packet.getItemInHand().getId();
+                            // Otherwise boats will not be able to be placed in survival and buckets, lily pads, and frogspawn won't work on mobile
+                            if (session.getItemMappings().getBoatIds().contains(itemId) ||
+                                    itemId == session.getItemMappings().getStoredItems().lilyPad() ||
+                                    itemId == session.getItemMappings().getStoredItems().frogspawn()) {
+                                // TODO lily pad and frogspawn also require mobile rotation fixes
                                 ServerboundUseItemPacket itemPacket = new ServerboundUseItemPacket(Hand.MAIN_HAND, session.getNextSequence());
                                 session.sendDownstreamPacket(itemPacket);
-                            } else if (session.getItemMappings().getBucketIds().contains(packet.getItemInHand().getId())) {
+                            } else if (session.getItemMappings().getBucketIds().contains(itemId)) {
                                 // Let the server decide if the bucket item should change, not the client, and revert the changes the client made
                                 InventorySlotPacket slotPacket = new InventorySlotPacket();
                                 slotPacket.setContainerId(ContainerId.INVENTORY);
@@ -284,7 +288,7 @@ public class BedrockInventoryTransactionTranslator extends PacketTranslator<Inve
                                 slotPacket.setItem(packet.getItemInHand());
                                 session.sendUpstreamPacket(slotPacket);
                                 // Don't send ServerboundUseItemPacket for powder snow buckets
-                                if (packet.getItemInHand().getId() != session.getItemMappings().getStoredItems().powderSnowBucket().getBedrockId()) {
+                                if (itemId != session.getItemMappings().getStoredItems().powderSnowBucket().getBedrockId()) {
                                     // Special check for crafting tables since clients don't send BLOCK_INTERACT when interacting
                                     int blockState = session.getGeyser().getWorldManager().getBlockAt(session, packet.getBlockPosition());
                                     if (session.isSneaking() || blockState != BlockRegistries.JAVA_IDENTIFIERS.get("minecraft:crafting_table")) {

--- a/core/src/main/java/org/geysermc/geyser/translator/protocol/bedrock/entity/player/BedrockActionTranslator.java
+++ b/core/src/main/java/org/geysermc/geyser/translator/protocol/bedrock/entity/player/BedrockActionTranslator.java
@@ -136,14 +136,6 @@ public class BedrockActionTranslator extends PacketTranslator<PlayerActionPacket
                 ServerboundPlayerCommandPacket stopSleepingPacket = new ServerboundPlayerCommandPacket(entity.getEntityId(), PlayerState.LEAVE_BED);
                 session.sendDownstreamPacket(stopSleepingPacket);
                 break;
-            case BLOCK_INTERACT:
-                // Client means to interact with a block; cancel bucket interaction, if any
-                if (session.getBucketScheduledFuture() != null) {
-                    session.getBucketScheduledFuture().cancel(true);
-                    session.setBucketScheduledFuture(null);
-                }
-                // Otherwise handled in BedrockInventoryTransactionTranslator
-                break;
             case START_BREAK:
                 // Start the block breaking animation
                 if (session.getGameMode() != GameMode.CREATIVE) {

--- a/core/src/main/java/org/geysermc/geyser/translator/protocol/bedrock/entity/player/BedrockMovePlayerTranslator.java
+++ b/core/src/main/java/org/geysermc/geyser/translator/protocol/bedrock/entity/player/BedrockMovePlayerTranslator.java
@@ -81,6 +81,7 @@ public class BedrockMovePlayerTranslator extends PacketTranslator<MovePlayerPack
             // Resend the rotation if it was changed by Geyser
             rotationChanged |= !session.getLookBackScheduledFuture().isDone();
             session.getLookBackScheduledFuture().cancel(false);
+            session.setLookBackScheduledFuture(null);
         }
 
         // If only the pitch and yaw changed

--- a/core/src/main/java/org/geysermc/geyser/translator/protocol/bedrock/entity/player/BedrockMovePlayerTranslator.java
+++ b/core/src/main/java/org/geysermc/geyser/translator/protocol/bedrock/entity/player/BedrockMovePlayerTranslator.java
@@ -77,6 +77,12 @@ public class BedrockMovePlayerTranslator extends PacketTranslator<MovePlayerPack
         boolean positionChanged = !entity.getPosition().equals(packet.getPosition());
         boolean rotationChanged = entity.getYaw() != yaw || entity.getPitch() != pitch || entity.getHeadYaw() != headYaw;
 
+        if (session.getLookBackScheduledFuture() != null) {
+            // Resend the rotation if it was changed by Geyser
+            rotationChanged |= !session.getLookBackScheduledFuture().isDone();
+            session.getLookBackScheduledFuture().cancel(false);
+        }
+
         // If only the pitch and yaw changed
         // This isn't needed, but it makes the packets closer to vanilla
         // It also means you can't "lag back" while only looking, in theory

--- a/core/src/main/java/org/geysermc/geyser/translator/protocol/java/level/JavaLevelChunkWithLightTranslator.java
+++ b/core/src/main/java/org/geysermc/geyser/translator/protocol/java/level/JavaLevelChunkWithLightTranslator.java
@@ -142,7 +142,7 @@ public class JavaLevelChunkWithLightTranslator extends PacketTranslator<Clientbo
                         }
 
                         // Check if block is piston or flower to see if we'll need to create additional block entities, as they're only block entities in Bedrock
-                        if (BlockStateValues.getFlowerPotValues().containsKey(javaId) || BlockStateValues.getPistonValues().containsKey(javaId) || BlockStateValues.isCauldron(javaId)) {
+                        if (BlockStateValues.getFlowerPotValues().containsKey(javaId) || BlockStateValues.getPistonValues().containsKey(javaId) || BlockStateValues.isNonWaterCauldron(javaId)) {
                             bedrockBlockEntities.add(BedrockOnlyBlockEntity.getTag(session,
                                     Vector3i.from((packet.getX() << 4) + (yzx & 0xF), ((sectionY + yOffset) << 4) + ((yzx >> 8) & 0xF), (packet.getZ() << 4) + ((yzx >> 4) & 0xF)),
                                     javaId
@@ -183,7 +183,7 @@ public class JavaLevelChunkWithLightTranslator extends PacketTranslator<Clientbo
                     }
 
                     // Check if block is piston, flower or cauldron to see if we'll need to create additional block entities, as they're only block entities in Bedrock
-                    if (BlockStateValues.getFlowerPotValues().containsKey(javaId) || BlockStateValues.getPistonValues().containsKey(javaId) || BlockStateValues.isCauldron(javaId)) {
+                    if (BlockStateValues.getFlowerPotValues().containsKey(javaId) || BlockStateValues.getPistonValues().containsKey(javaId) || BlockStateValues.isNonWaterCauldron(javaId)) {
                         bedrockOnlyBlockEntityIds.set(i);
                     }
                 }

--- a/core/src/main/java/org/geysermc/geyser/translator/sound/block/BucketSoundInteractionTranslator.java
+++ b/core/src/main/java/org/geysermc/geyser/translator/sound/block/BucketSoundInteractionTranslator.java
@@ -71,6 +71,7 @@ public class BucketSoundInteractionTranslator implements BlockSoundInteractionTr
             case "minecraft:salmon_bucket":
             case "minecraft:pufferfish_bucket":
             case "minecraft:tropical_fish_bucket":
+            case "minecraft:tadpole_bucket":
                 soundEvent = SoundEvent.BUCKET_EMPTY_FISH;
                 break;
             case "minecraft:water_bucket":

--- a/core/src/main/java/org/geysermc/geyser/translator/sound/block/BucketSoundInteractionTranslator.java
+++ b/core/src/main/java/org/geysermc/geyser/translator/sound/block/BucketSoundInteractionTranslator.java
@@ -38,7 +38,7 @@ public class BucketSoundInteractionTranslator implements BlockSoundInteractionTr
 
     @Override
     public void translate(GeyserSession session, Vector3f position, String identifier) {
-        if (session.getBucketScheduledFuture() == null) {
+        if (!session.isPlacedBucket()) {
             return; // No bucket was really interacted with
         }
         GeyserItemStack itemStack = session.getPlayerInventory().getItemInHand();
@@ -84,7 +84,7 @@ public class BucketSoundInteractionTranslator implements BlockSoundInteractionTr
         if (soundEvent != null) {
             soundEventPacket.setSound(soundEvent);
             session.sendUpstreamPacket(soundEventPacket);
-            session.setBucketScheduledFuture(null);
+            session.setPlacedBucket(false);
         }
     }
 }


### PR DESCRIPTION
List of changes
- Removed bedrock only banner patterns from the creative inventory
- Fixed sounds for tadpole bucket (Needs https://github.com/GeyserMC/mappings/pull/71)
- Cherrypicked and updated workaround from mobilebuckets branch (fixes GeyserMC#1891)
- Send UseItemPacket for lily pads, frogspawn, and glass bottles (fixes GeyserMC#3006, fixes GeyserMC#2836)
- Resend held item to fix GeyserMC#1247

I'm not sure if we want a config option to disable the mobilebuckets workaround since it almost certainly will trigger anti-cheats.

Needs https://github.com/GeyserMC/mappings/pull/72