### PR TITLE
Don't send softEnumPackets when command suggestions are false

### DIFF
--- a/core/src/main/java/org/geysermc/geyser/scoreboard/Scoreboard.java
+++ b/core/src/main/java/org/geysermc/geyser/scoreboard/Scoreboard.java
@@ -52,7 +52,6 @@ import static org.geysermc.geyser.scoreboard.UpdateType.*;
 
 public final class Scoreboard {
     private static final boolean SHOW_SCOREBOARD_LOGS = Boolean.parseBoolean(System.getProperty("Geyser.ShowScoreboardLogs", "true"));
-
     private static final boolean ADD_TEAM_SUGGESTIONS = Boolean.parseBoolean(System.getProperty("Geyser.AddTeamSuggestions", "true"));
 
     private final GeyserSession session;

--- a/core/src/main/java/org/geysermc/geyser/scoreboard/Scoreboard.java
+++ b/core/src/main/java/org/geysermc/geyser/scoreboard/Scoreboard.java
@@ -53,6 +53,8 @@ import static org.geysermc.geyser.scoreboard.UpdateType.*;
 public final class Scoreboard {
     private static final boolean SHOW_SCOREBOARD_LOGS = Boolean.parseBoolean(System.getProperty("Geyser.ShowScoreboardLogs", "true"));
 
+    private static final boolean ADD_TEAM_SUGGESTIONS = Boolean.parseBoolean(System.getProperty("Geyser.AddTeamSuggestions", "true"));
+
     private final GeyserSession session;
     private final GeyserLogger logger;
     @Getter
@@ -150,8 +152,9 @@ public final class Scoreboard {
         teams.put(teamName, team);
 
         // Update command parameters - is safe to send even if the command enum doesn't exist on the client (as of 1.19.51)
-        session.addCommandEnum("Geyser_Teams", team.getId());
-
+        if (ADD_TEAM_SUGGESTIONS) {
+            session.addCommandEnum("Geyser_Teams", team.getId());
+        }
         return team;
     }
 

--- a/core/src/main/java/org/geysermc/geyser/session/GeyserSession.java
+++ b/core/src/main/java/org/geysermc/geyser/session/GeyserSession.java
@@ -2008,6 +2008,9 @@ public class GeyserSession implements GeyserConnection, GeyserCommandSource {
     }
 
     private void softEnumPacket(String name, SoftEnumUpdateType type, String enums) {
+        if (!this.geyser.getConfig().isCommandSuggestions()) {
+            return;
+        }
         UpdateSoftEnumPacket packet = new UpdateSoftEnumPacket();
         packet.setType(type);
         packet.setSoftEnum(new CommandEnumData(name, Collections.singletonMap(enums, Collections.emptySet()), true));

--- a/core/src/main/java/org/geysermc/geyser/session/GeyserSession.java
+++ b/core/src/main/java/org/geysermc/geyser/session/GeyserSession.java
@@ -2008,6 +2008,7 @@ public class GeyserSession implements GeyserConnection, GeyserCommandSource {
     }
 
     private void softEnumPacket(String name, SoftEnumUpdateType type, String enums) {
+        // There is no need to send command enums if command suggestions are disabled
         if (!this.geyser.getConfig().isCommandSuggestions()) {
             return;
         }


### PR DESCRIPTION
Additionally to the above, this adds a system property (`-DGeyser.AddTeamSuggestions`) so this behavior can be set to false in cases where you still want command suggestions, just without teams being suggested (e.g. in the case where too many teams exist). Could yeet the property again if it's deemed not worthy to account for this one edge-case.
Thanks camo for the assist :)
Fixes https://github.com/GeyserMC/Geyser/issues/3929