### PR TITLE
Leniency when trimming incoming sound ids

### DIFF
--- a/core/src/main/java/org/geysermc/geyser/util/SoundUtils.java
+++ b/core/src/main/java/org/geysermc/geyser/util/SoundUtils.java
@@ -79,8 +79,9 @@ public final class SoundUtils {
 
     private static String trim(String identifier) {
         // Drop any namespace if applicable
-        if (identifier.contains(":")) {
-            return identifier.split(":")[1];
+        int i = identifier.indexOf(':');
+        if (i >= 0) {
+            return identifier.substring(i + 1);
         }
         return identifier;
     }


### PR DESCRIPTION
With this, if there is nothing after the `:`, then an empty string is returned.

Closes #3822