### PR TITLE
Fully strip formatting from chat and commands

### DIFF
--- a/core/src/main/java/org/geysermc/geyser/inventory/AnvilContainer.java
+++ b/core/src/main/java/org/geysermc/geyser/inventory/AnvilContainer.java
@@ -76,7 +76,7 @@ public class AnvilContainer extends Container {
         String originalName = ItemUtils.getCustomName(getInput().getNbt());
 
         String plainOriginalName = MessageTranslator.convertToPlainText(originalName, session.locale());
-        String plainNewName = MessageTranslator.convertToPlainText(rename, session.locale());
+        String plainNewName = MessageTranslator.convertToPlainText(rename);
         if (!plainOriginalName.equals(plainNewName)) {
             // Strip out formatting since Java Edition does not allow it
             correctRename = plainNewName;

--- a/core/src/main/java/org/geysermc/geyser/translator/protocol/bedrock/BedrockCommandRequestTranslator.java
+++ b/core/src/main/java/org/geysermc/geyser/translator/protocol/bedrock/BedrockCommandRequestTranslator.java
@@ -29,6 +29,7 @@ import com.nukkitx.protocol.bedrock.packet.CommandRequestPacket;
 import org.geysermc.common.PlatformType;
 import org.geysermc.geyser.GeyserImpl;
 import org.geysermc.geyser.session.GeyserSession;
+import org.geysermc.geyser.text.ChatColor;
 import org.geysermc.geyser.translator.protocol.PacketTranslator;
 import org.geysermc.geyser.translator.protocol.Translator;
 import org.geysermc.geyser.translator.text.MessageTranslator;
@@ -38,16 +39,14 @@ public class BedrockCommandRequestTranslator extends PacketTranslator<CommandReq
 
     @Override
     public void translate(GeyserSession session, CommandRequestPacket packet) {
-        String command = packet.getCommand().replace("/", "");
+        String command = MessageTranslator.convertToPlainText(packet.getCommand());
         if (!(session.getGeyser().getPlatformType() == PlatformType.STANDALONE
-                && GeyserImpl.getInstance().commandManager().runCommand(session, command))) {
-            String message = packet.getCommand().trim();
-
-            if (MessageTranslator.isTooLong(message, session)) {
+                && GeyserImpl.getInstance().commandManager().runCommand(session, command.substring(1)))) {
+            if (MessageTranslator.isTooLong(command, session)) {
                 return;
             }
 
-            session.sendCommand(message.substring(1));
+            session.sendCommand(command.substring(1));
         }
     }
 }

--- a/core/src/main/java/org/geysermc/geyser/translator/protocol/bedrock/BedrockTextTranslator.java
+++ b/core/src/main/java/org/geysermc/geyser/translator/protocol/bedrock/BedrockTextTranslator.java
@@ -37,21 +37,7 @@ public class BedrockTextTranslator extends PacketTranslator<TextPacket> {
 
     @Override
     public void translate(GeyserSession session, TextPacket packet) {
-        String message = packet.getMessage();
-
-        // The order here is important - strip out illegal characters first, then check if it's blank
-        // (in case the message is blank after removing)
-        if (message.indexOf(ChatColor.ESCAPE) != -1) {
-            // Filter out all escape characters - Java doesn't let you type these
-            StringBuilder builder = new StringBuilder();
-            for (int i = 0; i < message.length(); i++) {
-                char c = message.charAt(i);
-                if (c != ChatColor.ESCAPE) {
-                    builder.append(c);
-                }
-            }
-            message = builder.toString();
-        }
+        String message = MessageTranslator.convertToPlainText(packet.getMessage());
 
         if (message.isBlank()) {
             // Java Edition (as of 1.17.1) just doesn't pass on these messages, so... we won't either!

--- a/core/src/main/java/org/geysermc/geyser/translator/text/MessageTranslator.java
+++ b/core/src/main/java/org/geysermc/geyser/translator/text/MessageTranslator.java
@@ -201,6 +201,28 @@ public class MessageTranslator {
         return GSON_SERIALIZER.serialize(component);
     }
 
+
+    /**
+     * Convert legacy format message to plain text
+     *
+     * @param message Message to convert
+     * @return The plain text of the message
+     */
+    public static String convertToPlainText(String message) {
+        char[] input = message.toCharArray();
+        char[] output = new char[input.length];
+        int outputSize = 0;
+        for (int i = 0, inputLength = input.length; i < inputLength; i++) {
+            char c = input[i];
+            if (c == '§') {
+                i++;
+            } else {
+                output[outputSize++] = c;
+            }
+        }
+        return new String(output, 0, outputSize);
+    }
+
     /**
      * Convert JSON and legacy format message to plain text
      *

--- a/core/src/main/java/org/geysermc/geyser/translator/text/MessageTranslator.java
+++ b/core/src/main/java/org/geysermc/geyser/translator/text/MessageTranslator.java
@@ -214,7 +214,7 @@ public class MessageTranslator {
         int outputSize = 0;
         for (int i = 0, inputLength = input.length; i < inputLength; i++) {
             char c = input[i];
-            if (c == '§') {
+            if (c == ChatColor.ESCAPE) {
                 i++;
             } else {
                 output[outputSize++] = c;

--- a/core/src/test/java/org/geysermc/geyser/network/translators/chat/MessageTranslatorTest.java
+++ b/core/src/test/java/org/geysermc/geyser/network/translators/chat/MessageTranslatorTest.java
@@ -85,6 +85,7 @@ public class MessageTranslatorTest {
     @Test
     public void convertToPlainText() {
         Assert.assertEquals("JSON message is not handled properly", "Many colors here", MessageTranslator.convertToPlainText("{\"extra\":[{\"color\":\"red\",\"text\":\"M\"},{\"color\":\"gold\",\"text\":\"a\"},{\"color\":\"yellow\",\"text\":\"n\"},{\"color\":\"green\",\"text\":\"y \"},{\"color\":\"aqua\",\"text\":\"c\"},{\"color\":\"dark_purple\",\"text\":\"o\"},{\"color\":\"red\",\"text\":\"l\"},{\"color\":\"gold\",\"text\":\"o\"},{\"color\":\"yellow\",\"text\":\"r\"},{\"color\":\"green\",\"text\":\"s \"},{\"color\":\"aqua\",\"text\":\"h\"},{\"color\":\"dark_purple\",\"text\":\"e\"},{\"color\":\"red\",\"text\":\"r\"},{\"color\":\"gold\",\"text\":\"e\"}],\"text\":\"\"}", "en_US"));
+        Assert.assertEquals("Legacy formatted message is not handled properly (Colors)", "Many colors here", MessageTranslator.convertToPlainText("§cM§6a§en§ay §bc§5o§cl§6o§er§as §bh§5e§cr§6e"));
         Assert.assertEquals("Legacy formatted message is not handled properly (Colors)", "Many colors here", MessageTranslator.convertToPlainText("§cM§6a§en§ay §bc§5o§cl§6o§er§as §bh§5e§cr§6e", "en_US"));
         Assert.assertEquals("Legacy formatted message is not handled properly (Style)", "Obf Bold Strikethrough Underline Italic Reset", MessageTranslator.convertToPlainText("§kObf §lBold §mStrikethrough §nUnderline §oItalic §rReset", "en_US"));
         Assert.assertEquals("Valid lenient JSON is not handled properly", "Strange", MessageTranslator.convertToPlainText("§rStrange", "en_US"));


### PR DESCRIPTION
# Description
Fully strip formatting in chat and commands like it is already done when using anvil renaming. And use a more precise function, which doesn't looks if its json, because these messages should not be able to be interpreted as json. (can be misused)

# Testing