### PR TITLE
Update nbt to 2.2.0, update LevelGenericEventPacket event ids to leve…

### DIFF
--- a/build-logic/src/main/kotlin/Versions.kt
+++ b/build-logic/src/main/kotlin/Versions.kt
@@ -29,7 +29,6 @@ object Versions {
     const val nettyVersion = "4.1.80.Final"
     const val guavaVersion = "29.0-jre"
     const val gsonVersion = "2.3.1" // Provided by Spigot 1.8.8
-    const val nbtVersion = "2.1.0"
     const val websocketVersion = "1.5.1"
     const val protocolVersion = "fed46166"
     const val raknetVersion = "1.6.28-20220125.214016-6"

--- a/core/build.gradle.kts
+++ b/core/build.gradle.kts
@@ -16,8 +16,6 @@ dependencies {
     api("com.fasterxml.jackson.dataformat", "jackson-dataformat-yaml", Versions.jacksonVersion)
     api("com.google.guava", "guava", Versions.guavaVersion)
 
-    api("com.nukkitx", "nbt", Versions.nbtVersion)
-
     // Fastutil Maps
     implementation("com.nukkitx.fastutil", "fastutil-int-int-maps", Versions.fastutilVersion)
     implementation("com.nukkitx.fastutil", "fastutil-int-long-maps", Versions.fastutilVersion)

--- a/core/src/main/java/org/geysermc/geyser/translator/protocol/java/level/JavaLevelEventTranslator.java
+++ b/core/src/main/java/org/geysermc/geyser/translator/protocol/java/level/JavaLevelEventTranslator.java
@@ -263,7 +263,7 @@ public class JavaLevelEventTranslator extends PacketTranslator<ClientboundLevelE
                 LevelEventGenericPacket levelEventPacket = new LevelEventGenericPacket();
                 // TODO add SCULK_BLOCK_CHARGE sound
                 if (eventData.getCharge() > 0) {
-                    levelEventPacket.setEventId(2037);
+                    levelEventPacket.setEventId(2037/*LevelEventType.SCULK_CHARGE*/);
                     levelEventPacket.setTag(
                             NbtMap.builder()
                                     .putInt("x", packet.getPosition().getX())
@@ -274,7 +274,7 @@ public class JavaLevelEventTranslator extends PacketTranslator<ClientboundLevelE
                                     .build()
                     );
                 } else {
-                    levelEventPacket.setEventId(2038);
+                    levelEventPacket.setEventId(2038/*LevelEventType.SCULK_CHARGE_POP*/);
                     levelEventPacket.setTag(
                             NbtMap.builder()
                                     .putInt("x", packet.getPosition().getX())
@@ -288,7 +288,7 @@ public class JavaLevelEventTranslator extends PacketTranslator<ClientboundLevelE
             }
             case SCULK_SHRIEKER_SHRIEK -> {
                 LevelEventGenericPacket levelEventPacket = new LevelEventGenericPacket();
-                levelEventPacket.setEventId(2035);
+                levelEventPacket.setEventId(2035/*LevelEventType.PARTICLE_SCULK_SHRIEK*/);
                 levelEventPacket.setTag(
                         NbtMap.builder()
                                 .putInt("originX", packet.getPosition().getX())

--- a/core/src/main/java/org/geysermc/geyser/translator/protocol/java/level/JavaLevelParticlesTranslator.java
+++ b/core/src/main/java/org/geysermc/geyser/translator/protocol/java/level/JavaLevelParticlesTranslator.java
@@ -157,7 +157,7 @@ public class JavaLevelParticlesTranslator extends PacketTranslator<ClientboundLe
 
                 return (position) -> {
                     LevelEventGenericPacket packet = new LevelEventGenericPacket();
-                    packet.setEventId(2027);
+                    packet.setEventId(2027/*LevelEventType.PARTICLE_VIBRATION_SIGNAL*/);
                     packet.setTag(
                             NbtMap.builder()
                                     .putCompound("origin", buildVec3PositionTag(position))


### PR DESCRIPTION
# Description

Fixes NoSuchMethodError when sending LevelEventGenericPacket,  change LevelEventPacket to LevelEventGenericPacket for explosion translation as it is also the Packet used in Vanilla. Add details to the "arbitrary event ids" as it might could be replaced with LevelEventType (or they may change after a update)

# Testing

Has been tested on Waterfall