### PR TITLE
Let's print an error alongside UnknownHostException 

### DIFF
--- a/core/src/main/java/org/geysermc/geyser/Constants.java
+++ b/core/src/main/java/org/geysermc/geyser/Constants.java
@@ -46,6 +46,7 @@ public final class Constants {
         try {
             wsUri = new URI("wss://api.geysermc.org/ws");
         } catch (URISyntaxException e) {
+            GeyserImpl.getInstance().getLogger().error("Unable to resolve api.geysermc.org! Check your internet connection.");
             e.printStackTrace();
         }
         GLOBAL_API_WS_URI = wsUri;


### PR DESCRIPTION
A relatively minor thing, but - I've seen a few cases where people asked in the support channels asked where this error came from. Making Geyser also print an error stating that it's the internet connection could help make it clearer what caused this issue.
Feel free to dismiss this/adjust wording :)
