### PR TITLE
Fix compressor on FlameCord

### DIFF
--- a/bootstrap/bungeecord/src/main/java/org/geysermc/geyser/platform/bungeecord/GeyserBungeeCompressionDisabler.java
+++ b/bootstrap/bungeecord/src/main/java/org/geysermc/geyser/platform/bungeecord/GeyserBungeeCompressionDisabler.java
@@ -38,12 +38,7 @@ public class GeyserBungeeCompressionDisabler extends ChannelOutboundHandlerAdapt
         if (!(msg instanceof SetCompression)) {
             if (msg instanceof LoginSuccess) {
                 // We're past the point that compression can be enabled
-                if (ctx.pipeline().get("compress") != null) {
-                    ctx.pipeline().remove("compress");
-                }
-                if (ctx.pipeline().get("decompress") != null) {
-                    ctx.pipeline().remove("decompress");
-                }
+                ctx.setCompressionThreshold (-1); 
                 ctx.pipeline().remove(this);
             }
             super.write(ctx, msg, promise);


### PR DESCRIPTION
FlameCord has a custom compression system not compatible with GeyserMC disable compressor option. This fixes it by setting compression to -1 instead of directly removing the compression from the pipeline.