### PR TITLE
Fix missing cool down indicator when attacking mobs

### DIFF
--- a/core/src/main/java/org/geysermc/geyser/translator/protocol/bedrock/BedrockInventoryTransactionTranslator.java
+++ b/core/src/main/java/org/geysermc/geyser/translator/protocol/bedrock/BedrockInventoryTransactionTranslator.java
@@ -54,6 +54,7 @@ import org.geysermc.geyser.inventory.Inventory;
 import org.geysermc.geyser.inventory.PlayerInventory;
 import org.geysermc.geyser.inventory.click.Click;
 import org.geysermc.geyser.level.block.BlockStateValues;
+import org.geysermc.geyser.network.MinecraftProtocol;
 import org.geysermc.geyser.registry.BlockRegistries;
 import org.geysermc.geyser.registry.type.ItemMapping;
 import org.geysermc.geyser.registry.type.ItemMappings;
@@ -466,7 +467,10 @@ public class BedrockInventoryTransactionTranslator extends PacketTranslator<Inve
                                 InteractAction.ATTACK, session.isSneaking());
                         session.sendDownstreamPacket(attackPacket);
 
-                        CooldownUtils.sendCooldown(session);
+                        if (MinecraftProtocol.supports1_19_10(session)) {
+                            // Since 1.19.10, LevelSoundEventPackets are no longer sent by the client when attacking entities
+                            CooldownUtils.sendCooldown(session);
+                        }
                     }
                 }
                 break;

--- a/core/src/main/java/org/geysermc/geyser/translator/protocol/bedrock/BedrockInventoryTransactionTranslator.java
+++ b/core/src/main/java/org/geysermc/geyser/translator/protocol/bedrock/BedrockInventoryTransactionTranslator.java
@@ -62,10 +62,7 @@ import org.geysermc.geyser.translator.inventory.InventoryTranslator;
 import org.geysermc.geyser.translator.inventory.item.ItemTranslator;
 import org.geysermc.geyser.translator.protocol.PacketTranslator;
 import org.geysermc.geyser.translator.protocol.Translator;
-import org.geysermc.geyser.util.BlockUtils;
-import org.geysermc.geyser.util.EntityUtils;
-import org.geysermc.geyser.util.InteractionResult;
-import org.geysermc.geyser.util.InventoryUtils;
+import org.geysermc.geyser.util.*;
 
 import java.util.List;
 import java.util.concurrent.TimeUnit;
@@ -468,6 +465,8 @@ public class BedrockInventoryTransactionTranslator extends PacketTranslator<Inve
                         ServerboundInteractPacket attackPacket = new ServerboundInteractPacket(entityId,
                                 InteractAction.ATTACK, session.isSneaking());
                         session.sendDownstreamPacket(attackPacket);
+
+                        CooldownUtils.sendCooldown(session);
                     }
                 }
                 break;


### PR DESCRIPTION
Since 1.19.10, the client no longer sends a `LevelSountEventPacket` when attacking mobs which was used to show the cool down indicator.