### PR TITLE
let boats not sink down, use less choppy (but faster) animation

### DIFF
--- a/core/src/main/java/org/geysermc/geyser/entity/type/BoatEntity.java
+++ b/core/src/main/java/org/geysermc/geyser/entity/type/BoatEntity.java
@@ -66,7 +66,7 @@ public class BoatEntity extends Entity {
     private int variant;
 
     // Looks too fast and too choppy with 0.1f, which is how I believe the Microsoftian client handles it
-    private final float ROWING_SPEED = 0.05f;
+    private final float ROWING_SPEED = 0.1f;
 
     public BoatEntity(GeyserSession session, int entityId, long geyserId, UUID uuid, EntityDefinition<?> definition, Vector3f position, Vector3f motion, float yaw, float pitch, float headYaw) {
         // Initial rotation is incorrect

--- a/core/src/main/java/org/geysermc/geyser/translator/protocol/bedrock/BedrockMoveEntityAbsoluteTranslator.java
+++ b/core/src/main/java/org/geysermc/geyser/translator/protocol/bedrock/BedrockMoveEntityAbsoluteTranslator.java
@@ -36,7 +36,7 @@ import org.geysermc.geyser.translator.protocol.PacketTranslator;
 import org.geysermc.geyser.translator.protocol.Translator;
 
 /**
- * Sent by the client when moving a horse.
+ * Sent by the client when moving a horse or boat.
  */
 @Translator(packet = MoveEntityAbsolutePacket.class)
 public class BedrockMoveEntityAbsoluteTranslator extends PacketTranslator<MoveEntityAbsolutePacket> {
@@ -64,7 +64,7 @@ public class BedrockMoveEntityAbsoluteTranslator extends PacketTranslator<MoveEn
         }
 
         float y = packet.getPosition().getY();
-        if (ridingEntity instanceof BoatEntity) {
+        if (ridingEntity instanceof BoatEntity && !ridingEntity.isOnGround() && !ridingEntity.getPassengers().isEmpty()) {
             // Remove the offset to prevents boats from looking like they're floating in water
             y -= EntityDefinitions.BOAT.offset();
         }

--- a/core/src/main/java/org/geysermc/geyser/translator/protocol/bedrock/BedrockMoveEntityAbsoluteTranslator.java
+++ b/core/src/main/java/org/geysermc/geyser/translator/protocol/bedrock/BedrockMoveEntityAbsoluteTranslator.java
@@ -64,7 +64,7 @@ public class BedrockMoveEntityAbsoluteTranslator extends PacketTranslator<MoveEn
         }
 
         float y = packet.getPosition().getY();
-        if (ridingEntity instanceof BoatEntity && !ridingEntity.isOnGround() && !ridingEntity.getPassengers().isEmpty()) {
+        if (ridingEntity instanceof BoatEntity && !ridingEntity.isOnGround()) {
             // Remove the offset to prevents boats from looking like they're floating in water
             y -= EntityDefinitions.BOAT.offset();
         }

--- a/core/src/main/java/org/geysermc/geyser/translator/protocol/bedrock/BedrockPlayerInputTranslator.java
+++ b/core/src/main/java/org/geysermc/geyser/translator/protocol/bedrock/BedrockPlayerInputTranslator.java
@@ -74,7 +74,7 @@ public class BedrockPlayerInputTranslator extends PacketTranslator<PlayerInputPa
             if (timeSinceVehicleMove >= 100) {
                 Vector3f vehiclePosition = vehicle.getPosition();
 
-                if (vehicle instanceof BoatEntity && !vehicle.isOnGround() && !vehicle.getPassengers().isEmpty()) {
+                if (vehicle instanceof BoatEntity && !vehicle.isOnGround()) {
                     // Remove some Y position to prevents boats flying up
                     vehiclePosition = vehiclePosition.down(EntityDefinitions.BOAT.offset());
                 }

--- a/core/src/main/java/org/geysermc/geyser/translator/protocol/bedrock/BedrockPlayerInputTranslator.java
+++ b/core/src/main/java/org/geysermc/geyser/translator/protocol/bedrock/BedrockPlayerInputTranslator.java
@@ -74,7 +74,7 @@ public class BedrockPlayerInputTranslator extends PacketTranslator<PlayerInputPa
             if (timeSinceVehicleMove >= 100) {
                 Vector3f vehiclePosition = vehicle.getPosition();
 
-                if (vehicle instanceof BoatEntity) {
+                if (vehicle instanceof BoatEntity && !vehicle.isOnGround() && !vehicle.getPassengers().isEmpty()) {
                     // Remove some Y position to prevents boats flying up
                     vehiclePosition = vehiclePosition.down(EntityDefinitions.BOAT.offset());
                 }


### PR DESCRIPTION
These changes are really hacky; and if there's a better solution, this should probably be replaced or removed.
Essentially, our added offset is also being removed when a player enters a boat that is on the ground. The error seems to not occur on water, since the player appears to be adding additional offset? 
Also; checking for just isOnGround() lead to weird behavior with boats ending up above the player when exiting; having both checks works fine. Only issue is that the boat sinks down once/twice when entering it on ground initially.

As for animation - this seemed less choppy in my tests, but quicker - matching bedrock edition.