### PR TITLE
Fix sending forms with floodgate for 1.19.20

### DIFF
--- a/core/src/main/java/org/geysermc/geyser/translator/protocol/java/JavaCustomPayloadTranslator.java
+++ b/core/src/main/java/org/geysermc/geyser/translator/protocol/java/JavaCustomPayloadTranslator.java
@@ -73,17 +73,17 @@ public class JavaCustomPayloadTranslator extends PacketTranslator<ClientboundCus
 
             Form form = Forms.fromJson(dataString, type, (ignored, response) -> {
                 byte[] finalData;
-                if (response != null) {
+                if (response == null) {
+                    // Response data can be null as of 1.19.20 (same behaviour as empty response data)
+                    // Only need to send the form id
+                    finalData = new byte[]{data[1], data[2]};
+                } else {
                     byte[] raw = response.getBytes(StandardCharsets.UTF_8);
                     finalData = new byte[raw.length + 2];
 
                     finalData[0] = data[1];
                     finalData[1] = data[2];
                     System.arraycopy(raw, 0, finalData, 2, raw.length);
-                } else {
-                    // Response data can be null as of 1.19.20 (same behaviour as empty response data)
-                    // Only need to send the form id
-                    finalData = new byte[]{data[1], data[2]};
                 }
 
                 session.sendDownstreamPacket(new ServerboundCustomPayloadPacket(channel, finalData));

--- a/core/src/main/java/org/geysermc/geyser/translator/protocol/java/JavaCustomPayloadTranslator.java
+++ b/core/src/main/java/org/geysermc/geyser/translator/protocol/java/JavaCustomPayloadTranslator.java
@@ -72,12 +72,18 @@ public class JavaCustomPayloadTranslator extends PacketTranslator<ClientboundCus
             String dataString = new String(data, 3, data.length - 3, Charsets.UTF_8);
 
             Form form = Forms.fromJson(dataString, type, (ignored, response) -> {
-                byte[] raw = response.getBytes(StandardCharsets.UTF_8);
-                byte[] finalData = new byte[raw.length + 2];
+                byte[] finalData;
+                if (response != null) {
+                    byte[] raw = response.getBytes(StandardCharsets.UTF_8);
+                    finalData = new byte[raw.length + 2];
 
-                finalData[0] = data[1];
-                finalData[1] = data[2];
-                System.arraycopy(raw, 0, finalData, 2, raw.length);
+                    finalData[0] = data[1];
+                    finalData[1] = data[2];
+                    System.arraycopy(raw, 0, finalData, 2, raw.length);
+                } else {
+                    // Only need to send the form id
+                    finalData = new byte[]{data[1], data[2]};
+                }
 
                 session.sendDownstreamPacket(new ServerboundCustomPayloadPacket(channel, finalData));
             });

--- a/core/src/main/java/org/geysermc/geyser/translator/protocol/java/JavaCustomPayloadTranslator.java
+++ b/core/src/main/java/org/geysermc/geyser/translator/protocol/java/JavaCustomPayloadTranslator.java
@@ -81,6 +81,7 @@ public class JavaCustomPayloadTranslator extends PacketTranslator<ClientboundCus
                     finalData[1] = data[2];
                     System.arraycopy(raw, 0, finalData, 2, raw.length);
                 } else {
+                    // Response data can be null as of 1.19.20 (same behaviour as empty response data)
                     // Only need to send the form id
                     finalData = new byte[]{data[1], data[2]};
                 }


### PR DESCRIPTION
The response was always allowed to be null within Cumulus, but the rawResponse consumer is not annotated as such and the response was never practically null before 1.19.20

Fixes #3221