### PR TITLE
Play custom sounds again

### DIFF
--- a/core/src/main/java/org/geysermc/geyser/util/SoundUtils.java
+++ b/core/src/main/java/org/geysermc/geyser/util/SoundUtils.java
@@ -25,7 +25,6 @@
 
 package org.geysermc.geyser.util;
 
-import com.github.steveice10.mc.protocol.data.game.level.sound.BuiltinSound;
 import com.github.steveice10.mc.protocol.data.game.level.sound.Sound;
 import org.cloudburstmc.math.vector.Vector3f;
 import org.cloudburstmc.protocol.bedrock.data.LevelEvent;
@@ -66,9 +65,7 @@ public final class SoundUtils {
      * @return a Bedrock sound
      */
     public static String translatePlaySound(String javaIdentifier) {
-        javaIdentifier = trim(javaIdentifier);
-
-        SoundMapping soundMapping = Registries.SOUNDS.get(javaIdentifier);
+        SoundMapping soundMapping = Registries.SOUNDS.get(trim(javaIdentifier));
         if (soundMapping == null || soundMapping.getPlaysound() == null) {
             // no mapping
             GeyserImpl.getInstance().getLogger().debug("[PlaySound] Defaulting to sound server gave us for " + javaIdentifier);
@@ -104,13 +101,7 @@ public final class SoundUtils {
      * @param pitch the pitch
      */
     public static void playSound(GeyserSession session, Sound javaSound, Vector3f position, float volume, float pitch) {
-        String packetSound;
-        if (!(javaSound instanceof BuiltinSound)) {
-            // Identifier needs trimmed probably.
-            packetSound = trim(javaSound.getName());
-        } else {
-            packetSound = javaSound.getName();
-        }
+        String packetSound = javaSound.getName();
 
         SoundMapping soundMapping = Registries.SOUNDS.get(packetSound);
         if (soundMapping == null) {


### PR DESCRIPTION
Seems like we were trimming the identifier even when the sound was not in the sound registry - I've adjusted so the sound name is trimmed and searched for, and if it isn't found, the full identifier is sent to Bedrock to make the proper sound play.

fixes https://github.com/GeyserMC/Geyser/issues/3938