### PR TITLE
Improve behavior of block items overridden by custom items

### DIFF
--- a/core/src/main/java/org/geysermc/geyser/registry/populator/CustomItemRegistryPopulator.java
+++ b/core/src/main/java/org/geysermc/geyser/registry/populator/CustomItemRegistryPopulator.java
@@ -124,6 +124,10 @@ public class CustomItemRegistryPopulator {
             computeArmorProperties(mapping.getArmorType(), mapping.getProtectionValue(), componentBuilder);
         }
 
+        if (mapping.getFirstBlockRuntimeId() != null) {
+            computeBlockItemProperties(mapping.getBedrockIdentifier(), componentBuilder);
+        }
+
         computeRenderOffsets(false, customItemData, componentBuilder);
 
         componentBuilder.putCompound("item_properties", itemProperties.build());
@@ -258,6 +262,15 @@ public class CustomItemRegistryPopulator {
                 componentBuilder.putCompound("minecraft:armor", NbtMap.builder().putInt("protection", protectionValue).build());
             }
         }
+    }
+
+    private static void computeBlockItemProperties(String blockItem, NbtMapBuilder componentBuilder) {
+        // carved pumpkin should be able to be worn and for that we would need to add wearable and armor with protection 0 here
+        // however this would have the side effect of preventing carved pumpkins from working as an attachable on the RP side outside the head slot
+        // it also causes the item to glitch when right clicked to "equip" so this should only be added here later if these issues can be overcome
+
+        // all block items registered should be given this component to prevent double placement
+        componentBuilder.putCompound("minecraft:block_placer", NbtMap.builder().putString("block", blockItem).build());
     }
 
     private static void computeRenderOffsets(boolean isHat, CustomItemData customItemData, NbtMapBuilder componentBuilder) {


### PR DESCRIPTION
Currently, when a block item (e.g. `minecraft:carved_pumpkin`) is overridden by a registered custom item (e.g. `minecraft:carved_pumpkin{CustomModelData:1}`), placement is glitchy and results in a double placement due to the client not expecting the custom item to place a block.

This PR adds the component `minecraft:block_placer` to all registered custom items that override block items, which resolves the above issue.

I also note that for translating block items to custom items we should make the carved pumpkin wearable so the player can place it in their head. However, I am not comfortable adding this at the moment due to the issues introduced by the only solution I could think of at the moment (adding the armor and wearable components for the item) lead to the issue of attachables not working on the RP side and glitchy behavior when right clicking the carved pumpkin. The former is due to client hard coded behavior when wearable or armor components are specified and the latter is due to the client expecting all items with the armor component to be equip-able via right click. 