### PR TITLE
Add publishing to downloads site

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -67,16 +67,16 @@ pipeline {
             }
 
             steps {
-                withCredentials([sshUserPrivateKey(credentialsId: 'DOWNLOADS_PRIVATE_KEY', keyFileVariable: 'id_ecdsa')]) {
+                withCredentials([sshUserPrivateKey(credentialsId: 'DOWNLOADS_PRIVATE_KEY', keyFileVariable: 'id_ecdsa', usernameVariable: 'username'), string(credentialsId: 'DOWNLOADS_SERVER_IP', variable: 'server_ip')]) {
                     sh '''
                     # Get the version from gradle.properties
                     version=$(cat gradle.properties | grep -o "version=[0-9\\.]*" | cut -d"=" -f2)
 
                     # Copy over artifacts
-                    scp -B -o StrictHostKeyChecking=no -i ${id_ecdsa} bootstrap/**/build/libs/Geyser-*.jar build-upload@188.165.222.136:~/files/
+                    scp -B -o StrictHostKeyChecking=no -i ${id_ecdsa} bootstrap/**/build/libs/Geyser-*.jar ${username}@${server_ip}:~/files/
 
                     # Run the build script
-                    ssh -o StrictHostKeyChecking=no -i ${id_ecdsa} build-upload@188.165.222.136 ./handleBuild.sh geyser $version $BUILD_NUMBER $GIT_COMMIT
+                    ssh -o StrictHostKeyChecking=no -i ${id_ecdsa} ${username}@${server_ip} ./handleBuild.sh geyser $version $BUILD_NUMBER $GIT_COMMIT
                     '''
                 }
             }


### PR DESCRIPTION
Add a Jenkins stage to publish the built jars to https://download.geysermc.org/ via SSH

Test build:
Jenkins: https://ci.opencollab.dev/job/GeyserMC/job/Geyser/job/master/1284/
API: https://download.geysermc.org/v2/projects/geyser/versions/2.1.0/builds/1284