### PR TITLE
Update EmotePacket creation for 1.20

### DIFF
--- a/core/src/main/java/org/geysermc/geyser/session/GeyserSession.java
+++ b/core/src/main/java/org/geysermc/geyser/session/GeyserSession.java
@@ -1950,7 +1950,7 @@ public class GeyserSession implements GeyserConnection, GeyserCommandSource {
 
         EmotePacket packet = new EmotePacket();
         packet.setRuntimeEntityId(entity.getGeyserId());
-        packet.setXuid(""); // not required but cannot be null
+        packet.setXuid("");
         packet.setPlatformId(""); // BDS sends empty
         packet.setEmoteId(emoteId);
         sendUpstreamPacket(packet);

--- a/core/src/main/java/org/geysermc/geyser/session/GeyserSession.java
+++ b/core/src/main/java/org/geysermc/geyser/session/GeyserSession.java
@@ -1949,8 +1949,10 @@ public class GeyserSession implements GeyserConnection, GeyserCommandSource {
         }
 
         EmotePacket packet = new EmotePacket();
-        packet.setEmoteId(emoteId);
         packet.setRuntimeEntityId(entity.getGeyserId());
+        packet.setXuid(""); // not required but cannot be null
+        packet.setPlatformId(""); // BDS sends empty
+        packet.setEmoteId(emoteId);
         sendUpstreamPacket(packet);
     }
 

--- a/core/src/main/java/org/geysermc/geyser/translator/level/block/entity/SignBlockEntityTranslator.java
+++ b/core/src/main/java/org/geysermc/geyser/translator/level/block/entity/SignBlockEntityTranslator.java
@@ -133,13 +133,13 @@ public class SignBlockEntityTranslator extends BlockEntityTranslator {
         builder.putString("Text", signText.toString());
 
         // Java Edition 1.14 added the ability to change the text color of the whole sign using dye
-        Tag color = signData.get("Color");
+        Tag color = signData.get("color");
         if (color != null) {
             builder.putInt("SignTextColor", getBedrockSignColor(color.getValue().toString()));
         }
 
         // Glowing text
-        boolean isGlowing = getOrDefault(signData.get("GlowingText"), (byte) 0) != (byte) 0;
+        boolean isGlowing = getOrDefault(signData.get("has_glowing_text"), (byte) 0) != (byte) 0;
         builder.putBoolean("IgnoreLighting", isGlowing);
         return builder.build();
     }

--- a/core/src/main/java/org/geysermc/geyser/translator/protocol/bedrock/entity/player/BedrockEmoteTranslator.java
+++ b/core/src/main/java/org/geysermc/geyser/translator/protocol/bedrock/entity/player/BedrockEmoteTranslator.java
@@ -87,6 +87,7 @@ public class BedrockEmoteTranslator extends PacketTranslator<EmotePacket> {
             packet.setXuid(emoterXuid);
             packet.setPlatformId(""); // BDS sends empty
             packet.setEmoteId(emoteId);
+            session.sendUpstreamPacket(packet);
         }
     }
 }


### PR DESCRIPTION
The emoter xuid and platformId were introduced in v589 to the packet. They can be empty.

Closes #3838