### PR TITLE
Send cooldown when punching air

### DIFF
--- a/core/src/main/java/org/geysermc/geyser/translator/protocol/bedrock/entity/player/BedrockActionTranslator.java
+++ b/core/src/main/java/org/geysermc/geyser/translator/protocol/bedrock/entity/player/BedrockActionTranslator.java
@@ -55,6 +55,7 @@ import org.geysermc.geyser.translator.inventory.item.CustomItemTranslator;
 import org.geysermc.geyser.translator.protocol.PacketTranslator;
 import org.geysermc.geyser.translator.protocol.Translator;
 import org.geysermc.geyser.util.BlockUtils;
+import org.geysermc.geyser.util.CooldownUtils;
 
 @Translator(packet = PlayerActionPacket.class)
 public class BedrockActionTranslator extends PacketTranslator<PlayerActionPacket> {
@@ -281,6 +282,10 @@ public class BedrockActionTranslator extends PacketTranslator<PlayerActionPacket
                 entity.setOnGround(false); // Increase block break time while jumping
                 break;
             case MISSED_SWING:
+                // Java edition sends a cooldown when hitting air.
+                // Normally handled by BedrockLevelSoundEventTranslator, but there is no sound on Java for this.
+                CooldownUtils.sendCooldown(session);
+
                 // TODO Re-evaluate after pre-1.20.10 is no longer supported?
                 if (session.getArmAnimationTicks() == -1) {
                     session.sendDownstreamGamePacket(new ServerboundSwingPacket(Hand.MAIN_HAND));


### PR DESCRIPTION
Fixes #4252 

Normally, cooldowns are handled by the [BedrockLevelSoundEventTranslator](https://github.com/onebeastchris/Geyser/blob/6ca7a315017c15ef251f06d073462efc9c782656/core/src/main/java/org/geysermc/geyser/translator/protocol/bedrock/world/BedrockLevelSoundEventTranslator.java), but Java does not send a sound (and by extension, we don't translate one) for Bedrock edition. For parity reasons, i would not send the sound but send the cooldown - in theory we could also send the sound here.

Tested with 1.20.10, 1.20.30, 1.20.40