### PR TITLE
Loop through item palette versions in ascending order

### DIFF
--- a/core/src/main/java/org/geysermc/geyser/registry/populator/CreativeItemRegistryPopulator.java
+++ b/core/src/main/java/org/geysermc/geyser/registry/populator/CreativeItemRegistryPopulator.java
@@ -54,18 +54,18 @@ public class CreativeItemRegistryPopulator {
             (identifier, data) -> identifier.equals("minecraft:bordure_indented_banner_pattern") || identifier.equals("minecraft:field_masoned_banner_pattern")
     );
 
-    static void populate(Map.Entry<String, ItemRegistryPopulator.PaletteVersion> version, Map<String, ItemDefinition> definitions, Consumer<ItemData.Builder> itemConsumer) {
+    static void populate(ItemRegistryPopulator.PaletteVersion palette, Map<String, ItemDefinition> definitions, Consumer<ItemData.Builder> itemConsumer) {
         GeyserBootstrap bootstrap = GeyserImpl.getInstance().getBootstrap();
 
         // Load creative items
         JsonNode creativeItemEntries;
-        try (InputStream stream = bootstrap.getResource(String.format("bedrock/creative_items.%s.json", version.getKey()))) {
+        try (InputStream stream = bootstrap.getResource(String.format("bedrock/creative_items.%s.json", palette.version()))) {
             creativeItemEntries = GeyserImpl.JSON_MAPPER.readTree(stream).get("items");
         } catch (Exception e) {
             throw new AssertionError("Unable to load creative items", e);
         }
 
-        BlockMappings blockMappings = BlockRegistries.BLOCKS.forVersion(version.getValue().protocolVersion());
+        BlockMappings blockMappings = BlockRegistries.BLOCKS.forVersion(palette.protocolVersion());
         for (JsonNode itemNode : creativeItemEntries) {
             ItemData.Builder itemBuilder = createItemData(itemNode, blockMappings, definitions);
             if (itemBuilder == null) {

--- a/core/src/main/java/org/geysermc/geyser/registry/populator/ItemRegistryPopulator.java
+++ b/core/src/main/java/org/geysermc/geyser/registry/populator/ItemRegistryPopulator.java
@@ -68,10 +68,10 @@ import java.util.concurrent.atomic.AtomicInteger;
  */
 public class ItemRegistryPopulator {
 
-    record PaletteVersion(int protocolVersion, Map<Item, String> javaOnlyItems, Remapper remapper) {
+    record PaletteVersion(String version, int protocolVersion, Map<Item, String> javaOnlyItems, Remapper remapper) {
 
-        public PaletteVersion(int protocolVersion) {
-            this(protocolVersion, Collections.emptyMap(), (item, mapping) -> mapping);
+        public PaletteVersion(String version, int protocolVersion) {
+            this(version, protocolVersion, Collections.emptyMap(), (item, mapping) -> mapping);
         }
     }
 
@@ -88,8 +88,8 @@ public class ItemRegistryPopulator {
         legacyJavaOnly.put(Items.PITCHER_POD, "minecraft:beetroot");
         legacyJavaOnly.put(Items.SNIFFER_EGG, "minecraft:sniffer_spawn_egg"); // the BlockItem of the sniffer egg block
 
-        Map<String, PaletteVersion> paletteVersions = new Object2ObjectOpenHashMap<>();
-        paletteVersions.put("1_19_80", new PaletteVersion(Bedrock_v582.CODEC.getProtocolVersion(), legacyJavaOnly, (item, mapping) -> {
+        List<PaletteVersion> paletteVersions = new ArrayList<>(2);
+        paletteVersions.add(new PaletteVersion("1_19_80", Bedrock_v582.CODEC.getProtocolVersion(), legacyJavaOnly, (item, mapping) -> {
             String id = item.javaIdentifier();
             if (id.endsWith("pottery_sherd")) {
                 return mapping.withBedrockIdentifier(id.replace("sherd", "shard"));
@@ -101,7 +101,7 @@ public class ItemRegistryPopulator {
 
             return mapping;
         }));
-        paletteVersions.put("1_20_0", new PaletteVersion(Bedrock_v589.CODEC.getProtocolVersion()));
+        paletteVersions.add(new PaletteVersion("1_20_0", Bedrock_v589.CODEC.getProtocolVersion()));
 
         GeyserBootstrap bootstrap = GeyserImpl.getInstance().getBootstrap();
 
@@ -131,11 +131,11 @@ public class ItemRegistryPopulator {
         boolean firstMappingsPass = true;
 
         /* Load item palette */
-        for (Map.Entry<String, PaletteVersion> palette : paletteVersions.entrySet()) {
+        for (PaletteVersion palette : paletteVersions) {
             TypeReference<List<PaletteItem>> paletteEntriesType = new TypeReference<>() {};
 
             List<PaletteItem> itemEntries;
-            try (InputStream stream = bootstrap.getResource(String.format("bedrock/runtime_item_states.%s.json", palette.getKey()))) {
+            try (InputStream stream = bootstrap.getResource(String.format("bedrock/runtime_item_states.%s.json", palette.version()))) {
                 itemEntries = GeyserImpl.JSON_MAPPER.readValue(stream, paletteEntriesType);
             } catch (Exception e) {
                 throw new AssertionError("Unable to load Bedrock runtime item IDs", e);
@@ -193,7 +193,7 @@ public class ItemRegistryPopulator {
                 }
             });
 
-            BlockMappings blockMappings = BlockRegistries.BLOCKS.forVersion(palette.getValue().protocolVersion());
+            BlockMappings blockMappings = BlockRegistries.BLOCKS.forVersion(palette.protocolVersion());
 
             Set<Item> javaOnlyItems = new ObjectOpenHashSet<>();
             Collections.addAll(javaOnlyItems, Items.SPECTRAL_ARROW, Items.DEBUG_STICK,
@@ -202,7 +202,7 @@ public class ItemRegistryPopulator {
                 javaOnlyItems.add(Items.FURNACE_MINECART);
             }
             // Java-only items for this version
-            javaOnlyItems.addAll(palette.getValue().javaOnlyItems().keySet());
+            javaOnlyItems.addAll(palette.javaOnlyItems().keySet());
 
             Int2ObjectMap<String> customIdMappings = new Int2ObjectOpenHashMap<>();
             Set<String> registeredItemNames = new ObjectOpenHashSet<>(); // This is used to check for duplicate item names
@@ -213,12 +213,12 @@ public class ItemRegistryPopulator {
                     throw new RuntimeException("Extra item in mappings? " + entry.getKey());
                 }
                 GeyserMappingItem mappingItem;
-                String replacementItem = palette.getValue().javaOnlyItems().get(javaItem);
+                String replacementItem = palette.javaOnlyItems().get(javaItem);
                 if (replacementItem != null) {
                     mappingItem = items.get(replacementItem); // java only item, a java id fallback has been provided
                 } else {
                     // check if any mapping changes need to be made on this version
-                    mappingItem = palette.getValue().remapper().remap(javaItem, entry.getValue());
+                    mappingItem = palette.remapper().remap(javaItem, entry.getValue());
                 }
 
                 if (customItemsAllowed && javaItem == Items.FURNACE_MINECART) {
@@ -230,7 +230,7 @@ public class ItemRegistryPopulator {
                 String bedrockIdentifier = mappingItem.getBedrockIdentifier();
                 ItemDefinition definition = definitions.get(bedrockIdentifier);
                 if (definition == null) {
-                    throw new RuntimeException("Missing Bedrock ItemDefinition in version " + palette.getKey() + " for mapping: " + mappingItem);
+                    throw new RuntimeException("Missing Bedrock ItemDefinition in version " + palette.version() + " for mapping: " + mappingItem);
                 }
 
                 BlockDefinition bedrockBlock = null;
@@ -515,7 +515,7 @@ public class ItemRegistryPopulator {
                     .customIdMappings(customIdMappings)
                     .build();
 
-            Registries.ITEMS.register(palette.getValue().protocolVersion(), itemMappings);
+            Registries.ITEMS.register(palette.protocolVersion(), itemMappings);
 
             firstMappingsPass = false;
         }


### PR DESCRIPTION
Closes #3882

Old behaviour: if the 1.19.80 palette is processed last, then the fallback mapping for the `relic` record overrides the entry in `Registries.RECORDS`, and all versions hear `wait` instead of `relic`. 

The records registry *could* become versioned, but it doesn't seem worth it.

Now, 1.20 hears the relic disc, and 1.19.80 hears nothing.