### PR TITLE
Fix ChunkUtils.sendEmptyChunk biome count, which was fixed to 32 and …

### DIFF
--- a/core/src/main/java/org/geysermc/geyser/translator/protocol/java/JavaLoginTranslator.java
+++ b/core/src/main/java/org/geysermc/geyser/translator/protocol/java/JavaLoginTranslator.java
@@ -99,6 +99,8 @@ public class JavaLoginTranslator extends PacketTranslator<ClientboundLoginPacket
         if (needsSpawnPacket) {
             // The player has yet to spawn so let's do that using some of the information in this Java packet
             session.setDimension(newDimension);
+            session.setDimensionType(dimensions.get(newDimension));
+            ChunkUtils.loadDimension(session);
             session.connect();
 
             // It is now safe to send these packets
@@ -145,8 +147,5 @@ public class JavaLoginTranslator extends PacketTranslator<ClientboundLoginPacket
             // If the player is spawning into the "fake" nether, send them some fog
             session.sendFog("minecraft:fog_hell");
         }
-
-        session.setDimensionType(dimensions.get(newDimension));
-        ChunkUtils.loadDimension(session);
     }
 }

--- a/core/src/main/java/org/geysermc/geyser/translator/protocol/java/JavaRespawnTranslator.java
+++ b/core/src/main/java/org/geysermc/geyser/translator/protocol/java/JavaRespawnTranslator.java
@@ -36,7 +36,6 @@ import org.geysermc.geyser.session.GeyserSession;
 import org.geysermc.geyser.translator.inventory.InventoryTranslator;
 import org.geysermc.geyser.translator.protocol.PacketTranslator;
 import org.geysermc.geyser.translator.protocol.Translator;
-import org.geysermc.geyser.util.ChunkUtils;
 import org.geysermc.geyser.util.DimensionUtils;
 
 @Translator(packet = ClientboundRespawnPacket.class)
@@ -93,9 +92,6 @@ public class JavaRespawnTranslator extends PacketTranslator<ClientboundRespawnPa
             }
             session.setWorldName(packet.getWorldName());
             DimensionUtils.switchDimension(session, newDimension);
-
-            session.setDimensionType(session.getDimensions().get(newDimension));
-            ChunkUtils.loadDimension(session);
         }
     }
 }

--- a/core/src/main/java/org/geysermc/geyser/util/DimensionUtils.java
+++ b/core/src/main/java/org/geysermc/geyser/util/DimensionUtils.java
@@ -94,6 +94,8 @@ public class DimensionUtils {
         changeDimensionPacket.setPosition(pos);
         session.sendUpstreamPacket(changeDimensionPacket);
         session.setDimension(javaDimension);
+        session.setDimensionType(session.getDimensions().get(javaDimension));
+        ChunkUtils.loadDimension(session);
         player.setPosition(pos);
         session.setSpawned(false);
         session.setLastChunkPosition(null);


### PR DESCRIPTION
Fix ChunkUtils.sendEmptyChunk biome count, which was fixed to 32 and therefore might cause crashes; Remove extra data which isn't a thing anymore since and maybe also before 1.14.

Fixed also my crashes, which I had before I removed the dimension change screen.

Anyway seems to just not been updated, compared to the JavaLevelChunkWithLightTranslator (which sends 24 biomes only, or 16, or 8 depending on dimension).

