### PR TITLE
Fix jackson dependency for velocity launch

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -3,7 +3,7 @@ base-api = "1.0.0-SNAPSHOT"
 cumulus = "1.1.2"
 erosion = "1.0-20230406.174837-8"
 events = "1.1-SNAPSHOT"
-jackson = "2.14.0"
+jackson = { strictly = "2.14.0" } # Don't let other dependencies override
 fastutil = "8.5.2"
 netty = "4.1.80.Final"
 guava = "29.0-jre"


### PR DESCRIPTION
I'm sorry :( blockstateupdater was causing the version to be higher (2.14.2). Not sure if this error was because the version was actually higher or because it just caused desync between different jackson artifacts.

Tested on all platforms

Closes #4117 