### PR TITLE
Fix: Flying issues after 1.20.30 due to new PlayerAction cases

### DIFF
--- a/core/src/main/java/org/geysermc/geyser/translator/protocol/bedrock/BedrockRequestAbilityTranslator.java
+++ b/core/src/main/java/org/geysermc/geyser/translator/protocol/bedrock/BedrockRequestAbilityTranslator.java
@@ -42,6 +42,7 @@ public class BedrockRequestAbilityTranslator extends PacketTranslator<RequestAbi
 
     @Override
     public void translate(GeyserSession session, RequestAbilityPacket packet) {
+        // TODO: Since 1.20.30, this was replaced by a START_FLYING and STOP_FLYING case in BedrockActionTranslator
         if (packet.getAbility() == Ability.FLYING) {
             boolean isFlying = packet.isBoolValue();
             if (!isFlying && session.getGameMode() == GameMode.SPECTATOR) {


### PR DESCRIPTION
Implements the new 1.20.30 PlayerAction cases `START_FLYING` and `STOP_FLYING` . Found [here](https://github.com/CloudburstMC/Protocol/commit/81ef6bbb3bd5acba3de6dbe987bc41731f90b8c7#diff-d50c9c6b8702e1ce77b9b21588ce50f2b28ec17e6af1058223ff7f5880755429R61-R69)

Seems like the RequestAbilityPacket isn't used for bedrock players looking to fly anymore :p

Fixes https://github.com/GeyserMC/Geyser/issues/4144, closes https://github.com/GeyserMC/Geyser/issues/4136, closes https://github.com/GeyserMC/Geyser/issues/4184