### PR TITLE
Don't error when skull skin cache doesnt exist

### DIFF
--- a/core/src/main/java/org/geysermc/geyser/pack/SkullResourcePackManager.java
+++ b/core/src/main/java/org/geysermc/geyser/pack/SkullResourcePackManager.java
@@ -139,6 +139,11 @@ public class SkullResourcePackManager {
     }
 
     public static void cleanSkullSkinCache() {
+        // No need to clean up if skin cache does not exist
+        if (!Files.exists(SKULL_SKIN_CACHE_PATH)) {
+            return;
+        }
+
         try (Stream<Path> stream = Files.list(SKULL_SKIN_CACHE_PATH)) {
             int removeCount = 0;
             for (Path path : stream.toList()) {


### PR DESCRIPTION
https://paste.gg/p/anonymous/d49aa817661c4ff39170e8163d5fbc5d fixes this error that's thrown sometimes.
If there was no skin cached using `cacheSkullSkin`, the directory for if SKULL_SKIN_CACHE_PATH does not exist. Hence, no need to clean up :p