### PR TITLE
fix: Fix legacy ping passthough

### DIFF
--- a/core/src/main/java/org/geysermc/geyser/ping/GeyserLegacyPingPassthrough.java
+++ b/core/src/main/java/org/geysermc/geyser/ping/GeyserLegacyPingPassthrough.java
@@ -79,7 +79,8 @@ public class GeyserLegacyPingPassthrough implements IGeyserPingPassthrough, Runn
         try (Socket socket = new Socket()) {
             String address = geyser.getConfig().getRemote().address();
             int port = geyser.getConfig().getRemote().port();
-            socket.connect(new InetSocketAddress(address, port), 5000);
+            InetSocketAddress endpoint = new InetSocketAddress(address, port);
+            socket.connect(endpoint, 5000);
 
             ByteArrayOutputStream byteArrayStream = new ByteArrayOutputStream();
             try (DataOutputStream handshake = new DataOutputStream(byteArrayStream)) {
@@ -103,7 +104,8 @@ public class GeyserLegacyPingPassthrough implements IGeyserPingPassthrough, Runn
                             HAProxyProxiedProtocol.TCP4.byteValue() : HAProxyProxiedProtocol.TCP6.byteValue());
                     byte[] srcAddrBytes = NetUtil.createByteArrayFromIpAddressString(
                             ((InetSocketAddress) socket.getLocalSocketAddress()).getAddress().getHostAddress());
-                    byte[] dstAddrBytes = NetUtil.createByteArrayFromIpAddressString(address);
+                    byte[] dstAddrBytes = NetUtil.createByteArrayFromIpAddressString(
+                            endpoint.getAddress().getHostAddress());
                     dataOutputStream.writeShort(srcAddrBytes.length + dstAddrBytes.length + 4);
                     dataOutputStream.write(srcAddrBytes);
                     dataOutputStream.write(dstAddrBytes);


### PR DESCRIPTION
We use as `remote.address` a hostname that resolves multiple ips, this leads to the problem that the correct player number is not displayed and the runnable freezes when creating the `dstAddrBytes` variable.

I can't figure out why this is, but have found that if I pass the resolved IP address, the correct player count is displayed again. Likewise I tried if `localhost` still works and this is the case, so this PR should not break anything