### PR TITLE
Add support for client chunk cache (saving network bandwidth, has to …

### DIFF
--- a/core/build.gradle.kts
+++ b/core/build.gradle.kts
@@ -30,6 +30,7 @@ dependencies {
     api("com.github.CloudburstMC.Protocol", "bedrock-v554", Versions.protocolVersion) {
         exclude("com.nukkitx.network", "raknet")
     }
+    implementation("org.lz4:lz4-java:1.8.0")
 
     api("com.github.GeyserMC", "MCAuthLib", Versions.mcauthlibVersion)
     api("com.github.GeyserMC", "MCProtocolLib", Versions.mcprotocollibversion) {

--- a/core/src/main/java/org/geysermc/geyser/level/chunk/GeyserChunkSection.java
+++ b/core/src/main/java/org/geysermc/geyser/level/chunk/GeyserChunkSection.java
@@ -55,7 +55,9 @@ public class GeyserChunkSection {
     }
 
     public void writeToNetwork(ByteBuf buffer) {
-        buffer.writeByte(CHUNK_SECTION_VERSION);
+        if (this.storage.length != 1) {
+            buffer.writeByte(CHUNK_SECTION_VERSION);
+        }
         buffer.writeByte(this.storage.length);
         for (BlockStorage blockStorage : this.storage) {
             blockStorage.writeToNetwork(buffer);
@@ -63,7 +65,7 @@ public class GeyserChunkSection {
     }
 
     public int estimateNetworkSize() {
-        int size = 2; // Version + storage count
+        int size = this.storage.length != 1 ? 2 : 1; // Version (+ storage count)
         for (BlockStorage blockStorage : this.storage) {
             size += blockStorage.estimateNetworkSize();
         }

--- a/core/src/main/java/org/geysermc/geyser/session/cache/ChunkCache.java
+++ b/core/src/main/java/org/geysermc/geyser/session/cache/ChunkCache.java
@@ -52,6 +52,12 @@ public class ChunkCache {
     @Setter
     private BedrockDimension bedrockDimension = BedrockDimension.OVERWORLD;
 
+    @Getter
+    @Setter
+    private boolean clientCache;
+    @Getter
+    private final Long2ObjectMap<byte[]> clientChunks = new Long2ObjectOpenHashMap<>();
+
     public ChunkCache(GeyserSession session) {
         this.cache = !session.getGeyser().getWorldManager().hasOwnChunkCache(); // To prevent Spigot from initializing
         chunks = cache ? new Long2ObjectOpenHashMap<>() : null;
@@ -145,11 +151,10 @@ public class ChunkCache {
      * but it is the client that must clear sections in the event of proxy switches.
      */
     public void clear() {
-        if (!cache) {
-            return;
+        if (chunks != null) {
+            chunks.clear();
         }
-
-        chunks.clear();
+        clientChunks.clear();
     }
 
     public int getChunkMinY() {

--- a/core/src/main/java/org/geysermc/geyser/translator/protocol/bedrock/BedrockClientCacheBlobStatusTranslator.java
+++ b/core/src/main/java/org/geysermc/geyser/translator/protocol/bedrock/BedrockClientCacheBlobStatusTranslator.java
@@ -1,0 +1,54 @@
+/*
+ * Copyright (c) 2019-2022 GeyserMC. http://geysermc.org
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ *
+ * @author GeyserMC
+ * @link https://github.com/GeyserMC/Geyser
+ */
+
+package org.geysermc.geyser.translator.protocol.bedrock;
+
+import com.nukkitx.protocol.bedrock.packet.ClientCacheBlobStatusPacket;
+import com.nukkitx.protocol.bedrock.packet.ClientCacheMissResponsePacket;
+import org.geysermc.geyser.session.GeyserSession;
+import org.geysermc.geyser.translator.protocol.PacketTranslator;
+import org.geysermc.geyser.translator.protocol.Translator;
+import it.unimi.dsi.fastutil.longs.Long2ObjectMap;
+
+import java.util.function.LongConsumer;
+
+@Translator(packet = ClientCacheBlobStatusPacket.class)
+public class BedrockClientCacheBlobStatusTranslator extends PacketTranslator<ClientCacheBlobStatusPacket> {
+    @Override
+    public void translate(GeyserSession session, ClientCacheBlobStatusPacket packet) {
+        Long2ObjectMap<byte[]> clientChunks = session.getChunkCache().getClientChunks();
+
+        packet.getAcks().forEach(clientChunks::remove);
+
+        ClientCacheMissResponsePacket responsePacket = new ClientCacheMissResponsePacket();
+        packet.getNaks().forEach((LongConsumer) blobId -> {
+            byte[] clientChunk = clientChunks.remove(blobId);
+            if (clientChunk != null) {
+                responsePacket.getBlobs().put(blobId, clientChunk);
+            }
+        });
+        session.sendUpstreamPacket(responsePacket);
+    }
+}

--- a/core/src/main/java/org/geysermc/geyser/translator/protocol/bedrock/BedrockClientCacheStatusTranslator.java
+++ b/core/src/main/java/org/geysermc/geyser/translator/protocol/bedrock/BedrockClientCacheStatusTranslator.java
@@ -1,0 +1,39 @@
+/*
+ * Copyright (c) 2019-2022 GeyserMC. http://geysermc.org
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ *
+ * @author GeyserMC
+ * @link https://github.com/GeyserMC/Geyser
+ */
+
+package org.geysermc.geyser.translator.protocol.bedrock;
+
+import com.nukkitx.protocol.bedrock.packet.ClientCacheStatusPacket;
+import org.geysermc.geyser.session.GeyserSession;
+import org.geysermc.geyser.translator.protocol.PacketTranslator;
+import org.geysermc.geyser.translator.protocol.Translator;
+
+@Translator(packet = ClientCacheStatusPacket.class)
+public class BedrockClientCacheStatusTranslator extends PacketTranslator<ClientCacheStatusPacket> {
+    @Override
+    public void translate(GeyserSession session, ClientCacheStatusPacket packet) {
+        session.getChunkCache().setClientCache(packet.isSupported());
+    }
+}


### PR DESCRIPTION
# Description

Add support for client chunk cache, which drastically reduces network usage, by sacrifising loading time for chunks by rtt. 
Use v1 chunk sections for 1-layer sections, because its in spec, and may cause smaller allocation sizes for chunks.

I also removed the extra data length varint, because it doesn't exist since Bedrock 1.14, it just worked because 0 is a null nbt tag, and bedrock ignores tile entities that are null

# Testing

Has been tested on Waterfall connected to a 1.16 ViaVersion Paper server and a 1.8 ViaVersion Spigot server, with chunk caching enabled and disabled.