### PR TITLE
Fix potion recipes not working on ViaVersion servers before the recipe book was introduced

### DIFF
--- a/core/src/main/java/org/geysermc/geyser/session/GeyserSession.java
+++ b/core/src/main/java/org/geysermc/geyser/session/GeyserSession.java
@@ -629,6 +629,12 @@ public class GeyserSession implements GeyserConnection, GeyserCommandSource {
         creativePacket.setContents(this.itemMappings.getCreativeItems());
         upstream.sendPacket(creativePacket);
 
+        // Potion mixes are registered by default, as they are needed to be able to put ingredients into the brewing stand.
+        CraftingDataPacket craftingDataPacket = new CraftingDataPacket();
+        craftingDataPacket.setCleanRecipes(true);
+        craftingDataPacket.getPotionMixData().addAll(Registries.POTION_MIXES.get());
+        upstream.sendPacket(craftingDataPacket);
+
         PlayStatusPacket playStatusPacket = new PlayStatusPacket();
         playStatusPacket.setStatus(PlayStatusPacket.Status.PLAYER_SPAWN);
         upstream.sendPacket(playStatusPacket);


### PR DESCRIPTION
# Description
On servers before the recipe book was introduced, and use ViaVersion, no recipe packet is sent and thus none of the potion recipes are set, even if they always exist, which causes the potion brewing doesn't work. This pr will always sent default recipes which don't need registration.

# Testing
Can be tested with Spigot 1.8.9 until 1.11.2, by trying to brew potions, where it is not possible to use ingredients.