### PR TITLE
Add support for hiding enchantments via hide flags

### DIFF
--- a/core/src/main/java/org/geysermc/geyser/translator/inventory/item/nbt/EnchantmentTranslator.java
+++ b/core/src/main/java/org/geysermc/geyser/translator/inventory/item/nbt/EnchantmentTranslator.java
@@ -42,19 +42,11 @@ public class EnchantmentTranslator extends NbtItemStackTranslator {
 
     @Override
     public void translateToBedrock(GeyserSession session, CompoundTag itemTag, ItemMapping mapping) {
-        List<Tag> newTags = new ArrayList<>();
-        Tag enchantmentTag = itemTag.get("Enchantments");
-        if (enchantmentTag instanceof ListTag listTag) {
-            for (Tag tag : listTag.getValue()) {
-                if (!(tag instanceof CompoundTag)) continue;
+        IntTag hideFlagsTag = itemTag.get("HideFlags");
 
-                CompoundTag bedrockTag = remapEnchantment((CompoundTag) tag);
-                newTags.add(bedrockTag);
-            }
-            itemTag.remove("Enchantments");
-        }
-        enchantmentTag = itemTag.get("StoredEnchantments");
-        if (enchantmentTag instanceof ListTag listTag) {
+        List<Tag> newTags = new ArrayList<>();
+        Tag enchantmentTag = itemTag.get("StoredEnchantments");
+        if ((hideFlagsTag == null || (hideFlagsTag.getValue() & 32) == 0) && enchantmentTag instanceof ListTag listTag) {
             for (Tag tag : listTag.getValue()) {
                 if (!(tag instanceof CompoundTag)) continue;
 
@@ -65,6 +57,19 @@ public class EnchantmentTranslator extends NbtItemStackTranslator {
                 }
             }
             itemTag.remove("StoredEnchantments");
+        }
+        enchantmentTag = itemTag.get("Enchantments");
+        if (enchantmentTag instanceof ListTag listTag) {
+            if (hideFlagsTag == null || (hideFlagsTag.getValue() & 1) == 0) {
+                for (Tag tag : listTag.getValue()) {
+                    if (!(tag instanceof CompoundTag)) continue;
+
+                    CompoundTag bedrockTag = remapEnchantment((CompoundTag) tag);
+                    newTags.add(bedrockTag);
+                }
+                itemTag.remove("Enchantments");
+            }
+            itemTag.put(new ListTag("ench"));
         }
 
         if (!newTags.isEmpty()) {

--- a/core/src/main/java/org/geysermc/geyser/translator/inventory/item/nbt/EnchantmentTranslator.java
+++ b/core/src/main/java/org/geysermc/geyser/translator/inventory/item/nbt/EnchantmentTranslator.java
@@ -42,11 +42,9 @@ public class EnchantmentTranslator extends NbtItemStackTranslator {
 
     @Override
     public void translateToBedrock(GeyserSession session, CompoundTag itemTag, ItemMapping mapping) {
-        IntTag hideFlagsTag = itemTag.get("HideFlags");
-
         List<Tag> newTags = new ArrayList<>();
         Tag enchantmentTag = itemTag.get("StoredEnchantments");
-        if ((hideFlagsTag == null || (hideFlagsTag.getValue() & 32) == 0) && enchantmentTag instanceof ListTag listTag) {
+        if (enchantmentTag instanceof ListTag listTag) {
             for (Tag tag : listTag.getValue()) {
                 if (!(tag instanceof CompoundTag)) continue;
 
@@ -60,15 +58,13 @@ public class EnchantmentTranslator extends NbtItemStackTranslator {
         }
         enchantmentTag = itemTag.get("Enchantments");
         if (enchantmentTag instanceof ListTag listTag) {
-            if (hideFlagsTag == null || (hideFlagsTag.getValue() & 1) == 0) {
-                for (Tag tag : listTag.getValue()) {
-                    if (!(tag instanceof CompoundTag)) continue;
+            for (Tag tag : listTag.getValue()) {
+                if (!(tag instanceof CompoundTag)) continue;
 
-                    CompoundTag bedrockTag = remapEnchantment((CompoundTag) tag);
-                    newTags.add(bedrockTag);
-                }
-                itemTag.remove("Enchantments");
+                CompoundTag bedrockTag = remapEnchantment((CompoundTag) tag);
+                newTags.add(bedrockTag);
             }
+            itemTag.remove("Enchantments");
             itemTag.put(new ListTag("ench"));
         }
 


### PR DESCRIPTION
# Description

This fixes https://github.com/GeyserMC/Geyser/issues/1852
by only sending an empty ench:[] tag for hidden enchantments, which will add the foil effect, which should not affect the items client behavior.

I didn't add hide flags for other items yet, because it wouldn't be possible to remove the additional data of fireworks etc. but other items, etc could be tested.

# Testing

Has been tested on Waterfall connected to a 1.16 ViaVersion Paper server, with following command:
/minecraft:give @p acacia_button{Enchantments:[{id:aqua_affinity,lvl:1}],HideFlags:1} 1