### PR TITLE
Fix cache growing forever

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -35,8 +35,7 @@ jobs:
             ~/.m2
             ~/.gradle/caches
             ~/.gradle/wrapper
-          key: ${{ github.ref_name }}-gradle-${{ hashFiles('*.gradle.kts', 'gradle.properties', 'gradlew', 'gradle/*', 'gradle/**/*', 'build-logic/*', 'build-logic/**/**/**/*', '**/*.gradle.kts', '**/**/*.gradle.kts') }}
-          restore-keys: ${{ github.ref_name }}-gradle-
+          key: ${{ github.ref_name }}-gradle-${{ hashFiles('gradle.properties', 'gradlew', 'gradle/**', 'build-logic/**', '**.gradle.kts') }}
 
       - name: Build
         uses: gradle/gradle-build-action@v2


### PR DESCRIPTION
It seems that when `restore-keys` is included in the config for the cache action it will just hit on anything that starts with that... I had naively thought this was just some sort of filter since the cache action repo uses this in their Gradle example. This of course is not what we want since as a result the cache gets bigger every time the non-specific cache is hit. My apologies for this.

Related: https://github.com/GeyserMC/Geyser/pull/3593