### PR TITLE
Set Shulker Color by Default

### DIFF
--- a/core/src/main/java/org/geysermc/geyser/entity/type/living/monster/ShulkerEntity.java
+++ b/core/src/main/java/org/geysermc/geyser/entity/type/living/monster/ShulkerEntity.java
@@ -43,6 +43,9 @@ public class ShulkerEntity extends GolemEntity {
         super(session, entityId, geyserId, uuid, definition, position, motion, yaw, pitch, headYaw);
         // Indicate that invisibility should be fixed through the resource pack
         setFlag(EntityFlag.BRIBED, true);
+        // As of 1.19.4, it seems Java no longer sends the shulker color if it's the default color on initial spawn
+        // We still need the special case for 16 color in setShulkerColor though as it will send it for an entity metadata update
+        dirtyMetadata.put(EntityData.VARIANT, 16);
     }
 
     public void setAttachedFace(EntityMetadata<Direction, ?> entityMetadata) {

--- a/core/src/main/java/org/geysermc/geyser/entity/type/living/monster/ShulkerEntity.java
+++ b/core/src/main/java/org/geysermc/geyser/entity/type/living/monster/ShulkerEntity.java
@@ -43,6 +43,12 @@ public class ShulkerEntity extends GolemEntity {
         super(session, entityId, geyserId, uuid, definition, position, motion, yaw, pitch, headYaw);
         // Indicate that invisibility should be fixed through the resource pack
         setFlag(EntityFlag.BRIBED, true);
+
+    }
+
+    @Override
+    protected void initializeMetadata() {
+        super.initializeMetadata();
         // As of 1.19.4, it seems Java no longer sends the shulker color if it's the default color on initial spawn
         // We still need the special case for 16 color in setShulkerColor though as it will send it for an entity metadata update
         dirtyMetadata.put(EntityData.VARIANT, 16);


### PR DESCRIPTION
As of 1.19.4, it seems that Java will not send the byte for shulker color on initial spawn if the shulker is the default color. Therefore, we should assume the color is the default unless we encounter the color byte. I verified this through packet capture.

Closes https://github.com/GeyserMC/Geyser/issues/3646