### PR TITLE
Reduce Frequency of Crashes Due to Dispensers, Droppers, and Chiseled Bookshelves

### DIFF
--- a/core/src/main/java/org/geysermc/geyser/level/chunk/GeyserChunkSection.java
+++ b/core/src/main/java/org/geysermc/geyser/level/chunk/GeyserChunkSection.java
@@ -30,19 +30,18 @@ import org.cloudburstmc.protocol.common.util.Preconditions;
 
 public class GeyserChunkSection {
 
-    // As of at least 1.19.80
-    private static final int CHUNK_SECTION_VERSION = 9;
+    // Temporary reversion to v8 as it reduces the frequnecy of https://github.com/GeyserMC/Geyser/issues/4240
+    // This does not fully resolve the issue so a better solution is still needed
+    private static final int CHUNK_SECTION_VERSION = 8;
 
     private final BlockStorage[] storage;
-    private final int sectionY;
 
-    public GeyserChunkSection(int airBlockId, int sectionY) {
-        this(new BlockStorage[]{new BlockStorage(airBlockId), new BlockStorage(airBlockId)}, sectionY);
+    public GeyserChunkSection(int airBlockId) {
+        this(new BlockStorage[]{new BlockStorage(airBlockId), new BlockStorage(airBlockId)});
     }
 
-    public GeyserChunkSection(BlockStorage[] storage, int sectionY) {
+    public GeyserChunkSection(BlockStorage[] storage) {
         this.storage = storage;
-        this.sectionY = sectionY;
     }
 
     public int getFullBlock(int x, int y, int z, int layer) {
@@ -61,7 +60,6 @@ public class GeyserChunkSection {
         buffer.writeByte(CHUNK_SECTION_VERSION);
         buffer.writeByte(this.storage.length);
         // Required for chunk version 9+
-        buffer.writeByte(this.sectionY);
         for (BlockStorage blockStorage : this.storage) {
             blockStorage.writeToNetwork(buffer);
         }
@@ -88,12 +86,12 @@ public class GeyserChunkSection {
         return true;
     }
 
-    public GeyserChunkSection copy(int sectionY) {
+    public GeyserChunkSection copy() {
         BlockStorage[] storage = new BlockStorage[this.storage.length];
         for (int i = 0; i < storage.length; i++) {
             storage[i] = this.storage[i].copy();
         }
-        return new GeyserChunkSection(storage, sectionY);
+        return new GeyserChunkSection(storage);
     }
 
     public static int blockPosition(int x, int y, int z) {

--- a/core/src/main/java/org/geysermc/geyser/translator/protocol/java/level/JavaLevelChunkWithLightTranslator.java
+++ b/core/src/main/java/org/geysermc/geyser/translator/protocol/java/level/JavaLevelChunkWithLightTranslator.java
@@ -154,7 +154,7 @@ public class JavaLevelChunkWithLightTranslator extends PacketTranslator<Clientbo
                             }
     
                             BlockStorage[] layers = new BlockStorage[]{ layer0 };
-                            sections[bedrockSectionY] = new GeyserChunkSection(layers, bedrockSectionY);
+                            sections[bedrockSectionY] = new GeyserChunkSection(layers);
                         }
                         EXTENDED_COLLISIONS_STORAGE.get().clear();
                         extendedCollisionNextSection = false;
@@ -167,7 +167,7 @@ public class JavaLevelChunkWithLightTranslator extends PacketTranslator<Clientbo
 
                 if (javaPalette instanceof GlobalPalette) {
                     // As this is the global palette, simply iterate through the whole chunk section once
-                    GeyserChunkSection section = new GeyserChunkSection(session.getBlockMappings().getBedrockAir().getRuntimeId(), bedrockSectionY);
+                    GeyserChunkSection section = new GeyserChunkSection(session.getBlockMappings().getBedrockAir().getRuntimeId());
                     for (int yzx = 0; yzx < BlockStorage.SIZE; yzx++) {
                         int javaId = javaData.get(yzx);
                         int bedrockId = session.getBlockMappings().getBedrockBlockId(javaId);
@@ -217,9 +217,9 @@ public class JavaLevelChunkWithLightTranslator extends PacketTranslator<Clientbo
 
                     if (BlockRegistries.WATERLOGGED.get().get(javaId)) {
                         BlockStorage waterlogged = new BlockStorage(SingletonBitArray.INSTANCE, IntLists.singleton(session.getBlockMappings().getBedrockWater().getRuntimeId()));
-                        sections[bedrockSectionY] = new GeyserChunkSection(new BlockStorage[] {blockStorage, waterlogged}, bedrockSectionY);
+                        sections[bedrockSectionY] = new GeyserChunkSection(new BlockStorage[] {blockStorage, waterlogged});
                     } else {
-                        sections[bedrockSectionY] = new GeyserChunkSection(new BlockStorage[] {blockStorage}, bedrockSectionY);
+                        sections[bedrockSectionY] = new GeyserChunkSection(new BlockStorage[] {blockStorage});
                     }
                     if (useExtendedCollisions) {
                         EXTENDED_COLLISIONS_STORAGE.get().clear();
@@ -378,7 +378,7 @@ public class JavaLevelChunkWithLightTranslator extends PacketTranslator<Clientbo
                     layers = new BlockStorage[]{ layer0, new BlockStorage(BitArrayVersion.V1.createArray(BlockStorage.SIZE, layer1Data), layer1Palette) };
                 }
 
-                sections[bedrockSectionY] = new GeyserChunkSection(layers, bedrockSectionY);
+                sections[bedrockSectionY] = new GeyserChunkSection(layers);
                 extendedCollisionNextSection = thisExtendedCollisionNextSection;
             }
 

--- a/core/src/main/java/org/geysermc/geyser/translator/protocol/java/level/JavaLevelChunkWithLightTranslator.java
+++ b/core/src/main/java/org/geysermc/geyser/translator/protocol/java/level/JavaLevelChunkWithLightTranslator.java
@@ -432,7 +432,7 @@ public class JavaLevelChunkWithLightTranslator extends PacketTranslator<Clientbo
                             IntList palette = bedrockSection.getBlockStorageArray()[0].getPalette();
                             if (palette instanceof IntImmutableList || palette instanceof IntLists.Singleton) {
                                 // TODO there has to be a better way to expand the palette .-.
-                                bedrockSection = bedrockSection.copy(bedrockSectionY);
+                                bedrockSection = bedrockSection.copy();
                                 sections[bedrockSectionY] = bedrockSection;
                             }
                             bedrockSection.setFullBlock(x, y & 0xF, z, 0, blockDefinition.getRuntimeId());

--- a/core/src/main/java/org/geysermc/geyser/util/ChunkUtils.java
+++ b/core/src/main/java/org/geysermc/geyser/util/ChunkUtils.java
@@ -63,7 +63,7 @@ public class ChunkUtils {
     static {
         ByteBuf byteBuf = Unpooled.buffer();
         try {
-            new GeyserChunkSection(new BlockStorage[0], 0)
+            new GeyserChunkSection(new BlockStorage[0])
                     .writeToNetwork(byteBuf);
             SERIALIZED_CHUNK_DATA = new byte[byteBuf.readableBytes()];
             byteBuf.readBytes(SERIALIZED_CHUNK_DATA);


### PR DESCRIPTION
This PR temporarily revers the subchunk version to 8 which we have found in testing reduces, but does not eliminate, crashes due to https://github.com/GeyserMC/Geyser/issues/4240. We will continue work on a better solution.