### PR TITLE
Add SessionJoinEvent and SessionLoginEvent

### DIFF
--- a/api/src/main/java/org/geysermc/geyser/api/event/bedrock/SessionJoinEvent.java
+++ b/api/src/main/java/org/geysermc/geyser/api/event/bedrock/SessionJoinEvent.java
@@ -1,0 +1,39 @@
+/*
+ * Copyright (c) 2019-2023 GeyserMC. http://geysermc.org
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ *
+ * @author GeyserMC
+ * @link https://github.com/GeyserMC/Geyser
+ */
+
+package org.geysermc.geyser.api.event.bedrock;
+
+import org.checkerframework.checker.nullness.qual.NonNull;
+import org.geysermc.geyser.api.connection.GeyserConnection;
+import org.geysermc.geyser.api.event.connection.ConnectionEvent;
+
+/**
+ * Called when Geyser session finished connecting to a Java remote server and is in a play-ready state.
+ */
+public final class SessionJoinEvent extends ConnectionEvent {
+    public SessionJoinEvent(@NonNull GeyserConnection connection) {
+        super(connection);
+    }
+}

--- a/api/src/main/java/org/geysermc/geyser/api/event/bedrock/SessionJoinEvent.java
+++ b/api/src/main/java/org/geysermc/geyser/api/event/bedrock/SessionJoinEvent.java
@@ -30,7 +30,7 @@ import org.geysermc.geyser.api.connection.GeyserConnection;
 import org.geysermc.geyser.api.event.connection.ConnectionEvent;
 
 /**
- * Called when Geyser session finished connecting to a Java remote server and is in a play-ready state.
+ * Called when Geyser session connected to a Java remote server and is in a play-ready state.
  */
 public final class SessionJoinEvent extends ConnectionEvent {
     public SessionJoinEvent(@NonNull GeyserConnection connection) {

--- a/api/src/main/java/org/geysermc/geyser/api/event/bedrock/SessionLoginEvent.java
+++ b/api/src/main/java/org/geysermc/geyser/api/event/bedrock/SessionLoginEvent.java
@@ -72,7 +72,7 @@ public final class SessionLoginEvent extends ConnectionEvent implements Cancella
      * @param disconnectReason The reason for the cancellation.
      * If cancelled, the player disconnects without connecting to the remote server.
      */
-    public void setCancelled(boolean cancelled,  @NonNull String disconnectReason) {
+    public void setCancelled(boolean cancelled, @NonNull String disconnectReason) {
         this.cancelled = cancelled;
         this.disconnectReason = disconnectReason;
     }

--- a/api/src/main/java/org/geysermc/geyser/api/event/bedrock/SessionLoginEvent.java
+++ b/api/src/main/java/org/geysermc/geyser/api/event/bedrock/SessionLoginEvent.java
@@ -34,22 +34,21 @@ import org.geysermc.geyser.api.network.RemoteServer;
 
 /**
  * Called when a session has logged in, and is about to connect to a remote java server.
+ * This event is cancellable, and can be used to prevent the player from connecting to the remote server.
  */
 public final class SessionLoginEvent extends ConnectionEvent implements Cancellable {
     private RemoteServer remoteServer;
     private boolean cancelled;
     private String disconnectReason;
 
-    /**
-     * @param connection The connection that is logging in.
-     * @param remoteServer The {@link RemoteServer} the section will try to connect to.
-     */
     public SessionLoginEvent(@NonNull GeyserConnection connection, @NonNull RemoteServer remoteServer) {
         super(connection);
         this.remoteServer = remoteServer;
     }
 
     /**
+     * Returns whether the event is cancelled.
+     *
      * @return The cancel status of the event.
      */
     @Override
@@ -58,9 +57,11 @@ public final class SessionLoginEvent extends ConnectionEvent implements Cancella
     }
 
     /**
-     * @param cancelled If the login event should be cancelled.
+     * Cancels the login event, and disconnects the player.
      * If cancelled, the player disconnects without connecting to the remote server.
      * This method will use a default disconnect reason. To specify one, use {@link #setCancelled(boolean, String)}.
+     *
+     * @param cancelled If the login event should be cancelled.
      */
     @Override
     public void setCancelled(boolean cancelled) {
@@ -68,9 +69,11 @@ public final class SessionLoginEvent extends ConnectionEvent implements Cancella
     }
 
     /**
+     * Cancels the login event, and disconnects the player with the specified reason.
+     * If cancelled, the player disconnects without connecting to the remote server.
+     *
      * @param cancelled If the login event should be cancelled.
      * @param disconnectReason The reason for the cancellation.
-     * If cancelled, the player disconnects without connecting to the remote server.
      */
     public void setCancelled(boolean cancelled, @NonNull String disconnectReason) {
         this.cancelled = cancelled;
@@ -78,22 +81,27 @@ public final class SessionLoginEvent extends ConnectionEvent implements Cancella
     }
 
     /**
+     * Returns the reason for the cancellation, or null if there is no reason given.
+     *
      * @return The reason for the cancellation.
-     * Returns null if there is no reason given.
      */
     public @Nullable String disconnectReason() {
         return this.disconnectReason;
     }
 
     /**
-     * @return The {@link RemoteServer} the section will connect to.
+     * Gets the {@link RemoteServer} the section will attempt to connect to.
+     *
+     * @return the {@link RemoteServer} the section will attempt to connect to.
      */
     public @NonNull RemoteServer remoteServer() {
         return this.remoteServer;
     }
 
     /**
-     * @param remoteServer Sets the {@link RemoteServer}  to connect to.
+     * Sets the {@link RemoteServer} to connect the session to.
+     *
+     * @param remoteServer Sets the {@link RemoteServer} to connect to.
      */
     public void remoteServer(@NonNull RemoteServer remoteServer) {
         this.remoteServer = remoteServer;

--- a/api/src/main/java/org/geysermc/geyser/api/event/bedrock/SessionLoginEvent.java
+++ b/api/src/main/java/org/geysermc/geyser/api/event/bedrock/SessionLoginEvent.java
@@ -26,15 +26,55 @@
 package org.geysermc.geyser.api.event.bedrock;
 
 import org.checkerframework.checker.nullness.qual.NonNull;
+import org.geysermc.event.Cancellable;
 import org.geysermc.geyser.api.connection.GeyserConnection;
 import org.geysermc.geyser.api.event.connection.ConnectionEvent;
+import org.geysermc.geyser.api.network.RemoteServer;
 
 /**
- * Called when Geyser has finished initializing a session for a new bedrock client, but before
- * the session connects to a remote Java server.
+ * Called when a session has logged in, and is about to connect to a remote jav server.
  */
-public final class SessionPreJoinEvent extends ConnectionEvent {
-    public SessionPreJoinEvent(@NonNull GeyserConnection connection) {
+public final class SessionLoginEvent extends ConnectionEvent implements Cancellable {
+    private RemoteServer remoteServer;
+    private boolean cancelled;
+
+    /**
+     * @param connection The connection that is logging in.
+     * @param remoteServer The {@link RemoteServer} the section will try to connect to.
+     */
+    public SessionLoginEvent(@NonNull GeyserConnection connection, RemoteServer remoteServer) {
         super(connection);
+        this.remoteServer = remoteServer;
+    }
+
+    /**
+     * @return The cancel status of the event.
+     */
+    @Override
+    public boolean isCancelled() {
+        return this.cancelled;
+    }
+
+    /**
+     * @param cancelled If the login event should be cancelled.
+     * If cancelled, the player disconnects without connecting to the remote server.
+     */
+    @Override
+    public void setCancelled(boolean cancelled) {
+        this.cancelled = cancelled;
+    }
+
+    /**
+     * @return The {@link RemoteServer} the section will connect to.
+     */
+    public RemoteServer remoteServer() {
+        return this.remoteServer;
+    }
+
+    /**
+     * @param remoteServer Sets the {@link RemoteServer}  to connect to.
+     */
+    public void remoteServer(RemoteServer remoteServer) {
+        this.remoteServer = remoteServer;
     }
 }

--- a/api/src/main/java/org/geysermc/geyser/api/event/bedrock/SessionLoginEvent.java
+++ b/api/src/main/java/org/geysermc/geyser/api/event/bedrock/SessionLoginEvent.java
@@ -32,7 +32,7 @@ import org.geysermc.geyser.api.event.connection.ConnectionEvent;
 import org.geysermc.geyser.api.network.RemoteServer;
 
 /**
- * Called when a session has logged in, and is about to connect to a remote jav server.
+ * Called when a session has logged in, and is about to connect to a remote java server.
  */
 public final class SessionLoginEvent extends ConnectionEvent implements Cancellable {
     private RemoteServer remoteServer;

--- a/api/src/main/java/org/geysermc/geyser/api/event/bedrock/SessionLoginEvent.java
+++ b/api/src/main/java/org/geysermc/geyser/api/event/bedrock/SessionLoginEvent.java
@@ -26,6 +26,7 @@
 package org.geysermc.geyser.api.event.bedrock;
 
 import org.checkerframework.checker.nullness.qual.NonNull;
+import org.checkerframework.checker.nullness.qual.Nullable;
 import org.geysermc.event.Cancellable;
 import org.geysermc.geyser.api.connection.GeyserConnection;
 import org.geysermc.geyser.api.event.connection.ConnectionEvent;
@@ -37,12 +38,13 @@ import org.geysermc.geyser.api.network.RemoteServer;
 public final class SessionLoginEvent extends ConnectionEvent implements Cancellable {
     private RemoteServer remoteServer;
     private boolean cancelled;
+    private String disconnectReason;
 
     /**
      * @param connection The connection that is logging in.
      * @param remoteServer The {@link RemoteServer} the section will try to connect to.
      */
-    public SessionLoginEvent(@NonNull GeyserConnection connection, RemoteServer remoteServer) {
+    public SessionLoginEvent(@NonNull GeyserConnection connection, @NonNull RemoteServer remoteServer) {
         super(connection);
         this.remoteServer = remoteServer;
     }
@@ -58,6 +60,7 @@ public final class SessionLoginEvent extends ConnectionEvent implements Cancella
     /**
      * @param cancelled If the login event should be cancelled.
      * If cancelled, the player disconnects without connecting to the remote server.
+     * This method will use a default disconnect reason. To specify one, use {@link #setCancelled(boolean, String)}.
      */
     @Override
     public void setCancelled(boolean cancelled) {
@@ -65,16 +68,34 @@ public final class SessionLoginEvent extends ConnectionEvent implements Cancella
     }
 
     /**
+     * @param cancelled If the login event should be cancelled.
+     * @param disconnectReason The reason for the cancellation.
+     * If cancelled, the player disconnects without connecting to the remote server.
+     */
+    public void setCancelled(boolean cancelled,  @NonNull String disconnectReason) {
+        this.cancelled = cancelled;
+        this.disconnectReason = disconnectReason;
+    }
+
+    /**
+     * @return The reason for the cancellation.
+     * Returns null if there is no reason given.
+     */
+    public @Nullable String disconnectReason() {
+        return this.disconnectReason;
+    }
+
+    /**
      * @return The {@link RemoteServer} the section will connect to.
      */
-    public RemoteServer remoteServer() {
+    public @NonNull RemoteServer remoteServer() {
         return this.remoteServer;
     }
 
     /**
      * @param remoteServer Sets the {@link RemoteServer}  to connect to.
      */
-    public void remoteServer(RemoteServer remoteServer) {
+    public void remoteServer(@NonNull RemoteServer remoteServer) {
         this.remoteServer = remoteServer;
     }
 }

--- a/api/src/main/java/org/geysermc/geyser/api/event/bedrock/SessionPreJoinEvent.java
+++ b/api/src/main/java/org/geysermc/geyser/api/event/bedrock/SessionPreJoinEvent.java
@@ -1,0 +1,40 @@
+/*
+ * Copyright (c) 2019-2023 GeyserMC. http://geysermc.org
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ *
+ * @author GeyserMC
+ * @link https://github.com/GeyserMC/Geyser
+ */
+
+package org.geysermc.geyser.api.event.bedrock;
+
+import org.checkerframework.checker.nullness.qual.NonNull;
+import org.geysermc.geyser.api.connection.GeyserConnection;
+import org.geysermc.geyser.api.event.connection.ConnectionEvent;
+
+/**
+ * Called when Geyser has finished initializing a session for a new bedrock client, but before
+ * the session connects to a remote Java server.
+ */
+public final class SessionPreJoinEvent extends ConnectionEvent {
+    public SessionPreJoinEvent(@NonNull GeyserConnection connection) {
+        super(connection);
+    }
+}

--- a/core/src/main/java/org/geysermc/geyser/session/GeyserSession.java
+++ b/core/src/main/java/org/geysermc/geyser/session/GeyserSession.java
@@ -887,7 +887,9 @@ public class GeyserSession implements GeyserConnection, GeyserCommandSource {
         SessionLoginEvent loginEvent = new SessionLoginEvent(this, remoteServer);
         GeyserImpl.getInstance().eventBus().fire(loginEvent);
         if (loginEvent.isCancelled()) {
-            disconnect("Login event cancelled");
+            String disconnectReason = loginEvent.disconnectReason() == null ?
+                    GeyserLocale.getLocaleStringLog("geyser.network.disconnect.closed_by_remote_peer") : loginEvent.disconnectReason();
+            disconnect(disconnectReason);
             return;
         }
 

--- a/core/src/main/java/org/geysermc/geyser/session/GeyserSession.java
+++ b/core/src/main/java/org/geysermc/geyser/session/GeyserSession.java
@@ -86,6 +86,7 @@ import org.checkerframework.checker.nullness.qual.Nullable;
 import org.checkerframework.common.value.qual.IntRange;
 import org.cloudburstmc.math.vector.*;
 import org.cloudburstmc.nbt.NbtMap;
+import org.cloudburstmc.protocol.bedrock.BedrockDisconnectReasons;
 import org.cloudburstmc.protocol.bedrock.BedrockServerSession;
 import org.cloudburstmc.protocol.bedrock.data.*;
 import org.cloudburstmc.protocol.bedrock.data.command.CommandEnumData;
@@ -888,7 +889,7 @@ public class GeyserSession implements GeyserConnection, GeyserCommandSource {
         GeyserImpl.getInstance().eventBus().fire(loginEvent);
         if (loginEvent.isCancelled()) {
             String disconnectReason = loginEvent.disconnectReason() == null ?
-                    GeyserLocale.getLocaleStringLog("geyser.network.disconnect.closed_by_remote_peer") : loginEvent.disconnectReason();
+                    BedrockDisconnectReasons.DISCONNECTED : loginEvent.disconnectReason();
             disconnect(disconnectReason);
             return;
         }

--- a/core/src/main/java/org/geysermc/geyser/session/GeyserSession.java
+++ b/core/src/main/java/org/geysermc/geyser/session/GeyserSession.java
@@ -56,7 +56,11 @@ import com.github.steveice10.mc.protocol.packet.ingame.serverbound.player.Server
 import com.github.steveice10.mc.protocol.packet.login.serverbound.ServerboundCustomQueryPacket;
 import com.github.steveice10.packetlib.BuiltinFlags;
 import com.github.steveice10.packetlib.Session;
-import com.github.steveice10.packetlib.event.session.*;
+import com.github.steveice10.packetlib.event.session.ConnectedEvent;
+import com.github.steveice10.packetlib.event.session.DisconnectedEvent;
+import com.github.steveice10.packetlib.event.session.PacketErrorEvent;
+import com.github.steveice10.packetlib.event.session.PacketSendingEvent;
+import com.github.steveice10.packetlib.event.session.SessionAdapter;
 import com.github.steveice10.packetlib.packet.Packet;
 import com.github.steveice10.packetlib.tcp.TcpClientSession;
 import com.github.steveice10.packetlib.tcp.TcpSession;
@@ -104,7 +108,6 @@ import org.geysermc.geyser.GeyserImpl;
 import org.geysermc.geyser.api.connection.GeyserConnection;
 import org.geysermc.geyser.api.entity.type.GeyserEntity;
 import org.geysermc.geyser.api.entity.type.player.GeyserPlayerEntity;
-import org.geysermc.geyser.api.event.bedrock.SessionJoinEvent;
 import org.geysermc.geyser.api.event.bedrock.SessionPreJoinEvent;
 import org.geysermc.geyser.api.network.AuthType;
 import org.geysermc.geyser.api.network.RemoteServer;
@@ -669,8 +672,6 @@ public class GeyserSession implements GeyserConnection, GeyserCommandSource {
         // Ensure client doesn't try and do anything funky; the server handles this for us
         gamerulePacket.getGameRules().add(new GameRuleData<>("spawnradius", 0));
         upstream.sendPacket(gamerulePacket);
-
-        GeyserImpl.getInstance().eventBus().fire(new SessionJoinEvent(this));
     }
 
     public void authenticate(String username) {

--- a/core/src/main/java/org/geysermc/geyser/session/GeyserSession.java
+++ b/core/src/main/java/org/geysermc/geyser/session/GeyserSession.java
@@ -104,6 +104,8 @@ import org.geysermc.geyser.GeyserImpl;
 import org.geysermc.geyser.api.connection.GeyserConnection;
 import org.geysermc.geyser.api.entity.type.GeyserEntity;
 import org.geysermc.geyser.api.entity.type.player.GeyserPlayerEntity;
+import org.geysermc.geyser.api.event.bedrock.SessionJoinEvent;
+import org.geysermc.geyser.api.event.bedrock.SessionPreJoinEvent;
 import org.geysermc.geyser.api.network.AuthType;
 import org.geysermc.geyser.api.network.RemoteServer;
 import org.geysermc.geyser.command.GeyserCommandSource;
@@ -667,6 +669,8 @@ public class GeyserSession implements GeyserConnection, GeyserCommandSource {
         // Ensure client doesn't try and do anything funky; the server handles this for us
         gamerulePacket.getGameRules().add(new GameRuleData<>("spawnradius", 0));
         upstream.sendPacket(gamerulePacket);
+
+        GeyserImpl.getInstance().eventBus().fire(new SessionJoinEvent(this));
     }
 
     public void authenticate(String username) {
@@ -879,6 +883,8 @@ public class GeyserSession implements GeyserConnection, GeyserCommandSource {
      * After getting whatever credentials needed, we attempt to join the Java server.
      */
     private void connectDownstream() {
+        GeyserImpl.getInstance().eventBus().fire(new SessionPreJoinEvent(this));
+
         boolean floodgate = this.remoteServer.authType() == AuthType.FLOODGATE;
 
         // Start ticking

--- a/core/src/main/java/org/geysermc/geyser/session/GeyserSession.java
+++ b/core/src/main/java/org/geysermc/geyser/session/GeyserSession.java
@@ -108,7 +108,7 @@ import org.geysermc.geyser.GeyserImpl;
 import org.geysermc.geyser.api.connection.GeyserConnection;
 import org.geysermc.geyser.api.entity.type.GeyserEntity;
 import org.geysermc.geyser.api.entity.type.player.GeyserPlayerEntity;
-import org.geysermc.geyser.api.event.bedrock.SessionPreJoinEvent;
+import org.geysermc.geyser.api.event.bedrock.SessionLoginEvent;
 import org.geysermc.geyser.api.network.AuthType;
 import org.geysermc.geyser.api.network.RemoteServer;
 import org.geysermc.geyser.command.GeyserCommandSource;
@@ -884,8 +884,14 @@ public class GeyserSession implements GeyserConnection, GeyserCommandSource {
      * After getting whatever credentials needed, we attempt to join the Java server.
      */
     private void connectDownstream() {
-        GeyserImpl.getInstance().eventBus().fire(new SessionPreJoinEvent(this));
+        SessionLoginEvent loginEvent = new SessionLoginEvent(this, remoteServer);
+        GeyserImpl.getInstance().eventBus().fire(loginEvent);
+        if (loginEvent.isCancelled()) {
+            disconnect("Login event cancelled");
+            return;
+        }
 
+        this.remoteServer = loginEvent.remoteServer();
         boolean floodgate = this.remoteServer.authType() == AuthType.FLOODGATE;
 
         // Start ticking

--- a/core/src/main/java/org/geysermc/geyser/translator/protocol/bedrock/BedrockSetLocalPlayerAsInitializedTranslator.java
+++ b/core/src/main/java/org/geysermc/geyser/translator/protocol/bedrock/BedrockSetLocalPlayerAsInitializedTranslator.java
@@ -26,6 +26,8 @@
 package org.geysermc.geyser.translator.protocol.bedrock;
 
 import org.cloudburstmc.protocol.bedrock.packet.SetLocalPlayerAsInitializedPacket;
+import org.geysermc.geyser.GeyserImpl;
+import org.geysermc.geyser.api.event.bedrock.SessionJoinEvent;
 import org.geysermc.geyser.api.network.AuthType;
 import org.geysermc.geyser.session.GeyserSession;
 import org.geysermc.geyser.translator.protocol.PacketTranslator;
@@ -68,6 +70,8 @@ public class BedrockSetLocalPlayerAsInitializedTranslator extends PacketTranslat
 
                     // What am I to expect - as of Bedrock 1.18
                     session.getFormCache().resendAllForms();
+
+                    GeyserImpl.getInstance().eventBus().fire(new SessionJoinEvent(session));
                 }
             }
         }


### PR DESCRIPTION
Adding these events would allow extensions (but basically anything that uses the api) to get new connections in geyser in the api - allowing for things like blocking a player from joining before they ever reach the java server, or to grab input mode/xuid early.

~~SessionPreJoinEvent~~ SessionLoginEvent would be fired once the session is done initializing, but before the java connection is established. Is cancellable.
SessionJoinEvent would be fired once the bedrock player loaded in fully on the java server.

Feedback/Changes welcome; especially with where those events are fired/event names.