### PR TITLE
Fix shift clicking Stonecutter output

### DIFF
--- a/core/src/main/java/org/geysermc/geyser/translator/inventory/StonecutterInventoryTranslator.java
+++ b/core/src/main/java/org/geysermc/geyser/translator/inventory/StonecutterInventoryTranslator.java
@@ -62,19 +62,20 @@ public class StonecutterInventoryTranslator extends AbstractBlockInventoryTransl
         }
 
         StonecutterContainer container = (StonecutterContainer) inventory;
+        ItemStack javaOutput = craftingData.output();
         int button = craftingData.buttonId();
+
         // If we've already pressed the button with this item, no need to press it again!
         if (container.getStonecutterButton() != button) {
-            ItemStack javaOutput = craftingData.output();
-
             // Getting the index of the item in the Java stonecutter list
             ServerboundContainerButtonClickPacket packet = new ServerboundContainerButtonClickPacket(inventory.getJavaId(), button);
             session.sendDownstreamPacket(packet);
             container.setStonecutterButton(button);
-            if (inventory.getItem(1).getJavaId() != javaOutput.getId()) {
-                // We don't know there is an output here, so we tell ourselves that there is
-                inventory.setItem(1, GeyserItemStack.from(javaOutput), session);
-            }
+        }
+
+        if (inventory.getItem(1).getJavaId() != javaOutput.getId()) {
+            // We don't know there is an output here, so we tell ourselves that there is
+            inventory.setItem(1, GeyserItemStack.from(javaOutput), session);
         }
 
         return translateRequest(session, inventory, request);


### PR DESCRIPTION
Closes #3816
Also related to #3361

Clicking the output slot sets it to empty, which was confusing the request translator when transferring more than one item
https://github.com/GeyserMC/Geyser/blob/1788295291c1fc114e0e3c803175ee0b905d3e53/core/src/main/java/org/geysermc/geyser/inventory/click/ClickPlan.java#L231