### PR TITLE
Fix Sponge Launch

### DIFF
--- a/build-logic/src/main/kotlin/geyser.base-conventions.gradle.kts
+++ b/build-logic/src/main/kotlin/geyser.base-conventions.gradle.kts
@@ -11,7 +11,7 @@ tasks {
     processResources {
         filesMatching(listOf("plugin.yml", "bungee.yml", "velocity-plugin.json", "META-INF/sponge_plugins.json")) {
             expand(
-                "id" to "Geyser",
+                "id" to "geyser",
                 "name" to "Geyser",
                 "version" to project.version,
                 "description" to project.description,


### PR DESCRIPTION
This slipped past me and I guess I forgot to commit it. Sponge requires lowercase plugin identifies just like velocity.

`id` isn't used anywhere else.