### PR TITLE
Implement support for changing auth and session base URIs

### DIFF
--- a/core/src/main/java/org/geysermc/geyser/configuration/GeyserConfiguration.java
+++ b/core/src/main/java/org/geysermc/geyser/configuration/GeyserConfiguration.java
@@ -82,6 +82,10 @@ public interface GeyserConfiguration {
 
     boolean isAllowThirdPartyEars();
 
+    String getAuthBaseUri();
+
+    String getSessionBaseUri();
+
     String getShowCooldown();
 
     boolean isShowCoordinates();

--- a/core/src/main/java/org/geysermc/geyser/configuration/GeyserJacksonConfiguration.java
+++ b/core/src/main/java/org/geysermc/geyser/configuration/GeyserJacksonConfiguration.java
@@ -99,6 +99,12 @@ public abstract class GeyserJacksonConfiguration implements GeyserConfiguration 
     @JsonProperty("allow-third-party-capes")
     private boolean allowThirdPartyCapes = true;
 
+    @JsonProperty("auth-base-uri")
+    private String authBaseUri = "";
+
+    @JsonProperty("session-base-uri")
+    private String sessionBaseUri = "";
+
     @JsonProperty("show-cooldown")
     private String showCooldown = "title";
 

--- a/core/src/main/resources/config.yml
+++ b/core/src/main/resources/config.yml
@@ -117,6 +117,17 @@ allow-third-party-capes: false
 # MinecraftCapes
 allow-third-party-ears: false
 
+# Set a custom base URI for the authentication server.
+# Should look similar to the following: https://authserver.example.com/
+# You don't need this, unless you run your own auth server.
+# Leave empty to use the official auth servers.
+auth-base-uri: ""
+# Set a custom base URI for the session server.
+# Should look similar to the following: https://session.example.com/
+# You don't need this, unless you run your own session server.
+# Leave empty to use the official session servers.
+session-base-uri: ""
+
 # Allow a fake cooldown indicator to be sent. Bedrock players otherwise do not see a cooldown as they still use 1.8 combat.
 # Please note: if the cooldown is enabled, some users may see a black box during the cooldown sequence, like below:
 # https://cdn.discordapp.com/attachments/613170125696270357/957075682230419466/Screenshot_from_2022-03-25_20-35-08.png


### PR DESCRIPTION
This pull requests adds two configuration options:
```
# Set a custom base URI for the authentication server.
# Should look similar to the following: https://authserver.example.com/
# You don't need this, unless you run your own auth server.
# Leave empty to use the official auth servers.
auth-base-uri: ""
# Set a custom base URI for the session server.
# Should look similar to the following: https://session.example.com/
# You don't need this, unless you run your own session server.
# Leave empty to use the official session servers.
session-base-uri: ""
```

These allow changing the auth and session server (used for authentication in online mode) from Mojang's official servers to an instance of a custom Yggdrasil implementation.

After setting the configuration values to the URI of a custom Yggdrasil server, as well as `auth-type` to `online`, Bedrock Edition players will be authenticated with the custom Yggdrasil server instead of the official ones when choosing to log in with a Mojang account in Geyser.

Some people might think that the only reason to run a custom Yggdrasil server would be piracy, but there are multiple legitimate use cases I can think of for running a custom Yggdrasil server:
* Allowing Bedrock Edition players to connect to a **vanilla** Java Edition server that runs in online-mode. This actually is the reason I made this pull request. I wrote my own implementation of Yggdrasil, that allows players with legitimate Microsoft accounts to connect to the server normally, while letting me create additional accounts for Bedrock Edition players.
* Allowing admins to log in as other players.
* Being able to play on your own online-mode server when you don't have an internet connection, without losing progression.
* Being able to utilize the security benefits of online-mode instead needing to use offline mode and login plugins (which also isn't possible in vanilla). Aside from cracked servers, this is also useful for people in countries where access to the official servers is blocked.
* People refusing to migrate to Microsoft accounts / wanting to disable telemetry / chat reporting without needing to mod the game.

This has already been requested in issues such as #1095, and the reason for not implementing it at the time was due to the libraries being used not supporting it, however this has since been resolved, therefore I made this pull request.