### PR TITLE
Assign permission to the command

### DIFF
--- a/bootstrap/spigot/src/main/resources/plugin.yml
+++ b/bootstrap/spigot/src/main/resources/plugin.yml
@@ -9,3 +9,7 @@ commands:
   geyser:
     description: The main command for Geyser.
     usage: /geyser <subcommand>
+    permission: geyser.command
+permissions:
+  geysermc.command:
+    default: true

--- a/bootstrap/spigot/src/main/resources/plugin.yml
+++ b/bootstrap/spigot/src/main/resources/plugin.yml
@@ -9,7 +9,7 @@ commands:
   geyser:
     description: The main command for Geyser.
     usage: /geyser <subcommand>
-    permission: geyser.command
+    permission: geysermc.command
 permissions:
   geysermc.command:
     default: true

--- a/bootstrap/spigot/src/main/resources/plugin.yml
+++ b/bootstrap/spigot/src/main/resources/plugin.yml
@@ -9,7 +9,7 @@ commands:
   geyser:
     description: The main command for Geyser.
     usage: /geyser <subcommand>
-    permission: geysermc.command
+    permission: geyser.command
 permissions:
-  geysermc.command:
+  geyser.command:
     default: true


### PR DESCRIPTION
Assigning permission allows people to possibly deny that permission to hide the command from tab complete list. Permission is defaulted to true, so command keeps current behavior by default.