### PR TITLE
Fix bounding box for 1.19.40 after death + respawn

### DIFF
--- a/core/src/main/java/org/geysermc/geyser/entity/type/Entity.java
+++ b/core/src/main/java/org/geysermc/geyser/entity/type/Entity.java
@@ -427,15 +427,6 @@ public class Entity {
         setBoundingBoxWidth(definition.width());
     }
 
-    /**
-     * Since 1.19.40, the client must be re-informed of its bounding box on respawn
-     * See https://github.com/GeyserMC/Geyser/issues/3370
-     */
-    public void refreshBoundingBox() {
-        dirtyMetadata.put(EntityData.BOUNDING_BOX_HEIGHT, boundingBoxHeight);
-        dirtyMetadata.put(EntityData.BOUNDING_BOX_WIDTH, boundingBoxWidth);
-    }
-
     public boolean setBoundingBoxHeight(float height) {
         if (height != boundingBoxHeight) {
             boundingBoxHeight = height;

--- a/core/src/main/java/org/geysermc/geyser/entity/type/Entity.java
+++ b/core/src/main/java/org/geysermc/geyser/entity/type/Entity.java
@@ -427,6 +427,15 @@ public class Entity {
         setBoundingBoxWidth(definition.width());
     }
 
+    /**
+     * Since 1.19.40, the client must be re-informed of its bounding box on respawn
+     * See https://github.com/GeyserMC/Geyser/issues/3370
+     */
+    public void refreshBoundingBox() {
+        dirtyMetadata.put(EntityData.BOUNDING_BOX_HEIGHT, boundingBoxHeight);
+        dirtyMetadata.put(EntityData.BOUNDING_BOX_WIDTH, boundingBoxWidth);
+    }
+
     public boolean setBoundingBoxHeight(float height) {
         if (height != boundingBoxHeight) {
             boundingBoxHeight = height;

--- a/core/src/main/java/org/geysermc/geyser/entity/type/player/SessionPlayerEntity.java
+++ b/core/src/main/java/org/geysermc/geyser/entity/type/player/SessionPlayerEntity.java
@@ -124,9 +124,10 @@ public class SessionPlayerEntity extends PlayerEntity {
      * Since 1.19.40, the client must be re-informed of its bounding box on respawn
      * See https://github.com/GeyserMC/Geyser/issues/3370
      */
-    public void refreshBoundingBox() {
+    public void updateBoundingBox() {
         dirtyMetadata.put(EntityData.BOUNDING_BOX_HEIGHT, getBoundingBoxHeight());
         dirtyMetadata.put(EntityData.BOUNDING_BOX_WIDTH, getBoundingBoxWidth());
+        updateBedrockMetadata();
     }
 
     @Override

--- a/core/src/main/java/org/geysermc/geyser/entity/type/player/SessionPlayerEntity.java
+++ b/core/src/main/java/org/geysermc/geyser/entity/type/player/SessionPlayerEntity.java
@@ -120,6 +120,15 @@ public class SessionPlayerEntity extends PlayerEntity {
         refreshSpeed = true;
     }
 
+    /**
+     * Since 1.19.40, the client must be re-informed of its bounding box on respawn
+     * See https://github.com/GeyserMC/Geyser/issues/3370
+     */
+    public void refreshBoundingBox() {
+        dirtyMetadata.put(EntityData.BOUNDING_BOX_HEIGHT, getBoundingBoxHeight());
+        dirtyMetadata.put(EntityData.BOUNDING_BOX_WIDTH, getBoundingBoxWidth());
+    }
+
     @Override
     public boolean setBoundingBoxHeight(float height) {
         if (super.setBoundingBoxHeight(height)) {

--- a/core/src/main/java/org/geysermc/geyser/translator/protocol/bedrock/entity/player/BedrockActionTranslator.java
+++ b/core/src/main/java/org/geysermc/geyser/translator/protocol/bedrock/entity/player/BedrockActionTranslator.java
@@ -78,7 +78,6 @@ public class BedrockActionTranslator extends PacketTranslator<PlayerActionPacket
 
                 // Bounding box must be sent after a player dies and respawns since 1.19.40
                 entity.refreshBoundingBox();
-                entity.updateBedrockMetadata();
                 break;
             case START_SWIMMING:
                 if (!entity.getFlag(EntityFlag.SWIMMING)) {

--- a/core/src/main/java/org/geysermc/geyser/translator/protocol/bedrock/entity/player/BedrockActionTranslator.java
+++ b/core/src/main/java/org/geysermc/geyser/translator/protocol/bedrock/entity/player/BedrockActionTranslator.java
@@ -77,7 +77,7 @@ public class BedrockActionTranslator extends PacketTranslator<PlayerActionPacket
                 session.sendUpstreamPacket(attributesPacket);
 
                 // Bounding box must be sent after a player dies and respawns since 1.19.40
-                entity.refreshBoundingBox();
+                entity.updateBoundingBox();
                 break;
             case START_SWIMMING:
                 if (!entity.getFlag(EntityFlag.SWIMMING)) {

--- a/core/src/main/java/org/geysermc/geyser/translator/protocol/bedrock/entity/player/BedrockActionTranslator.java
+++ b/core/src/main/java/org/geysermc/geyser/translator/protocol/bedrock/entity/player/BedrockActionTranslator.java
@@ -75,6 +75,10 @@ public class BedrockActionTranslator extends PacketTranslator<PlayerActionPacket
                 attributesPacket.setRuntimeEntityId(entity.getGeyserId());
                 attributesPacket.getAttributes().addAll(entity.getAttributes().values());
                 session.sendUpstreamPacket(attributesPacket);
+
+                // Bounding box must be sent after a player dies and respawns since 1.19.40
+                entity.refreshBoundingBox();
+                entity.updateBedrockMetadata();
                 break;
             case START_SWIMMING:
                 if (!entity.getFlag(EntityFlag.SWIMMING)) {


### PR DESCRIPTION
Thanks to chris for looking into the differences in `SetEntityDataPacket` for BDS vs Geyser: https://paste.gg/p/anonymous/c9d62e15f69149e2973aa19c209ef0d4

This fixes the issue where 1.19.40 players are generally glitchy around anything that isn't flat ground.

Fixes #3370