### PR TITLE
Fix "Login Details" form not closing properly

### DIFF
--- a/core/src/main/java/org/geysermc/geyser/util/LoginEncryptionUtils.java
+++ b/core/src/main/java/org/geysermc/geyser/util/LoginEncryptionUtils.java
@@ -310,7 +310,14 @@ public class LoginEncryptionUtils {
                         .label("geyser.auth.login.form.details.desc")
                         .input("geyser.auth.login.form.details.email", "account@geysermc.org", "")
                         .input("geyser.auth.login.form.details.pass", "123456", "")
-                        .closedOrInvalidResultHandler(() -> buildAndShowLoginDetailsWindow(session))
+                        .invalidResultHandler(() -> buildAndShowLoginDetailsWindow(session))
+                        .closedResultHandler(() -> {
+                            if (session.isMicrosoftAccount()) {
+                                buildAndShowMicrosoftAuthenticationWindow(session);
+                            } else {
+                                buildAndShowLoginWindow(session);
+                            }
+                        })
                         .validResultHandler((response) -> session.authenticate(response.next(), response.next())));
     }
 


### PR DESCRIPTION
Fixes a bug where clicking the close button on the form where users enter their username/password reopens the form instead of going back to the login menu. This affects both the Mojang and Microsoft login forms.

https://user-images.githubusercontent.com/47281991/178076999-1506e76c-31ae-4272-a4ae-aac8fb83113c.mp4

