### PR TITLE
Update Minecraft Wiki links to new domain

### DIFF
--- a/core/src/main/java/org/geysermc/geyser/inventory/item/TippedArrowPotion.java
+++ b/core/src/main/java/org/geysermc/geyser/inventory/item/TippedArrowPotion.java
@@ -31,7 +31,7 @@ import java.util.Locale;
 
 /**
  * Potion identifiers and their respective Bedrock IDs used with arrows.
- * https://minecraft.gamepedia.com/Arrow#Item_Data
+ * https://minecraft.wiki/w/Arrow#Data_values
  */
 @Getter
 public enum TippedArrowPotion {

--- a/core/src/main/java/org/geysermc/geyser/text/MinecraftLocale.java
+++ b/core/src/main/java/org/geysermc/geyser/text/MinecraftLocale.java
@@ -76,7 +76,7 @@ public class MinecraftLocale {
     public static void downloadAndLoadLocale(String locale) {
         locale = locale.toLowerCase(Locale.ROOT);
         if (locale.equals("nb_no")) {
-            // Different locale code - https://minecraft.fandom.com/wiki/Language
+            // Different locale code - https://minecraft.wiki/w/Language
             locale = "no_no";
         }
 

--- a/core/src/main/java/org/geysermc/geyser/translator/protocol/java/entity/JavaEntityEventTranslator.java
+++ b/core/src/main/java/org/geysermc/geyser/translator/protocol/java/entity/JavaEntityEventTranslator.java
@@ -120,7 +120,7 @@ public class JavaEntityEventTranslator extends PacketTranslator<ClientboundEntit
                 if (fishingHook.getBedrockTargetId() == session.getPlayerEntity().getGeyserId()) {
                     Entity hookOwner = session.getEntityCache().getEntityByGeyserId(fishingHook.getBedrockOwnerId());
                     if (hookOwner != null) {
-                        // https://minecraft.gamepedia.com/Fishing_Rod#Hooking_mobs_and_other_entities
+                        // https://minecraft.wiki/w/Fishing_Rod#Hooking_mobs_and_other_entities
                         SetEntityMotionPacket motionPacket = new SetEntityMotionPacket();
                         motionPacket.setRuntimeEntityId(session.getPlayerEntity().getGeyserId());
                         motionPacket.setMotion(hookOwner.getPosition().sub(session.getPlayerEntity().getPosition()).mul(0.1f));

--- a/core/src/main/java/org/geysermc/geyser/translator/protocol/java/level/JavaSetTimeTranslator.java
+++ b/core/src/main/java/org/geysermc/geyser/translator/protocol/java/level/JavaSetTimeTranslator.java
@@ -40,7 +40,7 @@ public class JavaSetTimeTranslator extends PacketTranslator<ClientboundSetTimePa
         // Java just sends a negative long if there is no daylight cycle
         long time = packet.getTime();
 
-        // https://minecraft.gamepedia.com/Day-night_cycle#24-hour_Minecraft_day
+        // https://minecraft.wiki/w/Day-night_cycle#24-hour_Minecraft_day
         SetTimePacket setTimePacket = new SetTimePacket();
         // We use modulus to prevent an integer overflow
         // 24000 is the range of ticks that a Minecraft day can be; we times by 8 so all moon phases are visible

--- a/core/src/main/java/org/geysermc/geyser/util/AttributeUtils.java
+++ b/core/src/main/java/org/geysermc/geyser/util/AttributeUtils.java
@@ -32,7 +32,7 @@ import com.github.steveice10.mc.protocol.data.game.entity.attribute.ModifierOper
 public class AttributeUtils {
     /**
      * Retrieve the base attribute value with all modifiers applied.
-     * https://minecraft.gamepedia.com/Attribute#Modifiers
+     * https://minecraft.wiki/w/Attribute#Modifiers
      * @param attribute The attribute to calculate the total value.
      * @return The finished attribute with all modifiers applied.
      */

--- a/core/src/main/java/org/geysermc/geyser/util/BlockUtils.java
+++ b/core/src/main/java/org/geysermc/geyser/util/BlockUtils.java
@@ -64,7 +64,7 @@ public final class BlockUtils {
         if (toolType.equals("shears")) return isShearsEffective ? 5.0 : 15.0;
         if (toolType.equals("")) return 1.0;
         return switch (toolTier) {
-            // https://minecraft.gamepedia.com/Breaking#Speed
+            // https://minecraft.wiki/w/Breaking#Speed
             case "wooden" -> 2.0;
             case "stone" -> 4.0;
             case "iron" -> 6.0;
@@ -100,7 +100,7 @@ public final class BlockUtils {
         return true;
     }
 
-    // https://minecraft.gamepedia.com/Breaking
+    // https://minecraft.wiki/w/Breaking
     private static double calculateBreakTime(double blockHardness, String toolTier, boolean canHarvestWithHand, boolean correctTool, boolean canTierMineBlock,
                                              String toolType, boolean isShearsEffective, int toolEfficiencyLevel, int hasteLevel, int miningFatigueLevel,
                                              boolean insideOfWaterWithoutAquaAffinity, boolean onGround) {


### PR DESCRIPTION
The Minecraft Fandom wiki has been forked to a new domain: minecraft.wiki. Learn more here: https://minecraft.wiki/w/Minecraft_Wiki:Moving_from_Fandom. This PR updates all URLs accordingly.