### PR TITLE
lets not use the enchantment type that is slightly broken

### DIFF
--- a/core/src/main/java/org/geysermc/geyser/item/type/Item.java
+++ b/core/src/main/java/org/geysermc/geyser/item/type/Item.java
@@ -197,7 +197,7 @@ public class Item {
                 }
             }
             if (!enchantments.isEmpty()) {
-                tag.put(new ListTag("Enchantments", enchantments));
+                tag.put(new ListTag("StoredEnchantments", enchantments));
             }
         }
     }

--- a/core/src/main/java/org/geysermc/geyser/item/type/Item.java
+++ b/core/src/main/java/org/geysermc/geyser/item/type/Item.java
@@ -197,7 +197,11 @@ public class Item {
                 }
             }
             if (!enchantments.isEmpty()) {
-                tag.put(new ListTag("StoredEnchantments", enchantments));
+                if ((this instanceof EnchantedBookItem)) {
+                    tag.put(new ListTag("StoredEnchantments", enchantments));
+                } else {
+                    tag.put(new ListTag("Enchantments", enchantments));
+                }
             }
         }
     }


### PR DESCRIPTION
This just ensures that books from bedrock's creative inventory use the same enchantment type storing format as java. Additionally, this fixes the behavior with enchanted books that's present in normal java (which should never occur in normal gameplay, as the game does not store enchantments of enchanted books in a "Enchantment" tag, "StoredEnchantments" are now used.

Fixes https://github.com/GeyserMC/Geyser/issues/3711.
