### PR TITLE
Improve bungeecord ping passthrough integration, fixes motd with mult…

### DIFF
--- a/bootstrap/bungeecord/build.gradle.kts
+++ b/bootstrap/bungeecord/build.gradle.kts
@@ -1,4 +1,4 @@
-val bungeeVersion = "a7c6ede";
+val bungeeVersion = "71990e3";
 
 dependencies {
     api(projects.core)

--- a/bootstrap/bungeecord/src/main/java/org/geysermc/geyser/platform/bungeecord/GeyserBungeePingPassthrough.java
+++ b/bootstrap/bungeecord/src/main/java/org/geysermc/geyser/platform/bungeecord/GeyserBungeePingPassthrough.java
@@ -25,164 +25,554 @@
 
 package org.geysermc.geyser.platform.bungeecord;
 
-import lombok.AllArgsConstructor;
-import net.md_5.bungee.api.ProxyServer;
+import net.md_5.bungee.BungeeCord;
 import net.md_5.bungee.api.ServerPing;
-import net.md_5.bungee.api.chat.BaseComponent;
-import net.md_5.bungee.api.chat.TextComponent;
 import net.md_5.bungee.api.config.ListenerInfo;
-import net.md_5.bungee.api.connection.PendingConnection;
-import net.md_5.bungee.api.event.ProxyPingEvent;
 import net.md_5.bungee.api.plugin.Listener;
+import net.md_5.bungee.connection.InitialHandler;
+import net.md_5.bungee.netty.ChannelWrapper;
+import net.md_5.bungee.protocol.Protocol;
 import net.md_5.bungee.protocol.ProtocolConstants;
+import net.md_5.bungee.protocol.packet.Handshake;
+import net.md_5.bungee.protocol.packet.StatusRequest;
+import net.md_5.bungee.protocol.packet.StatusResponse;
 import org.geysermc.geyser.ping.GeyserPingInfo;
 import org.geysermc.geyser.ping.IGeyserPingPassthrough;
+import org.jetbrains.annotations.NotNull;
+import io.netty.buffer.ByteBufAllocator;
+import io.netty.channel.Channel;
+import io.netty.channel.ChannelConfig;
+import io.netty.channel.ChannelFuture;
+import io.netty.channel.ChannelHandler;
+import io.netty.channel.ChannelHandlerContext;
+import io.netty.channel.ChannelId;
+import io.netty.channel.ChannelMetadata;
+import io.netty.channel.ChannelPipeline;
+import io.netty.channel.ChannelProgressivePromise;
+import io.netty.channel.ChannelPromise;
+import io.netty.channel.DefaultChannelId;
+import io.netty.channel.EventLoop;
+import io.netty.util.Attribute;
+import io.netty.util.AttributeKey;
+import io.netty.util.concurrent.EventExecutor;
+import lombok.AllArgsConstructor;
 
 import java.net.InetSocketAddress;
 import java.net.SocketAddress;
 import java.util.Arrays;
-import java.util.UUID;
 import java.util.concurrent.CompletableFuture;
 
 @AllArgsConstructor
 public class GeyserBungeePingPassthrough implements IGeyserPingPassthrough, Listener {
 
-    private final ProxyServer proxyServer;
+    private final BungeeCord bungeeCord;
+    private final ListenerInfo listenerInfo;
 
     @Override
     public GeyserPingInfo getPingInformation(InetSocketAddress inetSocketAddress) {
-        CompletableFuture<ProxyPingEvent> future = new CompletableFuture<>();
-        proxyServer.getPluginManager().callEvent(new ProxyPingEvent(new GeyserPendingConnection(inetSocketAddress), getPingInfo(), (event, throwable) -> {
-            if (throwable != null) {
-                future.completeExceptionally(throwable);
-            } else {
-                future.complete(event);
-            }
-        }));
-        ProxyPingEvent event = future.join();
-        ServerPing response = event.getResponse();
+        CompletableFuture<ServerPing> future = new CompletableFuture<>();
+        try {
+            InitialHandler initialHandler = new InitialHandler(bungeeCord, listenerInfo);
+            initialHandler.connected(new GeyserChannelWrapper(inetSocketAddress, future));
+            InetSocketAddress serverAddress = (InetSocketAddress) listenerInfo.getSocketAddress();
+            initialHandler.handle(new Handshake(ProtocolConstants.MINECRAFT_1_19_1, serverAddress.getHostString(), serverAddress.getPort(), 1));
+            initialHandler.handle(new StatusRequest());
+        } catch (Throwable throwable) {
+            future.completeExceptionally(throwable);
+        }
+
+        ServerPing response = future.join();
         GeyserPingInfo geyserPingInfo = new GeyserPingInfo(
                 response.getDescriptionComponent().toLegacyText(),
                 new GeyserPingInfo.Players(response.getPlayers().getMax(), response.getPlayers().getOnline()),
                 new GeyserPingInfo.Version(response.getVersion().getName(), response.getVersion().getProtocol())
         );
-        if (event.getResponse().getPlayers().getSample() != null) {
-            Arrays.stream(event.getResponse().getPlayers().getSample()).forEach(proxiedPlayer ->
+        if (response.getPlayers().getSample() != null) {
+            Arrays.stream(response.getPlayers().getSample()).forEach(proxiedPlayer ->
                     geyserPingInfo.getPlayerList().add(proxiedPlayer.getName()));
         }
         return geyserPingInfo;
     }
 
-    // This is static so pending connection can use it
-    private static ListenerInfo getDefaultListener() {
-        return ProxyServer.getInstance().getConfig().getListeners().iterator().next();
-    }
-
-    private ServerPing getPingInfo() {
-        return new ServerPing(
-                new ServerPing.Protocol(
-                        proxyServer.getName() + " " + ProtocolConstants.SUPPORTED_VERSIONS.get(0) + "-" + ProtocolConstants.SUPPORTED_VERSIONS.get(ProtocolConstants.SUPPORTED_VERSIONS.size() - 1),
-                        ProtocolConstants.SUPPORTED_VERSION_IDS.get(ProtocolConstants.SUPPORTED_VERSION_IDS.size() - 1)),
-                new ServerPing.Players(getDefaultListener().getMaxPlayers(), proxyServer.getOnlineCount(), null),
-                TextComponent.fromLegacyText(getDefaultListener().getMotd())[0],
-                proxyServer.getConfig().getFaviconObject()
-        );
-    }
-
-    private static class GeyserPendingConnection implements PendingConnection {
-
-        private static final UUID FAKE_UUID = UUID.nameUUIDFromBytes("geyser!internal".getBytes());
+    private static class GeyserChannelWrapper extends ChannelWrapper {
 
         private final InetSocketAddress remote;
+        private final CompletableFuture<ServerPing> future;
 
-        public GeyserPendingConnection(InetSocketAddress remote) {
+        public GeyserChannelWrapper(InetSocketAddress remote, CompletableFuture<ServerPing> future) {
+            super(new GeyserChannelHandlerContext(remote));
             this.remote = remote;
+            this.future = future;
         }
 
         @Override
-        public String getName() {
-            throw new UnsupportedOperationException();
-        }
-
-        @Override
-        public int getVersion() {
-            return ProtocolConstants.SUPPORTED_VERSION_IDS.get(ProtocolConstants.SUPPORTED_VERSION_IDS.size() - 1);
-        }
-
-        @Override
-        public InetSocketAddress getVirtualHost() {
-            return null;
-        }
-
-        @Override
-        public ListenerInfo getListener() {
-            return getDefaultListener();
-        }
-
-        @Override
-        public String getUUID() {
-            return FAKE_UUID.toString();
-        }
-
-        @Override
-        public UUID getUniqueId() {
-            return FAKE_UUID;
-        }
-
-        @Override
-        public void setUniqueId(UUID uuid) {
-            throw new UnsupportedOperationException();
-        }
-
-        @Override
-        public boolean isOnlineMode() {
-            return true;
-        }
-
-        @Override
-        public void setOnlineMode(boolean b) {
-            throw new UnsupportedOperationException();
-        }
-
-        @Override
-        public boolean isLegacy() {
-            return false;
-        }
-
-        @Override
-        public InetSocketAddress getAddress() {
+        public SocketAddress getRemoteAddress() {
             return remote;
         }
 
         @Override
-        public SocketAddress getSocketAddress() {
-            return getAddress();
+        public void setProtocol(Protocol protocol) {
         }
 
         @Override
-        public void disconnect(String s) {
+        public void setVersion(int protocol) {
+        }
+
+        @Override
+        public void write(Object packet) {
+            if (packet instanceof StatusResponse) {
+                future.complete(BungeeCord.getInstance().gson.fromJson(((StatusResponse) packet).getResponse(), ServerPing.class));
+            }
+        }
+
+        @Override
+        public void close(Object packet) {
+            if (!isClosed()) markClosed();
+        }
+
+        @Override
+        public void addBefore(String baseName, String name, ChannelHandler handler) {
             throw new UnsupportedOperationException();
         }
 
         @Override
-        public void disconnect(BaseComponent... baseComponents) {
+        public void setCompressionThreshold(int compressionThreshold) {
+        }
+    }
+
+    private static class GeyserChannelHandlerContext implements ChannelHandlerContext {
+
+        private final Channel channel;
+
+        public GeyserChannelHandlerContext(SocketAddress remoteAddress) {
+            channel = new GeyserChannel(remoteAddress);
+        }
+
+        @Override
+        public Channel channel() {
+            return channel;
+        }
+
+        @Override
+        public EventExecutor executor() {
             throw new UnsupportedOperationException();
         }
 
         @Override
-        public void disconnect(BaseComponent baseComponent) {
+        public String name() {
             throw new UnsupportedOperationException();
         }
 
         @Override
-        public boolean isConnected() {
-            return false;
+        public ChannelHandler handler() {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public boolean isRemoved() {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public ChannelHandlerContext fireChannelRegistered() {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public ChannelHandlerContext fireChannelUnregistered() {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public ChannelHandlerContext fireChannelActive() {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public ChannelHandlerContext fireChannelInactive() {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public ChannelHandlerContext fireExceptionCaught(Throwable throwable) {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public ChannelHandlerContext fireUserEventTriggered(Object o) {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public ChannelHandlerContext fireChannelRead(Object o) {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public ChannelHandlerContext fireChannelReadComplete() {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public ChannelHandlerContext fireChannelWritabilityChanged() {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public ChannelFuture bind(SocketAddress socketAddress) {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public ChannelFuture connect(SocketAddress socketAddress) {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public ChannelFuture connect(SocketAddress socketAddress, SocketAddress socketAddress1) {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public ChannelFuture disconnect() {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public ChannelFuture close() {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public ChannelFuture deregister() {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public ChannelFuture bind(SocketAddress socketAddress, ChannelPromise channelPromise) {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public ChannelFuture connect(SocketAddress socketAddress, ChannelPromise channelPromise) {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public ChannelFuture connect(SocketAddress socketAddress, SocketAddress socketAddress1, ChannelPromise channelPromise) {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public ChannelFuture disconnect(ChannelPromise channelPromise) {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public ChannelFuture close(ChannelPromise channelPromise) {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public ChannelFuture deregister(ChannelPromise channelPromise) {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public ChannelHandlerContext read() {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public ChannelFuture write(Object o) {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public ChannelFuture write(Object o, ChannelPromise channelPromise) {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public ChannelHandlerContext flush() {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public ChannelFuture writeAndFlush(Object o, ChannelPromise channelPromise) {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public ChannelFuture writeAndFlush(Object o) {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public ChannelPromise newPromise() {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public ChannelProgressivePromise newProgressivePromise() {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public ChannelFuture newSucceededFuture() {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public ChannelFuture newFailedFuture(Throwable throwable) {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public ChannelPromise voidPromise() {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public ChannelPipeline pipeline() {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public ByteBufAllocator alloc() {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public <T> Attribute<T> attr(AttributeKey<T> attributeKey) {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public <T> boolean hasAttr(AttributeKey<T> attributeKey) {
+            throw new UnsupportedOperationException();
+        }
+    }
+
+    @AllArgsConstructor
+    private static class GeyserChannel implements Channel {
+
+        private final DefaultChannelId id = DefaultChannelId.newInstance();
+        private final SocketAddress remoteAddress;
+
+        @Override
+        public ChannelId id() {
+            return id;
+        }
+
+        @Override
+        public EventLoop eventLoop() {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public Channel parent() {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public ChannelConfig config() {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public boolean isOpen() {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public boolean isRegistered() {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public boolean isActive() {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public ChannelMetadata metadata() {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public SocketAddress localAddress() {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public SocketAddress remoteAddress() {
+            return remoteAddress;
+        }
+
+        @Override
+        public ChannelFuture closeFuture() {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public boolean isWritable() {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public long bytesBeforeUnwritable() {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public long bytesBeforeWritable() {
+            throw new UnsupportedOperationException();
         }
 
         @Override
         public Unsafe unsafe() {
             throw new UnsupportedOperationException();
         }
-    }
 
+        @Override
+        public ChannelPipeline pipeline() {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public ByteBufAllocator alloc() {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public ChannelFuture bind(SocketAddress socketAddress) {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public ChannelFuture connect(SocketAddress socketAddress) {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public ChannelFuture connect(SocketAddress socketAddress, SocketAddress socketAddress1) {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public ChannelFuture disconnect() {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public ChannelFuture close() {
+            return null;
+        }
+
+        @Override
+        public ChannelFuture deregister() {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public ChannelFuture bind(SocketAddress socketAddress, ChannelPromise channelPromise) {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public ChannelFuture connect(SocketAddress socketAddress, ChannelPromise channelPromise) {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public ChannelFuture connect(SocketAddress socketAddress, SocketAddress socketAddress1, ChannelPromise channelPromise) {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public ChannelFuture disconnect(ChannelPromise channelPromise) {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public ChannelFuture close(ChannelPromise channelPromise) {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public ChannelFuture deregister(ChannelPromise channelPromise) {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public Channel read() {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public ChannelFuture write(Object o) {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public ChannelFuture write(Object o, ChannelPromise channelPromise) {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public Channel flush() {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public ChannelFuture writeAndFlush(Object o, ChannelPromise channelPromise) {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public ChannelFuture writeAndFlush(Object o) {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public ChannelPromise newPromise() {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public ChannelProgressivePromise newProgressivePromise() {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public ChannelFuture newSucceededFuture() {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public ChannelFuture newFailedFuture(Throwable throwable) {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public ChannelPromise voidPromise() {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public <T> Attribute<T> attr(AttributeKey<T> attributeKey) {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public <T> boolean hasAttr(AttributeKey<T> attributeKey) {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public int compareTo(@NotNull Channel o) {
+            throw new UnsupportedOperationException();
+        }
+    }
 }

--- a/bootstrap/bungeecord/src/main/java/org/geysermc/geyser/platform/bungeecord/GeyserBungeePlugin.java
+++ b/bootstrap/bungeecord/src/main/java/org/geysermc/geyser/platform/bungeecord/GeyserBungeePlugin.java
@@ -203,7 +203,7 @@ public class GeyserBungeePlugin extends Plugin implements GeyserBootstrap {
         if (geyserConfig.isLegacyPingPassthrough()) {
             this.geyserBungeePingPassthrough = GeyserLegacyPingPassthrough.init(geyser);
         } else {
-            this.geyserBungeePingPassthrough = new GeyserBungeePingPassthrough(getProxy());
+            this.geyserBungeePingPassthrough = new GeyserBungeePingPassthrough((BungeeCord) getProxy(), getProxy().getConfig().getListeners().iterator().next());
         }
     }
 


### PR DESCRIPTION
# Description

This changes the way how the Geyser ping passthrough in BungeeCord works. Currently the ping passthrough tries to mimic the the InitialHandler behavior for pinging, which for example doesn't respect the ping passthrough configuration of the BungeeCord itself, and doesn't work with forced hosts, etc.

To fix this, I'm directly interfacing the InitialHandler, this should have an identical behavior as legacy ping passthrough.

# Testing

Has been tested on Waterfall with ping passthrough forced hosts enabled and normal ping, and in production environment.