### PR TITLE
Fix/proxy protocol missing message

### DIFF
--- a/core/src/main/java/org/geysermc/geyser/network/netty/GeyserServer.java
+++ b/core/src/main/java/org/geysermc/geyser/network/netty/GeyserServer.java
@@ -187,7 +187,16 @@ public final class GeyserServer {
 
     public BedrockPong onQuery(InetSocketAddress inetSocketAddress) {
         if (geyser.getConfig().isDebugMode() && PRINT_DEBUG_PINGS) {
-            String ip = geyser.getConfig().isLogPlayerIpAddresses() ? inetSocketAddress.toString() : "<IP address withheld>";
+            String ip;
+            if (geyser.getConfig().isLogPlayerIpAddresses()) {
+                if (geyser.getConfig().getBedrock().isEnableProxyProtocol()) {
+                    ip = this.proxiedAddresses.getOrDefault(inetSocketAddress, inetSocketAddress).toString();
+                } else {
+                    ip = inetSocketAddress.toString();
+                }
+            } else {
+                ip = "<IP address withheld>";
+            }
             geyser.getLogger().debug(GeyserLocale.getLocaleStringLog("geyser.network.pinged", ip));
         }
 

--- a/core/src/main/java/org/geysermc/geyser/network/netty/proxy/ProxyServerHandler.java
+++ b/core/src/main/java/org/geysermc/geyser/network/netty/proxy/ProxyServerHandler.java
@@ -73,10 +73,10 @@ public class ProxyServerHandler extends SimpleChannelInboundHandler<DatagramPack
             presentAddress = new InetSocketAddress(decoded.sourceAddress(), decoded.sourcePort());
             log.debug("Got PROXY header: (from {}) {}", packet.sender(), presentAddress);
             GeyserImpl.getInstance().getGeyserServer().getProxiedAddresses().put(packet.sender(), presentAddress);
-            return;
+        } else {
+            log.trace("Reusing PROXY header: (from {}) {}", packet.sender(), presentAddress);
         }
 
-        log.trace("Reusing PROXY header: (from {}) {}", packet.sender(), presentAddress);
         ctx.fireChannelRead(packet.retain());
     }
 }


### PR DESCRIPTION
When making use of proxy protocol, the first message with the proxy protocol header would not be passed along to the handlers. This causes an issue when trying to use something like mcsrvstat.us. It also created issues for console players using apps like bedrocktogether.