### PR TITLE
Publish entire java component and common

### DIFF
--- a/build-logic/src/main/kotlin/geyser.publish-conventions.gradle.kts
+++ b/build-logic/src/main/kotlin/geyser.publish-conventions.gradle.kts
@@ -11,8 +11,7 @@ publishing {
             artifactId = project.name
             version = project.version as String
 
-            artifact(tasks["shadowJar"])
-            artifact(tasks["sourcesJar"])
+            from(components["java"])
         }
     }
 }

--- a/common/build.gradle.kts
+++ b/common/build.gradle.kts
@@ -1,3 +1,7 @@
+plugins {
+    id("geyser.publish-conventions")
+}
+
 dependencies {
     api(libs.cumulus)
     api(libs.gson)


### PR DESCRIPTION
Currently, only the artifacts generated by `shadowJar` and `sourcesJar` are published to Maven repositories. This results in the following files being published:

```
[module]-[version].jar
[module]-[version].pom
[module]-[version]-sources.jar
```

However, this causes problems when another project depends on Geyser because the JAR artifact includes all of Geyser's dependencies which may already be present in the target environment. See GeyserMC/Geyser-Fabric#71 for an example of the problems that can happen as a result of this.

This PR makes Gradle publish the entire `java` component, which publishes all of the following files:

```
[module]-[version].jar
[module]-[version].module
[module]-[version].pom
[module]-[version]-sources.jar
[module]-[version]-unshaded.jar
```

Note the inclusion of the unshaded JAR file. I tested this with Geyser-Fabric (by publishing to Maven local) and it now correctly excludes the dependencies that are already present in the Fabric client/server. The `common` module also needs to be published since it obviously isn't included in the unshaded JARs of other modules.