### PR TITLE
Bump jackson-databind to 2.14.0 (CVE-2022-42003)

### DIFF
--- a/build-logic/build.gradle.kts
+++ b/build-logic/build.gradle.kts
@@ -16,7 +16,7 @@ dependencies {
 
     // Within the gradle plugin classpath, there is a version conflict between loom and some other
     // plugin for databind. This fixes it: minimum 2.13.2 is required by loom.
-    implementation("com.fasterxml.jackson.core:jackson-databind:2.13.3")
+    implementation("com.fasterxml.jackson.core:jackson-databind:2.14.0")
 }
 
 tasks.withType<KotlinCompile> {

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,5 +1,5 @@
 [versions]
-jackson = "2.13.4"
+jackson = "2.14.0"
 fastutil = "8.5.2"
 netty = "4.1.80.Final"
 guava = "29.0-jre"


### PR DESCRIPTION
Bumps jackson-databind to 2.14.0 to resolve CVE-2022-42003. The current version 2.13 is vulnerable, and therefore should be updated (hence the Pull Request).

Thanks to Discord user "Albert C" for informing about this on the GeyserMC Discord server. Reference: https://discord.com/channels/613163671870242838/613170125696270357/1042258174792704033