### PR TITLE
Fix duplicate extension's help command permission registration on Paper

### DIFF
--- a/bootstrap/spigot/src/main/java/org/geysermc/geyser/platform/spigot/GeyserSpigotPlugin.java
+++ b/bootstrap/spigot/src/main/java/org/geysermc/geyser/platform/spigot/GeyserSpigotPlugin.java
@@ -165,13 +165,6 @@ public class GeyserSpigotPlugin extends JavaPlugin implements GeyserBootstrap {
             return;
         }
 
-        // Remove this in like a year
-        if (Bukkit.getPluginManager().getPlugin("floodgate-bukkit") != null) {
-            geyserLogger.severe(GeyserLocale.getLocaleStringLog("geyser.bootstrap.floodgate.outdated", Constants.FLOODGATE_DOWNLOAD_LOCATION));
-            this.getPluginLoader().disablePlugin(this);
-            return;
-        }
-
         this.geyserCommandManager = new GeyserSpigotCommandManager(geyser);
         this.geyserCommandManager.init();
 
@@ -320,6 +313,12 @@ public class GeyserSpigotPlugin extends JavaPlugin implements GeyserBootstrap {
                     }
 
                     if (command.permission().isBlank()) {
+                        continue;
+                    }
+
+                    // Avoid registering the same permission twice, e.g. for the extension help commands
+                    if (Bukkit.getPluginManager().getPermission(command.permission()) != null) {
+                        GeyserImpl.getInstance().getLogger().debug("Skipping permission " + command.permission() + " as it is already registered");
                         continue;
                     }
 

--- a/core/src/main/java/org/geysermc/geyser/command/GeyserCommandManager.java
+++ b/core/src/main/java/org/geysermc/geyser/command/GeyserCommandManager.java
@@ -107,7 +107,8 @@ public class GeyserCommandManager {
 
         // Register help commands for all extensions with commands
         for (Map.Entry<Extension, Map<String, Command>> entry : this.extensionCommands.entrySet()) {
-            registerExtensionCommand(entry.getKey(), new HelpCommand(this.geyser, "help", "geyser.commands.exthelp.desc", "geyser.command.exthelp", entry.getKey().description().id(), entry.getValue()));
+            String id = entry.getKey().description().id();
+            registerExtensionCommand(entry.getKey(), new HelpCommand(this.geyser, "help", "geyser.commands.exthelp.desc", "geyser.command.exthelp." + id, id, entry.getValue()));
         }
     }
 

--- a/core/src/main/java/org/geysermc/geyser/command/defaults/HelpCommand.java
+++ b/core/src/main/java/org/geysermc/geyser/command/defaults/HelpCommand.java
@@ -63,7 +63,8 @@ public class HelpCommand extends GeyserCommand {
     public void execute(GeyserSession session, GeyserCommandSource sender, String[] args) {
         int page = 1;
         int maxPage = 1;
-        String header = GeyserLocale.getPlayerLocaleString("geyser.commands.help.header", sender.locale(), page, maxPage);
+        String translationKey = this.baseCommand.equals("geyser") ? "geyser.commands.help.header" : "geyser.commands.extensions.header";
+        String header = GeyserLocale.getPlayerLocaleString(translationKey, sender.locale(), page, maxPage);
         sender.sendMessage(header);
 
         this.commands.entrySet().stream().sorted(Map.Entry.comparingByKey()).forEach(entry -> {


### PR DESCRIPTION
Fixes https://github.com/GeyserMC/Geyser/issues/4078 by checking if a permission already exists before attempting to add it.

Caused by [Geyser registering multiple `/<extensionid> help` commands under the same permission](https://github.com/GeyserMC/Geyser/blob/master/core/src/main/java/org/geysermc/geyser/command/GeyserCommandManager.java#L109-L111). 
This fix would just avoid re-registering these permissions.
To help debugging issues, the duplicated permissions are logged in debug mode.

Additionally, i removed the check for floodgate-bukkit, which was added two years ago.