### PR TITLE
Validate written_book tags and fix writable book losing changes

### DIFF
--- a/core/src/main/java/org/geysermc/geyser/inventory/item/StoredItemMappings.java
+++ b/core/src/main/java/org/geysermc/geyser/inventory/item/StoredItemMappings.java
@@ -51,6 +51,7 @@ public class StoredItemMappings {
     private final ItemMapping egg;
     private final ItemMapping shield;
     private final ItemMapping wheat;
+    private final ItemMapping writableBook;
 
     public StoredItemMappings(Map<Item, ItemMapping> itemMappings) {
         this.bamboo = load(itemMappings, Items.BAMBOO);
@@ -64,6 +65,7 @@ public class StoredItemMappings {
         this.egg = load(itemMappings, Items.EGG);
         this.shield = load(itemMappings, Items.SHIELD);
         this.wheat = load(itemMappings, Items.WHEAT);
+        this.writableBook = load(itemMappings, Items.WRITABLE_BOOK);
     }
 
     @Nonnull

--- a/core/src/main/java/org/geysermc/geyser/item/Items.java
+++ b/core/src/main/java/org/geysermc/geyser/item/Items.java
@@ -1084,8 +1084,8 @@ public final class Items {
     public static final Item ZOMBIFIED_PIGLIN_SPAWN_EGG = register(new SpawnEggItem("zombified_piglin_spawn_egg", builder()));
     public static final Item EXPERIENCE_BOTTLE = register(new Item("experience_bottle", builder()));
     public static final Item FIRE_CHARGE = register(new Item("fire_charge", builder()));
-    public static final Item WRITABLE_BOOK = register(new ReadableBookItem("writable_book", builder().stackSize(1)));
-    public static final Item WRITTEN_BOOK = register(new ReadableBookItem("written_book", builder().stackSize(16)));
+    public static final Item WRITABLE_BOOK = register(new WritableBookItem("writable_book", builder().stackSize(1)));
+    public static final Item WRITTEN_BOOK = register(new WrittenBookItem("written_book", builder().stackSize(16)));
     public static final Item ITEM_FRAME = register(new Item("item_frame", builder()));
     public static final Item GLOW_ITEM_FRAME = register(new Item("glow_item_frame", builder()));
     public static final Item FLOWER_POT = register(new BlockItem("flower_pot", builder()));

--- a/core/src/main/java/org/geysermc/geyser/item/type/WritableBookItem.java
+++ b/core/src/main/java/org/geysermc/geyser/item/type/WritableBookItem.java
@@ -1,0 +1,86 @@
+/*
+ * Copyright (c) 2019-2023 GeyserMC. http://geysermc.org
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ *
+ * @author GeyserMC
+ * @link https://github.com/GeyserMC/Geyser
+ */
+
+package org.geysermc.geyser.item.type;
+
+import com.github.steveice10.opennbt.tag.builtin.CompoundTag;
+import com.github.steveice10.opennbt.tag.builtin.ListTag;
+import com.github.steveice10.opennbt.tag.builtin.StringTag;
+import com.github.steveice10.opennbt.tag.builtin.Tag;
+import org.checkerframework.checker.nullness.qual.NonNull;
+import org.geysermc.geyser.registry.type.ItemMapping;
+import org.geysermc.geyser.session.GeyserSession;
+import org.geysermc.geyser.translator.text.MessageTranslator;
+
+import java.util.ArrayList;
+import java.util.List;
+
+public class WritableBookItem extends Item {
+    public WritableBookItem(String javaIdentifier, Builder builder) {
+        super(javaIdentifier, builder);
+    }
+
+    @Override
+    public void translateNbtToBedrock(@NonNull GeyserSession session, @NonNull CompoundTag tag) {
+        super.translateNbtToBedrock(session, tag);
+
+        ListTag pagesTag = tag.remove("pages");
+        if (pagesTag == null) {
+            return;
+        }
+        List<Tag> pages = new ArrayList<>();
+        for (Tag subTag : pagesTag.getValue()) {
+            if (!(subTag instanceof StringTag textTag))
+                continue;
+
+            CompoundTag pageTag = new CompoundTag("");
+            pageTag.put(new StringTag("photoname", ""));
+            pageTag.put(new StringTag("text", MessageTranslator.convertMessageLenient(textTag.getValue())));
+            pages.add(pageTag);
+        }
+
+        tag.put(new ListTag("pages", pages));
+    }
+
+    @Override
+    public void translateNbtToJava(@NonNull CompoundTag tag, @NonNull ItemMapping mapping) {
+        super.translateNbtToJava(tag, mapping);
+
+        if (!tag.contains("pages")) {
+            return;
+        }
+        List<Tag> pages = new ArrayList<>();
+        ListTag pagesTag = tag.get("pages");
+        for (Tag subTag : pagesTag.getValue()) {
+            if (!(subTag instanceof CompoundTag pageTag))
+                continue;
+
+            StringTag textTag = pageTag.get("text");
+            pages.add(new StringTag("", textTag.getValue()));
+        }
+        tag.remove("pages");
+        tag.put(new ListTag("pages", pages));
+    }
+}

--- a/core/src/main/java/org/geysermc/geyser/item/type/WrittenBookItem.java
+++ b/core/src/main/java/org/geysermc/geyser/item/type/WrittenBookItem.java
@@ -62,7 +62,7 @@ public class WrittenBookItem extends WritableBookItem {
             invalidTagPage.put(new StringTag(
                     "text",
                     MessageTranslator.convertMessage(
-                            Component.translatable("book.invalid.tag").color(NamedTextColor.DARK_RED),
+                            Component.translatable("book.invalid.tag", NamedTextColor.DARK_RED),
                             session.locale()
                     )
             ));

--- a/core/src/main/java/org/geysermc/geyser/item/type/WrittenBookItem.java
+++ b/core/src/main/java/org/geysermc/geyser/item/type/WrittenBookItem.java
@@ -75,6 +75,7 @@ public class WrittenBookItem extends WritableBookItem {
             return false;
         }
         if (title.getValue().length() > (MAXIMUM_TITLE_LENGTH * 2)) {
+            // Java rejects books with titles more than 2x the maximum length allowed in the input box
             return false;
         }
 

--- a/core/src/main/java/org/geysermc/geyser/item/type/WrittenBookItem.java
+++ b/core/src/main/java/org/geysermc/geyser/item/type/WrittenBookItem.java
@@ -38,6 +38,11 @@ import org.geysermc.geyser.translator.text.MessageTranslator;
 import java.util.List;
 
 public class WrittenBookItem extends WritableBookItem {
+    public static final int MAXIMUM_PAGE_EDIT_LENGTH = 1024;
+    public static final int MAXIMUM_PAGE_LENGTH = 32768;
+    public static final int MAXIMUM_PAGE_COUNT = 100; // Java edition limit. Bedrock edition has a limit of 50 pages.
+    public static final int MAXIMUM_TITLE_LENGTH = 16;
+
     public WrittenBookItem(String javaIdentifier, Builder builder) {
         super(javaIdentifier, builder);
     }
@@ -69,7 +74,7 @@ public class WrittenBookItem extends WritableBookItem {
         if (!(tag.get("title") instanceof StringTag title)) {
             return false;
         }
-        if (title.getValue().length() > 32) {
+        if (title.getValue().length() > (MAXIMUM_TITLE_LENGTH * 2)) {
             return false;
         }
 
@@ -82,7 +87,7 @@ public class WrittenBookItem extends WritableBookItem {
         }
         for (Tag pageTag : pages) {
             if (pageTag instanceof StringTag page) {
-                if (page.getValue().length() > 32767) {
+                if (page.getValue().length() > MAXIMUM_PAGE_LENGTH) {
                     return false;
                 }
             }

--- a/core/src/main/java/org/geysermc/geyser/session/cache/BookEditCache.java
+++ b/core/src/main/java/org/geysermc/geyser/session/cache/BookEditCache.java
@@ -62,7 +62,7 @@ public class BookEditCache {
         if ((System.currentTimeMillis() - lastBookUpdate) < 1000) {
             return;
         }
-        // Don't send the update if the player isn't not holding a book, shouldn't happen if we catch all interactions
+        // Don't send the update if the player is not holding a book, shouldn't happen if we catch all interactions
         GeyserItemStack itemStack = session.getPlayerInventory().getItemInHand();
         if (itemStack == null || itemStack.asItem() != Items.WRITABLE_BOOK) {
             packet = null;

--- a/core/src/main/java/org/geysermc/geyser/translator/protocol/bedrock/BedrockInventoryTransactionTranslator.java
+++ b/core/src/main/java/org/geysermc/geyser/translator/protocol/bedrock/BedrockInventoryTransactionTranslator.java
@@ -44,6 +44,7 @@ import org.cloudburstmc.protocol.bedrock.data.inventory.ContainerType;
 import org.cloudburstmc.protocol.bedrock.data.inventory.ItemData;
 import org.cloudburstmc.protocol.bedrock.data.inventory.transaction.InventoryActionData;
 import org.cloudburstmc.protocol.bedrock.data.inventory.transaction.InventorySource;
+import org.cloudburstmc.protocol.bedrock.data.inventory.transaction.InventoryTransactionType;
 import org.cloudburstmc.protocol.bedrock.data.inventory.transaction.LegacySetItemSlotData;
 import org.cloudburstmc.protocol.bedrock.packet.ContainerOpenPacket;
 import org.cloudburstmc.protocol.bedrock.packet.InventoryTransactionPacket;
@@ -93,6 +94,15 @@ public class BedrockInventoryTransactionTranslator extends PacketTranslator<Inve
 
     @Override
     public void translate(GeyserSession session, InventoryTransactionPacket packet) {
+        if (packet.getTransactionType() == InventoryTransactionType.NORMAL && packet.getActions().size() == 3) {
+            InventoryActionData containerAction = packet.getActions().get(0);
+            if (containerAction.getSource().getType() == InventorySource.Type.CONTAINER &&
+                    session.getPlayerInventory().getHeldItemSlot() == containerAction.getSlot() &&
+                    containerAction.getFromItem().getDefinition() == session.getItemMappings().getStoredItems().writableBook().getBedrockDefinition()) {
+                // Ignore InventoryTransactions related to editing books as that is handled in BedrockBookEditTranslator
+                return;
+            }
+        }
         // Send book updates before opening inventories
         session.getBookEditCache().checkForSend();
 


### PR DESCRIPTION
Java edition checks the title tag, author tag, and page tag before displaying contents of the book.
If these tags don't exist or are too long, it will instead display `* Invalid book tag *`.
I've added `WrittenBookItem` to replicate this behavior for Bedrock edition.

I've changed the title length and page length limits to match the limits found in Java edition's text inputs.

I've also fixed https://github.com/GeyserMC/Geyser/issues/3471 by ignoring the `InventoryTransactionPacket`s sent after each page edit.
These packets caused Geyser to send an outdated `ServerboundEditBookPacket` before the `BookEditPacket` could be processed.

Mapping-generator pr: https://github.com/GeyserMC/mappings-generator/pull/56