### PR TITLE
Correct version names

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ The ultimate goal of this project is to allow Minecraft: Bedrock Edition users t
 
 Special thanks to the DragonProxy project for being a trailblazer in protocol translation and for all the team members who have joined us here!
 
-### Currently supporting Minecraft Bedrock 1.19 and Minecraft Java 1.19.0.
+### Currently supporting Minecraft Bedrock 1.19.0 - 1.19.2 and Minecraft Java 1.19.
 
 ## Setting Up
 Take a look [here](https://wiki.geysermc.org/geyser/setup/) for how to set up Geyser.


### PR DESCRIPTION
In bedrock, there's no version called 1.19, instead of 1.19.0
![image](https://user-images.githubusercontent.com/68630033/176899345-8bfa9446-a3c0-451d-82d6-83de67fc0bf8.png)
Wiki: https://minecraft.fandom.com/wiki/Bedrock_Edition_version_history#1.19
In Java, there's no version called 1.19.0, instead of 1.19
![image](https://user-images.githubusercontent.com/68630033/176899522-64d6563c-b4af-4088-b3db-db296639ccde.png)
Wiki: https://minecraft.fandom.com/wiki/Java_Edition_version_history#1.19

Replace: #3052 