### PR TITLE
Bring back `MAX_MTU` option

### DIFF
--- a/core/src/main/java/org/geysermc/geyser/network/netty/GeyserServer.java
+++ b/core/src/main/java/org/geysermc/geyser/network/netty/GeyserServer.java
@@ -171,10 +171,12 @@ public final class GeyserServer {
 
         GeyserServerInitializer serverInitializer = new GeyserServerInitializer(this.geyser);
         playerGroup = serverInitializer.getEventLoopGroup();
+        this.geyser.getLogger().debug("Setting MTU to " + this.geyser.getConfig().getMtu());
         return new ServerBootstrap()
                 .channelFactory(RakChannelFactory.server(TRANSPORT.datagramChannel()))
                 .group(group)
                 .option(RakChannelOption.RAK_HANDLE_PING, true)
+                .option(RakChannelOption.RAK_MAX_MTU, this.geyser.getConfig().getMtu())
                 .childHandler(serverInitializer);
     }
 


### PR DESCRIPTION
Ever since the protocol 3.0 update, the mtu config option was not actually used, as max mtu setting was removed here: https://github.com/GeyserMC/Geyser/commit/74798d80714bc155c560f8169018ced0fecb21bf#diff-364712ce3c4db828a2267e3af40a952577d762e23ac7f113e9039f9418b72dfaL287-L290 
This should set max mtu again.