### PR TITLE
Force loading help-text using utf-8 to fix encoding errors

### DIFF
--- a/core/src/main/java/org/geysermc/geyser/GeyserMain.java
+++ b/core/src/main/java/org/geysermc/geyser/GeyserMain.java
@@ -28,6 +28,7 @@ package org.geysermc.geyser;
 import javax.swing.*;
 import java.io.InputStream;
 import java.lang.reflect.Method;
+import java.nio.charset.StandardCharsets;
 import java.util.Locale;
 import java.util.Scanner;
 
@@ -60,7 +61,7 @@ public class GeyserMain {
             helpStream = GeyserMain.class.getClassLoader().getResourceAsStream("languages/run-help/en_US.txt");
         }
 
-        Scanner help = new Scanner(helpStream).useDelimiter("\\Z");
+        Scanner help = new Scanner(helpStream, StandardCharsets.UTF_8).useDelimiter("\\Z");
         String line = "";
         while (help.hasNext()) {
             line = help.next();


### PR DESCRIPTION
This should fix formatting issues like this from happening on the help popup
![image](https://github.com/GeyserMC/Geyser/assets/5401186/960e3156-dae7-466a-bfe4-eeecec822db7)
