### PR TITLE
Loopback exemption fixes

### DIFF
--- a/core/src/main/java/org/geysermc/geyser/util/LoopbackUtil.java
+++ b/core/src/main/java/org/geysermc/geyser/util/LoopbackUtil.java
@@ -50,12 +50,12 @@ public final class LoopbackUtil {
         if (os.equalsIgnoreCase("Windows 10") || os.equalsIgnoreCase("Windows 11")) {
             try {
                 Process process = Runtime.getRuntime().exec(checkExemption);
-                process.waitFor();
                 InputStream is = process.getInputStream();
 
+                int data;
                 StringBuilder sb = new StringBuilder();
-                while (is.available() != 0) {
-                    sb.append((char) is.read());
+                while ((data = is.read()) != -1) {
+                    sb.append((char) data);
                 }
 
                 return !sb.toString().contains(minecraftApplication);

--- a/core/src/main/java/org/geysermc/geyser/util/LoopbackUtil.java
+++ b/core/src/main/java/org/geysermc/geyser/util/LoopbackUtil.java
@@ -35,7 +35,7 @@ import java.nio.file.Paths;
 
 public final class LoopbackUtil {
     private static final String checkExemption = "CheckNetIsolation LoopbackExempt -s";
-    private static final String loopbackCommand = "CheckNetIsolation LoopbackExempt -a -n='Microsoft.MinecraftUWP_8wekyb3d8bbwe'";
+    private static final String loopbackCommand = "CheckNetIsolation LoopbackExempt -a -n=Microsoft.MinecraftUWP_8wekyb3d8bbwe";
     /**
      * This string needs to be checked in the event Minecraft is not installed - no Minecraft string will be present in the checkExemption command.
      */


### PR DESCRIPTION
This fixes a potential hang when checking loopback exemptions. This can happen when the user has a lot of exemptions. The external process is stuck waiting for space in the standard output buffer, because Geyser does not read from it until the process ends.

This also removes the single quotes surrounding `Microsoft.MinecraftUWP_8wekyb3d8bbwe`. This was causing the wrong SID to be added to the list of loopback exemptions in my testing. I think this is because cmd does not process single quotes unlike powershell. Execution of the CheckNetIsolation command was recently changed to cmd instead of powershell in commit 0efd04dd87183064f51de93bc93b7058aeec9b69