### PR TITLE
Let the fabric module really use Java 17

### DIFF
--- a/bootstrap/fabric/build.gradle.kts
+++ b/bootstrap/fabric/build.gradle.kts
@@ -10,6 +10,12 @@ java {
     sourceCompatibility = JavaVersion.VERSION_17
 }
 
+indra {
+    javaVersions {
+        target(17)
+    }
+}
+
 dependencies {
     //to change the versions see the gradle.properties file
     minecraft(libs.fabric.minecraft)

--- a/bootstrap/fabric/build.gradle.kts
+++ b/bootstrap/fabric/build.gradle.kts
@@ -5,11 +5,6 @@ plugins {
     id("com.modrinth.minotaur") version "2.+"
 }
 
-java {
-    targetCompatibility = JavaVersion.VERSION_17
-    sourceCompatibility = JavaVersion.VERSION_17
-}
-
 indra {
     javaVersions {
         target(17)


### PR DESCRIPTION
This really shouldn't change much; but it would ensure the fabric module is really built with java 17. At the very least, IntelliJ would recognize the module properly as a java 17 one; and dependencies that use java 17 could be added.