### PR TITLE
Add property to show scoreboard logs

### DIFF
--- a/core/src/main/java/org/geysermc/geyser/scoreboard/Scoreboard.java
+++ b/core/src/main/java/org/geysermc/geyser/scoreboard/Scoreboard.java
@@ -48,6 +48,8 @@ import java.util.concurrent.atomic.AtomicLong;
 import static org.geysermc.geyser.scoreboard.UpdateType.*;
 
 public final class Scoreboard {
+    private static final boolean SHOW_SCOREBOARD_LOGS = Boolean.parseBoolean(System.getProperty("Geyser.ShowScoreboardLogs", "true"));
+
     private final GeyserSession session;
     private final GeyserLogger logger;
     @Getter
@@ -134,7 +136,7 @@ public final class Scoreboard {
     public Team registerNewTeam(String teamName, String[] players) {
         Team team = teams.get(teamName);
         if (team != null) {
-            if (Boolean.parseBoolean(System.getProperty("Geyser.ShowScoreboardLogs", "true"))) {
+            if (SHOW_SCOREBOARD_LOGS) {
                 logger.info(GeyserLocale.getLocaleStringLog("geyser.network.translator.team.failed_overrides", teamName));
             }
             return team;

--- a/core/src/main/java/org/geysermc/geyser/scoreboard/Scoreboard.java
+++ b/core/src/main/java/org/geysermc/geyser/scoreboard/Scoreboard.java
@@ -134,7 +134,9 @@ public final class Scoreboard {
     public Team registerNewTeam(String teamName, String[] players) {
         Team team = teams.get(teamName);
         if (team != null) {
-            logger.info(GeyserLocale.getLocaleStringLog("geyser.network.translator.team.failed_overrides", teamName));
+            if (Boolean.parseBoolean(System.getProperty("Geyser.ShowScoreboardLogs", "true"))) {
+                logger.info(GeyserLocale.getLocaleStringLog("geyser.network.translator.team.failed_overrides", teamName));
+            }
             return team;
         }
 

--- a/core/src/main/java/org/geysermc/geyser/translator/protocol/java/scoreboard/JavaSetScoreTranslator.java
+++ b/core/src/main/java/org/geysermc/geyser/translator/protocol/java/scoreboard/JavaSetScoreTranslator.java
@@ -58,7 +58,9 @@ public class JavaSetScoreTranslator extends PacketTranslator<ClientboundSetScore
 
         Objective objective = scoreboard.getObjective(packet.getObjective());
         if (objective == null && packet.getAction() != ScoreboardAction.REMOVE) {
-            logger.info(GeyserLocale.getLocaleStringLog("geyser.network.translator.score.failed_objective", packet.getObjective()));
+            if (Boolean.parseBoolean(System.getProperty("Geyser.ShowScoreboardLogs", "true"))) {
+                logger.info(GeyserLocale.getLocaleStringLog("geyser.network.translator.score.failed_objective", packet.getObjective()));
+            }
             return;
         }
 

--- a/core/src/main/java/org/geysermc/geyser/translator/protocol/java/scoreboard/JavaSetScoreTranslator.java
+++ b/core/src/main/java/org/geysermc/geyser/translator/protocol/java/scoreboard/JavaSetScoreTranslator.java
@@ -44,6 +44,8 @@ import org.geysermc.geyser.translator.protocol.Translator;
 
 @Translator(packet = ClientboundSetScorePacket.class)
 public class JavaSetScoreTranslator extends PacketTranslator<ClientboundSetScorePacket> {
+    private static final boolean SHOW_SCOREBOARD_LOGS = Boolean.parseBoolean(System.getProperty("Geyser.ShowScoreboardLogs", "true"));
+
     private final GeyserLogger logger;
 
     public JavaSetScoreTranslator() {
@@ -58,7 +60,7 @@ public class JavaSetScoreTranslator extends PacketTranslator<ClientboundSetScore
 
         Objective objective = scoreboard.getObjective(packet.getObjective());
         if (objective == null && packet.getAction() != ScoreboardAction.REMOVE) {
-            if (Boolean.parseBoolean(System.getProperty("Geyser.ShowScoreboardLogs", "true"))) {
+            if (SHOW_SCOREBOARD_LOGS) {
                 logger.info(GeyserLocale.getLocaleStringLog("geyser.network.translator.score.failed_objective", packet.getObjective()));
             }
             return;


### PR DESCRIPTION
On large networks these messages produce a lot of unnecessary spam. Add a property to allow disabling these. Alternatively, could even consider making these log level debug instead (not sure how important these are to normal users).