### PR TITLE
Fix serverbound hanging sign updates

### DIFF
--- a/core/src/main/java/org/geysermc/geyser/level/block/BlockStateValues.java
+++ b/core/src/main/java/org/geysermc/geyser/level/block/BlockStateValues.java
@@ -45,7 +45,6 @@ import java.util.Locale;
  */
 public final class BlockStateValues {
     private static final IntSet ALL_CAULDRONS = new IntOpenHashSet();
-    private static final IntSet HANGING_SIGNS = new IntOpenHashSet();
     private static final Int2IntMap BANNER_COLORS = new FixedInt2IntMap();
     private static final Int2ByteMap BED_COLORS = new FixedInt2ByteMap();
     private static final Int2IntMap BRUSH_PROGRESS = new Int2IntOpenHashMap();
@@ -88,12 +87,6 @@ public final class BlockStateValues {
      * @param blockData      JsonNode of info about the block from blocks.json
      */
     public static void storeBlockStateValues(String javaId, int javaBlockState, JsonNode blockData) {
-        if (javaId.contains("_hanging_sign")) {
-            // covers hanging_sign and wall_hanging_sign
-            HANGING_SIGNS.add(javaBlockState);
-            return;
-        }
-
         JsonNode bannerColor = blockData.get("banner_color");
         if (bannerColor != null) {
             BANNER_COLORS.put(javaBlockState, (byte) bannerColor.intValue());
@@ -218,17 +211,6 @@ public final class BlockStateValues {
         if (javaId.contains("_cauldron") && !javaId.contains("water_")) {
              NON_WATER_CAULDRONS.add(javaBlockState);
         }
-    }
-
-    /**
-     * Hanging signs have a different maximum text width than "normal" signs. As a result, when the client
-     * updates the text of a sign without indication of the sign type, we must determine it.
-     *
-     * @param state BlockState of the block
-     * @return true if the sign is any hanging variant
-     */
-    public static boolean isHangingSign(int state) {
-        return HANGING_SIGNS.contains(state);
     }
 
     /**

--- a/core/src/main/java/org/geysermc/geyser/translator/protocol/bedrock/BedrockBlockEntityDataTranslator.java
+++ b/core/src/main/java/org/geysermc/geyser/translator/protocol/bedrock/BedrockBlockEntityDataTranslator.java
@@ -43,9 +43,9 @@ public class BedrockBlockEntityDataTranslator extends PacketTranslator<BlockEnti
     public void translate(GeyserSession session, BlockEntityDataPacket packet) {
         NbtMap tag = packet.getData();
         String id = tag.getString("id");
-        if (id.equals("Sign")) {
+        if (id.endsWith("Sign")) {
             // Hanging signs are narrower
-            int widthMax = SignUtils.getSignWidthMax(session.getGeyser().getWorldManager().getBlockAt(session, packet.getBlockPosition()));
+            int widthMax = SignUtils.getSignWidthMax(id.startsWith("Hanging"));
 
             String text = MessageTranslator.convertToPlainText(
                 tag.getCompound(session.getWorldCache().isEditingSignOnFront() ? "FrontText" : "BackText").getString("Text"));

--- a/core/src/main/java/org/geysermc/geyser/util/SignUtils.java
+++ b/core/src/main/java/org/geysermc/geyser/util/SignUtils.java
@@ -61,8 +61,8 @@ public class SignUtils {
         };
     }
 
-    public static int getSignWidthMax(int javaBlockState) {
-        if (BlockStateValues.isHangingSign(javaBlockState)) {
+    public static int getSignWidthMax(boolean hanging) {
+        if (hanging) {
             return HANGING_SIGN_WIDTH_MAX;
         }
         return SIGN_WIDTH_MAX;


### PR DESCRIPTION
oops.

this was causing
- the bedrock client to see sign updates it made that never reached the server and other players (adding/removing text and waxing)
- signs placed/edited by bedrock to be non-editable to other players. likely because the server was never told the client was done editing.

Closes #3903