### PR TITLE
Remove block state version, Add unknown mapping when no bedrock id is found for a given java id

### DIFF
--- a/core/src/main/java/org/geysermc/geyser/entity/type/ItemFrameEntity.java
+++ b/core/src/main/java/org/geysermc/geyser/entity/type/ItemFrameEntity.java
@@ -81,9 +81,7 @@ public class ItemFrameEntity extends Entity {
     public ItemFrameEntity(GeyserSession session, int entityId, long geyserId, UUID uuid, EntityDefinition<?> definition, Vector3f position, Vector3f motion, float yaw, float pitch, float headYaw, Direction direction) {
         super(session, entityId, geyserId, uuid, definition, position, motion, yaw, pitch, headYaw);
 
-        NbtMapBuilder blockBuilder = NbtMap.builder()
-                .putString("name", this.definition.entityType() == EntityType.GLOW_ITEM_FRAME ? "minecraft:glow_frame" : "minecraft:frame")
-                .putInt("version", session.getBlockMappings().getBlockStateVersion());
+        NbtMapBuilder blockBuilder = NbtMap.builder().putString("name", this.definition.entityType() == EntityType.GLOW_ITEM_FRAME ? "minecraft:glow_frame" : "minecraft:frame");
         NbtMapBuilder statesBuilder = NbtMap.builder()
                 .putInt("facing_direction", direction.ordinal())
                 .putByte("item_frame_map_bit", (byte) 0)

--- a/core/src/main/java/org/geysermc/geyser/registry/populator/ItemRegistryPopulator.java
+++ b/core/src/main/java/org/geysermc/geyser/registry/populator/ItemRegistryPopulator.java
@@ -547,6 +547,11 @@ public class ItemRegistryPopulator {
                 throw new RuntimeException("Lodestone compass not found in item palette!");
             }
 
+            int unknownId = entries.get("minecraft:unknown").getId();
+            if (unknownId == 0) {
+                throw new RuntimeException("Unknown not found in item palette!");
+            }
+
             // Add the lodestone compass since it doesn't exist on java but we need it for item conversion
             ItemMapping lodestoneEntry = ItemMapping.builder()
                     .javaIdentifier("")
@@ -556,6 +561,16 @@ public class ItemRegistryPopulator {
                     .bedrockData(0)
                     .bedrockBlockId(-1)
                     .stackSize(1)
+                    .customItemOptions(Collections.emptyList())
+                    .build();
+            ItemMapping unknownEntry = ItemMapping.builder()
+                    .javaIdentifier("")
+                    .bedrockIdentifier("minecraft:unknown")
+                    .javaId(-1)
+                    .bedrockId(unknownId)
+                    .bedrockData(0)
+                    .bedrockBlockId(-1)
+                    .stackSize(64)
                     .customItemOptions(Collections.emptyList())
                     .build();
 
@@ -658,6 +673,7 @@ public class ItemRegistryPopulator {
                     .carpets(carpets)
                     .componentItemData(componentItemData)
                     .lodestoneCompass(lodestoneEntry)
+                    .unknown(unknownEntry)
                     .customIdMappings(customIdMappings)
                     .build();
 

--- a/core/src/main/java/org/geysermc/geyser/registry/type/BlockMappings.java
+++ b/core/src/main/java/org/geysermc/geyser/registry/type/BlockMappings.java
@@ -40,8 +40,7 @@ public class BlockMappings {
     int bedrockAirId;
     int bedrockWaterId;
     int bedrockMovingBlockId;
-
-    int blockStateVersion;
+    int bedrockUnknownId;
 
     int[] javaToBedrockBlocks;
 
@@ -56,7 +55,7 @@ public class BlockMappings {
 
     public int getBedrockBlockId(int state) {
         if (state >= this.javaToBedrockBlocks.length) {
-            return bedrockAirId;
+            return bedrockUnknownId;
         }
         return this.javaToBedrockBlocks[state];
     }

--- a/core/src/main/java/org/geysermc/geyser/registry/type/ItemMappings.java
+++ b/core/src/main/java/org/geysermc/geyser/registry/type/ItemMappings.java
@@ -54,6 +54,7 @@ public class ItemMappings {
      * A unique exception as this is an item in Bedrock, but not in Java.
      */
     ItemMapping lodestoneCompass;
+    ItemMapping unknown;
 
     ItemData[] creativeItems;
     List<StartGamePacket.ItemEntry> itemEntries;
@@ -90,7 +91,7 @@ public class ItemMappings {
      */
     @Nonnull
     public ItemMapping getMapping(int javaId) {
-        return javaId >= 0 && javaId < this.items.length ? this.items[javaId] : ItemMapping.AIR;
+        return javaId >= 0 && javaId < this.items.length ? this.items[javaId] : unknown;
     }
 
     /**


### PR DESCRIPTION
# Description

Remove block state version, because it is always constant (otherwise the world would be corrupted anyway), and it isn't sent by vanilla for persistent block state.

Add unknown blocks/items as fallback, when no bedrock id is associated to a Java Id instead of air, because air would cause players to get stuck in invisible blocks, and items can fill up the inventory and the player can't remove them from the inventory.
They also indicate that there is something wrong and doesn't just result in a bugged out behavior.

# Testing

Can be tested by removing a mapping for a block or item.