### PR TITLE
Option to specify the "unusable inventory space" item

### DIFF
--- a/core/src/main/java/org/geysermc/geyser/configuration/GeyserConfiguration.java
+++ b/core/src/main/java/org/geysermc/geyser/configuration/GeyserConfiguration.java
@@ -111,6 +111,8 @@ public interface GeyserConfiguration {
 
     boolean isNotifyOnNewBedrockUpdate();
 
+    String getUnusableSpaceBlock();
+
     IMetricsInfo getMetrics();
 
     int getPendingAuthenticationTimeout();

--- a/core/src/main/java/org/geysermc/geyser/configuration/GeyserJacksonConfiguration.java
+++ b/core/src/main/java/org/geysermc/geyser/configuration/GeyserJacksonConfiguration.java
@@ -154,6 +154,9 @@ public abstract class GeyserJacksonConfiguration implements GeyserConfiguration 
     @JsonProperty("notify-on-new-bedrock-update")
     private boolean notifyOnNewBedrockUpdate = true;
 
+    @JsonProperty("unusable-space-block")
+    private String unusableSpaceBlock = "minecraft:barrier";
+
     private MetricsInfo metrics = new MetricsInfo();
 
     @JsonProperty("pending-authentication-timeout")

--- a/core/src/main/java/org/geysermc/geyser/util/InventoryUtils.java
+++ b/core/src/main/java/org/geysermc/geyser/util/InventoryUtils.java
@@ -193,7 +193,7 @@ public class InventoryUtils {
     private static int getUnusableSpaceBlockID(int protocolVersion) {
         String unusableSpaceBlock = GeyserImpl.getInstance().getConfig().getUnusableSpaceBlock();
         ItemMapping unusableSpaceBlockID = Registries.ITEMS.forVersion(protocolVersion).getMapping(unusableSpaceBlock);
-        if (unusableSpaceBlockID != null){
+        if (unusableSpaceBlockID != null) {
             return unusableSpaceBlockID.getBedrockId();
         } else {
             GeyserImpl.getInstance().getLogger().error("Invalid value" + unusableSpaceBlock + ". Resorting to barrier block.");

--- a/core/src/main/java/org/geysermc/geyser/util/InventoryUtils.java
+++ b/core/src/main/java/org/geysermc/geyser/util/InventoryUtils.java
@@ -38,6 +38,7 @@ import com.nukkitx.protocol.bedrock.data.inventory.ContainerId;
 import com.nukkitx.protocol.bedrock.data.inventory.ItemData;
 import com.nukkitx.protocol.bedrock.packet.InventorySlotPacket;
 import com.nukkitx.protocol.bedrock.packet.PlayerHotbarPacket;
+import org.geysermc.geyser.GeyserImpl;
 import org.geysermc.geyser.inventory.Container;
 import org.geysermc.geyser.inventory.GeyserItemStack;
 import org.geysermc.geyser.inventory.Inventory;
@@ -184,9 +185,20 @@ public class InventoryUtils {
 
         root.put("display", display.build());
         return protocolVersion -> ItemData.builder()
-                .id(Registries.ITEMS.forVersion(protocolVersion).getStoredItems().barrier().getBedrockId())
+                .id(getUnusableSpaceBlockID(protocolVersion))
                 .count(1)
                 .tag(root.build()).build();
+    }
+
+    private static int getUnusableSpaceBlockID(int protocolVersion){
+        String unusableSpaceBlock = GeyserImpl.getInstance().getConfig().getUnusableSpaceBlock();
+        ItemMapping unusableSpaceBlockID = Registries.ITEMS.forVersion(protocolVersion).getMapping(unusableSpaceBlock);
+        if (unusableSpaceBlockID != null){
+            return unusableSpaceBlockID.getBedrockId();
+        } else {
+            GeyserImpl.getInstance().getLogger().error("Invalid value" + unusableSpaceBlock + ". Resorting to barrier block.");
+            return Registries.ITEMS.forVersion(protocolVersion).getStoredItems().barrier().getBedrockId();
+        }
     }
 
     /**

--- a/core/src/main/java/org/geysermc/geyser/util/InventoryUtils.java
+++ b/core/src/main/java/org/geysermc/geyser/util/InventoryUtils.java
@@ -190,7 +190,7 @@ public class InventoryUtils {
                 .tag(root.build()).build();
     }
 
-    private static int getUnusableSpaceBlockID(int protocolVersion){
+    private static int getUnusableSpaceBlockID(int protocolVersion) {
         String unusableSpaceBlock = GeyserImpl.getInstance().getConfig().getUnusableSpaceBlock();
         ItemMapping unusableSpaceBlockID = Registries.ITEMS.forVersion(protocolVersion).getMapping(unusableSpaceBlock);
         if (unusableSpaceBlockID != null){

--- a/core/src/main/resources/config.yml
+++ b/core/src/main/resources/config.yml
@@ -183,6 +183,10 @@ log-player-ip-addresses: true
 # auto-update.
 notify-on-new-bedrock-update: true
 
+# Which item to use to mark unavailable slots in a Bedrock player inventory. Examples of this are the 2x2 crafting grid while in creative,
+# or custom inventory menus with sizes different from the usual 3x9. A barrier block is the default item.
+unusable-space-block: minecraft:barrier
+
 # bStats is a stat tracker that is entirely anonymous and tracks only basic information
 # about Geyser, such as how many people are online, how many servers are using Geyser,
 # what OS is being used, etc. You can learn more about bStats here: https://bstats.org/.


### PR DESCRIPTION
My first Geyser PR, so please correct mistakes :D
I've added a config.yml setting to set a java item identifier as the unusable space item. If said item isn't available, it defaults to a barrier and throws an error.

Adds/Fixes https://github.com/GeyserMC/Geyser/issues/2495


