### PR TITLE
Fix: Require the `geyser.settings.server` permission for client side gamemode changes

### DIFF
--- a/core/src/main/java/org/geysermc/geyser/registry/PacketTranslatorRegistry.java
+++ b/core/src/main/java/org/geysermc/geyser/registry/PacketTranslatorRegistry.java
@@ -29,7 +29,6 @@ import com.github.steveice10.mc.protocol.packet.ingame.clientbound.ClientboundDe
 import com.github.steveice10.mc.protocol.packet.ingame.clientbound.ClientboundTabListPacket;
 import com.github.steveice10.mc.protocol.packet.ingame.clientbound.level.ClientboundLightUpdatePacket;
 import io.netty.channel.EventLoop;
-import org.cloudburstmc.protocol.bedrock.packet.RequestPermissionsPacket;
 import org.geysermc.geyser.GeyserImpl;
 import org.geysermc.geyser.registry.loader.RegistryLoaders;
 import org.geysermc.geyser.session.GeyserSession;
@@ -47,7 +46,6 @@ public class PacketTranslatorRegistry<T> extends AbstractMappedRegistry<Class<? 
         IGNORED_PACKETS.add(ClientboundLightUpdatePacket.class); // Light is handled on Bedrock for us
         IGNORED_PACKETS.add(ClientboundTabListPacket.class); // Cant be implemented in Bedrock
         IGNORED_PACKETS.add(ClientboundDelimiterPacket.class); // Not implemented, spams logs
-        IGNORED_PACKETS.add(RequestPermissionsPacket.class); // Bedrock client asks permission to switch default game mode, but we handle this ourselves
     }
 
     protected PacketTranslatorRegistry() {

--- a/core/src/main/java/org/geysermc/geyser/translator/protocol/bedrock/entity/player/BedrockRequestPermissionsPacket.java
+++ b/core/src/main/java/org/geysermc/geyser/translator/protocol/bedrock/entity/player/BedrockRequestPermissionsPacket.java
@@ -25,24 +25,19 @@
 
 package org.geysermc.geyser.translator.protocol.bedrock.entity.player;
 
-import com.github.steveice10.mc.protocol.data.game.setting.Difficulty;
-import org.cloudburstmc.protocol.bedrock.packet.SetDifficultyPacket;
+import org.cloudburstmc.protocol.bedrock.packet.RequestPermissionsPacket;
 import org.geysermc.geyser.session.GeyserSession;
 import org.geysermc.geyser.translator.protocol.PacketTranslator;
 import org.geysermc.geyser.translator.protocol.Translator;
 
-@Translator(packet = SetDifficultyPacket.class)
-public class BedrockSetDifficultyTranslator extends PacketTranslator<SetDifficultyPacket> {
+/**
+ * Sent occasionally by a BDS client when opening the client side server settings menu.
+ */
+@Translator(packet = RequestPermissionsPacket.class)
+public class BedrockRequestPermissionsPacket extends PacketTranslator<RequestPermissionsPacket> {
 
-    /**
-     * Sets the Java server's difficulty via the Bedrock client's "world" menu (given sufficient permissions).
-     */
     @Override
-    public void translate(GeyserSession session, SetDifficultyPacket packet) {
-        if (session.getOpPermissionLevel() >= 2 && session.hasPermission("geyser.settings.server")) {
-            if (packet.getDifficulty() != session.getWorldCache().getDifficulty().ordinal()) {
-                session.getGeyser().getWorldManager().setDifficulty(session, Difficulty.from(packet.getDifficulty()));
-            }
-        }
+    public void translate(GeyserSession session, RequestPermissionsPacket packet) {
+        session.sendAdventureSettings();
     }
 }

--- a/core/src/main/java/org/geysermc/geyser/translator/protocol/bedrock/entity/player/BedrockSetDefaultGameTypeTranslator.java
+++ b/core/src/main/java/org/geysermc/geyser/translator/protocol/bedrock/entity/player/BedrockSetDefaultGameTypeTranslator.java
@@ -41,7 +41,7 @@ public class BedrockSetDefaultGameTypeTranslator extends PacketTranslator<SetDef
      */
     @Override
     public void translate(GeyserSession session, SetDefaultGameTypePacket packet) {
-        if (session.getOpPermissionLevel() >= 2 || session.hasPermission("geyser.settings.server")) {
+        if (session.getOpPermissionLevel() >= 2 && session.hasPermission("geyser.settings.server")) {
             session.getGeyser().getWorldManager().setDefaultGameMode(session, GameMode.byId(packet.getGamemode()));
         }
         // Stop the client from updating their own Gamemode without telling the server

--- a/core/src/main/java/org/geysermc/geyser/translator/protocol/bedrock/entity/player/BedrockSetPlayerGameTypeTranslator.java
+++ b/core/src/main/java/org/geysermc/geyser/translator/protocol/bedrock/entity/player/BedrockSetPlayerGameTypeTranslator.java
@@ -45,7 +45,7 @@ public class BedrockSetPlayerGameTypeTranslator extends PacketTranslator<SetPlay
     @Override
     public void translate(GeyserSession session, SetPlayerGameTypePacket packet) {
         // yes, if you are OP
-        if (session.getOpPermissionLevel() >= 2 || session.hasPermission("geyser.settings.server")) {
+        if (session.getOpPermissionLevel() >= 2 && session.hasPermission("geyser.settings.server")) {
             if (packet.getGamemode() != session.getGameMode().ordinal()) {
                 // Bedrock has more Gamemodes than Java, leading to cases 5 (for "default") and 6 (for "spectator") being sent
                 // https://github.com/CloudburstMC/Protocol/blob/3.0/bedrock-codec/src/main/java/org/cloudburstmc/protocol/bedrock/data/GameType.java


### PR DESCRIPTION
From some debugging, it looks like - for once - it's not the client going rogue, but rather our trust in the default permission value of 2 or higher being misplaced (since we operate under the assumption that, as in vanilla, a permission value of 2 or higher allows access to the /gamemode command).

This seems to not be the case, as some plugins seem to send a permission of 4 for some damn reason. Cool. For example, the FN3perm plugin does that.
As for the fix - since client side gamemode switching isn't too harmless (e.g. allows flying) - i've now added a check for *both* the permission value and the `geyser.settings.server` permission.

Downside:
- buttons aren't grayed out, but that can be argued is the fault of plugins that send this high permission value
- We can't gray them out by relying on both options to set the PlayerPermission/CommandPermission level, as that would remove the access to e.g. the Bedrock command completion. Which, arguably, is quite a cool little thing.

As a safety measure, we're now also responding to a server-bound RequestPermissionsPacket by updating the sessions AdventureSettings.