### PR TITLE
Fix IronGolem cracked texture and sound

### DIFF
--- a/core/src/main/java/org/geysermc/geyser/entity/type/living/IronGolemEntity.java
+++ b/core/src/main/java/org/geysermc/geyser/entity/type/living/IronGolemEntity.java
@@ -46,6 +46,7 @@ public class IronGolemEntity extends GolemEntity {
         // Required, or else the overlay is black
         dirtyMetadata.put(EntityData.COLOR_2, (byte) 0);
         // Default max health. Ensures correct cracked texture is used
+        // Bug reproducible in 1.19.0 JE vanilla/fabric when spawning a new iron golem
         maxHealth = 100f;
     }
 

--- a/core/src/main/java/org/geysermc/geyser/entity/type/living/IronGolemEntity.java
+++ b/core/src/main/java/org/geysermc/geyser/entity/type/living/IronGolemEntity.java
@@ -45,6 +45,8 @@ public class IronGolemEntity extends GolemEntity {
         setFlag(EntityFlag.BRIBED, true);
         // Required, or else the overlay is black
         dirtyMetadata.put(EntityData.COLOR_2, (byte) 0);
+        // Default max health. Ensures correct cracked texture is used
+        maxHealth = 100f;
     }
 
     @Nonnull


### PR DESCRIPTION
The vanilla server does not send the max health attribute of 100 when spawning an IronGolem. This leads to Geyser sending 20 max health, causing the client to display the wrong cracked texture.

This PR also updates the mappings submodule to fix the crack and repair sounds.