### PR TITLE
Fix: Beacon effects broken since 1.20.2

### DIFF
--- a/core/src/main/java/org/geysermc/geyser/translator/inventory/BeaconInventoryTranslator.java
+++ b/core/src/main/java/org/geysermc/geyser/translator/inventory/BeaconInventoryTranslator.java
@@ -119,7 +119,7 @@ public class BeaconInventoryTranslator extends AbstractBlockInventoryTranslator 
     }
 
     private OptionalInt toJava(int effectChoice) {
-        return effectChoice == 0 ? OptionalInt.empty() : OptionalInt.of(effectChoice);
+        return effectChoice == 0 ? OptionalInt.empty() : OptionalInt.of(effectChoice - 1);
     }
 
     @Override


### PR DESCRIPTION
Since 1.20.2, Java effect IDs start at 0, not 1. Bedrock of course doesn't respect that, so we need to subtract 1!
Similar to https://github.com/GeyserMC/MCProtocolLib/commit/2151d360b1e840f6adfc8bf41c666a9365e69405 - we had to substract/add 1 to the ordinals; now we have to do the opposite here for Bedrock edition. Fun!

Fixes https://github.com/GeyserMC/Geyser/issues/4166