### PR TITLE
Fix closing inventory confirmation behavior

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -47,7 +47,7 @@ jobs:
           # Copy over artifacts
           scp -B -o StrictHostKeyChecking=no -i id_ecdsa bootstrap/**/build/libs/Geyser-*.jar $DOWNLOADS_USERNAME@$DOWNLOADS_SERVER_IP:~/files/
           # Run the build script
-          ssh -o StrictHostKeyChecking=no -i id_ecdsa $DOWNLOADS_USERNAME@$DOWNLOADS_SERVER_IP ./handleBuild.sh geyser $version $GITHUB_RUN_ID $GITHUB_SHA
+          ssh -o StrictHostKeyChecking=no -i id_ecdsa $DOWNLOADS_USERNAME@$DOWNLOADS_SERVER_IP ./handleBuild.sh geyser $version $GITHUB_RUN_NUMBER $GITHUB_SHA
 
       - name: Notify Discord
         if: ${{ (success() || failure()) && github.repository == 'GeyserMC/Geyser' }}

--- a/core/src/main/java/org/geysermc/geyser/inventory/Inventory.java
+++ b/core/src/main/java/org/geysermc/geyser/inventory/Inventory.java
@@ -89,6 +89,10 @@ public abstract class Inventory {
     @Setter
     private boolean pending = false;
 
+    @Getter
+    @Setter
+    private boolean displayed = false;
+
     protected Inventory(int id, int size, ContainerType containerType) {
         this("Inventory", id, size, containerType);
     }

--- a/core/src/main/java/org/geysermc/geyser/util/InventoryUtils.java
+++ b/core/src/main/java/org/geysermc/geyser/util/InventoryUtils.java
@@ -95,6 +95,7 @@ public class InventoryUtils {
                     if (openInv != null && openInv.getJavaId() == inventory.getJavaId()) {
                         translator.openInventory(session, inventory);
                         translator.updateInventory(session, inventory);
+                        openInv.setDisplayed(true);
                     } else if (openInv != null && openInv.isPending()) {
                         // Presumably, this inventory is no longer relevant, and the client doesn't care about it
                         displayInventory(session, openInv);
@@ -117,7 +118,7 @@ public class InventoryUtils {
         if (inventory != null) {
             InventoryTranslator translator = session.getInventoryTranslator();
             translator.closeInventory(session, inventory);
-            if (confirm && !inventory.isPending() && !(translator instanceof LecternInventoryTranslator)) {
+            if (confirm && inventory.isDisplayed() && !inventory.isPending() && !(translator instanceof LecternInventoryTranslator)) {
                 session.setClosingInventory(true);
             }
         }

--- a/core/src/main/java/org/geysermc/geyser/util/InventoryUtils.java
+++ b/core/src/main/java/org/geysermc/geyser/util/InventoryUtils.java
@@ -104,6 +104,7 @@ public class InventoryUtils {
             } else {
                 translator.openInventory(session, inventory);
                 translator.updateInventory(session, inventory);
+                inventory.setDisplayed(true);
             }
         } else {
             session.setOpenInventory(null);


### PR DESCRIPTION
Fixes an issue with Geyser thinking that an inventory is open where it's actually not open for the client.

With the current code it is possible for the following situation to happen:
- server sends an open inventory packet and then immediately a close inventory packet
- the open inventory packet is handled on Geyser, `openInventory` is called, this sets the open inventory via `session.setOpenInventory` and schedules a task in an event loop that does further processing.
- the close inventory packet is handled **before** the event loop task runs, which sets the openInventory to `null` and then awaits the inventory to close by setting `closingInventory` to `true`
- only now the event loop task runs, but `openInventory` is already set to `null` so it doesn't do anything
- we have a situation in which `openInventory` is `null`, there is no inventory opened for the client but `closingInventory` is set to `true` which makes it impossible to open new inventories because Geyser still waits for the old inventory to close

This PR fixes this issue by making it so close confirmation is not required if the inventory wasn't opened in the first place.