### PR TITLE
Add option to hide the version in the ping response, add option to disable query/UT3 protocol

### DIFF
--- a/core/src/main/java/org/geysermc/geyser/configuration/GeyserConfiguration.java
+++ b/core/src/main/java/org/geysermc/geyser/configuration/GeyserConfiguration.java
@@ -53,6 +53,10 @@ public interface GeyserConfiguration {
 
     boolean isCommandSuggestions();
 
+    boolean isEnableQuery();
+
+    boolean isHideVersion();
+
     @JsonIgnore
     boolean isPassthroughMotd();
 

--- a/core/src/main/java/org/geysermc/geyser/configuration/GeyserJacksonConfiguration.java
+++ b/core/src/main/java/org/geysermc/geyser/configuration/GeyserJacksonConfiguration.java
@@ -75,6 +75,12 @@ public abstract class GeyserJacksonConfiguration implements GeyserConfiguration 
     @JsonProperty("command-suggestions")
     private boolean commandSuggestions = true;
 
+    @JsonProperty("enable-query")
+    private boolean isEnableQuery = true;
+
+    @JsonProperty("hide-version")
+    private boolean isHideVersion = false;
+
     @JsonProperty("passthrough-motd")
     private boolean isPassthroughMotd = false;
 

--- a/core/src/main/resources/config.yml
+++ b/core/src/main/resources/config.yml
@@ -84,6 +84,10 @@ pending-authentication-timeout: 120
 # Disabling this will prevent command suggestions from being sent and solve freezing for Bedrock clients.
 command-suggestions: true
 
+# Enables support for the Java Edition Query Protocol, which is running on the same port as the Bedrock server.
+enable-query: true
+# Hides the version in ping, which is normally be appended as " - 1.x.x".
+hide-version: false
 # The following three options enable "ping passthrough" - the MOTD, player count and/or protocol name gets retrieved from the Java server.
 # Relay the MOTD from the remote server to Bedrock players.
 passthrough-motd: false


### PR DESCRIPTION
# Description
Add an option to hide the version, which might be useful to free-up additional space, when no version is sent the " - ..." will also be omitted.
Add an option to disable the query/UT3 protocol, because some services could think that this an Java Edition server as it is not a Bedrock Feature.

By default this PR doesn't change any behavior, if the config is not modified.

# Testing