### PR TITLE
Update Geyser download URL

### DIFF
--- a/core/src/main/java/org/geysermc/geyser/Constants.java
+++ b/core/src/main/java/org/geysermc/geyser/Constants.java
@@ -36,7 +36,7 @@ public final class Constants {
 
     public static final String FLOODGATE_DOWNLOAD_LOCATION = "https://ci.opencollab.dev/job/GeyserMC/job/Floodgate/job/master/";
 
-    public static final String GEYSER_DOWNLOAD_LOCATION = "https://ci.geysermc.org";
+    public static final String GEYSER_DOWNLOAD_LOCATION = "https://geysermc.org/download";
     public static final String UPDATE_PERMISSION = "geyser.update";
 
     static final String SAVED_REFRESH_TOKEN_FILE = "saved-refresh-tokens.json";

--- a/core/src/main/java/org/geysermc/geyser/command/defaults/VersionCommand.java
+++ b/core/src/main/java/org/geysermc/geyser/command/defaults/VersionCommand.java
@@ -84,7 +84,7 @@ public class VersionCommand extends GeyserCommand {
                         sender.sendMessage(GeyserLocale.getPlayerLocaleString("geyser.commands.version.no_updates", sender.locale()));
                     } else {
                         sender.sendMessage(GeyserLocale.getPlayerLocaleString("geyser.commands.version.outdated",
-                                sender.locale(), (latestBuildNum - buildNum), "https://ci.geysermc.org/"));
+                                sender.locale(), (latestBuildNum - buildNum), "https://geysermc.org/download"));
                     }
                 } else {
                     throw new AssertionError("buildNumber missing");

--- a/core/src/main/java/org/geysermc/geyser/command/defaults/VersionCommand.java
+++ b/core/src/main/java/org/geysermc/geyser/command/defaults/VersionCommand.java
@@ -26,6 +26,7 @@
 package org.geysermc.geyser.command.defaults;
 
 import org.cloudburstmc.protocol.bedrock.codec.BedrockCodec;
+import org.geysermc.geyser.Constants;
 import org.geysermc.geyser.api.util.PlatformType;
 import org.geysermc.geyser.GeyserImpl;
 import org.geysermc.geyser.command.GeyserCommand;
@@ -84,7 +85,7 @@ public class VersionCommand extends GeyserCommand {
                         sender.sendMessage(GeyserLocale.getPlayerLocaleString("geyser.commands.version.no_updates", sender.locale()));
                     } else {
                         sender.sendMessage(GeyserLocale.getPlayerLocaleString("geyser.commands.version.outdated",
-                                sender.locale(), (latestBuildNum - buildNum), "https://geysermc.org/download"));
+                                sender.locale(), (latestBuildNum - buildNum), Constants.GEYSER_DOWNLOAD_LOCATION));
                     }
                 } else {
                     throw new AssertionError("buildNumber missing");


### PR DESCRIPTION
Updates the old GeyserMC CI URL to the new Downloads page at https://geysermc.org/download. Resolves an issue where the URL is outdated in the "Outdated Geyser proxy" error messages.