### PR TITLE
fix commands with trailing whitespaces

### DIFF
--- a/core/src/main/java/org/geysermc/geyser/translator/protocol/bedrock/BedrockCommandRequestTranslator.java
+++ b/core/src/main/java/org/geysermc/geyser/translator/protocol/bedrock/BedrockCommandRequestTranslator.java
@@ -45,6 +45,8 @@ public class BedrockCommandRequestTranslator extends PacketTranslator<CommandReq
                 return;
             }
 
+            // running commands via Bedrock's command select menu adds a trailing whitespace which Java doesn't like
+            // https://github.com/GeyserMC/Geyser/issues/3877
             session.sendCommand(command.substring(1).stripTrailing());
         }
     }

--- a/core/src/main/java/org/geysermc/geyser/translator/protocol/bedrock/BedrockCommandRequestTranslator.java
+++ b/core/src/main/java/org/geysermc/geyser/translator/protocol/bedrock/BedrockCommandRequestTranslator.java
@@ -45,7 +45,7 @@ public class BedrockCommandRequestTranslator extends PacketTranslator<CommandReq
                 return;
             }
 
-            session.sendCommand(command.substring(1).trim());
+            session.sendCommand(command.substring(1).stripTrailing());
         }
     }
 }

--- a/core/src/main/java/org/geysermc/geyser/translator/protocol/bedrock/BedrockCommandRequestTranslator.java
+++ b/core/src/main/java/org/geysermc/geyser/translator/protocol/bedrock/BedrockCommandRequestTranslator.java
@@ -29,7 +29,6 @@ import org.cloudburstmc.protocol.bedrock.packet.CommandRequestPacket;
 import org.geysermc.common.PlatformType;
 import org.geysermc.geyser.GeyserImpl;
 import org.geysermc.geyser.session.GeyserSession;
-import org.geysermc.geyser.text.ChatColor;
 import org.geysermc.geyser.translator.protocol.PacketTranslator;
 import org.geysermc.geyser.translator.protocol.Translator;
 import org.geysermc.geyser.translator.text.MessageTranslator;
@@ -46,7 +45,7 @@ public class BedrockCommandRequestTranslator extends PacketTranslator<CommandReq
                 return;
             }
 
-            session.sendCommand(command.substring(1));
+            session.sendCommand(command.substring(1).trim());
         }
     }
 }


### PR DESCRIPTION
Apparently, Bedrock automatically adds a whitespace with default commands. Adding a stripTrailing() at the end ensures that this does not happen.
Fixes https://github.com/GeyserMC/Geyser/issues/3877