### PR TITLE
fix mixin clashes due to default refmap name

### DIFF
--- a/bootstrap/fabric/build.gradle.kts
+++ b/bootstrap/fabric/build.gradle.kts
@@ -35,6 +35,10 @@ dependencies {
     }
 }
 
+loom {
+    mixin.defaultRefmapName.set("geyser-fabric-refmap.json")
+}
+
 repositories {
     mavenLocal()
     maven("https://repo.opencollab.dev/maven-releases/")
@@ -114,7 +118,7 @@ modrinth {
     syncBodyFrom.set(rootProject.file("README.md").readText())
 
     uploadFile.set(tasks.getByPath("remapModrinthJar"))
-    gameVersions.addAll("1.20")
+    gameVersions.addAll("1.20", "1.20.1")
 
     loaders.add("fabric")
     failSilently.set(true)

--- a/bootstrap/fabric/src/main/resources/geyser-fabric.mixins.json
+++ b/bootstrap/fabric/src/main/resources/geyser-fabric.mixins.json
@@ -2,6 +2,7 @@
   "required": true,
   "package": "org.geysermc.geyser.platform.fabric.mixin",
   "compatibilityLevel": "JAVA_16",
+  "refmap": "geyser-fabric-refmap.json",
   "client": [
     "client.IntegratedServerMixin"
   ],


### PR DESCRIPTION
Fixes https://github.com/GeyserMC/Geyser/issues/3423 by setting a refmap name with modid.
https://cdn.discordapp.com/attachments/613194828359925800/1126935726207017111/image.png
Also shows 1.20.1 support on modrinth; because why not.