### PR TITLE
Allow srv resolving to be set per remote server

### DIFF
--- a/api/src/main/java/org/geysermc/geyser/api/network/RemoteServer.java
+++ b/api/src/main/java/org/geysermc/geyser/api/network/RemoteServer.java
@@ -67,4 +67,11 @@ public interface RemoteServer {
      */
     @NonNull
     AuthType authType();
+
+    /**
+     * Gets if we should attempt to resolve the SRV record for this server.
+     *
+     * @return if we should attempt to resolve the SRV record for this server
+     */
+    boolean resolveSrv();
 }

--- a/core/src/main/java/org/geysermc/geyser/configuration/GeyserJacksonConfiguration.java
+++ b/core/src/main/java/org/geysermc/geyser/configuration/GeyserJacksonConfiguration.java
@@ -270,6 +270,15 @@ public abstract class GeyserJacksonConfiguration implements GeyserConfiguration 
             return authType;
         }
 
+        @Setter
+        @JsonProperty("resolve-srv")
+        private boolean resolveSrv = false;
+
+        @Override
+        public boolean resolveSrv() {
+            return resolveSrv;
+        }
+
         @Getter
         @JsonProperty("allow-password-authentication")
         private boolean passwordAuthentication = true;

--- a/core/src/main/java/org/geysermc/geyser/configuration/GeyserJacksonConfiguration.java
+++ b/core/src/main/java/org/geysermc/geyser/configuration/GeyserJacksonConfiguration.java
@@ -270,13 +270,9 @@ public abstract class GeyserJacksonConfiguration implements GeyserConfiguration 
             return authType;
         }
 
-        @Setter
-        @JsonProperty("resolve-srv")
-        private boolean resolveSrv = false;
-
         @Override
         public boolean resolveSrv() {
-            return resolveSrv;
+            return false;
         }
 
         @Getter

--- a/core/src/main/java/org/geysermc/geyser/session/GeyserSession.java
+++ b/core/src/main/java/org/geysermc/geyser/session/GeyserSession.java
@@ -935,7 +935,15 @@ public class GeyserSession implements GeyserConnection, GeyserCommandSource {
         } else {
             downstream = new TcpClientSession(this.remoteServer.address(), this.remoteServer.port(), this.protocol);
             this.downstream = new DownstreamSession(downstream);
-            disableSrvResolving();
+
+            boolean resolveSrv = false;
+            try {
+                resolveSrv = this.remoteServer.resolveSrv();
+            } catch (AbstractMethodError | NoSuchMethodError ignored) {
+                // Ignore if the method doesn't exist
+                // This will happen with extensions using old APIs
+            }
+            this.downstream.getSession().setFlag(BuiltinFlags.ATTEMPT_SRV_RESOLVE, resolveSrv);
         }
 
         if (geyser.getConfig().getRemote().isUseProxyProtocol()) {
@@ -1417,13 +1425,6 @@ public class GeyserSession implements GeyserConnection, GeyserCommandSource {
         ServerboundPlayerActionPacket swapHandsPacket = new ServerboundPlayerActionPacket(PlayerAction.SWAP_HANDS, Vector3i.ZERO,
                 Direction.DOWN, 0);
         sendDownstreamPacket(swapHandsPacket);
-    }
-
-    /**
-     * Will be overwritten for GeyserConnect.
-     */
-    protected void disableSrvResolving() {
-        this.downstream.getSession().setFlag(BuiltinFlags.ATTEMPT_SRV_RESOLVE, false);
     }
 
     @Override


### PR DESCRIPTION
This is to allow extensions to set if a server address should be attempted to be resolved as an SRV record.
Mostly to fix SRV records in GeyserConnect.