### PR TITLE
Fix: Versioned potion mappings

### DIFF
--- a/core/src/main/java/org/geysermc/geyser/registry/loader/PotionMixRegistryLoader.java
+++ b/core/src/main/java/org/geysermc/geyser/registry/loader/PotionMixRegistryLoader.java
@@ -31,7 +31,6 @@ import org.cloudburstmc.protocol.bedrock.data.inventory.crafting.PotionMixData;
 import org.geysermc.geyser.inventory.item.Potion;
 import org.geysermc.geyser.item.Items;
 import org.geysermc.geyser.item.type.Item;
-import org.geysermc.geyser.network.GameProtocol;
 import org.geysermc.geyser.registry.Registries;
 import org.geysermc.geyser.registry.type.ItemMapping;
 import org.geysermc.geyser.registry.type.ItemMappings;
@@ -115,7 +114,7 @@ public class PotionMixRegistryLoader implements RegistryLoader<Object, Int2Objec
     }
 
     private static ItemMapping getNonNull(ItemMappings mappings, Item javaItem) {
-        ItemMapping itemMapping = Registries.ITEMS.forVersion(GameProtocol.DEFAULT_BEDROCK_CODEC.getProtocolVersion()).getMapping(javaItem);
+        ItemMapping itemMapping = mappings.getMapping(javaItem);
         if (itemMapping == null)
             throw new NullPointerException("No item entry exists for java identifier: " + javaItem.javaIdentifier());
 


### PR DESCRIPTION
Noticed while making https://github.com/GeyserMC/Geyser/pull/4238; made separate to make it easier to back-track.
This should also fix https://github.com/GeyserMC/Geyser/issues/3790 again - due to what i assume was a protocol 3.0 merge bug the versioned mappings parameter were not used to get the brewing recipe items, but rather the default bedrock item mappings were. 