### PR TITLE
Fix wrong render distance calculation

### DIFF
--- a/core/src/main/java/org/geysermc/geyser/session/GeyserSession.java
+++ b/core/src/main/java/org/geysermc/geyser/session/GeyserSession.java
@@ -1378,7 +1378,6 @@ public class GeyserSession implements GeyserConnection, GeyserCommandSource {
     }
 
     public void setServerRenderDistance(int renderDistance) {
-        renderDistance = GenericMath.ceil(++renderDistance * MathUtils.SQRT_OF_TWO); //square to circle
         this.serverRenderDistance = renderDistance;
 
         ChunkRadiusUpdatedPacket chunkRadiusUpdatedPacket = new ChunkRadiusUpdatedPacket();

--- a/core/src/main/java/org/geysermc/geyser/translator/protocol/java/entity/player/JavaPlayerPositionTranslator.java
+++ b/core/src/main/java/org/geysermc/geyser/translator/protocol/java/entity/player/JavaPlayerPositionTranslator.java
@@ -85,7 +85,7 @@ public class JavaPlayerPositionTranslator extends PacketTranslator<ClientboundPl
 
             acceptTeleport(session, packet.getX(), packet.getY(), packet.getZ(), packet.getYaw(), packet.getPitch(), packet.getTeleportId());
 
-            if (session.getServerRenderDistance() > 47 && !session.isEmulatePost1_13Logic()) {
+            if (session.getServerRenderDistance() > 32 && !session.isEmulatePost1_13Logic()) {
                 // See DimensionUtils for an explanation
                 ChunkRadiusUpdatedPacket chunkRadiusUpdatedPacket = new ChunkRadiusUpdatedPacket();
                 chunkRadiusUpdatedPacket.setRadius(session.getServerRenderDistance());

--- a/core/src/main/java/org/geysermc/geyser/util/DimensionUtils.java
+++ b/core/src/main/java/org/geysermc/geyser/util/DimensionUtils.java
@@ -75,18 +75,17 @@ public class DimensionUtils {
         session.getPistonCache().clear();
         session.getSkullCache().clear();
 
-        if (session.getServerRenderDistance() > 47 && !session.isEmulatePost1_13Logic()) {
+        if (session.getServerRenderDistance() > 32 && !session.isEmulatePost1_13Logic()) {
             // The server-sided view distance wasn't a thing until Minecraft Java 1.14
             // So ViaVersion compensates by sending a "view distance" of 64
             // That's fine, except when the actual view distance sent from the server is five chunks
             // The client locks up when switching dimensions, expecting more chunks than it's getting
             // To solve this, we cap at 32 unless we know that the render distance actually exceeds 32
-            // 47 is the Bedrock equivalent of 32
             // Also, as of 1.19: PS4 crashes with a ChunkRadiusUpdatedPacket too large
             session.getGeyser().getLogger().debug("Applying dimension switching workaround for Bedrock render distance of "
                     + session.getServerRenderDistance());
             ChunkRadiusUpdatedPacket chunkRadiusUpdatedPacket = new ChunkRadiusUpdatedPacket();
-            chunkRadiusUpdatedPacket.setRadius(47);
+            chunkRadiusUpdatedPacket.setRadius(32);
             session.sendUpstreamPacket(chunkRadiusUpdatedPacket);
             // Will be re-adjusted on spawn
         }


### PR DESCRIPTION
Currently the render distance is calculated by fitting a square into a circle, which is not the way how bedrock does interpret the render distance.

Which can be verified by removing the empty chunk sending in the chunk unload packet, because chunks don't get unloaded anymore at the edge, when directly using the square render distance, chunks getting unloaded as expected.

This also fixes the fog. See #3458

Had this fix already running for a month, without problems so far.