### PR TITLE
Add switch case for player

### DIFF
--- a/core/src/main/java/org/geysermc/geyser/util/EntityUtils.java
+++ b/core/src/main/java/org/geysermc/geyser/util/EntityUtils.java
@@ -93,6 +93,7 @@ public final class EntityUtils {
                 mountedHeightOffset = height - (isBaby ? 0.2f : 0.15f);
             }
             case PIGLIN -> mountedHeightOffset = height * 0.92f;
+            case PLAYER -> mountedHeightOffset = -.4f;
             case RAVAGER -> mountedHeightOffset = 2.1f;
             case SKELETON_HORSE -> mountedHeightOffset -= 0.1875f;
             case STRIDER -> mountedHeightOffset = height - 0.19f;


### PR DESCRIPTION
Adds switch case for player. This change was made by Nils while he was creating a plugin that requires adding an entity as a passenger to player. Without this change; for Java client there is no issue. However, without this change, Bedrock client is not able to properly offset entity and/or maintain a consistent position on player. After a couple weeks of testing, it does not appear to adversely affect anything for Java or Bedrock clients. Plugins that affect tab or custom player name tag have been observed to function as expected.