### PR TITLE
New entity mount offsets

### DIFF
--- a/core/src/main/java/org/geysermc/geyser/entity/type/Entity.java
+++ b/core/src/main/java/org/geysermc/geyser/entity/type/Entity.java
@@ -493,9 +493,10 @@ public class Entity implements GeyserEntity {
      * Update the mount offsets of each passenger on this vehicle
      */
     protected void updatePassengerOffsets() {
-        for (Entity passenger : passengers) {
+        for (int i = 0; i < passengers.size(); i++) {
+            Entity passenger = passengers.get(i);
             if (passenger != null) {
-                boolean rider = passengers.get(0) == this;
+                boolean rider = i == 0;
                 EntityUtils.updateMountOffset(passenger, this, rider, true, passengers.size() > 1);
                 passenger.updateBedrockMetadata();
             }

--- a/core/src/main/java/org/geysermc/geyser/entity/type/living/animal/horse/CamelEntity.java
+++ b/core/src/main/java/org/geysermc/geyser/entity/type/living/animal/horse/CamelEntity.java
@@ -103,7 +103,7 @@ public class CamelEntity extends AbstractHorseEntity {
     @Override
     protected void setDimensions(Pose pose) {
         if (pose == Pose.SITTING) {
-            setBoundingBoxWidth(definition.height() - SITTING_HEIGHT_DIFFERENCE);
+            setBoundingBoxHeight(definition.height() - SITTING_HEIGHT_DIFFERENCE);
             setBoundingBoxWidth(definition.width());
         } else {
             super.setDimensions(pose);

--- a/core/src/main/java/org/geysermc/geyser/entity/type/living/animal/horse/CamelEntity.java
+++ b/core/src/main/java/org/geysermc/geyser/entity/type/living/animal/horse/CamelEntity.java
@@ -43,7 +43,7 @@ import java.util.UUID;
 
 public class CamelEntity extends AbstractHorseEntity {
 
-    private static final float SITTING_HEIGHT_DIFFERENCE = 1.43F;
+    public static final float SITTING_HEIGHT_DIFFERENCE = 1.43F;
 
     public CamelEntity(GeyserSession session, int entityId, long geyserId, UUID uuid, EntityDefinition<?> definition, Vector3f position, Vector3f motion, float yaw, float pitch, float headYaw) {
         super(session, entityId, geyserId, uuid, definition, position, motion, yaw, pitch, headYaw);

--- a/core/src/main/java/org/geysermc/geyser/util/EntityUtils.java
+++ b/core/src/main/java/org/geysermc/geyser/util/EntityUtils.java
@@ -202,10 +202,11 @@ public final class EntityUtils {
              * Horses are tinier
              * Players, Minecarts, and Boats have different origins
              */
+            if (mount.getDefinition().entityType() == EntityType.PLAYER) {
+                yOffset -= EntityDefinitions.PLAYER.offset();
+            }
             if (passenger.getDefinition().entityType() == EntityType.PLAYER) {
-                if (mount.getDefinition().entityType() != EntityType.PLAYER && mount.getDefinition().entityType() != EntityType.AREA_EFFECT_CLOUD) {
-                    yOffset += EntityDefinitions.PLAYER.offset();
-                }
+                yOffset += EntityDefinitions.PLAYER.offset();
             }
             switch (mount.getDefinition().entityType()) {
                 case MINECART, HOPPER_MINECART, TNT_MINECART, CHEST_MINECART, FURNACE_MINECART, SPAWNER_MINECART,

--- a/core/src/main/java/org/geysermc/geyser/util/EntityUtils.java
+++ b/core/src/main/java/org/geysermc/geyser/util/EntityUtils.java
@@ -82,19 +82,28 @@ public final class EntityUtils {
         float height = mount.getBoundingBoxHeight();
         float mountedHeightOffset = height * 0.75f;
         switch (mount.getDefinition().entityType()) {
+            case CAMEL -> {
+                boolean isBaby = mount.getFlag(EntityFlag.BABY);
+                mountedHeightOffset = height - (isBaby ? 0.35f : 0.6f);
+            }
             case CHICKEN, SPIDER -> mountedHeightOffset = height * 0.5f;
             case DONKEY, MULE -> mountedHeightOffset -= 0.25f;
             case TRADER_LLAMA, LLAMA -> mountedHeightOffset = height * 0.6f;
             case MINECART, HOPPER_MINECART, TNT_MINECART, CHEST_MINECART, FURNACE_MINECART, SPAWNER_MINECART,
                     COMMAND_BLOCK_MINECART -> mountedHeightOffset = 0;
-            case BOAT, CHEST_BOAT -> mountedHeightOffset = -0.1f;
+            case BOAT, CHEST_BOAT -> {
+                boolean isBamboo = ((BoatEntity) mount).getVariant() == 8;
+                mountedHeightOffset = isBamboo ? 0.25f : -0.1f;
+            }
             case HOGLIN, ZOGLIN -> {
                 boolean isBaby = mount.getFlag(EntityFlag.BABY);
                 mountedHeightOffset = height - (isBaby ? 0.2f : 0.15f);
             }
             case PIGLIN -> mountedHeightOffset = height * 0.92f;
+            case PHANTOM -> mountedHeightOffset = height * 0.85f;
             case RAVAGER -> mountedHeightOffset = 2.1f;
             case SKELETON_HORSE -> mountedHeightOffset -= 0.1875f;
+            case SNIFFER -> mountedHeightOffset = 1.8f;
             case STRIDER -> mountedHeightOffset = height - 0.19f;
         }
         return mountedHeightOffset;
@@ -103,9 +112,9 @@ public final class EntityUtils {
     private static float getHeightOffset(Entity passenger) {
         boolean isBaby;
         switch (passenger.getDefinition().entityType()) {
-            case SKELETON:
-            case STRAY:
-            case WITHER_SKELETON:
+            case ALLAY, VEX:
+                return 0.4f;
+            case SKELETON, STRAY, WITHER_SKELETON:
                 return -0.6f;
             case ARMOR_STAND:
                 if (((ArmorStandEntity) passenger).isMarker()) {
@@ -113,26 +122,24 @@ public final class EntityUtils {
                 } else {
                     return 0.1f;
                 }
-            case ENDERMITE:
-            case SILVERFISH:
+            case ENDERMITE, SILVERFISH:
                 return 0.1f;
-            case PIGLIN:
-            case PIGLIN_BRUTE:
-            case ZOMBIFIED_PIGLIN:
+            case PIGLIN, PIGLIN_BRUTE, ZOMBIFIED_PIGLIN:
                 isBaby = passenger.getFlag(EntityFlag.BABY);
                 return isBaby ? -0.05f : -0.45f;
             case ZOMBIE:
                 isBaby = passenger.getFlag(EntityFlag.BABY);
                 return isBaby ? 0.0f : -0.45f;
-            case EVOKER:
-            case ILLUSIONER:
-            case PILLAGER:
-            case RAVAGER:
-            case VINDICATOR:
-            case WITCH:
+            case EVOKER, ILLUSIONER, PILLAGER, RAVAGER, VINDICATOR, WITCH:
                 return -0.45f;
             case PLAYER:
                 return -0.35f;
+            case SHULKER:
+                // TODO check and test!
+                Entity vehicle = passenger.getVehicle();
+                if (vehicle instanceof BoatEntity || vehicle.getDefinition() == EntityDefinitions.MINECART) {
+                    return 0.1875f - getMountedHeightOffset(vehicle);
+                }
         }
         if (passenger instanceof AnimalEntity) {
             return 0.14f;

--- a/core/src/main/java/org/geysermc/geyser/util/EntityUtils.java
+++ b/core/src/main/java/org/geysermc/geyser/util/EntityUtils.java
@@ -214,9 +214,7 @@ public final class EntityUtils {
             switch (passenger.getDefinition().entityType()) {
                 case MINECART, HOPPER_MINECART, TNT_MINECART, CHEST_MINECART, FURNACE_MINECART, SPAWNER_MINECART,
                         COMMAND_BLOCK_MINECART, BOAT, CHEST_BOAT -> yOffset += passenger.getDefinition().height() * 0.5f;
-            }
-            if (passenger.getDefinition().entityType() == EntityType.FALLING_BLOCK) {
-                yOffset += 0.5f;
+                case FALLING_BLOCK -> yOffset += 0.5f;
             }
             if (mount instanceof ArmorStandEntity armorStand) {
                 yOffset -= armorStand.getYOffset();

--- a/core/src/main/java/org/geysermc/geyser/util/EntityUtils.java
+++ b/core/src/main/java/org/geysermc/geyser/util/EntityUtils.java
@@ -87,7 +87,7 @@ public final class EntityUtils {
                 boolean isBaby = mount.getFlag(EntityFlag.BABY);
                 mountedHeightOffset = height - (isBaby ? 0.35f : 0.6f);
             }
-            case CHICKEN, SPIDER -> mountedHeightOffset = height * 0.5f;
+            case CAVE_SPIDER, CHICKEN, SPIDER -> mountedHeightOffset = height * 0.5f;
             case DONKEY, MULE -> mountedHeightOffset -= 0.25f;
             case TRADER_LLAMA, LLAMA -> mountedHeightOffset = height * 0.6f;
             case MINECART, HOPPER_MINECART, TNT_MINECART, CHEST_MINECART, FURNACE_MINECART, SPAWNER_MINECART,
@@ -101,7 +101,7 @@ public final class EntityUtils {
                 mountedHeightOffset = height - (isBaby ? 0.2f : 0.15f);
             }
             case PIGLIN -> mountedHeightOffset = height * 0.92f;
-            case PHANTOM -> mountedHeightOffset = height * 0.85f;
+            case PHANTOM -> mountedHeightOffset = height * 0.35f;
             case RAVAGER -> mountedHeightOffset = 2.1f;
             case SKELETON_HORSE -> mountedHeightOffset -= 0.1875f;
             case SNIFFER -> mountedHeightOffset = 1.8f;
@@ -128,7 +128,7 @@ public final class EntityUtils {
             case PIGLIN, PIGLIN_BRUTE, ZOMBIFIED_PIGLIN:
                 isBaby = passenger.getFlag(EntityFlag.BABY);
                 return isBaby ? -0.05f : -0.45f;
-            case ZOMBIE:
+            case DROWNED, HUSK, ZOMBIE_VILLAGER, ZOMBIE:
                 isBaby = passenger.getFlag(EntityFlag.BABY);
                 return isBaby ? 0.0f : -0.45f;
             case EVOKER, ILLUSIONER, PILLAGER, RAVAGER, VINDICATOR, WITCH:

--- a/core/src/main/java/org/geysermc/geyser/util/EntityUtils.java
+++ b/core/src/main/java/org/geysermc/geyser/util/EntityUtils.java
@@ -136,7 +136,6 @@ public final class EntityUtils {
             case PLAYER:
                 return -0.35f;
             case SHULKER:
-                // TODO check and test!
                 Entity vehicle = passenger.getVehicle();
                 if (vehicle instanceof BoatEntity || vehicle.getDefinition() == EntityDefinitions.MINECART) {
                     return 0.1875f - getMountedHeightOffset(vehicle);
@@ -197,12 +196,6 @@ public final class EntityUtils {
                 case CHICKEN -> zOffset = -0.1f;
                 case TRADER_LLAMA, LLAMA -> zOffset = -0.3f;
             }
-            if (passenger.getDefinition().entityType() == EntityType.SHULKER) {
-                switch (mount.getDefinition().entityType()) {
-                    case MINECART, HOPPER_MINECART, TNT_MINECART, CHEST_MINECART, FURNACE_MINECART, SPAWNER_MINECART,
-                            COMMAND_BLOCK_MINECART, BOAT, CHEST_BOAT -> yOffset = 0.1875f;
-                }
-            }
             /*
              * Bedrock Differences
              * Zoglin & Hoglin seem to be taller in Bedrock edition
@@ -217,6 +210,10 @@ public final class EntityUtils {
             switch (mount.getDefinition().entityType()) {
                 case MINECART, HOPPER_MINECART, TNT_MINECART, CHEST_MINECART, FURNACE_MINECART, SPAWNER_MINECART,
                         COMMAND_BLOCK_MINECART, BOAT, CHEST_BOAT -> yOffset -= mount.getDefinition().height() * 0.5f;
+            }
+            switch (passenger.getDefinition().entityType()) {
+                case MINECART, HOPPER_MINECART, TNT_MINECART, CHEST_MINECART, FURNACE_MINECART, SPAWNER_MINECART,
+                        COMMAND_BLOCK_MINECART, BOAT, CHEST_BOAT -> yOffset += passenger.getDefinition().height() * 0.5f;
             }
             if (passenger.getDefinition().entityType() == EntityType.FALLING_BLOCK) {
                 yOffset += 0.5f;

--- a/core/src/main/java/org/geysermc/geyser/util/EntityUtils.java
+++ b/core/src/main/java/org/geysermc/geyser/util/EntityUtils.java
@@ -36,6 +36,7 @@ import org.geysermc.geyser.entity.type.BoatEntity;
 import org.geysermc.geyser.entity.type.Entity;
 import org.geysermc.geyser.entity.type.living.ArmorStandEntity;
 import org.geysermc.geyser.entity.type.living.animal.AnimalEntity;
+import org.geysermc.geyser.entity.type.living.animal.horse.CamelEntity;
 import org.geysermc.geyser.inventory.GeyserItemStack;
 import org.geysermc.geyser.item.Items;
 
@@ -163,10 +164,33 @@ public final class EntityUtils {
             switch (mount.getDefinition().entityType()) {
                 case BOAT -> {
                     // Without the X offset, more than one entity on a boat is stacked on top of each other
-                    if (rider && moreThanOneEntity) {
-                        xOffset = 0.2f;
-                    } else if (moreThanOneEntity) {
-                        xOffset = -0.6f;
+                    if (moreThanOneEntity) {
+                        if (rider) {
+                            xOffset = 0.2f;
+                        } else {
+                            xOffset = -0.6f;
+                        }
+                        if (passenger instanceof AnimalEntity) {
+                            xOffset += 0.2f;
+                        }
+                    }
+                }
+                case CAMEL -> {
+                    zOffset = 0.5f;
+                    if (moreThanOneEntity) {
+                        if (!rider) {
+                            zOffset = -0.7f;
+                        }
+                        if (passenger instanceof AnimalEntity) {
+                            zOffset += 0.2f;
+                        }
+                    }
+                    if (mount.getFlag(EntityFlag.SITTING)) {
+                        if (mount.getFlag(EntityFlag.BABY)) {
+                            yOffset += CamelEntity.SITTING_HEIGHT_DIFFERENCE * 0.5f;
+                        } else {
+                            yOffset += CamelEntity.SITTING_HEIGHT_DIFFERENCE;
+                        }
                     }
                 }
                 case CHEST_BOAT -> xOffset = 0.15F;


### PR DESCRIPTION
I've updated `getMountedHeightOffsets` and `getHeightOffset` to match 1.20 Java edition.
Affected entities:
- Camel
- Cave Spider
- Bamboo boat
- Sniffer
- Allay
- Vex
- Drowned, Husk, and Zombie Villager
- Shulker

I adjusted the yOffset for entities riding on players so they don't appear floating above the player.
I also increased the yOffset for boats and minecarts that are riding other entities so they visually match Java edition.