### PR TITLE
Fix `/geyser reload` on Velocity

### DIFF
--- a/bootstrap/bungeecord/src/main/java/org/geysermc/geyser/platform/bungeecord/GeyserBungeePlugin.java
+++ b/bootstrap/bungeecord/src/main/java/org/geysermc/geyser/platform/bungeecord/GeyserBungeePlugin.java
@@ -70,6 +70,8 @@ public class GeyserBungeePlugin extends Plugin implements GeyserBootstrap {
 
     private GeyserImpl geyser;
 
+    private static boolean INITIALIZED = false;
+
     @Override
     public void onLoad() {
         GeyserLocale.init(this);
@@ -133,7 +135,12 @@ public class GeyserBungeePlugin extends Plugin implements GeyserBootstrap {
         // Big hack - Bungee does not provide us an event to listen to, so schedule a repeating
         // task that waits for a field to be filled which is set after the plugin enable
         // process is complete
-        this.awaitStartupCompletion(0);
+        if (!INITIALIZED) {
+            this.awaitStartupCompletion(0);
+        } else {
+            // No need to "wait" for startup completion, just start Geyser - we're reloading.
+            this.postStartup();
+        }
     }
 
     @SuppressWarnings("unchecked")
@@ -166,8 +173,10 @@ public class GeyserBungeePlugin extends Plugin implements GeyserBootstrap {
     private void postStartup() {
         GeyserImpl.start();
 
-        this.geyserInjector = new GeyserBungeeInjector(this);
-        this.geyserInjector.initializeLocalChannel(this);
+        if (!INITIALIZED) {
+            this.geyserInjector = new GeyserBungeeInjector(this);
+            this.geyserInjector.initializeLocalChannel(this);
+        }
 
         this.geyserCommandManager = new GeyserCommandManager(geyser);
         this.geyserCommandManager.init();
@@ -187,6 +196,8 @@ public class GeyserBungeePlugin extends Plugin implements GeyserBootstrap {
         } else {
             this.geyserBungeePingPassthrough = new GeyserBungeePingPassthrough(getProxy());
         }
+
+        INITIALIZED = true;
     }
 
     @Override

--- a/bootstrap/velocity/src/main/java/org/geysermc/geyser/platform/velocity/GeyserVelocityPlugin.java
+++ b/bootstrap/velocity/src/main/java/org/geysermc/geyser/platform/velocity/GeyserVelocityPlugin.java
@@ -64,6 +64,11 @@ import java.util.UUID;
 @Plugin(id = "geyser", name = GeyserImpl.NAME + "-Velocity", version = GeyserImpl.VERSION, url = "https://geysermc.org", authors = "GeyserMC")
 public class GeyserVelocityPlugin implements GeyserBootstrap {
 
+    /**
+     * Determines if the plugin has been ran once before, including before /geyser reload.
+     */
+    private static boolean INITIALIZED = false;
+
     @Inject
     private Logger logger;
 
@@ -114,6 +119,16 @@ public class GeyserVelocityPlugin implements GeyserBootstrap {
         GeyserConfiguration.checkGeyserConfiguration(geyserConfig, geyserLogger);
 
         this.geyser = GeyserImpl.load(PlatformType.VELOCITY, this);
+
+        // Hack: Normally triggered by ListenerBoundEvent, but that doesn't fire on /geyser reload
+        if (INITIALIZED) {
+            this.postStartup();
+
+            if (geyserInjector != null) {
+                // After this bound, we know that the channel initializer cannot change without it being ineffective for Velocity, too
+                geyserInjector.initializeLocalChannel(this);
+            }
+        }
     }
 
     private void postStartup() {
@@ -195,6 +210,8 @@ public class GeyserVelocityPlugin implements GeyserBootstrap {
                 geyserInjector.initializeLocalChannel(this);
             }
         }
+
+        INITIALIZED = true;
     }
 
     @Override

--- a/bootstrap/velocity/src/main/java/org/geysermc/geyser/platform/velocity/GeyserVelocityPlugin.java
+++ b/bootstrap/velocity/src/main/java/org/geysermc/geyser/platform/velocity/GeyserVelocityPlugin.java
@@ -123,19 +123,16 @@ public class GeyserVelocityPlugin implements GeyserBootstrap {
         // Hack: Normally triggered by ListenerBoundEvent, but that doesn't fire on /geyser reload
         if (INITIALIZED) {
             this.postStartup();
-
-            if (geyserInjector != null) {
-                // After this bound, we know that the channel initializer cannot change without it being ineffective for Velocity, too
-                geyserInjector.initializeLocalChannel(this);
-            }
         }
     }
 
     private void postStartup() {
         GeyserImpl.start();
 
-        this.geyserInjector = new GeyserVelocityInjector(proxyServer);
-        // Will be initialized after the proxy has been bound
+        if (!INITIALIZED) {
+            this.geyserInjector = new GeyserVelocityInjector(proxyServer);
+            // Will be initialized after the proxy has been bound
+        }
 
         this.geyserCommandManager = new GeyserCommandManager(geyser);
         this.geyserCommandManager.init();


### PR DESCRIPTION
Without this workaround, Geyser will shut down and not start back up fully after `/geyser reload` due to no `ListenerBoundEvent` being fired. This PR adds a workaround, similarly how it's done with the Spigot bootstrap. The command manager seems to have no issue too with us registering commands again, so no special handling should be needed there.

Fixes https://github.com/GeyserMC/Geyser/issues/3788