### PR TITLE
Allow custom unusable-space blocker item

### DIFF
--- a/core/src/main/java/org/geysermc/geyser/util/InventoryUtils.java
+++ b/core/src/main/java/org/geysermc/geyser/util/InventoryUtils.java
@@ -65,7 +65,6 @@ import java.util.Arrays;
 import java.util.Collections;
 import java.util.Objects;
 import java.util.concurrent.TimeUnit;
-import java.util.concurrent.atomic.AtomicReference;
 import java.util.function.IntFunction;
 
 public class InventoryUtils {
@@ -209,17 +208,21 @@ public class InventoryUtils {
 
     private static ItemDefinition getUnusableSpaceBlockDefinition(int protocolVersion) {
         String unusableSpaceBlock = GeyserImpl.getInstance().getConfig().getUnusableSpaceBlock();
-        AtomicReference<ItemDefinition> itemDefinition = new AtomicReference<>();
-        Registries.ITEMS.forVersion(protocolVersion).getItemDefinitions().values().forEach(definition -> {
+        ItemDefinition itemDefinition = null;
+
+        // looping through all the items to find the one with the specified Bedrock identifier
+        for (ItemDefinition definition : Registries.ITEMS.forVersion(protocolVersion).getItemDefinitions().values()) {
             if (definition.getIdentifier().equals(unusableSpaceBlock)) {
-                itemDefinition.set(definition);
+                itemDefinition = definition;
+                break;
             }
-        });
-        if (itemDefinition.get() == null) {
+        }
+
+        if (itemDefinition == null) {
             GeyserImpl.getInstance().getLogger().error("Invalid value " + unusableSpaceBlock + ". Resorting to barrier block.");
             return Registries.ITEMS.forVersion(protocolVersion).getStoredItems().barrier().getBedrockDefinition();
         } else {
-            return itemDefinition.get();
+            return itemDefinition;
         }
     }
 

--- a/core/src/main/java/org/geysermc/geyser/util/InventoryUtils.java
+++ b/core/src/main/java/org/geysermc/geyser/util/InventoryUtils.java
@@ -65,6 +65,7 @@ import java.util.Arrays;
 import java.util.Collections;
 import java.util.Objects;
 import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicReference;
 import java.util.function.IntFunction;
 
 public class InventoryUtils {
@@ -208,12 +209,17 @@ public class InventoryUtils {
 
     private static ItemDefinition getUnusableSpaceBlockDefinition(int protocolVersion) {
         String unusableSpaceBlock = GeyserImpl.getInstance().getConfig().getUnusableSpaceBlock();
-        ItemMapping unusableSpaceBlockID = Registries.ITEMS.forVersion(protocolVersion).getMapping(unusableSpaceBlock);
-        if (unusableSpaceBlockID != null) {
-            return unusableSpaceBlockID.getBedrockDefinition();
-        } else {
+        AtomicReference<ItemDefinition> itemDefinition = new AtomicReference<>();
+        Registries.ITEMS.forVersion(protocolVersion).getItemDefinitions().values().forEach(definition -> {
+            if (definition.getIdentifier().equals(unusableSpaceBlock)) {
+                itemDefinition.set(definition);
+            }
+        });
+        if (itemDefinition.get() == null) {
             GeyserImpl.getInstance().getLogger().error("Invalid value" + unusableSpaceBlock + ". Resorting to barrier block.");
             return Registries.ITEMS.forVersion(protocolVersion).getStoredItems().barrier().getBedrockDefinition();
+        } else {
+            return itemDefinition.get();
         }
     }
 

--- a/core/src/main/java/org/geysermc/geyser/util/InventoryUtils.java
+++ b/core/src/main/java/org/geysermc/geyser/util/InventoryUtils.java
@@ -216,7 +216,7 @@ public class InventoryUtils {
             }
         });
         if (itemDefinition.get() == null) {
-            GeyserImpl.getInstance().getLogger().error("Invalid value" + unusableSpaceBlock + ". Resorting to barrier block.");
+            GeyserImpl.getInstance().getLogger().error("Invalid value " + unusableSpaceBlock + ". Resorting to barrier block.");
             return Registries.ITEMS.forVersion(protocolVersion).getStoredItems().barrier().getBedrockDefinition();
         } else {
             return itemDefinition.get();


### PR DESCRIPTION
This change would allow the specifying of a custom item (aka via custom model data) by specifying the Bedrock custom identifier ( as suggested in https://github.com/GeyserMC/Geyser/issues/3512#issuecomment-1405631704.)

A few changes/issues:
- since there doesn't appear to be a clean method to get item definitions by their bedrock identifier (there is one for java, not bedrock), a loop through all the items until the item with the Bedrock identifier is needed
- the namespace needs to be specified too; so something like
`unusable-space-block: "geyser_custom:my_item"` would be needed.

Fixes https://github.com/GeyserMC/Geyser/issues/3512