### PR TITLE
Allow Null Texture for Block Mappings/API

### DIFF
--- a/api/src/main/java/org/geysermc/geyser/api/block/custom/component/MaterialInstance.java
+++ b/api/src/main/java/org/geysermc/geyser/api/block/custom/component/MaterialInstance.java
@@ -25,7 +25,6 @@
 
 package org.geysermc.geyser.api.block.custom.component;
 
-import org.checkerframework.checker.nullness.qual.NonNull;
 import org.checkerframework.checker.nullness.qual.Nullable;
 import org.geysermc.geyser.api.GeyserApi;
 
@@ -38,7 +37,7 @@ public interface MaterialInstance {
      *
      * @return The texture of the block.
      */
-    @NonNull String texture();
+    @Nullable String texture();
 
     /**
      * Gets the render method of the block
@@ -52,14 +51,14 @@ public interface MaterialInstance {
      * 
      * @return If the block should be dimmed on certain faces.
      */
-    @Nullable boolean faceDimming();
+    boolean faceDimming();
 
     /**
      * Gets if the block should have ambient occlusion
      * 
      * @return If the block should have ambient occlusion.
      */
-    @Nullable boolean ambientOcclusion();
+    boolean ambientOcclusion();
 
     /**
      * Creates a builder for MaterialInstance.
@@ -71,13 +70,13 @@ public interface MaterialInstance {
     }
 
     interface Builder {
-        Builder texture(@NonNull String texture);
+        Builder texture(@Nullable String texture);
 
         Builder renderMethod(@Nullable String renderMethod);
 
-        Builder faceDimming(@Nullable boolean faceDimming);
+        Builder faceDimming(boolean faceDimming);
 
-        Builder ambientOcclusion(@Nullable boolean ambientOcclusion);
+        Builder ambientOcclusion(boolean ambientOcclusion);
 
         MaterialInstance build();
     }

--- a/core/src/main/java/org/geysermc/geyser/level/block/GeyserMaterialInstance.java
+++ b/core/src/main/java/org/geysermc/geyser/level/block/GeyserMaterialInstance.java
@@ -26,7 +26,6 @@
 package org.geysermc.geyser.level.block;
 
 import lombok.RequiredArgsConstructor;
-import org.checkerframework.checker.nullness.qual.NonNull;
 import org.checkerframework.checker.nullness.qual.Nullable;
 import org.geysermc.geyser.api.block.custom.component.MaterialInstance;
 
@@ -45,7 +44,7 @@ public class GeyserMaterialInstance implements MaterialInstance {
     }
 
     @Override
-    public @NonNull String texture() {
+    public @Nullable String texture() {
         return texture;
     }
 
@@ -55,12 +54,12 @@ public class GeyserMaterialInstance implements MaterialInstance {
     }
 
     @Override
-    public @Nullable boolean faceDimming() {
+    public boolean faceDimming() {
         return faceDimming;
     }
 
     @Override
-    public @Nullable boolean ambientOcclusion() {
+    public boolean ambientOcclusion() {
         return ambientOcclusion;
     }
 
@@ -71,7 +70,7 @@ public class GeyserMaterialInstance implements MaterialInstance {
         private boolean ambientOcclusion;
 
         @Override
-        public Builder texture(@NonNull String texture) {
+        public Builder texture(@Nullable String texture) {
             this.texture = texture;
             return this;
         }
@@ -83,13 +82,13 @@ public class GeyserMaterialInstance implements MaterialInstance {
         }
 
         @Override
-        public Builder faceDimming(@Nullable boolean faceDimming) {
+        public Builder faceDimming(boolean faceDimming) {
             this.faceDimming = faceDimming;
             return this;
         }
 
         @Override
-        public Builder ambientOcclusion(@Nullable boolean ambientOcclusion) {
+        public Builder ambientOcclusion(boolean ambientOcclusion) {
             this.ambientOcclusion = ambientOcclusion;
             return this;
         }

--- a/core/src/main/java/org/geysermc/geyser/registry/mappings/versions/MappingsReader_v1.java
+++ b/core/src/main/java/org/geysermc/geyser/registry/mappings/versions/MappingsReader_v1.java
@@ -626,7 +626,7 @@ public class MappingsReader_v1 extends MappingsReader {
      */
     private MaterialInstance createMaterialInstanceComponent(JsonNode node, String name) {
         // Set default values, and use what the user provides if they have provided something
-        String texture = name;
+        String texture = null;
         if (node.has("texture")) {
             texture = node.get("texture").asText();
         }

--- a/core/src/main/java/org/geysermc/geyser/registry/populator/CustomBlockRegistryPopulator.java
+++ b/core/src/main/java/org/geysermc/geyser/registry/populator/CustomBlockRegistryPopulator.java
@@ -325,12 +325,15 @@ public class CustomBlockRegistryPopulator {
             NbtMapBuilder materialsBuilder = NbtMap.builder();
             for (Map.Entry<String, MaterialInstance> entry : components.materialInstances().entrySet()) {
                 MaterialInstance materialInstance = entry.getValue();
-                materialsBuilder.putCompound(entry.getKey(), NbtMap.builder()
-                        .putString("texture", materialInstance.texture())
+                NbtMapBuilder materialBuilder = NbtMap.builder()
                         .putString("render_method", materialInstance.renderMethod())
                         .putBoolean("face_dimming", materialInstance.faceDimming())
-                        .putBoolean("ambient_occlusion", materialInstance.faceDimming())
-                        .build());
+                        .putBoolean("ambient_occlusion", materialInstance.faceDimming());
+                // Texture can be unspecified when blocks.json is used in RP (https://wiki.bedrock.dev/blocks/blocks-stable.html#minecraft-material-instances)
+                if (materialInstance.texture() != null) {
+                    materialBuilder.putString("texture", materialInstance.texture())
+                }
+                materialsBuilder.putCompound(entry.getKey(), materialBuilder.build());
             }
 
             builder.putCompound("minecraft:material_instances", NbtMap.builder()

--- a/core/src/main/java/org/geysermc/geyser/registry/populator/CustomBlockRegistryPopulator.java
+++ b/core/src/main/java/org/geysermc/geyser/registry/populator/CustomBlockRegistryPopulator.java
@@ -331,7 +331,7 @@ public class CustomBlockRegistryPopulator {
                         .putBoolean("ambient_occlusion", materialInstance.faceDimming());
                 // Texture can be unspecified when blocks.json is used in RP (https://wiki.bedrock.dev/blocks/blocks-stable.html#minecraft-material-instances)
                 if (materialInstance.texture() != null) {
-                    materialBuilder.putString("texture", materialInstance.texture())
+                    materialBuilder.putString("texture", materialInstance.texture());
                 }
                 materialsBuilder.putCompound(entry.getKey(), materialBuilder.build());
             }


### PR DESCRIPTION
Technically texture can be null for a material instance which then allows one to specify the texture in blocks.json of the resource pack. There are some things you can only do with blocks.json so we might as well allow it. Also removes some unneeded nullable annotations from primitives. 