### PR TITLE
Fall back to default secure random on all platforms

### DIFF
--- a/common/src/main/java/org/geysermc/floodgate/crypto/AesKeyProducer.java
+++ b/common/src/main/java/org/geysermc/floodgate/crypto/AesKeyProducer.java
@@ -55,19 +55,20 @@ public final class AesKeyProducer implements KeyProducer {
     }
 
     private SecureRandom secureRandom() throws NoSuchAlgorithmException {
-        // use Windows-PRNG for windows (default impl is SHA1PRNG)
-        if (System.getProperty("os.name").startsWith("Windows")) {
-            return SecureRandom.getInstance("Windows-PRNG");
-        } else {
-            try {
+        try {
+            // use Windows-PRNG for windows (default impl is SHA1PRNG)
+            if (System.getProperty("os.name").startsWith("Windows")) {
+                return SecureRandom.getInstance("Windows-PRNG");
+            } else {
                 // NativePRNG (which should be the default on unix-systems) can still block your
                 // system. Even though it isn't as bad as NativePRNGBlocking, we still try to
                 // prevent that if possible
                 return SecureRandom.getInstance("NativePRNGNonBlocking");
-            } catch (NoSuchAlgorithmException ignored) {
-                // at this point we just have to go with the default impl even if it blocks
-                return new SecureRandom();
+                
             }
+        } catch (NoSuchAlgorithmException ignored) {
+            // Fall back to the default impl as we couldn't load any others
+            return new SecureRandom();
         }
     }
 }


### PR DESCRIPTION
This will prevent the below happening on some systems
```
NoSuchAlgorithmException: Windows-PRNG SecureRandom not available
    at java.base/GetInstance.getInstance(Unknown Source)
    at java.base/SecureRandom.getInstance(Unknown Source)
    at floodgate-spigot.jar//AesKeyProducer.secureRandom(AesKeyProducer.java:60)
    at floodgate-spigot.jar//AesKeyProducer.produce(AesKeyProducer.java:41)
```

From an issue on Discord
* https://mclo.gs/SU5vpC1
* https://dump.geysermc.org/6fOcIW03ky6Y1XYYRXBbrUdVRFlf47QD