### PR TITLE
Fix haste effect being scaled differently in Bedrock

### DIFF
--- a/core/src/main/java/org/geysermc/geyser/translator/protocol/java/entity/JavaUpdateMobEffectTranslator.java
+++ b/core/src/main/java/org/geysermc/geyser/translator/protocol/java/entity/JavaUpdateMobEffectTranslator.java
@@ -25,6 +25,7 @@
 
 package org.geysermc.geyser.translator.protocol.java.entity;
 
+import com.github.steveice10.mc.protocol.data.game.entity.Effect;
 import com.github.steveice10.mc.protocol.packet.ingame.clientbound.entity.ClientboundUpdateMobEffectPacket;
 import com.nukkitx.protocol.bedrock.packet.MobEffectPacket;
 import org.geysermc.geyser.entity.type.Entity;
@@ -32,6 +33,7 @@ import org.geysermc.geyser.session.GeyserSession;
 import org.geysermc.geyser.translator.protocol.PacketTranslator;
 import org.geysermc.geyser.translator.protocol.Translator;
 import org.geysermc.geyser.util.EntityUtils;
+import org.geysermc.geyser.util.MathUtils;
 
 @Translator(packet = ClientboundUpdateMobEffectPacket.class)
 public class JavaUpdateMobEffectTranslator extends PacketTranslator<ClientboundUpdateMobEffectPacket> {
@@ -45,8 +47,13 @@ public class JavaUpdateMobEffectTranslator extends PacketTranslator<ClientboundU
         if (entity == null)
             return;
 
+        // There is no nearest equivalent for haste 0, and is therefore ignored
+        if (packet.getEffect() == Effect.HASTE && packet.getAmplifier() == 0) {
+            return;
+        }
+
         MobEffectPacket mobEffectPacket = new MobEffectPacket();
-        mobEffectPacket.setAmplifier(packet.getAmplifier());
+        mobEffectPacket.setAmplifier(packet.getEffect() != Effect.HASTE ? packet.getAmplifier() : MathUtils.floorLog2(packet.getAmplifier()) - 1);
         mobEffectPacket.setDuration(packet.getDuration());
         mobEffectPacket.setEvent(MobEffectPacket.Event.ADD);
         mobEffectPacket.setRuntimeEntityId(entity.getGeyserId());

--- a/core/src/main/java/org/geysermc/geyser/util/MathUtils.java
+++ b/core/src/main/java/org/geysermc/geyser/util/MathUtils.java
@@ -148,4 +148,31 @@ public class MathUtils {
     public static int getGlobalPaletteForSize(int size) {
         return 32 - Integer.numberOfLeadingZeros(size - 1);
     }
+
+    /**
+     * Returns the binary logarithm of the given value, rounded down.
+     *
+     * @param value the value to get the logb from
+     * @return the binary logarithm of the value, rounded down
+     */
+    public static int floorLog2(int value) {
+        int log = 0;
+        if (value > 0xffff) {
+            value >>>= 16;
+            log = 16;
+        }
+        if (value > 0xff) {
+            value >>>= 8;
+            log |= 8;
+        }
+        if (value > 0xf) {
+            value >>>= 4;
+            log |= 4;
+        }
+        if (value > 0b11) {
+            value >>>= 2;
+            log |= 2;
+        }
+        return log + (value >>> 1);
+    }
 }


### PR DESCRIPTION
Bedrock has a different scaling for haste compared to Java, which means that all anti-cheats with mining-speed detection will flag players when they have haste.

Scaling comparison
haste lvl - java time - bedrock time - difference
[] 7.85 7.74 0.11
-- diff 1.36 2.21
0 6.49 5.53 0.96
-- diff 0.81 1.64
1 5.68 3.89 1.79
-- diff 0.71 1.14
2 4.97 2.75 2.22
-- diff 0.48 0.76
3 4.49 1.99 2.5
-- diff 0.46 0.53
4 4.03 1.46 2.57
-- diff 0.31 0.27
5 3.72 1.19 2.53
...
20 1.44 0.00 1.44
(manually measured)