### PR TITLE
Armor stand fixes

### DIFF
--- a/core/src/main/java/org/geysermc/geyser/entity/type/living/ArmorStandEntity.java
+++ b/core/src/main/java/org/geysermc/geyser/entity/type/living/ArmorStandEntity.java
@@ -106,11 +106,7 @@ public class ArmorStandEntity extends LivingEntity {
 
     @Override
     public void moveRelative(double relX, double relY, double relZ, float yaw, float pitch, float headYaw, boolean isOnGround) {
-        Vector3f newPosition = position.add(relX, relY, relZ);
-        if (secondEntity != null) {
-            secondEntity.moveAbsolute(newPosition, yaw, pitch, headYaw, onGround, false);
-        }
-        moveAbsolute(newPosition, yaw, pitch, headYaw, onGround, false);
+        moveAbsolute(position.add(relX, relY, relZ), yaw, pitch, headYaw, onGround, false);
     }
 
     @Override
@@ -119,7 +115,8 @@ public class ArmorStandEntity extends LivingEntity {
             secondEntity.moveAbsolute(position, yaw, pitch, headYaw, isOnGround, teleported);
         }
         // Fake the height to be above where it is so the nametag appears in the right location
-        super.moveAbsolute(position.up(getYOffset()), yaw, yaw, yaw, isOnGround, teleported);
+        float yOffset = getYOffset();
+        super.moveAbsolute(yOffset != 0 ? position.up(yOffset) : position , yaw, yaw, yaw, isOnGround, teleported);
         this.position = position;
     }
 

