### PR TITLE
Fix git branch on Jenkins

### DIFF
--- a/core/build.gradle.kts
+++ b/core/build.gradle.kts
@@ -79,7 +79,7 @@ configure<BlossomExtension> {
     val indra = the<IndraGitExtension>()
 
     val mainFile = "src/main/java/org/geysermc/geyser/GeyserImpl.java"
-    val branchName = indra.branchName() ?: "DEV"
+    val branchName = indra.branchName() ?: System.getenv("GIT_BRANCH") ?: "DEV"
     val commit = indra.commit()
     val git = indra.git()
     val gitVersion = "git-${branchName}-${commit?.name?.substring(0, 7) ?: "0000000"}"

--- a/core/build.gradle.kts
+++ b/core/build.gradle.kts
@@ -79,6 +79,7 @@ configure<BlossomExtension> {
     val indra = the<IndraGitExtension>()
 
     val mainFile = "src/main/java/org/geysermc/geyser/GeyserImpl.java"
+    // On Jenkins, a detached head is checked out, so indra cannot determine the branch. Fortunately, this environment variable is available.
     val branchName = indra.branchName() ?: System.getenv("GIT_BRANCH") ?: "DEV"
     val commit = indra.commit()
     val git = indra.git()


### PR DESCRIPTION
Jenkins checks out a detached head, so there is no branch for indra to record. Results in "DEV" on CI builds. This falls back to the environment variable, for Jenkins.