### PR TITLE
Fix uppercase item attribute modifier names

### DIFF
--- a/core/src/main/java/org/geysermc/geyser/translator/inventory/item/ItemTranslator.java
+++ b/core/src/main/java/org/geysermc/geyser/translator/inventory/item/ItemTranslator.java
@@ -253,21 +253,17 @@ public final class ItemTranslator {
 
         String operationTotal;
         Tag operationTag = modifier.get("Operation");
-        if (operationTag == null) {
-            operationTotal = ATTRIBUTE_FORMAT.format(amount); // apparently not required
-        } else {
-            ModifierOperation operation = ModifierOperation.from((int) operationTag.getValue());
-            if (operation == ModifierOperation.ADD) {
-                if (name.equals("knockback_resistance")) {
-                    amount *= 10;
-                }
-                operationTotal = ATTRIBUTE_FORMAT.format(amount);
-            } else if (operation == ModifierOperation.ADD_MULTIPLIED || operation == ModifierOperation.MULTIPLY) {
-                operationTotal = ATTRIBUTE_FORMAT.format(amount * 100) + "%";
-            } else {
-                GeyserImpl.getInstance().getLogger().warning("Unhandled ModifierOperation while adding item attributes: " + operation);
-                return null;
+        ModifierOperation operation;
+        if (operationTag == null || (operation = ModifierOperation.from((int) operationTag.getValue())) == ModifierOperation.ADD) {
+            if (name.equals("generic.knockback_resistance")) {
+                amount *= 10;
             }
+            operationTotal = ATTRIBUTE_FORMAT.format(amount);
+        } else if (operation == ModifierOperation.ADD_MULTIPLIED || operation == ModifierOperation.MULTIPLY) {
+            operationTotal = ATTRIBUTE_FORMAT.format(amount * 100) + "%";
+        } else {
+            GeyserImpl.getInstance().getLogger().warning("Unhandled ModifierOperation while adding item attributes: " + operation);
+            return null;
         }
         if (amount > 0) {
             operationTotal = "+" + operationTotal;

--- a/core/src/main/java/org/geysermc/geyser/translator/inventory/item/ItemTranslator.java
+++ b/core/src/main/java/org/geysermc/geyser/translator/inventory/item/ItemTranslator.java
@@ -248,12 +248,11 @@ public final class ItemTranslator {
             return null;
         }
 
-        String name;
-        if (modifier.get("AttributeName") instanceof StringTag nameTag) {
-            name = nameTag.getValue().toLowerCase(Locale.ROOT);
-        } else {
+        if (!(modifier.get("AttributeName") instanceof StringTag nameTag)) {
             return null;
         }
+        String name = nameTag.getValue().replace("minecraft:", "");
+        // the namespace does not need to be present, but if it is, the java client ignores it
 
         String operationTotal;
         Tag operationTag = modifier.get("Operation");

--- a/core/src/main/java/org/geysermc/geyser/translator/inventory/item/ItemTranslator.java
+++ b/core/src/main/java/org/geysermc/geyser/translator/inventory/item/ItemTranslator.java
@@ -197,15 +197,15 @@ public final class ItemTranslator {
             }
 
             StringTag loreTag = new StringTag("", loreEntry);
-            if (modifierTag.get("Slot") == null) {
+            StringTag slotTag = modifierTag.get("Slot");
+            if (slotTag == null) {
                 // modifier applies to all slots implicitly
                 for (String slot : ALL_SLOTS) {
                     slotsToModifiers.computeIfAbsent(slot, s -> new ArrayList<>()).add(loreTag);
                 }
             } else {
                 // modifier applies to only the specified slot
-                String slot = ((StringTag) modifierTag.get("Slot")).getValue();
-                slotsToModifiers.computeIfAbsent(slot, s -> new ArrayList<>()).add(loreTag);
+                slotsToModifiers.computeIfAbsent(slotTag.getValue(), s -> new ArrayList<>()).add(loreTag);
             }
         }
 
@@ -236,14 +236,11 @@ public final class ItemTranslator {
 
     @Nullable
     private static String attributeToLore(CompoundTag modifier, String language) {
-        double amount;
-        if (modifier.get("Amount") instanceof IntTag intTag) {
-            amount = (double) intTag.getValue();
-        } else if (modifier.get("Amount") instanceof DoubleTag doubleTag) {
-            amount = doubleTag.getValue();
-        } else {
+        Tag amountTag = modifier.get("Amount");
+        if (amountTag == null || !(amountTag.getValue() instanceof Number number)) {
             return null;
         }
+        double amount = number.doubleValue();
         if (amount == 0) {
             return null;
         }

--- a/core/src/main/java/org/geysermc/geyser/translator/inventory/item/ItemTranslator.java
+++ b/core/src/main/java/org/geysermc/geyser/translator/inventory/item/ItemTranslator.java
@@ -202,6 +202,7 @@ public final class ItemTranslator {
                 continue;
             }
 
+            // e.g. "When in Main Hand"
             Component slotComponent = Component.text()
                     .resetStyle()
                     .color(NamedTextColor.GRAY)
@@ -209,6 +210,7 @@ public final class ItemTranslator {
                     .build();
             lore.add(new StringTag("", MessageTranslator.convertMessage(slotComponent, language)));
 
+            // Then list all the modifiers when used in this slot
             for (CompoundTag modifier : modifiers) {
                 double amount;
                 if (modifier.get("Amount") instanceof IntTag intTag) {
@@ -229,18 +231,23 @@ public final class ItemTranslator {
                     continue;
                 }
 
-                ModifierOperation operation = ModifierOperation.from((int) modifier.get("Operation").getValue());
                 String operationTotal;
-                if (operation == ModifierOperation.ADD) {
-                    if (name.equals("knockback_resistance")) {
-                        amount *= 10;
-                    }
-                    operationTotal = ATTRIBUTE_FORMAT.format(amount);
-                } else if (operation == ModifierOperation.ADD_MULTIPLIED || operation == ModifierOperation.MULTIPLY) {
-                    operationTotal = ATTRIBUTE_FORMAT.format(amount * 100) + "%";
+                Tag operationTag = modifier.get("Operation");
+                if (operationTag == null) {
+                    operationTotal = ATTRIBUTE_FORMAT.format(amount); // apparently not required
                 } else {
-                    GeyserImpl.getInstance().getLogger().warning("Unhandled ModifierOperation while adding item attributes: " + operation);
-                    continue;
+                    ModifierOperation operation = ModifierOperation.from((int) operationTag.getValue());
+                    if (operation == ModifierOperation.ADD) {
+                        if (name.equals("knockback_resistance")) {
+                            amount *= 10;
+                        }
+                        operationTotal = ATTRIBUTE_FORMAT.format(amount);
+                    } else if (operation == ModifierOperation.ADD_MULTIPLIED || operation == ModifierOperation.MULTIPLY) {
+                        operationTotal = ATTRIBUTE_FORMAT.format(amount * 100) + "%";
+                    } else {
+                        GeyserImpl.getInstance().getLogger().warning("Unhandled ModifierOperation while adding item attributes: " + operation);
+                        continue;
+                    }
                 }
                 if (amount > 0) {
                     operationTotal = "+" + operationTotal;


### PR DESCRIPTION
- `Name` was being used instead of `AttributeName`. It appears that the JE client doesn't require `Name` and requires `AttributeName` to be lowercase.
- Each modifier is now processed once instead of however many slots it applies to (either 1 or 6)
- The "hide attributes" item flag is now respected