--- a/core/src/main/java/org/geysermc/geyser/entity/type/living/ArmorStandEntity.java
+++ b/core/src/main/java/org/geysermc/geyser/entity/type/living/ArmorStandEntity.java
@@ -292,9 +292,13 @@ public class ArmorStandEntity extends LivingEntity {
     private void updateSecondEntityStatus(boolean sendMetadata) {
         // A secondary entity always has to have the offset applied, so it remains invisible and the nametag shows.
         if (!primaryEntity) return;
-        if (!isInvisible || isMarker) {
+        
+        if(!isInvisible) {
             // It is either impossible to show armor, or the armor stand isn't invisible. We good.
             setFlag(EntityFlag.INVISIBLE, false);
+        }
+
+        if (!isInvisible || isMarker) {
             updateOffsetRequirement(false);
             if (positionUpdateRequired) {
                 positionUpdateRequired = false;

--- a/core/src/main/java/org/geysermc/geyser/entity/type/living/ArmorStandEntity.java
+++ b/core/src/main/java/org/geysermc/geyser/entity/type/living/ArmorStandEntity.java
@@ -293,12 +293,10 @@ public class ArmorStandEntity extends LivingEntity {
         // A secondary entity always has to have the offset applied, so it remains invisible and the nametag shows.
         if (!primaryEntity) return;
         
-        if (!isInvisible || isMarker) {
+        if (!isInvisible) {
             // The armor stand isn't invisible. We good.
             setFlag(EntityFlag.INVISIBLE, false);
-        }
-
-        if (!isInvisible) {
+            
             updateOffsetRequirement(!isMarker);
             if (positionUpdateRequired) {
                 positionUpdateRequired = false;

--- a/core/src/main/java/org/geysermc/geyser/entity/type/living/ArmorStandEntity.java
+++ b/core/src/main/java/org/geysermc/geyser/entity/type/living/ArmorStandEntity.java
@@ -128,16 +128,12 @@ public class ArmorStandEntity extends LivingEntity {
 
     public void setArmorStandFlags(ByteEntityMetadata entityMetadata) {
         byte xd = entityMetadata.getPrimitiveValue();
-        boolean updateSecondEntity = false;
+        boolean offsetChanged = false;
         // isSmall
         boolean newIsSmall = (xd & 0x01) == 0x01;
         if (newIsSmall != isSmall) {
-            if (positionRequiresOffset) {
-                positionUpdateRequired = true;
-            }
-
             isSmall = newIsSmall;
-            updateSecondEntity = true;
+            offsetChanged = true;
             // Update the passenger offset as the armor stand's height has changed
             updatePassengerOffsets();
         }
@@ -155,10 +151,15 @@ public class ArmorStandEntity extends LivingEntity {
             }
 
             updateMountOffset();
-            updateSecondEntity = true;
+            offsetChanged = true;
         }
 
-        if (updateSecondEntity) {
+        if (offsetChanged) {
+            if (positionRequiresOffset) {
+                positionUpdateRequired = true;
+            } else if (secondEntity != null) {
+                secondEntity.positionUpdateRequired = true;
+            }
             updateSecondEntityStatus(false);
         }
 

--- a/core/src/main/java/org/geysermc/geyser/entity/type/living/ArmorStandEntity.java
+++ b/core/src/main/java/org/geysermc/geyser/entity/type/living/ArmorStandEntity.java
@@ -294,7 +294,7 @@ public class ArmorStandEntity extends LivingEntity {
         if (!primaryEntity) return;
         
         if (!isInvisible) {
-            // It is either impossible to show armor, or the armor stand isn't invisible. We good.
+            // The armor stand isn't invisible. We good.
             setFlag(EntityFlag.INVISIBLE, false);
         }
 

--- a/core/src/main/java/org/geysermc/geyser/entity/type/living/ArmorStandEntity.java
+++ b/core/src/main/java/org/geysermc/geyser/entity/type/living/ArmorStandEntity.java
@@ -150,7 +150,6 @@ public class ArmorStandEntity extends LivingEntity {
             if (isMarker) {
                 setBoundingBoxWidth(0.0f);
                 setBoundingBoxHeight(0.0f);
-                dirtyMetadata.put(EntityData.SCALE, 0f);
             } else {
                 toggleSmallStatus();
             }

--- a/core/src/main/java/org/geysermc/geyser/entity/type/living/ArmorStandEntity.java
+++ b/core/src/main/java/org/geysermc/geyser/entity/type/living/ArmorStandEntity.java
@@ -26,6 +26,7 @@
 package org.geysermc.geyser.entity.type.living;
 
 import com.github.steveice10.mc.protocol.data.game.entity.metadata.EntityMetadata;
+import com.github.steveice10.mc.protocol.data.game.entity.metadata.type.BooleanEntityMetadata;
 import com.github.steveice10.mc.protocol.data.game.entity.metadata.type.ByteEntityMetadata;
 import com.github.steveice10.mc.protocol.data.game.entity.player.Hand;
 import com.nukkitx.math.vector.Vector3f;
@@ -53,6 +54,8 @@ public class ArmorStandEntity extends LivingEntity {
     private boolean isInvisible = false;
     @Getter
     private boolean isSmall = false;
+
+    private boolean isNameTagVisible = false;
 
     /**
      * On Java Edition, armor stands always show their name. Invisibility hides the name on Bedrock.
@@ -284,6 +287,13 @@ public class ArmorStandEntity extends LivingEntity {
         updateSecondEntityStatus(true);
     }
 
+    @Override
+    public void setDisplayNameVisible(BooleanEntityMetadata entityMetadata) {
+        super.setDisplayNameVisible(entityMetadata);
+        isNameTagVisible = entityMetadata.getPrimitiveValue();
+        updateSecondEntityStatus(false);
+    }
+
     /**
      * Determine if we need to load or unload the second entity.
      *
@@ -326,7 +336,8 @@ public class ArmorStandEntity extends LivingEntity {
             }
             // Copy metadata
             secondEntity.isSmall = isSmall;
-            //secondEntity.getDirtyMetadata().putAll(dirtyMetadata); //TODO check
+            secondEntity.getDirtyMetadata().put(EntityData.NAMETAG, nametag);
+            secondEntity.getDirtyMetadata().put(EntityData.NAMETAG_ALWAYS_SHOW, isNameTagVisible ? (byte) 1 : (byte) 0);
             secondEntity.flags.merge(this.flags);
             // Guarantee this copy is NOT invisible
             secondEntity.setFlag(EntityFlag.INVISIBLE, false);

--- a/core/src/main/java/org/geysermc/geyser/entity/type/living/ArmorStandEntity.java
+++ b/core/src/main/java/org/geysermc/geyser/entity/type/living/ArmorStandEntity.java
@@ -306,7 +306,6 @@ public class ArmorStandEntity extends LivingEntity {
     private void updateSecondEntityStatus(boolean sendMetadata) {
         // A secondary entity always has to have the offset applied, so it remains invisible and the nametag shows.
         if (!primaryEntity) return;
-        
         if (!isInvisible) {
             // The armor stand isn't invisible. We good.
             setFlag(EntityFlag.INVISIBLE, false);

--- a/core/src/main/java/org/geysermc/geyser/entity/type/living/ArmorStandEntity.java
+++ b/core/src/main/java/org/geysermc/geyser/entity/type/living/ArmorStandEntity.java
@@ -293,7 +293,7 @@ public class ArmorStandEntity extends LivingEntity {
         // A secondary entity always has to have the offset applied, so it remains invisible and the nametag shows.
         if (!primaryEntity) return;
         
-        if(!isInvisible) {
+        if (!isInvisible) {
             // It is either impossible to show armor, or the armor stand isn't invisible. We good.
             setFlag(EntityFlag.INVISIBLE, false);
         }

--- a/core/src/main/java/org/geysermc/geyser/entity/type/living/ArmorStandEntity.java
+++ b/core/src/main/java/org/geysermc/geyser/entity/type/living/ArmorStandEntity.java
@@ -293,13 +293,13 @@ public class ArmorStandEntity extends LivingEntity {
         // A secondary entity always has to have the offset applied, so it remains invisible and the nametag shows.
         if (!primaryEntity) return;
         
-        if (!isInvisible) {
+        if (!isInvisible || isMarker) {
             // The armor stand isn't invisible. We good.
             setFlag(EntityFlag.INVISIBLE, false);
         }
 
-        if (!isInvisible || isMarker) {
-            updateOffsetRequirement(false);
+        if (!isInvisible) {
+            updateOffsetRequirement(!isMarker);
             if (positionUpdateRequired) {
                 positionUpdateRequired = false;
                 updatePosition();

--- a/core/src/main/java/org/geysermc/geyser/entity/type/living/ArmorStandEntity.java
+++ b/core/src/main/java/org/geysermc/geyser/entity/type/living/ArmorStandEntity.java
@@ -296,8 +296,7 @@ public class ArmorStandEntity extends LivingEntity {
         if (!isInvisible) {
             // The armor stand isn't invisible. We good.
             setFlag(EntityFlag.INVISIBLE, false);
-            
-            updateOffsetRequirement(!isMarker);
+            updateOffsetRequirement(false);
             if (positionUpdateRequired) {
                 positionUpdateRequired = false;
                 updatePosition();
@@ -363,7 +362,7 @@ public class ArmorStandEntity extends LivingEntity {
             setFlag(EntityFlag.INVISIBLE, false);
             dirtyMetadata.put(EntityData.SCALE, 0.0f);
             // As the above is applied, we need an offset
-            updateOffsetRequirement(true);
+            updateOffsetRequirement(!isMarker);
 
             if (secondEntity != null) {
                 secondEntity.despawnEntity();

--- a/core/src/main/java/org/geysermc/geyser/entity/type/living/ArmorStandEntity.java
+++ b/core/src/main/java/org/geysermc/geyser/entity/type/living/ArmorStandEntity.java
@@ -352,7 +352,9 @@ public class ArmorStandEntity extends LivingEntity {
             // No bounding box as we don't want to interact with this entity
             secondEntity.getDirtyMetadata().put(EntityData.BOUNDING_BOX_WIDTH, 0.0f);
             secondEntity.getDirtyMetadata().put(EntityData.BOUNDING_BOX_HEIGHT, 0.0f);
-            secondEntity.spawnEntity();
+            if (!secondEntity.valid) { // Spawn the entity once
+                secondEntity.spawnEntity();
+            }
         } else if (isNametagEmpty) {
             // We can just make an invisible entity
             // Reset scale of the proper armor stand

--- a/core/src/main/java/org/geysermc/geyser/util/EntityUtils.java
+++ b/core/src/main/java/org/geysermc/geyser/util/EntityUtils.java
@@ -190,11 +190,8 @@ public final class EntityUtils {
             if (passenger.getDefinition().entityType() == EntityType.FALLING_BLOCK) {
                 yOffset += 0.5f;
             }
-            if (mount.getDefinition().entityType() == EntityType.ARMOR_STAND) {
-                ArmorStandEntity armorStand = (ArmorStandEntity) mount;
-                if (armorStand.isPositionRequiresOffset()) {
-                    yOffset -= EntityDefinitions.ARMOR_STAND.height() * (armorStand.isSmall() ? 0.55d : 1d);
-                }
+            if (mount instanceof ArmorStandEntity armorStand) {
+                yOffset -= armorStand.getYOffset();
             }
             Vector3f offset = Vector3f.from(xOffset, yOffset, zOffset);
             passenger.setRiderSeatPosition(offset);


### PR DESCRIPTION
This includes changes from https://github.com/GeyserMC/Geyser/pull/3092 which with https://github.com/GeyserMC/Geyser/commit/c371be2a09326813b875295c565378140f49264e should fix https://github.com/GeyserMC/Geyser/issues/3089 without any additional issues.

In addition this PR should fix
- The missing name tags for invisible armor stands with armor/items
- Small armor stand scale (0.55 -> 0.5) and bounding box size
- Passenger offset not being removed when offset requirement changes
- Armor stand scale when going from Invisible to not Invisible