### PR TITLE
Don't throw errors when loading chunks with invalid skulls

### DIFF
--- a/core/src/main/java/org/geysermc/geyser/session/cache/SkullCache.java
+++ b/core/src/main/java/org/geysermc/geyser/session/cache/SkullCache.java
@@ -98,6 +98,8 @@ public class SkullCache {
                 if (GeyserImpl.getInstance().getConfig().isDebugMode()) {
                     e.printStackTrace();
                 }
+            } catch (IllegalArgumentException ignored) {
+                // no-op
             }
         }
         skull.blockState = blockState;

--- a/core/src/main/java/org/geysermc/geyser/session/cache/SkullCache.java
+++ b/core/src/main/java/org/geysermc/geyser/session/cache/SkullCache.java
@@ -98,8 +98,6 @@ public class SkullCache {
                 if (GeyserImpl.getInstance().getConfig().isDebugMode()) {
                     e.printStackTrace();
                 }
-            } catch (IllegalArgumentException ignored) {
-                // no-op
             }
         }
         skull.blockState = blockState;

--- a/core/src/main/java/org/geysermc/geyser/skin/SkinManager.java
+++ b/core/src/main/java/org/geysermc/geyser/skin/SkinManager.java
@@ -278,7 +278,14 @@ public class SkinManager {
         }
 
         public static GameProfileData loadFromJson(String encodedJson) throws IOException, IllegalArgumentException {
-            JsonNode skinObject = GeyserImpl.JSON_MAPPER.readTree(new String(Base64.getDecoder().decode(encodedJson), StandardCharsets.UTF_8));
+            JsonNode skinObject;
+            try {
+                skinObject = GeyserImpl.JSON_MAPPER.readTree(new String(Base64.getDecoder().decode(encodedJson), StandardCharsets.UTF_8));
+            } catch (IllegalArgumentException e) {
+                GeyserImpl.getInstance().getLogger().debug("Invalid base64 encoded skin entry: " + encodedJson);
+                return null;
+            }
+
             JsonNode textures = skinObject.get("textures");
 
             if (textures == null) {


### PR DESCRIPTION
When loading chunks with invalid skulls, errors like [these](https://cdn.discordapp.com/attachments/613168464634576897/1144359547566313602/image.png) could be thrown for invalid skulls.
This change catches the exception & logs the invalid encoded skin json in debug mode.