### PR TITLE
Add API for Music Packet

### DIFF
--- a/api/base/src/main/java/org/geysermc/api/GeyserApiBase.java
+++ b/api/base/src/main/java/org/geysermc/api/GeyserApiBase.java
@@ -96,6 +96,44 @@ public interface GeyserApiBase {
      */
     boolean transfer(@NonNull UUID uuid, @NonNull String address, @IntRange(from = 0, to = 65535) int port);
 
+    /**
+     * Queue a music track to be played for the connection later.
+     * @param uuid The UUID of the connection to queue the music for
+     * @param fadeSeconds The amount of time in seconds to fade the music in and out from 0 to 10 seconds
+     * @param repeatMode Whether the music should repeat
+     * @param trackName The name of the music track to queue
+     * @param volume The volume of the music track from 0 to 1
+     * @return true if the music was successfully queued
+     */
+    boolean queueMusic(@NonNull UUID uuid, float fadeSeconds, boolean repeatMode, @NonNull String trackName, float volume);
+
+    /**
+     * Play a music track for the connection.
+     * @param uuid The UUID of the connection to play the music for
+     * @param fadeSeconds The amount of time in seconds to fade the music in and out from 0 to 10 seconds
+     * @param repeatMode Whether the music should repeat
+     * @param trackName The name of the music track to play
+     * @param volume The volume of the music track from 0 to 1
+     * @return true if the music was successfully played
+     */
+    boolean playMusic(@NonNull UUID uuid, float fadeSeconds, boolean repeatMode, @NonNull String trackName, float volume);
+
+    /**
+     * Stop the current music track for the connection.
+     * @param uuid The UUID of the connection to stop the music for
+     * @param fadeSeconds The amount of time in seconds to fade the music in and out from 0 to 10 seconds
+     * @return true if the music was successfully stopped
+     */
+    boolean stopMusic(@NonNull UUID uuid, float fadeSeconds);
+
+    /**
+     * Set the volume of the current music track for the connection.
+     * @param uuid The UUID of the connection to set the music volume for
+     * @param volume The volume of the music track from 0 to 1
+     * @return true if the music volume was successfully set
+     */
+    boolean setMusicVolume(@NonNull UUID uuid, float volume);
+
 
     /**
      * Returns all the online connections.

--- a/api/base/src/main/java/org/geysermc/api/connection/Connection.java
+++ b/api/base/src/main/java/org/geysermc/api/connection/Connection.java
@@ -118,4 +118,39 @@ public interface Connection {
      * @return true if the transfer was a success
      */
     boolean transfer(@NonNull String address, @IntRange(from = 0, to = 65535) int port);
+
+    /**
+     * Queue a music track to be played for the connection later.
+     * @param fadeSeconds The amount of time in seconds to fade the music in and out from 0 to 10 seconds
+     * @param repeatMode Whether the music should repeat
+     * @param trackName The name of the music track to queue
+     * @param volume The volume of the music track from 0 to 1
+     * @return true if the music was successfully queued
+     */
+    boolean queueMusic(float fadeSeconds, boolean repeatMode, @NonNull String trackName, float volume);
+
+
+    /**
+     * Play a music track for the connection immediately.
+     * @param fadeSeconds The amount of time in seconds to fade the music in and out from 0 to 10 seconds
+     * @param repeatMode Whether the music should repeat
+     * @param trackName The name of the music track to play
+     * @param volume The volume of the music track from 0 to 1
+     * @return true if the music was successfully played
+     */
+    boolean playMusic(float fadeSeconds, boolean repeatMode, @NonNull String trackName, float volume);
+
+    /**
+     * Stop the current music track for the connection.
+     * @param fadeSeconds The amount of time in seconds to fade the music in and out from 0 to 10 seconds
+     * @return true if the music was successfully stopped
+     */
+    boolean stopMusic(float fadeSeconds);
+
+    /**
+     * Set the volume of the current music track for the connection.
+     * @param volume The volume of the music track from 0 to 1
+     * @return true if the music volume was successfully set
+     */
+    boolean setMusicVolume(float volume);
 }

