### PR TITLE
Ignore invalid animations from ClientboundAnimatePacket

### DIFF
--- a/core/src/main/java/org/geysermc/geyser/translator/protocol/java/entity/JavaAnimateTranslator.java
+++ b/core/src/main/java/org/geysermc/geyser/translator/protocol/java/entity/JavaAnimateTranslator.java
@@ -25,6 +25,7 @@
 
 package org.geysermc.geyser.translator.protocol.java.entity;
 
+import com.github.steveice10.mc.protocol.data.game.entity.player.Animation;
 import com.github.steveice10.mc.protocol.packet.ingame.clientbound.entity.ClientboundAnimatePacket;
 import org.cloudburstmc.math.vector.Vector3f;
 import org.cloudburstmc.protocol.bedrock.packet.AnimateEntityPacket;
@@ -44,12 +45,17 @@ public class JavaAnimateTranslator extends PacketTranslator<ClientboundAnimatePa
     @Override
     public void translate(GeyserSession session, ClientboundAnimatePacket packet) {
         Entity entity = session.getEntityCache().getEntityByJavaId(packet.getEntityId());
-        if (entity == null)
+        if (entity == null) {
             return;
+        }
+        Animation animation = packet.getAnimation();
+        if (animation == null) {
+            return;
+        }
 
         AnimatePacket animatePacket = new AnimatePacket();
         animatePacket.setRuntimeEntityId(entity.getGeyserId());
-        switch (packet.getAnimation()) {
+        switch (animation) {
             case SWING_ARM:
                 animatePacket.setAction(AnimatePacket.Action.SWING_ARM);
                 if (entity.getEntityId() == session.getPlayerEntity().getEntityId()) {
@@ -86,7 +92,7 @@ public class JavaAnimateTranslator extends PacketTranslator<ClientboundAnimatePa
                 animatePacket.setAction(AnimatePacket.Action.WAKE_UP);
                 break;
             default:
-                // Unknown Animation
+                session.getGeyser().getLogger().debug("Unhandled java animation: " + animation);
                 return;
         }
 


### PR DESCRIPTION
The vanilla client does nothing gracefully on an unknown id (`ClientPacketListener#handleAnimate`).

It would be nice to include an MCPL bump to include https://github.com/GeyserMC/MCProtocolLib/commit/a0076aac3e01e4a4d9422ef9f25525cf62d70bf8 (can't be published currently), but it isn't required to avoid null `animation`s that are deserialized from the network ByteBuf.

Closes #4023