### PR TITLE
Update AddEntityPacket to include headYaw

### DIFF
--- a/core/src/main/java/org/geysermc/geyser/entity/type/Entity.java
+++ b/core/src/main/java/org/geysermc/geyser/entity/type/Entity.java
@@ -36,6 +36,7 @@ import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.Setter;
 import net.kyori.adventure.text.Component;
+import org.cloudburstmc.math.vector.Vector2f;
 import org.cloudburstmc.math.vector.Vector3f;
 import org.cloudburstmc.protocol.bedrock.data.entity.EntityDataTypes;
 import org.cloudburstmc.protocol.bedrock.data.entity.EntityEventType;
@@ -171,7 +172,9 @@ public class Entity implements GeyserEntity {
         addEntityPacket.setUniqueEntityId(geyserId);
         addEntityPacket.setPosition(position);
         addEntityPacket.setMotion(motion);
-        addEntityPacket.setRotation(getBedrockRotation().toVector2(false)); // TODO: Check this
+        addEntityPacket.setRotation(Vector2f.from(pitch, yaw));
+        addEntityPacket.setHeadRotation(headYaw);
+        addEntityPacket.setBodyRotation(yaw); // TODO: This should be bodyYaw
         addEntityPacket.getMetadata().putFlags(flags);
         dirtyMetadata.apply(addEntityPacket.getMetadata());
         addAdditionalSpawnData(addEntityPacket);


### PR DESCRIPTION
This fixes entities spawned from having incorrect rotation on initial spawn. I'm not too sure what to do about yBodyRot

To replicate original issue:
1.
```java
player.getLocation().getWorld().spawn(player.getLocation(), Pig.class, (mob) -> {
        ((Mob) mob).setAI(false);
});
```
2. Notice that the Mob is always looking towards 0 regardless of player's orientation.
3. Mobs with AI are unaffected, generally because they move very soon to the first tick they spawn in. AI-controlled mobs rapidly spin to the correct rotation after spawning.