### PR TITLE
Register extension commands on Geyser-Fabric

### DIFF
--- a/bootstrap/fabric/src/main/java/org/geysermc/geyser/platform/fabric/command/GeyserFabricCommandExecutor.java
+++ b/bootstrap/fabric/src/main/java/org/geysermc/geyser/platform/fabric/command/GeyserFabricCommandExecutor.java
@@ -53,6 +53,10 @@ public class GeyserFabricCommandExecutor extends GeyserCommandExecutor implement
 
     @Override
     public int run(CommandContext context) {
+        return runWithArgs(context, "");
+    }
+
+    public int runWithArgs(CommandContext context, String args) {
         CommandSourceStack source = (CommandSourceStack) context.getSource();
         FabricCommandSender sender = new FabricCommandSender(source);
         GeyserSession session = getGeyserSession(sender);
@@ -68,7 +72,8 @@ public class GeyserFabricCommandExecutor extends GeyserCommandExecutor implement
             sender.sendMessage(ChatColor.RED + GeyserLocale.getPlayerLocaleString("geyser.bootstrap.command.bedrock_only", sender.locale()));
             return 0;
         }
-        command.execute(session, sender, new String[0]);
+
+        command.execute(session, sender, args.split(" "));
         return 0;
     }
 }


### PR DESCRIPTION
For some reason, Extension commands were not registered at all on Fabric...

Changes:
- register extension commands, and running just `/<extensionid>` will show the same as the help command for that extension
- add a greedy string argument type to extension commands so arguments are parsed
- remove warning suppression that didn't suppress warnings (using IntelliJ IDEA community edition)

Todo:
- [ ] running the help commands (both for Geyser and extensions) in console does not actually show any commands