### PR TITLE
Fix: Skull rotation issues since 1.20.2

### DIFF
--- a/core/src/main/java/org/geysermc/geyser/level/block/BlockStateValues.java
+++ b/core/src/main/java/org/geysermc/geyser/level/block/BlockStateValues.java
@@ -173,8 +173,8 @@ public final class BlockStateValues {
         }
 
         if (javaId.contains("wall_skull") || javaId.contains("wall_head")) {
-            String direction = javaId.substring(javaId.lastIndexOf("facing=") + 7);
-            int rotation = switch (direction.substring(0, direction.length() - 1)) {
+            String direction = javaId.substring(javaId.lastIndexOf("facing=") + 7, javaId.lastIndexOf("powered=") - 1);
+            int rotation = switch (direction) {
                 case "north" -> 180;
                 case "west" -> 90;
                 case "east" -> 270;


### PR DESCRIPTION
Closes https://github.com/GeyserMC/Geyser/issues/4171

Caused by a mappings update (https://github.com/GeyserMC/mappings/commit/75906e5e36b387e5d846c1b400fece9bef8c5a4a) that caused the BlockStateValues reader to incorrectly fall back to a rotation of 0 regardless of actual direction.