### PR TITLE
Translate armour trims on items

### DIFF
--- a/core/src/main/java/org/geysermc/geyser/item/type/ArmorItem.java
+++ b/core/src/main/java/org/geysermc/geyser/item/type/ArmorItem.java
@@ -25,7 +25,12 @@
 
 package org.geysermc.geyser.item.type;
 
+import com.github.steveice10.opennbt.tag.builtin.CompoundTag;
+import com.github.steveice10.opennbt.tag.builtin.StringTag;
+import org.checkerframework.checker.nullness.qual.NonNull;
 import org.geysermc.geyser.item.ArmorMaterial;
+import org.geysermc.geyser.registry.type.ItemMapping;
+import org.geysermc.geyser.session.GeyserSession;
 
 public class ArmorItem extends Item {
     private final ArmorMaterial material;
@@ -36,7 +41,41 @@ public class ArmorItem extends Item {
     }
 
     @Override
+    public void translateNbtToBedrock(@NonNull GeyserSession session, @NonNull CompoundTag tag) {
+        super.translateNbtToBedrock(session, tag);
+
+        if (tag.get("Trim") instanceof CompoundTag trim) {
+            StringTag material = trim.remove("material");
+            StringTag pattern = trim.remove("pattern");
+            // bedrock has an uppercase first letter key, and the value is not namespaced
+            trim.put(new StringTag("Material", stripNamespace(material.getValue())));
+            trim.put(new StringTag("Pattern", stripNamespace(pattern.getValue())));
+        }
+    }
+
+    @Override
+    public void translateNbtToJava(@NonNull CompoundTag tag, @NonNull ItemMapping mapping) {
+        super.translateNbtToJava(tag, mapping);
+
+        if (tag.get("Trim") instanceof CompoundTag trim) {
+            StringTag material = trim.remove("Material");
+            StringTag pattern = trim.remove("Pattern");
+            // java has a lowercase key, and namespaced value
+            trim.put(new StringTag("material", "minecraft:" + material.getValue()));
+            trim.put(new StringTag("pattern", "minecraft:" + pattern.getValue()));
+        }
+    }
+
+    @Override
     public boolean isValidRepairItem(Item other) {
         return material.getRepairIngredient() == other;
+    }
+
+    private static String stripNamespace(String identifier) {
+        int i = identifier.indexOf(':');
+        if (i >= 0) {
+            return identifier.substring(i + 1);
+        }
+        return identifier;
     }
 }

--- a/core/src/main/java/org/geysermc/geyser/item/type/Item.java
+++ b/core/src/main/java/org/geysermc/geyser/item/type/Item.java
@@ -144,7 +144,7 @@ public class Item {
     }
 
     /**
-     * Takes NBT from Java Edition and converts any value that Bedrock parses differently. <br>
+     * Takes NBT from Bedrock Edition and converts any value that Java parses differently. <br>
      * Do note that this method is, these days, only called in three places (as of 2023/~1.19):
      * <ul>
      *     <li>Extra recipe loading</li>


### PR DESCRIPTION
case and namespace differences (thanks bedrock)

I guess we don't know if the namespace is `minecraft` or not, but custom trims aren't supported anyway, so there isn't really anything to do.

Closes #3830