### PR TITLE
Bring Rain/Thunder Behavior Inline With Java

### DIFF
--- a/core/src/main/java/org/geysermc/geyser/translator/protocol/java/level/JavaGameEventTranslator.java
+++ b/core/src/main/java/org/geysermc/geyser/translator/protocol/java/level/JavaGameEventTranslator.java
@@ -45,14 +45,15 @@ import org.geysermc.geyser.translator.inventory.PlayerInventoryTranslator;
 import org.geysermc.geyser.translator.protocol.PacketTranslator;
 import org.geysermc.geyser.translator.protocol.Translator;
 
+
 @Translator(packet = ClientboundGameEventPacket.class)
 public class JavaGameEventTranslator extends PacketTranslator<ClientboundGameEventPacket> {
+    // Strength of rainstorms and thunderstorms is a 0-1 float on Java, while on Bedrock it is a 0-65535 int
+    private static final int MAX_STORM_STRENGTH = 65535;
 
     @Override
     public void translate(GeyserSession session, ClientboundGameEventPacket packet) {
         PlayerEntity entity = session.getPlayerEntity();
-        // Strength of rainstorms and thunderstorms is a 0-1 float on Java, while on Bedrock it is a 0-65535 int 
-        final int MAX_STORM_STRENGTH = 65535;
 
         switch (packet.getNotification()) {
             // Yes, START_RAIN and STOP_RAIN are swapped in terms of what they cause the client to do.

--- a/core/src/main/java/org/geysermc/geyser/translator/protocol/java/level/JavaGameEventTranslator.java
+++ b/core/src/main/java/org/geysermc/geyser/translator/protocol/java/level/JavaGameEventTranslator.java
@@ -62,6 +62,7 @@ public class JavaGameEventTranslator extends PacketTranslator<ClientboundGameEve
             // This is indeed the behavior of the vanilla server
             // However, it seems most server software (at least Spigot and Paper) did not go along with this
             // As a result many developers use these packets for the opposite of what their names implies
+            // Behavior last verified with Java 1.19.4 and Bedrock 1.19.71
             case START_RAIN:
                 LevelEventPacket stopRainPacket = new LevelEventPacket();
                 stopRainPacket.setType(LevelEventType.STOP_RAINING);

--- a/core/src/main/java/org/geysermc/geyser/translator/protocol/java/level/JavaGameEventTranslator.java
+++ b/core/src/main/java/org/geysermc/geyser/translator/protocol/java/level/JavaGameEventTranslator.java
@@ -51,17 +51,18 @@ public class JavaGameEventTranslator extends PacketTranslator<ClientboundGameEve
     @Override
     public void translate(GeyserSession session, ClientboundGameEventPacket packet) {
         PlayerEntity entity = session.getPlayerEntity();
+        // Strength of rainstorms and thunderstorms is a 0-1 float on Java, while on Bedrock it is a 0-65535 int 
+        final int MAX_STORM_STRENGTH = 65535;
 
         switch (packet.getNotification()) {
+            // Yes, START_RAIN and STOP_RAIN are swapped in terms of what they cause the client to do.
+            // This is how the Mojang mappings name them, so we go with it
+            // It seems Mojang's intent was that START_RAIN would set the rain strength to 0 so that it can then be incremeneted on a gradient by the server
+            // The inverse is true for STOP_RAIN
+            // This is indeed the behavior of the vanilla server
+            // However, it seems most server software (at least Spigot and Paper) did not go along with this
+            // As a result many developers use these packets for the opposite of what their names implies
             case START_RAIN:
-                LevelEventPacket startRainPacket = new LevelEventPacket();
-                startRainPacket.setType(LevelEventType.START_RAINING);
-                startRainPacket.setData(Integer.MAX_VALUE);
-                startRainPacket.setPosition(Vector3f.ZERO);
-                session.sendUpstreamPacket(startRainPacket);
-                session.setRaining(true);
-                break;
-            case STOP_RAIN:
                 LevelEventPacket stopRainPacket = new LevelEventPacket();
                 stopRainPacket.setType(LevelEventType.STOP_RAINING);
                 stopRainPacket.setData(0);
@@ -69,34 +70,35 @@ public class JavaGameEventTranslator extends PacketTranslator<ClientboundGameEve
                 session.sendUpstreamPacket(stopRainPacket);
                 session.setRaining(false);
                 break;
+            case STOP_RAIN:
+                LevelEventPacket startRainPacket = new LevelEventPacket();
+                startRainPacket.setType(LevelEventType.START_RAINING);
+                startRainPacket.setData(MAX_STORM_STRENGTH);
+                startRainPacket.setPosition(Vector3f.ZERO);
+                session.sendUpstreamPacket(startRainPacket);
+                session.setRaining(true);
+                break;
             case RAIN_STRENGTH:
-                // While the above values are used, they CANNOT BE TRUSTED on a vanilla server as they are swapped around
-                // Spigot and forks implement it correctly
-                // Rain strength is your best way for determining if there is any rain
-                RainStrengthValue value = (RainStrengthValue) packet.getValue();
-                boolean isCurrentlyRaining = value.getStrength() > 0f;
-                // Java sends the rain level. Bedrock doesn't care, so we don't care if it's already raining.
-                if (isCurrentlyRaining != session.isRaining()) {
-                    LevelEventPacket changeRainPacket = new LevelEventPacket();
-                    changeRainPacket.setType(isCurrentlyRaining ? LevelEventType.START_RAINING : LevelEventType.STOP_RAINING);
-                    changeRainPacket.setData(Integer.MAX_VALUE); // Dunno what this does; used to be implemented with ThreadLocalRandom
-                    changeRainPacket.setPosition(Vector3f.ZERO);
-                    session.sendUpstreamPacket(changeRainPacket);
-                    session.setRaining(isCurrentlyRaining);
-                }
+                float rainStrength = ((RainStrengthValue) packet.getValue()).getStrength();
+                boolean isCurrentlyRaining = rainStrength > 0f;
+                LevelEventPacket changeRainPacket = new LevelEventPacket();
+                changeRainPacket.setType(isCurrentlyRaining ? LevelEventType.START_RAINING : LevelEventType.STOP_RAINING);
+                // This is the rain strength on LevelEventType.START_RAINING, but can be any value on LevelEventType.STOP_RAINING
+                changeRainPacket.setData((int) (rainStrength * MAX_STORM_STRENGTH));
+                changeRainPacket.setPosition(Vector3f.ZERO);
+                session.sendUpstreamPacket(changeRainPacket);
+                session.setRaining(isCurrentlyRaining);
                 break;
             case THUNDER_STRENGTH:
                 // See above, same process
-                ThunderStrengthValue thunderValue = (ThunderStrengthValue) packet.getValue();
-                boolean isCurrentlyThundering = thunderValue.getStrength() > 0f;
-                if (isCurrentlyThundering != session.isThunder()) {
-                    LevelEventPacket changeThunderPacket = new LevelEventPacket();
-                    changeThunderPacket.setType(isCurrentlyThundering ? LevelEventType.START_THUNDERSTORM : LevelEventType.STOP_THUNDERSTORM);
-                    changeThunderPacket.setData(Integer.MAX_VALUE);
-                    changeThunderPacket.setPosition(Vector3f.ZERO);
-                    session.sendUpstreamPacket(changeThunderPacket);
-                    session.setThunder(isCurrentlyThundering);
-                }
+                float thunderStrength = ((ThunderStrengthValue) packet.getValue()).getStrength();
+                boolean isCurrentlyThundering = thunderStrength > 0f;
+                LevelEventPacket changeThunderPacket = new LevelEventPacket();
+                changeThunderPacket.setType(isCurrentlyThundering ? LevelEventType.START_THUNDERSTORM : LevelEventType.STOP_THUNDERSTORM);
+                changeThunderPacket.setData((int) (thunderStrength * MAX_STORM_STRENGTH));
+                changeThunderPacket.setPosition(Vector3f.ZERO);
+                session.sendUpstreamPacket(changeThunderPacket);
+                session.setThunder(isCurrentlyThundering);
                 break;
             case CHANGE_GAMEMODE:
                 GameMode gameMode = (GameMode) packet.getValue();

--- a/core/src/main/java/org/geysermc/geyser/translator/protocol/java/level/JavaGameEventTranslator.java
+++ b/core/src/main/java/org/geysermc/geyser/translator/protocol/java/level/JavaGameEventTranslator.java
@@ -45,7 +45,6 @@ import org.geysermc.geyser.translator.inventory.PlayerInventoryTranslator;
 import org.geysermc.geyser.translator.protocol.PacketTranslator;
 import org.geysermc.geyser.translator.protocol.Translator;
 
-
 @Translator(packet = ClientboundGameEventPacket.class)
 public class JavaGameEventTranslator extends PacketTranslator<ClientboundGameEventPacket> {
     // Strength of rainstorms and thunderstorms is a 0-1 float on Java, while on Bedrock it is a 0-65535 int


### PR DESCRIPTION
This PR should resolve many issues related to rain/weather, as it brings Geyser's rain behavior fully inline with Java. Rather than looking at rain as a boolean, we now properly set the rain strength as specified in the rain strength packet from Java. Per info from the PocketMine devs and my own testing, rain strength on Bedrock ranges from 0 to 65535 and is applies via the data field of `LevelEventType.START_RAINING`. We also properly set `START_RAIN` as stopping rain, and `STOP_RAIN` as starting rain. Oddly enough, this is inline with Java behavior, as it seems these packets were intended to be the beginning of a gradient that slowly begins or ends the storm. However, this is of course up to the server's implementation since it controls rain strength through the RAIN_STRENGTH packet.

We do the same for THUNDER_STRENGTH.

Tested with standard weather command, as well as Worldguard's weather lock, which appeared to be causing issues before. Would appreciate testing with PlotSquared, as people also reported issues with it, though I am not sure what the conditions were for that case.

The PR should close:
- https://github.com/GeyserMC/Geyser/issues/3611
- https://github.com/GeyserMC/Geyser/issues/2588
- https://github.com/GeyserMC/Geyser/issues/2499

This supersedes:
- https://github.com/GeyserMC/MCProtocolLib/pull/730

CC: @Camotoy @basaigh @Redned235 