### PR TITLE
Update ringing bell block event logic

### DIFF
--- a/core/src/main/java/org/geysermc/geyser/level/block/BlockStateValues.java
+++ b/core/src/main/java/org/geysermc/geyser/level/block/BlockStateValues.java
@@ -68,7 +68,6 @@ public final class BlockStateValues {
 
     public static final int JAVA_AIR_ID = 0;
 
-    public static int JAVA_BELL_ID;
     public static int JAVA_COBWEB_ID;
     public static int JAVA_FURNACE_ID;
     public static int JAVA_FURNACE_LIT_ID;

--- a/core/src/main/java/org/geysermc/geyser/registry/populator/BlockRegistryPopulator.java
+++ b/core/src/main/java/org/geysermc/geyser/registry/populator/BlockRegistryPopulator.java
@@ -223,7 +223,6 @@ public final class BlockRegistryPopulator {
         Deque<String> cleanIdentifiers = new ArrayDeque<>();
 
         int javaRuntimeId = -1;
-        int bellBlockId = -1;
         int cobwebBlockId = -1;
         int furnaceRuntimeId = -1;
         int furnaceLitRuntimeId = -1;
@@ -300,10 +299,7 @@ public final class BlockRegistryPopulator {
             // It's possible to only have this store differences in names, but the key set of all Java names is used in sending command suggestions
             BlockRegistries.JAVA_TO_BEDROCK_IDENTIFIERS.register(cleanJavaIdentifier.intern(), bedrockIdentifier.intern());
 
-            if (javaId.startsWith("minecraft:bell[")) {
-                bellBlockId = uniqueJavaId;
-
-            } else if (javaId.contains("cobweb")) {
+            if (javaId.contains("cobweb")) {
                 cobwebBlockId = uniqueJavaId;
 
             } else if (javaId.startsWith("minecraft:furnace[facing=north")) {
@@ -324,10 +320,6 @@ public final class BlockRegistryPopulator {
                 slimeBlockRuntimeId = javaRuntimeId;
             }
         }
-        if (bellBlockId == -1) {
-            throw new AssertionError("Unable to find bell in palette");
-        }
-        BlockStateValues.JAVA_BELL_ID = bellBlockId;
 
         if (cobwebBlockId == -1) {
             throw new AssertionError("Unable to find cobwebs in palette");

--- a/core/src/main/java/org/geysermc/geyser/translator/protocol/java/level/JavaBlockEventTranslator.java
+++ b/core/src/main/java/org/geysermc/geyser/translator/protocol/java/level/JavaBlockEventTranslator.java
@@ -103,7 +103,7 @@ public class JavaBlockEventTranslator extends PacketTranslator<ClientboundBlockE
         } else if (packet.getValue() instanceof EndGatewayValue) {
             blockEventPacket.setEventType(1);
             session.sendUpstreamPacket(blockEventPacket);
-        } else if (packet.getValue() instanceof GenericBlockValue bellValue && packet.getBlockId() == BlockStateValues.JAVA_BELL_ID) {
+        } else if (packet.getValue() instanceof BellValue bellValue) {
             // Bells - needed to show ring from other players
             BlockEntityDataPacket blockEntityPacket = new BlockEntityDataPacket();
             blockEntityPacket.setBlockPosition(position);
@@ -113,11 +113,12 @@ public class JavaBlockEventTranslator extends PacketTranslator<ClientboundBlockE
             builder.putInt("y", position.getY());
             builder.putInt("z", position.getZ());
             builder.putString("id", "Bell");
-            int bedrockRingDirection = switch (bellValue.getValue()) {
-                case 3 -> 0; // north
-                case 4 -> 1; // east
-                case 5 -> 3;// west
-                default -> bellValue.getValue(); // south (2) is identical
+            int bedrockRingDirection = switch (bellValue.getDirection()) {
+                case SOUTH -> 0;
+                case WEST -> 1;
+                case NORTH -> 2;
+                case EAST -> 3;
+                default -> throw new IllegalStateException("Unexpected BellValue Direction: " + bellValue.getDirection());
             };
             builder.putInt("Direction", bedrockRingDirection);
             builder.putByte("Ringing", (byte) 1);


### PR DESCRIPTION
Ringing bells now result in a `BellValue` instead of a `GenericBlockValue` with https://github.com/GeyserMC/MCProtocolLib/commit/edace8900fdd192b4d2e8c701cbb3d9551f5beb8#diff-bfa4deb249469649fd5a0f832a8983c8b431200127fc5dfbc7484d51a4245783R56 and https://github.com/GeyserMC/MCProtocolLib/pull/729