### PR TITLE
Update handling of sign color/glow for 1.20

### DIFF
--- a/core/src/main/java/org/geysermc/geyser/translator/level/block/entity/SignBlockEntityTranslator.java
+++ b/core/src/main/java/org/geysermc/geyser/translator/level/block/entity/SignBlockEntityTranslator.java
@@ -133,13 +133,13 @@ public class SignBlockEntityTranslator extends BlockEntityTranslator {
         builder.putString("Text", signText.toString());
 
         // Java Edition 1.14 added the ability to change the text color of the whole sign using dye
-        Tag color = signData.get("Color");
+        Tag color = signData.get("color");
         if (color != null) {
             builder.putInt("SignTextColor", getBedrockSignColor(color.getValue().toString()));
         }
 
         // Glowing text
-        boolean isGlowing = getOrDefault(signData.get("GlowingText"), (byte) 0) != (byte) 0;
+        boolean isGlowing = getOrDefault(signData.get("has_glowing_text"), (byte) 0) != (byte) 0;
         builder.putBoolean("IgnoreLighting", isGlowing);
         return builder.build();
     }


### PR DESCRIPTION
The NBT of color/glow changed slightly in 1.20 java edition. For reference: <https://github.com/ViaVersion/ViaVersion/blob/7f347231bbdd0c279de52eb228bed310f52f0b5e/common/src/main/java/com/viaversion/viaversion/protocols/protocol1_20to1_19_4/packets/InventoryPackets.java#L187-L195>

Closes #3831