### PR TITLE
Bump logj4 (standalone)

### DIFF
--- a/bootstrap/standalone/build.gradle.kts
+++ b/bootstrap/standalone/build.gradle.kts
@@ -7,10 +7,8 @@ dependencies {
     api(projects.core)
 
     implementation(libs.terminalconsoleappender) {
-        exclude("org.apache.logging.log4j", "log4j-core")
-        exclude("org.jline", "jline-reader")
-        exclude("org.jline", "jline-terminal")
-        exclude("org.jline", "jline-terminal-jna")
+        exclude("org.apache.logging.log4j")
+        exclude("org.jline")
     }
 
     implementation(libs.bundles.jline)

--- a/bootstrap/standalone/src/main/java/org/geysermc/geyser/platform/standalone/GeyserStandaloneLogger.java
+++ b/bootstrap/standalone/src/main/java/org/geysermc/geyser/platform/standalone/GeyserStandaloneLogger.java
@@ -92,6 +92,7 @@ public class GeyserStandaloneLogger extends SimpleTerminalConsole implements Gey
         Configurator.setLevel(log.getName(), debug ? Level.DEBUG : Level.INFO);
     }
 
+    @Override
     public boolean isDebug() {
         return log.isDebugEnabled();
     }

--- a/bootstrap/standalone/src/main/resources/log4j2.xml
+++ b/bootstrap/standalone/src/main/resources/log4j2.xml
@@ -2,10 +2,10 @@
 <Configuration status="WARN">
     <Appenders>
         <TerminalConsole name="TerminalConsole">
-            <PatternLayout pattern="[%d{HH:mm:ss} %style{%highlight{%level}{FATAL=red dark, ERROR=red, WARN=yellow bright, INFO=cyan bright, DEBUG=green, TRACE=white}}] %minecraftFormatting{%msg}%n"/>
+            <PatternLayout pattern="[%d{HH:mm:ss} %style{%highlight{%level}{FATAL=red, ERROR=red, WARN=yellow bright, INFO=cyan bright, DEBUG=green, TRACE=white}}] %minecraftFormatting{%msg}%n"/>
         </TerminalConsole>
         <Console name="Console" target="SYSTEM_OUT" follow="true">
-            <PatternLayout pattern="[%d{HH:mm:ss} %style{%highlight{%level}{FATAL=red dark, ERROR=red, WARN=yellow bright, INFO=cyan bright, DEBUG=green, TRACE=white}}] %minecraftFormatting{%msg}%n"/>
+            <PatternLayout pattern="[%d{HH:mm:ss} %style{%highlight{%level}{FATAL=red, ERROR=red, WARN=yellow bright, INFO=cyan bright, DEBUG=green, TRACE=white}}] %minecraftFormatting{%msg}%n"/>
         </Console>
         <RollingRandomAccessFile name="File" fileName="logs/latest.log" filePattern="logs/%d{yyyy-MM-dd}-%i.log.gz">
             <PatternLayout pattern="[%d{HH:mm:ss.SSS} %t/%level] %minecraftFormatting{%msg}{strip}%n"/>

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -18,7 +18,7 @@ adventure = "4.14.0-20230424.215040-7"
 adventure-platform = "4.1.2"
 junit = "5.9.2"
 checkerframework = "3.19.0"
-log4j = "2.17.1"
+log4j = "2.20.0"
 jline = "3.21.0"
 terminalconsoleappender = "1.2.0"
 folia = "1.19.4-R0.1-SNAPSHOT"
@@ -65,7 +65,7 @@ netty-transport-native-kqueue = { group = "io.netty", name = "netty-transport-na
 
 log4j-api = { group = "org.apache.logging.log4j", name = "log4j-api", version.ref = "log4j" }
 log4j-core = { group = "org.apache.logging.log4j", name = "log4j-core", version.ref = "log4j" }
-log4j-slf4j18-impl = { group = "org.apache.logging.log4j", name = "log4j-slf4j18-impl", version.ref = "log4j" }
+log4j-slf4j2-impl = { group = "org.apache.logging.log4j", name = "log4j-slf4j2-impl", version.ref = "log4j" }
 
 jline-terminal = { group = "org.jline", name = "jline-terminal", version.ref = "jline" }
 jline-terminal-jna = { group = "org.jline", name = "jline-terminal-jna", version.ref = "jline" }
@@ -103,6 +103,6 @@ protocol-connection = { group = "org.cloudburstmc.protocol", name = "bedrock-con
 jackson = [ "jackson-annotations", "jackson-core", "jackson-dataformat-yaml" ]
 fastutil = [ "fastutil-int-int-maps", "fastutil-int-long-maps", "fastutil-int-byte-maps", "fastutil-int-boolean-maps", "fastutil-object-int-maps", "fastutil-object-object-maps" ]
 adventure = [ "adventure-text-serializer-gson", "adventure-text-serializer-legacy", "adventure-text-serializer-plain" ]
-log4j = [ "log4j-api", "log4j-core", "log4j-slf4j18-impl" ]
+log4j = [ "log4j-api", "log4j-core", "log4j-slf4j2-impl" ]
 jline = [ "jline-terminal", "jline-terminal-jna", "jline-reader" ]
 protocol = [ "protocol-common", "protocol-codec", "protocol-connection" ]


### PR DESCRIPTION
Nothing other than standalone uses the log4j version/libraries/bundle in `libs.versions.toml` so this should be safe.

Removed the "dark" from the log4j2 config because of removals/changes to the AnsiEscape enum or something that doesn't seem worth the time to figure out.

Closes #3887 