### PR TITLE
Pin all actions to sha commit hash

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -19,54 +19,59 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository and submodules
-        uses: actions/checkout@v3
+        # See https://github.com/actions/checkout/commits
+        uses: actions/checkout@72f2cec99f417b1a1c5e2e88945068983b7965f9
         with:
           submodules: recursive
 
       - name: Validate Gradle Wrapper
-        uses: gradle/wrapper-validation-action@v1
+        # See https://github.com/gradle/wrapper-validation-action/commits
+        uses: gradle/wrapper-validation-action@56b90f209b02bf6d1deae490e9ef18b21a389cd4
 
-      - uses: actions/setup-java@v3
+        # See https://github.com/actions/setup-java/commits
+      - uses: actions/setup-java@4075bfc1b51bf22876335ae1cd589602d60d8758
         with:
           java-version: 17
           distribution: temurin
           
       - name: Build
-        uses: gradle/gradle-build-action@v2
+        # See https://github.com/gradle/gradle-build-action/commits
+        uses: gradle/gradle-build-action@3bfe3a46584a206fb8361cdedd0647b0c4204232
         with:
           arguments: build
           gradle-home-cache-cleanup: true
           
       - name: Archive artifacts (Geyser Fabric)
-        uses: actions/upload-artifact@v3
+        # See https://github.com/actions/upload-artifact/commits
+        uses: actions/upload-artifact@a8a3f3ad30e3422c9c7b888a15615d19a852ae32
         if: success()
         with:
           name: Geyser Fabric
           path: bootstrap/fabric/build/libs/Geyser-Fabric.jar
           if-no-files-found: error
       - name: Archive artifacts (Geyser Standalone)
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@a8a3f3ad30e3422c9c7b888a15615d19a852ae32
         if: success()
         with:
           name: Geyser Standalone
           path: bootstrap/standalone/build/libs/Geyser-Standalone.jar
           if-no-files-found: error
       - name: Archive artifacts (Geyser Spigot)
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@a8a3f3ad30e3422c9c7b888a15615d19a852ae32
         if: success()
         with:
           name: Geyser Spigot
           path: bootstrap/spigot/build/libs/Geyser-Spigot.jar
           if-no-files-found: error
       - name: Archive artifacts (Geyser BungeeCord)
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@a8a3f3ad30e3422c9c7b888a15615d19a852ae32
         if: success()
         with:
           name: Geyser BungeeCord
           path: bootstrap/bungeecord/build/libs/Geyser-BungeeCord.jar
           if-no-files-found: error
       - name: Archive artifacts (Geyser Velocity)
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@a8a3f3ad30e3422c9c7b888a15615d19a852ae32
         if: success()
         with:
           name: Geyser Velocity
@@ -75,7 +80,7 @@ jobs:
 
       - name: Publish to Maven Repository
         if: ${{ success() && github.repository == 'GeyserMC/Geyser' && github.ref_name == 'master' }}
-        uses: gradle/gradle-build-action@v2
+        uses: gradle/gradle-build-action@3bfe3a46584a206fb8361cdedd0647b0c4204232
         env:
           ORG_GRADLE_PROJECT_geysermcUsername: ${{ vars.DEPLOY_USER }}
           ORG_GRADLE_PROJECT_geysermcPassword: ${{ secrets.DEPLOY_PASS }}
@@ -107,7 +112,7 @@ jobs:
           rsync -P -e "ssh -o StrictHostKeyChecking=no -i id_ecdsa" metadata.json $DOWNLOADS_USERNAME@$DOWNLOADS_SERVER_IP:~/uploads/$project/$GITHUB_RUN_NUMBER/
 
       - name: Publish to Modrinth
-        uses: gradle/gradle-build-action@v2
+        uses: gradle/gradle-build-action@3bfe3a46584a206fb8361cdedd0647b0c4204232
         if: ${{ success() && github.repository == 'GeyserMC/Geyser' && github.ref_name == 'master' }}
         env:
           MODRINTH_TOKEN: ${{ secrets.MODRINTH_TOKEN }}
@@ -117,7 +122,8 @@ jobs:
           
       - name: Notify Discord
         if: ${{ (success() || failure()) && github.repository == 'GeyserMC/Geyser' }}
-        uses: Tim203/actions-git-discord-webhook@main
+        # See https://github.com/Tim203/actions-git-discord-webhook/commits
+        uses: Tim203/actions-git-discord-webhook@70f38ded3aca51635ec978ab4e1a58cd4cd0c2ff
         with:
           webhook_url: ${{ secrets.DISCORD_WEBHOOK }}
           status: ${{ job.status }}