--- a/common/src/main/java/org/geysermc/floodgate/pluginmessage/PluginMessageChannels.java
+++ b/common/src/main/java/org/geysermc/floodgate/pluginmessage/PluginMessageChannels.java
@@ -31,6 +31,10 @@ public final class PluginMessageChannels {
     public static final String SKIN = "floodgate:skin";
     public static final String FORM = "floodgate:form";
     public static final String TRANSFER = "floodgate:transfer";
+    public static final String MUSIC_QUEUE = "floodgate:music:queue";
+    public static final String MUSIC_PLAY = "floodgate:music:play";
+    public static final String MUSIC_STOP = "floodgate:music:stop";
+    public static final String MUSIC_VOLUME = "floodgate:music:volume";
     public static final String PACKET = "floodgate:packet";
 
     private static final byte[] FLOODGATE_REGISTER_DATA =

--- a/common/src/main/java/org/geysermc/floodgate/pluginmessage/PluginMessageChannels.java
+++ b/common/src/main/java/org/geysermc/floodgate/pluginmessage/PluginMessageChannels.java
@@ -31,14 +31,14 @@ public final class PluginMessageChannels {
     public static final String SKIN = "floodgate:skin";
     public static final String FORM = "floodgate:form";
     public static final String TRANSFER = "floodgate:transfer";
-    public static final String MUSIC_QUEUE = "floodgate:music:queue";
-    public static final String MUSIC_PLAY = "floodgate:music:play";
-    public static final String MUSIC_STOP = "floodgate:music:stop";
-    public static final String MUSIC_VOLUME = "floodgate:music:volume";
+    public static final String MUSIC_QUEUE = "floodgate:music_queue";
+    public static final String MUSIC_PLAY = "floodgate:music_play";
+    public static final String MUSIC_STOP = "floodgate:music_stop";
+    public static final String MUSIC_VOLUME = "floodgate:music_volume";
     public static final String PACKET = "floodgate:packet";
 
     private static final byte[] FLOODGATE_REGISTER_DATA =
-            String.join("\0", SKIN, FORM, TRANSFER, PACKET)
+            String.join("\0", SKIN, FORM, TRANSFER, MUSIC_QUEUE, MUSIC_PLAY, MUSIC_STOP, MUSIC_VOLUME, PACKET)
                     .getBytes(StandardCharsets.UTF_8);
 
     /**

--- a/core/src/main/java/org/geysermc/geyser/GeyserImpl.java
+++ b/core/src/main/java/org/geysermc/geyser/GeyserImpl.java
@@ -552,6 +552,46 @@ public class GeyserImpl implements GeyserApi {
         return session.transfer(address, port);
     }
 
+    @Override
+    public boolean queueMusic(@NonNull UUID uuid, float fadeSeconds, boolean repeatMode, @NonNull String trackName, float volume) {
+        Objects.requireNonNull(uuid);
+        GeyserSession session = connectionByUuid(uuid);
+        if (session == null) {
+            return false;
+        }
+        return session.queueMusic(fadeSeconds, repeatMode, trackName, volume);
+    }
+
+    @Override
+    public boolean playMusic(@NonNull UUID uuid, float fadeSeconds, boolean repeatMode, @NonNull String trackName, float volume) {
+        Objects.requireNonNull(uuid);
+        GeyserSession session = connectionByUuid(uuid);
+        if (session == null) {
+            return false;
+        }
+        return session.playMusic(fadeSeconds, repeatMode, trackName, volume);
+    }
+
+    @Override
+    public boolean stopMusic(@NonNull UUID uuid, float fadeSeconds) {
+        Objects.requireNonNull(uuid);
+        GeyserSession session = connectionByUuid(uuid);
+        if (session == null) {
+            return false;
+        }
+        return session.stopMusic(fadeSeconds);
+    }
+
+    @Override
+    public boolean setMusicVolume(@NonNull UUID uuid, float volume) {
+        Objects.requireNonNull(uuid);
+        GeyserSession session = connectionByUuid(uuid);
+        if (session == null) {
+            return false;
+        }
+        return session.setMusicVolume(volume);
+    }
+
     public void shutdown() {
         bootstrap.getGeyserLogger().info(GeyserLocale.getLocaleStringLog("geyser.core.shutdown"));
         shuttingDown = true;

--- a/core/src/main/java/org/geysermc/geyser/session/GeyserSession.java
+++ b/core/src/main/java/org/geysermc/geyser/session/GeyserSession.java
@@ -1898,6 +1898,84 @@ public class GeyserSession implements GeyserConnection, GeyserCommandSource {
         return true;
     }
 
+    @Override
+    public boolean queueMusic(float fadeSeconds, boolean repeatMode, @NonNull String trackName, float volume) {
+        if (trackName == null || trackName.isBlank()) {
+            throw new IllegalArgumentException("Track name cannot be null or blank");
+        } else if (volume < 0f || volume > 1f) {
+            throw new IllegalArgumentException("Volume must be between 0f and 1f, was " + volume);
+        } else if (fadeSeconds < 0f || fadeSeconds > 10f) {
+            throw new IllegalArgumentException("Fade seconds must be between 0f and 10f, was " + fadeSeconds);
+        }
+        LevelEventGenericPacket levelEventGenericPacket = new LevelEventGenericPacket();
+        levelEventGenericPacket.setEventId(1900);
+        levelEventGenericPacket.setTag(
+            NbtMap.builder()
+                    .putFloat("fadeSeconds", fadeSeconds)
+                    .putByte("repeatMode", (byte) (repeatMode ? 1 : 0))
+                    .putString("trackName", trackName)
+                    .putFloat("volume", volume)
+                    .build()
+        );
+        sendUpstreamPacket(levelEventGenericPacket);
+        return true;
+    }
+
+    @Override
+    public boolean playMusic(float fadeSeconds, boolean repeatMode, @NonNull String trackName, float volume) {
+        if (trackName == null || trackName.isBlank()) {
+            throw new IllegalArgumentException("Track name cannot be null or blank");
+        } else if (volume < 0f || volume > 1f) {
+            throw new IllegalArgumentException("Volume must be between 0f and 1f, was " + volume);
+        } else if (fadeSeconds < 0f || fadeSeconds > 10f) {
+            throw new IllegalArgumentException("Fade seconds must be between 0f and 10f, was " + fadeSeconds);
+        }
+        LevelEventGenericPacket levelEventGenericPacket = new LevelEventGenericPacket();
+        levelEventGenericPacket.setEventId(1901);
+        levelEventGenericPacket.setTag(
+            NbtMap.builder()
+                    .putFloat("fadeSeconds", fadeSeconds)
+                    .putByte("repeatMode", (byte) (repeatMode ? 1 : 0))
+                    .putString("trackName", trackName)
+                    .putFloat("volume", volume)
+                    .build()
+        );
+        sendUpstreamPacket(levelEventGenericPacket);
+        return true;
+    }
+
+    @Override
+    public boolean stopMusic(float fadeSeconds) {
+        if (fadeSeconds < 0f || fadeSeconds > 10f) {
+            throw new IllegalArgumentException("Fade seconds must be between 0f and 10f, was " + fadeSeconds);
+        }
+        LevelEventGenericPacket levelEventGenericPacket = new LevelEventGenericPacket();
+        levelEventGenericPacket.setEventId(1902);
+        levelEventGenericPacket.setTag(
+            NbtMap.builder()
+                    .putFloat("fadeSeconds", fadeSeconds)
+                    .build()
+        );
+        sendUpstreamPacket(levelEventGenericPacket);
+        return true;
+    }
+
+    @Override
+    public boolean setMusicVolume(float volume) {
+        if (volume < 0f || volume > 1f) {
+            throw new IllegalArgumentException("Volume must be between 0f and 1f, was " + volume);
+        }
+        LevelEventGenericPacket levelEventGenericPacket = new LevelEventGenericPacket();
+        levelEventGenericPacket.setEventId(1903);
+        levelEventGenericPacket.setTag(
+            NbtMap.builder()
+                    .putFloat("volume", volume)
+                    .build()
+        );
+        sendUpstreamPacket(levelEventGenericPacket);
+        return true;
+    }
+
     public void addCommandEnum(String name, String... enums) {
         softEnumPacket(name, SoftEnumUpdateType.ADD, enums);
     }


### PR DESCRIPTION
See https://minecraft.fandom.com/wiki/Commands/music

API allows for playing and queuing of multiple songs on Bedrock clients with the ability to fade between tracks and on stop.

Depends on: https://github.com/GeyserMC/Floodgate/pull/382
