### PR TITLE
Update PR Build Action for API

### DIFF
--- a/.github/workflows/pullrequest.yml
+++ b/.github/workflows/pullrequest.yml
@@ -15,6 +15,22 @@ jobs:
           distribution: 'temurin'
           java-version: 17
           cache: 'gradle'
+      - name: Check if PR user has API repo
+        uses: Kas-tle/ForkFinder@v1.0.1
+        id: find_forks
+        with:
+          owner: 'GeyserMC'
+          repo: 'api'
+          token: ${{ secrets.GITHUB_TOKEN }}
+      - name: Cache PR user API repo
+        if: steps.find_forks.outputs.target_branch_found == 'true'
+        env:
+          API_FORK_URL: ${{ steps.find_forks.outputs.user_fork_url }}
+          API_FORK_BRANCH: ${{ github.event.pull_request.head.ref }}
+        run: |
+          git clone "${API_FORK_URL}" --single-branch --branch "${API_FORK_BRANCH}" api
+          cd api
+          ./gradlew publishToMavenLocal
       - name: submodules-init
         uses: snickerbockers/submodules-init@v4
       - name: Build with Gradle

--- a/.github/workflows/pullrequest.yml
+++ b/.github/workflows/pullrequest.yml
@@ -28,8 +28,8 @@ jobs:
           API_FORK_URL: ${{ steps.find_forks.outputs.user_fork_url }}
           API_FORK_BRANCH: ${{ github.event.pull_request.head.ref }}
         run: |
-          git clone "${API_FORK_URL}" --single-branch --branch "${API_FORK_BRANCH}" api
-          cd api
+          git clone "${API_FORK_URL}" --single-branch --branch "${API_FORK_BRANCH}" geyser_base_api
+          cd geyser_base_api
           ./gradlew publishToMavenLocal
       - name: submodules-init
         uses: snickerbockers/submodules-init@v4

--- a/.github/workflows/pullrequest.yml
+++ b/.github/workflows/pullrequest.yml
@@ -4,37 +4,44 @@ on: [pull_request]
 
 jobs:
   build:
-
     runs-on: ubuntu-latest
-
     steps:
-      - uses: actions/checkout@v2
       - name: Set up JDK 17
         uses: actions/setup-java@v1
         with:
-          distribution: 'temurin'
           java-version: 17
-          cache: 'gradle'
+          distribution: temurin
+          cache: gradle
+
       - name: Check if the author has forked the API repo
         uses: Kas-tle/ForkFinder@v1.0.1
         id: find_forks
         with:
-          owner: 'GeyserMC'
-          repo: 'api'
+          owner: GeyserMC
+          repo: api
           token: ${{ secrets.GITHUB_TOKEN }}
+
       - name: Use author's API repo if it exists
         if: steps.find_forks.outputs.target_branch_found == 'true'
         env:
           API_FORK_URL: ${{ steps.find_forks.outputs.user_fork_url }}
           API_FORK_BRANCH: ${{ github.event.pull_request.head.ref }}
         run: |
-          git clone "${API_FORK_URL}" --single-branch --branch "${API_FORK_BRANCH}" geyser_base_api
-          cd geyser_base_api
+          git clone "${API_FORK_URL}" --single-branch --branch "${API_FORK_BRANCH}" api
+          cd api
           ./gradlew publishToMavenLocal
-      - name: submodules-init
-        uses: snickerbockers/submodules-init@v4
-      - name: Build with Gradle
-        run: ./gradlew build
+
+      - name: Checkout repository and submodules
+        uses: actions/checkout@v3
+        with:
+          submodules: recursive
+          path: geyser
+
+      - name: Build Geyser
+        uses: gradle/gradle-build-action@v2
+        with:
+          arguments: build
+          build-root-directory: geyser
 
       - name: Archive artifacts (Geyser Fabric)
         uses: actions/upload-artifact@v2

--- a/.github/workflows/pullrequest.yml
+++ b/.github/workflows/pullrequest.yml
@@ -15,14 +15,14 @@ jobs:
           distribution: 'temurin'
           java-version: 17
           cache: 'gradle'
-      - name: Check if PR user has API repo
+      - name: Check if the author has forked the API repo
         uses: Kas-tle/ForkFinder@v1.0.1
         id: find_forks
         with:
           owner: 'GeyserMC'
           repo: 'api'
           token: ${{ secrets.GITHUB_TOKEN }}
-      - name: Cache PR user API repo
+      - name: Use author's API repo if it exists
         if: steps.find_forks.outputs.target_branch_found == 'true'
         env:
           API_FORK_URL: ${{ steps.find_forks.outputs.user_fork_url }}

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -50,4 +50,4 @@ The nature of our software requires a lot of arrays and maps to be stored - wher
 
 We have a rundown of all the tools you need to develop over on our [wiki](https://wiki.geysermc.org/other/developer-guide/). If you have any questions, please feel free to reach out to our [Discord](https://discord.gg/geysermc)!
 
-If making a pull request that also depends on changes to [Geyser's API](https://github.com/GeyserMC/api), simply fork the API repo and create a branch with the same name as your PR to Geyser. The pull request [action](https://github.com/GeyserMC/Geyser/blob/master/.github/workflows/pullrequest.yml) will automatically cache your Geyser API changes before building your changes to Geyser.
+If you're making a pull request that also depends on changes to [the base API](https://github.com/GeyserMC/api), simply fork the API repo and create a branch with the same name as your Geyser PR. The pull request [action](https://github.com/GeyserMC/Geyser/blob/master/.github/workflows/pullrequest.yml) will automatically use your API changes while building your changes to Geyser.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -48,4 +48,6 @@ Make sure to comment your code where possible.
 
 The nature of our software requires a lot of arrays and maps to be stored - where possible, use Fastutil's specialized maps. For example, if you're storing block state translations, use an `Int2IntMap`.
 
-We have a rundown of all the tools you need to develop over on our [wiki](https://github.com/GeyserMC/Geyser/wiki/Developer-Guide). If you have any questions, please feel free to reach out to our [Discord](https://discord.gg/geysermc)!
+We have a rundown of all the tools you need to develop over on our [wiki](https://wiki.geysermc.org/other/developer-guide/). If you have any questions, please feel free to reach out to our [Discord](https://discord.gg/geysermc)!
+
+If making a pull request that also depends on changes to [Geyser's API](https://github.com/GeyserMC/api), simply fork the API repo and create a branch with the same name as your PR to Geyser. The pull request [action](https://github.com/GeyserMC/Geyser/blob/master/.github/workflows/pullrequest.yml) will automatically cache your Geyser API changes before building your changes to Geyser.


### PR DESCRIPTION
Because the API is now in a separate repo, PRs that rely on API changes will fail to build with the current PR build action. This PR updates the action to check if the user initiating the PR has a fork of the API repo with a branch matching the name of their PR. If this is the case, the action will clone the users API repo and cache it to the action runner's local maven repo before building Geyser. As a result, the action can then use the user's changes to the API when building Geyser.

Validation: https://github.com/Kas-tle/Geyser/pull/4