### PR TITLE
Fix building on eclipse

### DIFF
--- a/build-logic/src/main/kotlin/geyser.base-conventions.gradle.kts
+++ b/build-logic/src/main/kotlin/geyser.base-conventions.gradle.kts
@@ -1,5 +1,6 @@
 plugins {
     `java-library`
+    `eclipse`
     id("net.kyori.indra")
 }
 
@@ -32,6 +33,16 @@ tasks {
                 "url" to "https://geysermc.org",
                 "author" to "GeyserMC"
             )
+        }
+    }
+}
+
+eclipse {
+    classpath.file.whenMerged {
+        (this as org.gradle.plugins.ide.eclipse.model.Classpath).entries.forEach { entry ->
+            if (entry is org.gradle.plugins.ide.eclipse.model.Library) {
+                entry.entryAttributes["module"] = false
+            }
         }
     }
 }


### PR DESCRIPTION
https://github.com/KyoriPowered/indra/blob/main/3.x/indra-common/src/main/java/net/kyori/indra/internal/multirelease/IndraMultireleasePlugin.java#L540-L569 for its [multi-release system](https://github.com/KyoriPowered/indra/wiki/indra#multi-release-jar-configuration) Indra (`net.kyori.indra`) seems to make its own decisions about what should and should not be considered a JPMS module. This seems to occur because the isModule check seems to return true in many cases https://github.com/KyoriPowered/indra/blob/main/3.x/indra-common/src/main/java/net/kyori/indra/internal/ModularityDetecter.java#L53-L117. 

The eclipse plugin can be used to undo this change, and adventure even has to do this for their logger: https://github.com/KyoriPowered/adventure/blob/main/4/text-logger-slf4j/build.gradle.kts#L36-L45.

Note that this only affects behavior for those using the Eclipse IDE (or other implementations of Eclipse Buildship such as the VSCode Java Language Extension). There is absolutely no change to the build process in any other circumstances.

I made a similar PR for issues with building eclipse in Floodgate (https://github.com/GeyserMC/Floodgate/pull/381) and received some internal push back since Eclipse is much less common, especially among those that contribute to this project. But I really don't get this sentiment. I think it benefits Geyser and open source projects in general to make it as easy to contribute as possible. And part of that is making Geyser work in a potential contributors IDE of choice. I think that most people looking to contribute that use Eclipse in the current state of the project would likely just give up and move onto something else, as I doubt they'd be inclined to troubleshoot the obscure behavior of one of the build plugins. While I understand that one response to this may be "just use IntelliJ", I really don't see the argument when we can easily make it compatible with 0 impact on users of other IDEs and Geyser's build and publishing process.