--- a/.github/workflows/pullrequest.yml
+++ b/.github/workflows/pullrequest.yml
@@ -16,14 +16,20 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
+      - name: Validate Gradle Wrapper
+        # See https://github.com/gradle/wrapper-validation-action/commits
+        uses: gradle/wrapper-validation-action@56b90f209b02bf6d1deae490e9ef18b21a389cd4
+
       - name: Set up JDK 17
-        uses: actions/setup-java@v3
+        # See https://github.com/actions/setup-java/commits
+        uses: actions/setup-java@4075bfc1b51bf22876335ae1cd589602d60d8758
         with:
           java-version: 17
           distribution: temurin
 
       - name: Check if the author has forked the API repo
-        uses: Kas-tle/find-forks-action@v1.0.1
+        # See https://github.com/Kas-tle/find-forks-action/commits
+        uses: Kas-tle/find-forks-action@1b5447d1e3c7a8ed79583dd817cc5399686eed3a
         id: find_forks
         with:
           owner: GeyserMC
@@ -41,47 +47,50 @@ jobs:
           ./gradlew publishToMavenLocal
 
       - name: Checkout repository and submodules
-        uses: actions/checkout@v3
+        # See https://github.com/actions/checkout/commits
+        uses: actions/checkout@72f2cec99f417b1a1c5e2e88945068983b7965f9
         with:
           submodules: recursive
           path: geyser
 
       - name: Build Geyser
-        uses: gradle/gradle-build-action@v2
+        # See https://github.com/gradle/gradle-build-action/commits
+        uses: gradle/gradle-build-action@3bfe3a46584a206fb8361cdedd0647b0c4204232
         with:
           arguments: build
           build-root-directory: geyser
 
       - name: Archive artifacts (Geyser Fabric)
-        uses: actions/upload-artifact@v3
+        # See https://github.com/actions/upload-artifact/commits
+        uses: actions/upload-artifact@a8a3f3ad30e3422c9c7b888a15615d19a852ae32
         if: success()
         with:
           name: Geyser Fabric
           path: geyser/bootstrap/fabric/build/libs/Geyser-Fabric.jar
           if-no-files-found: error
       - name: Archive artifacts (Geyser Standalone)
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@a8a3f3ad30e3422c9c7b888a15615d19a852ae32
         if: success()
         with:
           name: Geyser Standalone
           path: geyser/bootstrap/standalone/build/libs/Geyser-Standalone.jar
           if-no-files-found: error
       - name: Archive artifacts (Geyser Spigot)
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@a8a3f3ad30e3422c9c7b888a15615d19a852ae32
         if: success()
         with:
           name: Geyser Spigot
           path: geyser/bootstrap/spigot/build/libs/Geyser-Spigot.jar
           if-no-files-found: error
       - name: Archive artifacts (Geyser BungeeCord)
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@a8a3f3ad30e3422c9c7b888a15615d19a852ae32
         if: success()
         with:
           name: Geyser BungeeCord
           path: geyser/bootstrap/bungeecord/build/libs/Geyser-BungeeCord.jar
           if-no-files-found: error
       - name: Archive artifacts (Geyser Velocity)
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@a8a3f3ad30e3422c9c7b888a15615d19a852ae32
         if: success()
         with:
           name: Geyser Velocity

--- a/.github/workflows/pullrequest.yml
+++ b/.github/workflows/pullrequest.yml
@@ -16,10 +16,6 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-      - name: Validate Gradle Wrapper
-        # See https://github.com/gradle/wrapper-validation-action/commits
-        uses: gradle/wrapper-validation-action@56b90f209b02bf6d1deae490e9ef18b21a389cd4
-
       - name: Set up JDK 17
         # See https://github.com/actions/setup-java/commits
         uses: actions/setup-java@4075bfc1b51bf22876335ae1cd589602d60d8758
@@ -52,6 +48,10 @@ jobs:
         with:
           submodules: recursive
           path: geyser
+
+      - name: Validate Gradle Wrapper
+        # See https://github.com/gradle/wrapper-validation-action/commits
+        uses: gradle/wrapper-validation-action@56b90f209b02bf6d1deae490e9ef18b21a389cd4
 
       - name: Build Geyser
         # See https://github.com/gradle/gradle-build-action/commits


### PR DESCRIPTION
Currently, we use tags to specify what actions we run. This creates a problem because the tags can technically be pointed to a different commit at any time.

Before the downloads API, this was largely a non-issue as even if the workflow were to be compromised, at most we would be building a bad jar that no one could access. But now that we instead publish the actual jar built from the workflow, I think this is important. A more targeted attack could even compromise the downloads API itself since these actions need access to our API keys for the downloads API and Modrinth.

Github also recommends this: https://docs.github.com/en/actions/security-guides/security-hardening-for-github-actions#using-third-party-actions