### PR TITLE
Don't block chunk loading if an invalid skull is found

### DIFF
--- a/core/src/main/java/org/geysermc/geyser/translator/level/block/entity/SkullBlockEntityTranslator.java
+++ b/core/src/main/java/org/geysermc/geyser/translator/level/block/entity/SkullBlockEntityTranslator.java
@@ -107,11 +107,12 @@ public class SkullBlockEntityTranslator extends BlockEntityTranslator implements
         CompletableFuture<String> texturesFuture = getTextures(owner, uuid);
         if (texturesFuture.isDone()) {
             try {
-                if (texturesFuture.get() == null) {
+                String texture = texturesFuture.get();
+                if (texture == null) {
                     session.getGeyser().getLogger().debug("Custom skull with invalid SkullOwner tag: " + blockPosition + " " + tag);
                     return null;
                 }
-                SkullCache.Skull skull = session.getSkullCache().putSkull(blockPosition, uuid, texturesFuture.get(), blockState);
+                SkullCache.Skull skull = session.getSkullCache().putSkull(blockPosition, uuid, texture, blockState);
                 return skull.getBlockDefinition();
             } catch (InterruptedException | ExecutionException e) {
                 session.getGeyser().getLogger().debug("Failed to acquire textures for custom skull: " + blockPosition + " " + tag);

--- a/core/src/main/java/org/geysermc/geyser/translator/level/block/entity/SkullBlockEntityTranslator.java
+++ b/core/src/main/java/org/geysermc/geyser/translator/level/block/entity/SkullBlockEntityTranslator.java
@@ -107,6 +107,10 @@ public class SkullBlockEntityTranslator extends BlockEntityTranslator implements
         CompletableFuture<String> texturesFuture = getTextures(owner, uuid);
         if (texturesFuture.isDone()) {
             try {
+                if (texturesFuture.get() == null) {
+                    session.getGeyser().getLogger().debug("Custom skull with invalid SkullOwner tag: " + blockPosition + " " + tag);
+                    return null;
+                }
                 SkullCache.Skull skull = session.getSkullCache().putSkull(blockPosition, uuid, texturesFuture.get(), blockState);
                 return skull.getBlockDefinition();
             } catch (InterruptedException | ExecutionException e) {


### PR DESCRIPTION
Should fix https://github.com/GeyserMC/Geyser/issues/4128 and fix https://github.com/GeyserMC/Geyser/issues/4084, since this avoids a call of `session.getSkullCache().putSkull()` which doesn't handle null texture values (similarly done [below](https://github.com/onebeastchris/Geyser/blob/7fe9f97ccd7de4cb895d7107dccda055cc58eb1e/core/src/main/java/org/geysermc/geyser/translator/level/block/entity/SkullBlockEntityTranslator.java#L127-L130))