### PR TITLE
Remove blockstate version

### DIFF
--- a/core/src/main/java/org/geysermc/geyser/entity/type/ItemFrameEntity.java
+++ b/core/src/main/java/org/geysermc/geyser/entity/type/ItemFrameEntity.java
@@ -83,8 +83,7 @@ public class ItemFrameEntity extends Entity {
         super(session, entityId, geyserId, uuid, definition, position, motion, yaw, pitch, headYaw);
 
         NbtMapBuilder blockBuilder = NbtMap.builder()
-                .putString("name", this.definition.entityType() == EntityType.GLOW_ITEM_FRAME ? "minecraft:glow_frame" : "minecraft:frame")
-                .putInt("version", session.getBlockMappings().getBlockStateVersion());
+                .putString("name", this.definition.entityType() == EntityType.GLOW_ITEM_FRAME ? "minecraft:glow_frame" : "minecraft:frame");
         NbtMapBuilder statesBuilder = NbtMap.builder()
                 .putInt("facing_direction", direction.ordinal())
                 .putByte("item_frame_map_bit", (byte) 0)

--- a/core/src/main/java/org/geysermc/geyser/registry/type/BlockMappings.java
+++ b/core/src/main/java/org/geysermc/geyser/registry/type/BlockMappings.java
@@ -41,8 +41,6 @@ public class BlockMappings implements DefinitionRegistry<GeyserBedrockBlock> {
     BlockDefinition bedrockWater;
     BlockDefinition bedrockMovingBlock;
 
-    int blockStateVersion;
-
     GeyserBedrockBlock[] javaToBedrockBlocks;
 
     Map<NbtMap, GeyserBedrockBlock> stateDefinitionMap;


### PR DESCRIPTION
Remove blockstate version as it is only used internally in Geyser, and adds boilerplate. Its also not required in the persistent block palette format (which is used for client-side chunk caching)

Theoretically they are used to upgrade block states, from older version (savegame).