### PR TITLE
Add way to specify key for encrypted packs

### DIFF
--- a/core/src/main/java/org/geysermc/geyser/network/UpstreamPacketHandler.java
+++ b/core/src/main/java/org/geysermc/geyser/network/UpstreamPacketHandler.java
@@ -106,7 +106,7 @@ public class UpstreamPacketHandler extends LoggingPacketHandler {
             ResourcePackManifest.Header header = resourcePack.getManifest().getHeader();
             resourcePacksInfo.getResourcePackInfos().add(new ResourcePacksInfoPacket.Entry(
                     header.getUuid().toString(), header.getVersionString(), resourcePack.getFile().length(),
-                            "", "", "", false, false));
+                            resourcePack.getContentKey(), "", header.getUuid().toString(), false, false));
         }
         resourcePacksInfo.setForcedToAccept(GeyserImpl.getInstance().getConfig().isForceResourcePacks());
         session.sendUpstreamPacket(resourcePacksInfo);

--- a/core/src/main/java/org/geysermc/geyser/pack/ResourcePack.java
+++ b/core/src/main/java/org/geysermc/geyser/pack/ResourcePack.java
@@ -26,15 +26,19 @@
 package org.geysermc.geyser.pack;
 
 import org.geysermc.geyser.GeyserImpl;
-import org.geysermc.geyser.util.FileUtils;
 import org.geysermc.geyser.text.GeyserLocale;
+import org.geysermc.geyser.util.FileUtils;
 
 import java.io.File;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.stream.Stream;
 import java.util.zip.ZipEntry;
 import java.util.zip.ZipFile;
+
+import lombok.Getter;
 
 /**
  * This represents a resource pack and all the data relevant to it
@@ -54,6 +58,9 @@ public class ResourcePack {
     private File file;
     private ResourcePackManifest manifest;
     private ResourcePackManifest.Version version;
+
+    @Getter
+    private String contentKey;
 
     /**
      * Loop through the packs directory and locate valid resource pack files
@@ -97,6 +104,11 @@ public class ResourcePack {
                             }
                         }
                     });
+
+                    // Check if a file exists with the same name as the resource pack suffixed by .key,
+                    // and set this as content key. (e.g. test.zip, key file would be test.zip.key)
+                    File keyFile = new File(file.getParentFile(), file.getName() + ".key");
+                    pack.contentKey = keyFile.exists() ? Files.readString(keyFile.toPath(), StandardCharsets.UTF_8) : "";
                 } catch (Exception e) {
                     GeyserImpl.getInstance().getLogger().error(GeyserLocale.getLocaleStringLog("geyser.resource_pack.broken", file.getName()));
                     e.printStackTrace();


### PR DESCRIPTION
# Description

Adds support for specifing keys for encrypted packs, it checks for a file with the same name as the resource pack, but suffixed with .key, and sets this as content key.  (e.g. packs/test.zip, key file would be packs/test.zip.key)

# Testing

Has been tested with an encrypted pack on bungeecord platform.