### PR TITLE
Apply fallback skins to custom skulls with invalid or empty texture values

### DIFF
--- a/core/src/main/java/org/geysermc/geyser/entity/type/player/SkullPlayerEntity.java
+++ b/core/src/main/java/org/geysermc/geyser/entity/type/player/SkullPlayerEntity.java
@@ -26,6 +26,7 @@
 package org.geysermc.geyser.entity.type.player;
 
 import com.nukkitx.math.vector.Vector3f;
+import com.nukkitx.math.vector.Vector3i;
 import com.nukkitx.protocol.bedrock.data.GameType;
 import com.nukkitx.protocol.bedrock.data.PlayerPermission;
 import com.nukkitx.protocol.bedrock.data.command.CommandPermission;
@@ -50,6 +51,9 @@ public class SkullPlayerEntity extends PlayerEntity {
 
     @Getter
     private UUID skullUUID;
+
+    @Getter
+    private Vector3i skullPosition;
 
     public SkullPlayerEntity(GeyserSession session, long geyserId) {
         super(session, 0, geyserId, UUID.randomUUID(), Vector3f.ZERO, Vector3f.ZERO, 0, 0, 0, "", null);
@@ -107,6 +111,8 @@ public class SkullPlayerEntity extends PlayerEntity {
     }
 
     public void updateSkull(SkullCache.Skull skull) {
+        skullPosition = skull.getPosition();
+
         if (!Objects.equals(skull.getTexturesProperty(), getTexturesProperty()) ||
             (skull.getTexturesProperty() == null && !Objects.equals(skullUUID, skull.getUuid()))) {
             // Make skull invisible as we change skins

--- a/core/src/main/java/org/geysermc/geyser/entity/type/player/SkullPlayerEntity.java
+++ b/core/src/main/java/org/geysermc/geyser/entity/type/player/SkullPlayerEntity.java
@@ -113,8 +113,7 @@ public class SkullPlayerEntity extends PlayerEntity {
     public void updateSkull(SkullCache.Skull skull) {
         skullPosition = skull.getPosition();
 
-        if (!Objects.equals(skull.getTexturesProperty(), getTexturesProperty()) ||
-            (skull.getTexturesProperty() == null && !Objects.equals(skullUUID, skull.getUuid()))) {
+        if (!Objects.equals(skull.getTexturesProperty(), getTexturesProperty()) || !Objects.equals(skullUUID, skull.getUuid())) {
             // Make skull invisible as we change skins
             setFlag(EntityFlag.INVISIBLE, true);
             updateBedrockMetadata();

--- a/core/src/main/java/org/geysermc/geyser/entity/type/player/SkullPlayerEntity.java
+++ b/core/src/main/java/org/geysermc/geyser/entity/type/player/SkullPlayerEntity.java
@@ -32,11 +32,13 @@ import com.nukkitx.protocol.bedrock.data.command.CommandPermission;
 import com.nukkitx.protocol.bedrock.data.entity.EntityData;
 import com.nukkitx.protocol.bedrock.data.entity.EntityFlag;
 import com.nukkitx.protocol.bedrock.packet.AddPlayerPacket;
+import lombok.Getter;
 import org.geysermc.geyser.level.block.BlockStateValues;
 import org.geysermc.geyser.session.GeyserSession;
 import org.geysermc.geyser.session.cache.SkullCache;
 import org.geysermc.geyser.skin.SkullSkinManager;
 
+import java.util.Objects;
 import java.util.UUID;
 import java.util.concurrent.TimeUnit;
 
@@ -45,6 +47,9 @@ import java.util.concurrent.TimeUnit;
  * custom player skulls in Bedrock.
  */
 public class SkullPlayerEntity extends PlayerEntity {
+
+    @Getter
+    private UUID skullUUID;
 
     public SkullPlayerEntity(GeyserSession session, long geyserId) {
         super(session, 0, geyserId, UUID.randomUUID(), Vector3f.ZERO, Vector3f.ZERO, 0, 0, 0, "", null);
@@ -102,11 +107,13 @@ public class SkullPlayerEntity extends PlayerEntity {
     }
 
     public void updateSkull(SkullCache.Skull skull) {
-        if (!skull.getTexturesProperty().equals(getTexturesProperty())) {
+        if (!Objects.equals(skull.getTexturesProperty(), getTexturesProperty()) ||
+            (skull.getTexturesProperty() == null && !Objects.equals(skullUUID, skull.getUuid()))) {
             // Make skull invisible as we change skins
             setFlag(EntityFlag.INVISIBLE, true);
             updateBedrockMetadata();
 
+            skullUUID = skull.getUuid();
             setTexturesProperty(skull.getTexturesProperty());
 
             SkullSkinManager.requestAndHandleSkin(this, session, (skin -> session.scheduleInEventLoop(() -> {

--- a/core/src/main/java/org/geysermc/geyser/session/cache/SkullCache.java
+++ b/core/src/main/java/org/geysermc/geyser/session/cache/SkullCache.java
@@ -71,8 +71,9 @@ public class SkullCache {
         this.skullRenderDistanceSquared = distance * distance;
     }
 
-    public void putSkull(Vector3i position, String texturesProperty, int blockState) {
+    public void putSkull(Vector3i position, UUID uuid, String texturesProperty, int blockState) {
         Skull skull = skulls.computeIfAbsent(position, Skull::new);
+        skull.uuid = uuid;
         skull.texturesProperty = texturesProperty;
         skull.blockState = blockState;
 
@@ -201,6 +202,7 @@ public class SkullCache {
     @RequiredArgsConstructor
     @Data
     public static class Skull {
+        private UUID uuid;
         private String texturesProperty;
         private int blockState;
         private SkullPlayerEntity entity;

--- a/core/src/main/java/org/geysermc/geyser/skin/SkinManager.java
+++ b/core/src/main/java/org/geysermc/geyser/skin/SkinManager.java
@@ -255,24 +255,29 @@ public class SkinManager {
          * @return The built GameProfileData
          */
         public static @Nullable GameProfileData from(PlayerEntity entity) {
-            try {
-                String texturesProperty = entity.getTexturesProperty();
+            String texturesProperty = entity.getTexturesProperty();
+            if (texturesProperty == null) {
+                // Likely offline mode
+                return null;
+            }
 
-                if (texturesProperty == null) {
-                    // Likely offline mode
-                    return null;
-                }
+            try {
                 return loadFromJson(texturesProperty);
             } catch (IOException exception) {
                 GeyserImpl.getInstance().getLogger().debug("Something went wrong while processing skin for " + entity.getUsername());
                 if (GeyserImpl.getInstance().getConfig().isDebugMode()) {
                     exception.printStackTrace();
                 }
-                return null;
+            } catch (IllegalArgumentException exception) {
+                GeyserImpl.getInstance().getLogger().debug("Texture property is invalid for " + entity.getUsername() + " Value: " + texturesProperty);
+                if (GeyserImpl.getInstance().getConfig().isDebugMode()) {
+                    exception.printStackTrace();
+                }
             }
+            return null;
         }
 
-        private static GameProfileData loadFromJson(String encodedJson) throws IOException {
+        private static GameProfileData loadFromJson(String encodedJson) throws IOException, IllegalArgumentException {
             JsonNode skinObject = GeyserImpl.JSON_MAPPER.readTree(new String(Base64.getDecoder().decode(encodedJson), StandardCharsets.UTF_8));
             JsonNode textures = skinObject.get("textures");
 

--- a/core/src/main/java/org/geysermc/geyser/skin/SkinManager.java
+++ b/core/src/main/java/org/geysermc/geyser/skin/SkinManager.java
@@ -290,14 +290,23 @@ public class SkinManager {
                 return null;
             }
 
-            String skinUrl = skinTexture.get("url").asText().replace("http://", "https://");
+            String skinUrl;
+            JsonNode skinUrlNode = skinTexture.get("url");
+            if (skinUrlNode != null && skinUrlNode.isTextual()) {
+                skinUrl = skinUrlNode.asText().replace("http://", "https://");
+            } else {
+                return null;
+            }
 
             boolean isAlex = skinTexture.has("metadata");
 
             String capeUrl = null;
             JsonNode capeTexture = textures.get("CAPE");
             if (capeTexture != null) {
-                capeUrl = capeTexture.get("url").asText().replace("http://", "https://");
+                JsonNode capeUrlNode = capeTexture.get("url");
+                if (capeUrlNode != null && capeUrlNode.isTextual()) {
+                    capeUrl = capeUrlNode.asText().replace("http://", "https://");
+                }
             }
 
             return new GameProfileData(skinUrl, capeUrl, isAlex);

--- a/core/src/main/java/org/geysermc/geyser/skin/SkinManager.java
+++ b/core/src/main/java/org/geysermc/geyser/skin/SkinManager.java
@@ -35,6 +35,7 @@ import com.nukkitx.protocol.bedrock.packet.PlayerListPacket;
 import com.nukkitx.protocol.bedrock.packet.PlayerSkinPacket;
 import org.geysermc.geyser.GeyserImpl;
 import org.geysermc.geyser.entity.type.player.PlayerEntity;
+import org.geysermc.geyser.entity.type.player.SkullPlayerEntity;
 import org.geysermc.geyser.session.GeyserSession;
 import org.geysermc.geyser.session.auth.BedrockClientData;
 import org.geysermc.geyser.text.GeyserLocale;
@@ -263,13 +264,12 @@ public class SkinManager {
 
             try {
                 return loadFromJson(texturesProperty);
-            } catch (IOException exception) {
-                GeyserImpl.getInstance().getLogger().debug("Something went wrong while processing skin for " + entity.getUsername());
-                if (GeyserImpl.getInstance().getConfig().isDebugMode()) {
-                    exception.printStackTrace();
+            } catch (Exception exception) {
+                if (entity instanceof SkullPlayerEntity skullEntity) {
+                    GeyserImpl.getInstance().getLogger().debug("Something went wrong while processing skin for skull at " + skullEntity.getSkullPosition() + " with Value: " + texturesProperty);
+                } else {
+                    GeyserImpl.getInstance().getLogger().debug("Something went wrong while processing skin for " + entity.getUsername() + " with Value: " + texturesProperty);
                 }
-            } catch (IllegalArgumentException exception) {
-                GeyserImpl.getInstance().getLogger().debug("Texture property is invalid for " + entity.getUsername() + " Value: " + texturesProperty);
                 if (GeyserImpl.getInstance().getConfig().isDebugMode()) {
                     exception.printStackTrace();
                 }

--- a/core/src/main/java/org/geysermc/geyser/skin/SkinManager.java
+++ b/core/src/main/java/org/geysermc/geyser/skin/SkinManager.java
@@ -69,7 +69,7 @@ public class SkinManager {
             // The server either didn't have a texture to send, or we didn't have the texture ID cached.
             // Let's see if this player is a Bedrock player, and if so, let's pull their skin.
             // Otherwise, grab the default player skin
-            SkinProvider.SkinData fallbackSkinData = SkinProvider.determineFallbackSkinData(playerEntity);
+            SkinProvider.SkinData fallbackSkinData = SkinProvider.determineFallbackSkinData(playerEntity.getUuid());
             if (skin == null) {
                 skin = fallbackSkinData.skin();
                 geometry = fallbackSkinData.geometry();

--- a/core/src/main/java/org/geysermc/geyser/skin/SkullSkinManager.java
+++ b/core/src/main/java/org/geysermc/geyser/skin/SkullSkinManager.java
@@ -73,7 +73,7 @@ public class SkullSkinManager extends SkinManager {
         if (data == null) {
             GeyserImpl.getInstance().getLogger().debug("Using fallback skin for skull.");
             // No texture available, fallback using the UUID
-            SkinProvider.SkinData fallback = SkinProvider.determineFallbackSkinData(entity);
+            SkinProvider.SkinData fallback = SkinProvider.determineFallbackSkinData(entity.getSkullUUID());
             applySkin.accept(fallback.skin(), null);
         } else {
             SkinProvider.requestSkin(entity.getUuid(), data.skinUrl(), true)

--- a/core/src/main/java/org/geysermc/geyser/skin/SkullSkinManager.java
+++ b/core/src/main/java/org/geysermc/geyser/skin/SkullSkinManager.java
@@ -71,7 +71,7 @@ public class SkullSkinManager extends SkinManager {
 
         GameProfileData data = GameProfileData.from(entity);
         if (data == null) {
-            GeyserImpl.getInstance().getLogger().debug("Using fallback skin for skull.");
+            GeyserImpl.getInstance().getLogger().debug("Using fallback skin for skull at " + entity.getSkullPosition());
             // No texture available, fallback using the UUID
             SkinProvider.SkinData fallback = SkinProvider.determineFallbackSkinData(entity.getSkullUUID());
             applySkin.accept(fallback.skin(), null);

--- a/core/src/main/java/org/geysermc/geyser/skin/SkullSkinManager.java
+++ b/core/src/main/java/org/geysermc/geyser/skin/SkullSkinManager.java
@@ -29,11 +29,12 @@ import com.nukkitx.protocol.bedrock.data.skin.ImageData;
 import com.nukkitx.protocol.bedrock.data.skin.SerializedSkin;
 import com.nukkitx.protocol.bedrock.packet.PlayerSkinPacket;
 import org.geysermc.geyser.GeyserImpl;
-import org.geysermc.geyser.entity.type.player.PlayerEntity;
+import org.geysermc.geyser.entity.type.player.SkullPlayerEntity;
 import org.geysermc.geyser.session.GeyserSession;
 import org.geysermc.geyser.text.GeyserLocale;
 
 import java.util.Collections;
+import java.util.function.BiConsumer;
 import java.util.function.Consumer;
 
 public class SkullSkinManager extends SkinManager {
@@ -48,28 +49,36 @@ public class SkullSkinManager extends SkinManager {
         );
     }
 
-    public static void requestAndHandleSkin(PlayerEntity entity, GeyserSession session,
+    public static void requestAndHandleSkin(SkullPlayerEntity entity, GeyserSession session,
                                             Consumer<SkinProvider.Skin> skinConsumer) {
+        BiConsumer<SkinProvider.Skin, Throwable> applySkin = (skin, throwable) -> {
+            try {
+                PlayerSkinPacket packet = new PlayerSkinPacket();
+                packet.setUuid(entity.getUuid());
+                packet.setOldSkinName("");
+                packet.setNewSkinName(skin.getTextureUrl());
+                packet.setSkin(buildSkullEntryManually(skin.getTextureUrl(), skin.getSkinData()));
+                packet.setTrustedSkin(true);
+                session.sendUpstreamPacket(packet);
+            } catch (Exception e) {
+                GeyserImpl.getInstance().getLogger().error(GeyserLocale.getLocaleStringLog("geyser.skin.fail", entity.getUuid()), e);
+            }
+
+            if (skinConsumer != null) {
+                skinConsumer.accept(skin);
+            }
+        };
+
         GameProfileData data = GameProfileData.from(entity);
-
-        SkinProvider.requestSkin(entity.getUuid(), data.skinUrl(), true)
-                .whenCompleteAsync((skin, throwable) -> {
-                    try {
-                        PlayerSkinPacket packet = new PlayerSkinPacket();
-                        packet.setUuid(entity.getUuid());
-                        packet.setOldSkinName("");
-                        packet.setNewSkinName(skin.getTextureUrl());
-                        packet.setSkin(buildSkullEntryManually(skin.getTextureUrl(), skin.getSkinData()));
-                        packet.setTrustedSkin(true);
-                        session.sendUpstreamPacket(packet);
-                    } catch (Exception e) {
-                        GeyserImpl.getInstance().getLogger().error(GeyserLocale.getLocaleStringLog("geyser.skin.fail", entity.getUuid()), e);
-                    }
-
-                    if (skinConsumer != null) {
-                        skinConsumer.accept(skin);
-                    }
-                });
+        if (data == null) {
+            GeyserImpl.getInstance().getLogger().debug("Using fallback skin for skull.");
+            // No texture available, fallback using the UUID
+            SkinProvider.SkinData fallback = SkinProvider.determineFallbackSkinData(entity);
+            applySkin.accept(fallback.skin(), null);
+        } else {
+            SkinProvider.requestSkin(entity.getUuid(), data.skinUrl(), true)
+                    .whenCompleteAsync(applySkin);
+        }
     }
 
 }

--- a/core/src/main/java/org/geysermc/geyser/skin/SkullSkinManager.java
+++ b/core/src/main/java/org/geysermc/geyser/skin/SkullSkinManager.java
@@ -71,7 +71,8 @@ public class SkullSkinManager extends SkinManager {
 
         GameProfileData data = GameProfileData.from(entity);
         if (data == null) {
-            GeyserImpl.getInstance().getLogger().debug("Using fallback skin for skull at " + entity.getSkullPosition());
+            GeyserImpl.getInstance().getLogger().debug("Using fallback skin for skull at " + entity.getSkullPosition() +
+                    " with texture value: " + entity.getTexturesProperty() + " and UUID: " + entity.getSkullUUID());
             // No texture available, fallback using the UUID
             SkinProvider.SkinData fallback = SkinProvider.determineFallbackSkinData(entity.getSkullUUID());
             applySkin.accept(fallback.skin(), null);

--- a/core/src/main/java/org/geysermc/geyser/translator/level/block/entity/SkullBlockEntityTranslator.java
+++ b/core/src/main/java/org/geysermc/geyser/translator/level/block/entity/SkullBlockEntityTranslator.java
@@ -95,11 +95,7 @@ public class SkullBlockEntityTranslator extends BlockEntityTranslator implements
         Vector3i blockPosition = Vector3i.from(posX, posY, posZ);
         CompoundTag owner = tag.get("SkullOwner");
         if (owner == null) {
-            if (session.getEventLoop().inEventLoop()) {
-                session.getSkullCache().removeSkull(blockPosition);
-            } else {
-                session.executeInEventLoop(() -> session.getSkullCache().removeSkull(blockPosition));
-            }
+            session.getSkullCache().removeSkull(blockPosition);
             return;
         }
 

--- a/core/src/main/java/org/geysermc/geyser/translator/level/block/entity/SkullBlockEntityTranslator.java
+++ b/core/src/main/java/org/geysermc/geyser/translator/level/block/entity/SkullBlockEntityTranslator.java
@@ -27,6 +27,7 @@ package org.geysermc.geyser.translator.level.block.entity;
 
 import com.github.steveice10.mc.protocol.data.game.level.block.BlockEntityType;
 import com.github.steveice10.opennbt.tag.builtin.CompoundTag;
+import com.github.steveice10.opennbt.tag.builtin.IntArrayTag;
 import com.github.steveice10.opennbt.tag.builtin.ListTag;
 import com.github.steveice10.opennbt.tag.builtin.StringTag;
 import com.nukkitx.math.vector.Vector3i;
@@ -35,7 +36,10 @@ import org.geysermc.geyser.level.block.BlockStateValues;
 import org.geysermc.geyser.session.GeyserSession;
 import org.geysermc.geyser.skin.SkinProvider;
 
+import java.nio.charset.StandardCharsets;
 import java.util.LinkedHashMap;
+import java.util.Locale;
+import java.util.UUID;
 import java.util.concurrent.CompletableFuture;
 
 @BlockEntity(type = BlockEntityType.SKULL)
@@ -53,12 +57,38 @@ public class SkullBlockEntityTranslator extends BlockEntityTranslator implements
         builder.put("SkullType", skullVariant);
     }
 
-    private static CompletableFuture<String> getTextures(CompoundTag tag) {
+    private static UUID getUUID(CompoundTag tag) {
+        CompoundTag owner = tag.get("SkullOwner");
+        if (owner != null) {
+            if (owner.get("Id") instanceof IntArrayTag uuidTag && uuidTag.length() == 4) {
+                int[] uuidAsArray = uuidTag.getValue();
+                // thank u viaversion
+                return new UUID((long) uuidAsArray[0] << 32 | ((long) uuidAsArray[1] & 0xFFFFFFFFL),
+                        (long) uuidAsArray[2] << 32 | ((long) uuidAsArray[3] & 0xFFFFFFFFL));
+            }
+            // Convert username to an offline uuid
+            String username = null;
+            if (owner.get("Name") instanceof StringTag nameTag) {
+                username = nameTag.getValue().toLowerCase(Locale.ROOT);
+            }
+            return UUID.nameUUIDFromBytes(("OfflinePlayer:" + username).getBytes(StandardCharsets.UTF_8));
+        }
+        return null;
+    }
+
+    private static CompletableFuture<String> getTextures(CompoundTag tag, UUID uuid) {
         CompoundTag owner = tag.get("SkullOwner");
         if (owner != null) {
             CompoundTag properties = owner.get("Properties");
             if (properties == null) {
-                return SkinProvider.requestTexturesFromUsername(owner);
+                if (uuid != null && uuid.version() == 4) {
+                    String uuidString = uuid.toString().replace("-", "");
+                    return SkinProvider.requestTexturesFromUUID(uuidString);
+                } else if (owner.get("Name") instanceof StringTag nameTag) {
+                    // Fall back to username if UUID was missing or was an offline mode UUID
+                    return SkinProvider.requestTexturesFromUsername(nameTag.getValue());
+                }
+                return CompletableFuture.completedFuture(null);
             }
 
             ListTag textures = properties.get("textures");
@@ -71,15 +101,12 @@ public class SkullBlockEntityTranslator extends BlockEntityTranslator implements
 
     public static void translateSkull(GeyserSession session, CompoundTag tag, int posX, int posY, int posZ, int blockState) {
         Vector3i blockPosition = Vector3i.from(posX, posY, posZ);
-        getTextures(tag).whenComplete((texturesProperty, throwable) -> {
-            if (texturesProperty == null) {
-                session.getGeyser().getLogger().debug("Custom skull with invalid SkullOwner tag: " + blockPosition + " " + tag);
-                return;
-            }
+        UUID uuid = getUUID(tag);
+        getTextures(tag, uuid).whenComplete((texturesProperty, throwable) -> {
             if (session.getEventLoop().inEventLoop()) {
-                session.getSkullCache().putSkull(blockPosition, texturesProperty, blockState);
+                session.getSkullCache().putSkull(blockPosition, uuid, texturesProperty, blockState);
             } else {
-                session.executeInEventLoop(() -> session.getSkullCache().putSkull(blockPosition, texturesProperty, blockState));
+                session.executeInEventLoop(() -> session.getSkullCache().putSkull(blockPosition, uuid, texturesProperty, blockState));
             }
         });
     }


### PR DESCRIPTION
This should resolve
```
Could not translate packet MovePlayerPacket
java.lang.NullPointerException: Cannot invoke "org.geysermc.geyser.skin.SkinManager$GameProfileData.skinUrl()" because "data" is null
	at org.geysermc.geyser.skin.SkullSkinManager.requestAndHandleSkin(SkullSkinManager.java:55) ~[classes/:?]
	at org.geysermc.geyser.entity.type.player.SkullPlayerEntity.updateSkull(SkullPlayerEntity.java:112) ~[classes/:?]
	at org.geysermc.geyser.session.cache.SkullCache.assignSkullEntity(SkullCache.java:175) ~[classes/:?]
	...
	at java.lang.Thread.run(Thread.java:833) [?:?]
> java.lang.NullPointerException: Cannot invoke "org.geysermc.geyser.skin.SkinManager$GameProfileData.skinUrl()" because "data" is null
	at org.geysermc.geyser.skin.SkullSkinManager.requestAndHandleSkin(SkullSkinManager.java:55)
	at org.geysermc.geyser.entity.type.player.SkullPlayerEntity.updateSkull(SkullPlayerEntity.java:112)
	at org.geysermc.geyser.session.cache.SkullCache.assignSkullEntity(SkullCache.java:175)
	...
```
Which occurs when the `Value` tag is empty, contains invalid Base64, or the decoded JSON data does not contain a skin url.

Test cases:
`/setblock ~ ~1 ~ minecraft:player_head[rotation=0]{SkullOwner:{Id:[I;-841226976,-800896373,-1580425271,803089359],Properties:{textures:[{Value:""}]}}} replace`
`/setblock ~ ~1 ~ minecraft:player_head[rotation=0]{SkullOwner:{Id:[I;-657485210,93077940,-1543410694,2057783509],Properties:{textures:[{Value:"eyJ0ZXh0dXJlcyI6eyJTS0lOIjp7InVybCI6Imh0dHA6Ly90ZXh0dXJlcy5taW5lY3JhZnQubmV0L3RleHR1cmUvNzA1MmQ4OTAzZGEyYTNiZGNlNGRiNDYwMDA0OGQ4M2IwNDkxYzFlODU0MGJhZmNhYzVlMzZmNWRlZTY3ZWZmZSJ9fX0=="}]}}} replace`
`/setblock ~ ~1 ~ minecraft:player_head[rotation=0]{SkullOwner:{Id:[I;-657485210,93077940,-1543410694,2057783509],Properties:{textures:[{Value:"qq"}]}}} replace`
`/setblock ~ ~1 ~ minecraft:player_head[rotation=0]{SkullOwner:{Id:[I;-841226976,-800896373,-1580425271,803089359],Properties:{textures:[{Value:"eyJ0ZXh0dXJlcyI6eyJTS0lOIjp7fX19"}]}}} replace`