### PR TITLE
Relocate org.yaml for bungee and spigot

### DIFF
--- a/bootstrap/bungeecord/build.gradle.kts
+++ b/bootstrap/bungeecord/build.gradle.kts
@@ -8,6 +8,7 @@ platformRelocate("net.md_5.bungee.jni")
 platformRelocate("com.fasterxml.jackson")
 platformRelocate("io.netty.channel.kqueue") // This is not used because relocating breaks natives, but we must include it or else we get ClassDefNotFound
 platformRelocate("net.kyori")
+platformRelocate("org.yaml") // Broken as of 1.20
 
 // These dependencies are already present on the platform
 provided(libs.bungeecord.proxy)
@@ -21,7 +22,6 @@ tasks.withType<com.github.jengelman.gradle.plugins.shadow.tasks.ShadowJar> {
 
     dependencies {
         exclude(dependency("com.google.*:.*"))
-        exclude(dependency("org.yaml:.*"))
         exclude(dependency("io.netty:netty-transport-native-epoll:.*"))
         exclude(dependency("io.netty:netty-transport-native-unix-common:.*"))
         exclude(dependency("io.netty:netty-handler:.*"))

--- a/bootstrap/spigot/build.gradle.kts
+++ b/bootstrap/spigot/build.gradle.kts
@@ -29,6 +29,7 @@ platformRelocate("com.fasterxml.jackson")
 platformRelocate("net.kyori", "net.kyori.adventure.text.logger.slf4j.ComponentLogger")
 platformRelocate("org.objectweb.asm")
 platformRelocate("me.lucko.commodore")
+platformRelocate("org.yaml") // Broken as of 1.20
 
 // These dependencies are already present on the platform
 provided(libs.viaversion)
@@ -42,7 +43,6 @@ tasks.withType<com.github.jengelman.gradle.plugins.shadow.tasks.ShadowJar> {
 
     dependencies {
         exclude(dependency("com.google.*:.*"))
-        exclude(dependency("org.yaml:.*"))
 
         // We cannot shade Netty, or else native libraries will not load
         // Needed because older Spigot builds do not provide the haproxy module


### PR DESCRIPTION
Closes https://github.com/GeyserMC/Geyser/issues/3819
```
[WARNING] Error loading plugin Geyser-BungeeCord
java.lang.NoSuchMethodError: 'void org.yaml.snakeyaml.parser.ParserImpl.<init>(org.yaml.snakeyaml.reader.StreamReader)'
    at org.geysermc.geyser.platform.bungeecord.shaded.com.fasterxml.jackson.dataformat.yaml.YAMLParser.<init>(YAMLParser.java:191)
    at org.geysermc.geyser.platform.bungeecord.shaded.com.fasterxml.jackson.dataformat.yaml.YAMLFactory._createParser(YAMLFactory.java:504)
    at org.geysermc.geyser.platform.bungeecord.shaded.com.fasterxml.jackson.dataformat.yaml.YAMLFactory.createParser(YAMLFactory.java:392)
    at org.geysermc.geyser.platform.bungeecord.shaded.com.fasterxml.jackson.dataformat.yaml.YAMLFactory.createParser(YAMLFactory.java:15)
    at org.geysermc.geyser.platform.bungeecord.shaded.com.fasterxml.jackson.databind.ObjectMapper.readValue(ObjectMapper.java:3542)
    at org.geysermc.geyser.util.FileUtils.loadConfig(FileUtils.java:57)
    at org.geysermc.geyser.platform.bungeecord.GeyserBungeePlugin.onLoad(GeyserBungeePlugin.java:99)
    at net.md_5.bungee.api.plugin.PluginManager.enablePlugin(PluginManager.java:345)
    at net.md_5.bungee.api.plugin.PluginManager.loadPlugins(PluginManager.java:251)
    at net.md_5.bungee.BungeeCord.start(BungeeCord.java:281)
    at net.md_5.bungee.BungeeCordLauncher.main(BungeeCordLauncher.java:67)
    at net.md_5.bungee.Bootstrap.main(Bootstrap.java:15)
```
CC: @Redned235 