### PR TITLE
Properly Cache Build Dependencies, Optimize Build Action, and Save Build Action Artifacts

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,6 +1,17 @@
 name: Build
 
-on: [push]
+on:
+  push:
+    paths-ignore:
+      - './github/ISSUE_TEMPLATE/*.yml'
+      - './github/actions/pullrequest.yml'
+      - '.idea/copyright/*.xml' 
+      - '.gitignore'
+      - 'CONTRIBUTING.md'
+      - 'LICENSE'
+      - 'Jenkinsfile '
+      - 'README.md'
+      - 'licenseheader.txt'
 
 jobs:
   build:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -3,8 +3,8 @@ name: Build
 on:
   push:
     paths-ignore:
-      - './github/ISSUE_TEMPLATE/*.yml'
-      - './github/actions/pullrequest.yml'
+      - '.github/ISSUE_TEMPLATE/*.yml'
+      - '.github/actions/pullrequest.yml'
       - '.idea/copyright/*.xml' 
       - '.gitignore'
       - 'CONTRIBUTING.md'

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -15,12 +15,21 @@ jobs:
         with:
           java-version: 17
           distribution: temurin
-          cache: gradle
+          
+      - name: Cache Gradle Packages
+        uses: actions/cache@v3
+        with:
+          path: | 
+            ~/.m2
+            ~/.gradle/caches
+            ~/.gradle/wrapper
+          key: ${{ github.ref_name }}-gradle-${{ hashFiles('*.gradle.kts', 'gradle.properties', 'gradlew', 'gradle/*', 'gradle/**/*', 'build-logic/*', 'build-logic/**/**/**/*', '**/*.gradle.kts', '**/**/*.gradle.kts') }}
+          restore-keys: ${{ github.ref_name }}-gradle-
 
       - name: Build
         uses: gradle/gradle-build-action@v2
         with:
