### PR TITLE
Update inventory titles in e.g. chest GUIs

### DIFF
--- a/core/src/main/java/org/geysermc/geyser/translator/protocol/java/inventory/JavaOpenScreenTranslator.java
+++ b/core/src/main/java/org/geysermc/geyser/translator/protocol/java/inventory/JavaOpenScreenTranslator.java
@@ -73,7 +73,8 @@ public class JavaOpenScreenTranslator extends PacketTranslator<ClientboundOpenSc
         if (openInventory != null) {
             // If the window type is the same, don't close.
             // In rare cases, inventories can do funny things where it keeps the same window type up but change the contents.
-            if (openInventory.getContainerType() != packet.getType()) {
+            // Or, inventory names can change (useful for JsonUI). In these cases, we need to close the old inventory.
+            if (openInventory.getContainerType() != packet.getType() || !openInventory.getTitle().equals(name)) {
                 // Sometimes the server can double-open an inventory with the same ID - don't confirm in that instance.
                 InventoryUtils.closeInventory(session, openInventory.getJavaId(), openInventory.getJavaId() != packet.getContainerId());
             }


### PR DESCRIPTION
This little change makes sure that e.g. chest GUIs that depend on the change of a chest title to change for new content (e.g. for JsonUI) are properly updated.

Tested by agaloth, here's the result:
https://cdn.discordapp.com/attachments/1101917862072942622/1149004660099797002/2023-09-06_17-33-29.mp4

The only thing i'm not sure about is whether ` InventoryUtils.closeInventory(...)` should be called with or without the `confirm` boolean set - would appreciate some input on that :)

fixes https://github.com/GeyserMC/Geyser/issues/3578