### PR TITLE
Fix chunk loading issues on Fabric and Spigot

### DIFF
--- a/core/src/main/java/org/geysermc/geyser/session/GeyserSession.java
+++ b/core/src/main/java/org/geysermc/geyser/session/GeyserSession.java
@@ -1402,6 +1402,10 @@ public class GeyserSession implements GeyserConnection, GeyserCommandSource {
     }
 
     public void setServerRenderDistance(int renderDistance) {
+        // +1 is for Fabric and Spigot
+        // Without the client misses loading some chunks per https://github.com/GeyserMC/Geyser/issues/3490
+        // Fog still appears essentially normally
+        renderDistance = renderDistance + 1;
         this.serverRenderDistance = renderDistance;
 
         ChunkRadiusUpdatedPacket chunkRadiusUpdatedPacket = new ChunkRadiusUpdatedPacket();


### PR DESCRIPTION
Seems that for whatever reason Fabric and Spigot need a bit of a buffer in the server render distance sent to the client, or the client will occasionally fail to render certain chunks. This seems to be completely resolved by adding one to the the render distance value sent to the client, but still maintains essentially the same appearance of fog, for which this change was initially implemented.

- See https://github.com/GeyserMC/Geyser/pull/3459
- Resolves https://github.com/GeyserMC/Geyser/issues/3490

Tested on Spigot and Fabric to ensure issue is fixed and Paper to ensure there are no adverse consequences. 