-          arguments: build
+          arguments: build --no-daemon
 
       - name: Publish to Maven Repository
         if: ${{ job.status == 'success' && github.repository == 'GeyserMC/Geyser' && github.ref_name == 'master' }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,6 +1,7 @@
 name: Build
 
 on:
+  workflow_dispatch:
   push:
     paths-ignore:
       - '.github/ISSUE_TEMPLATE/*.yml'

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -30,6 +30,49 @@ jobs:
         uses: gradle/gradle-build-action@v2
         with:
           arguments: build --no-daemon
+          
+      - name: Archive artifacts (Geyser Fabric)
+        uses: actions/upload-artifact@v3
+        if: success()
+        with:
+          name: Geyser Fabric
+          path: bootstrap/fabric/build/libs/Geyser-Fabric.jar
+          if-no-files-found: error
+      - name: Archive artifacts (Geyser Standalone)
+        uses: actions/upload-artifact@v3
+        if: success()
+        with:
+          name: Geyser Standalone
+          path: bootstrap/standalone/build/libs/Geyser-Standalone.jar
+          if-no-files-found: error
+      - name: Archive artifacts (Geyser Spigot)
+        uses: actions/upload-artifact@v3
+        if: success()
+        with:
+          name: Geyser Spigot
+          path: bootstrap/spigot/build/libs/Geyser-Spigot.jar
+          if-no-files-found: error
+      - name: Archive artifacts (Geyser BungeeCord)
+        uses: actions/upload-artifact@v3
+        if: success()
+        with:
+          name: Geyser BungeeCord
+          path: bootstrap/bungeecord/build/libs/Geyser-BungeeCord.jar
+          if-no-files-found: error
+      - name: Archive artifacts (Geyser Sponge)
+        uses: actions/upload-artifact@v3
+        if: success()
+        with:
+          name: Geyser Sponge
+          path: bootstrap/sponge/build/libs/Geyser-Sponge.jar
+          if-no-files-found: error
+      - name: Archive artifacts (Geyser Velocity)
+        uses: actions/upload-artifact@v3
+        if: success()
+        with:
+          name: Geyser Velocity
+          path: bootstrap/velocity/build/libs/Geyser-Velocity.jar
+          if-no-files-found: error
 
       - name: Publish to Maven Repository
         if: ${{ job.status == 'success' && github.repository == 'GeyserMC/Geyser' && github.ref_name == 'master' }}

--- a/.github/workflows/pullrequest.yml
+++ b/.github/workflows/pullrequest.yml
@@ -3,7 +3,7 @@ name: Build Pull Request
 on: 
   pull_request:
     paths-ignore:
-      - './github/ISSUE_TEMPLATE/*.yml'
+      - '.github/ISSUE_TEMPLATE/*.yml'
       - '.idea/copyright/*.xml' 
       - '.gitignore'
       - 'CONTRIBUTING.md'

--- a/.github/workflows/pullrequest.yml
+++ b/.github/workflows/pullrequest.yml
@@ -1,6 +1,16 @@
 name: Build Pull Request
 
-on: [pull_request]
+on: 
+  pull_request:
+    paths-ignore:
+      - './github/ISSUE_TEMPLATE/*.yml'
+      - '.idea/copyright/*.xml' 
+      - '.gitignore'
+      - 'CONTRIBUTING.md'
+      - 'LICENSE'
+      - 'Jenkinsfile '
+      - 'README.md'
+      - 'licenseheader.txt'
 
 jobs:
   build:
@@ -44,38 +54,44 @@ jobs:
           build-root-directory: geyser
 
       - name: Archive artifacts (Geyser Fabric)
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v3
         if: success()
         with:
           name: Geyser Fabric
           path: geyser/bootstrap/fabric/build/libs/Geyser-Fabric.jar
+          if-no-files-found: error
       - name: Archive artifacts (Geyser Standalone)
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v3
         if: success()
         with:
           name: Geyser Standalone
           path: geyser/bootstrap/standalone/build/libs/Geyser-Standalone.jar
+          if-no-files-found: error
       - name: Archive artifacts (Geyser Spigot)
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v3
         if: success()
         with:
           name: Geyser Spigot
           path: geyser/bootstrap/spigot/build/libs/Geyser-Spigot.jar
+          if-no-files-found: error
       - name: Archive artifacts (Geyser BungeeCord)
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v3
         if: success()
         with:
           name: Geyser BungeeCord
           path: geyser/bootstrap/bungeecord/build/libs/Geyser-BungeeCord.jar
+          if-no-files-found: error
       - name: Archive artifacts (Geyser Sponge)
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v3
         if: success()
         with:
           name: Geyser Sponge
           path: geyser/bootstrap/sponge/build/libs/Geyser-Sponge.jar
+          if-no-files-found: error
       - name: Archive artifacts (Geyser Velocity)
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v3
         if: success()
         with:
           name: Geyser Velocity
           path: geyser/bootstrap/velocity/build/libs/Geyser-Velocity.jar
+          if-no-files-found: error

--- a/.github/workflows/pullrequest.yml
+++ b/.github/workflows/pullrequest.yml
@@ -21,7 +21,6 @@ jobs:
         with:
           java-version: 17
           distribution: temurin
-          cache: gradle
 
       - name: Check if the author has forked the API repo
         uses: Kas-tle/ForkFinder@v1.0.1


### PR DESCRIPTION
Currently, the builtin cache function for the java setup action only saves the Gradle caches folder, but not the local .m2 repo or the Gradle wrapper. Furthermore, the Gradle build files it hashes to tag the cache do not really make sense for Geyser, being a multi-module project. See https://github.com/actions/setup-java#caching-packages-dependencies.

This PR properly caches these, cutting build times in half.
- [Before Caching](https://github.com/Kas-tle/Geyser/actions/runs/4332647023/jobs/7565280185) (5:22)
- [After Caching](https://github.com/Kas-tle/Geyser/actions/runs/4332697239/jobs/7565363184) (2:49)

Caches are kept separate by branch to ensure no weirdness and that any changes on other branches cannot affect the cache of master. I have also intentionally chosen not to include PRs in caching. This is because the Github repo cache limit is 10GB, and the current cache size with this PR is ~690MB. When the 10GB limit is reached, caches are removed in order of longest last access time until there is space for the new cache. I would like to avoid the possibility of too many PRs leading to the deletion of the master cache, and thus increasing build times for master. But this can easily be added in if you do not believe it is an issue. Note that while it would also be possible to share the caches for PRs and main builds, I would also like to avoid the possibility of any sort of cache injection by a PR...

This PR also adds exclusions so that no build is pushed when files that would not lead to a change in the underlying build are modified, such as the README: https://github.com/Kas-tle/Geyser/blob/feature/actions-cache/.github/workflows/build.yml#L5-L14

I also add saving of build artifacts for the main build action. I don't really see any reason not to do this.

Finally, both the PR action and Build action are modified to ensure the action is failed if the proper platform artifacts don't exist.

By request from @rtm516, the ability to manually trigger the workflow is also added by adding the `workflow_dispatch` event. This allows manually triggering of actions like so: https://docs.github.com/en/actions/managing-workflow-runs/manually-running-a-workflow