### PR TITLE
Let text displays show up again

### DIFF
--- a/core/src/main/java/org/geysermc/geyser/entity/EntityDefinitions.java
+++ b/core/src/main/java/org/geysermc/geyser/entity/EntityDefinitions.java
@@ -299,8 +299,9 @@ public final class EntityDefinitions {
                     .build();
 
             EntityDefinition<Entity> displayBase = EntityDefinition.inherited(entityBase.factory(), entityBase)
-                    .addTranslator(null) // Interpolation start ticks
-                    .addTranslator(null) // Interpolation duration ID
+                    .addTranslator(null) // Interpolation delay
+                    .addTranslator(null) // Transformation interpolation duration
+                    .addTranslator(null) // Position/Rotation interpolation duration
                     .addTranslator(null) // Translation
                     .addTranslator(null) // Scale
                     .addTranslator(null) // Left rotation
@@ -318,6 +319,10 @@ public final class EntityDefinitions {
                     .type(EntityType.TEXT_DISPLAY)
                     .identifier("minecraft:armor_stand")
                     .addTranslator(MetadataType.CHAT, TextDisplayEntity::setText)
+                    .addTranslator(null) // Line width
+                    .addTranslator(null) // Background color
+                    .addTranslator(null) // Text opacity
+                    .addTranslator(null) // Bit mask
                     .build();
 
             INTERACTION = EntityDefinition.inherited(InteractionEntity::new, entityBase)


### PR DESCRIPTION
Seems like 1.20.2 added more fields - one more to base display, and 4 more to text displays. We still cannot use them though... but atleast text displays shows up again.

Screenshot + command used:
![image](https://github.com/GeyserMC/Geyser/assets/105284508/3684b7f3-0f4f-4c1c-acb5-00c14874f98a)
```
summon minecraft:text_display ~ ~1 ~ {text:"{\"text\":\"Example\",\"color\":\"red\"}",interpolation_duration:0,start_interpolation:0,transformation:[1.000f, 0.000f, 0.000f,0.000f,0.000f, 1.000f, 0.000f,0.000f,0.000f, 0.000f, 1.000f,0.000f,0.000f, 0.000f, 0.000f,1.000f]}
```

Source:
https://wiki.vg/Entity_metadata#Display
https://wiki.vg/Entity_metadata#Text_Display

Should fix https://github.com/GeyserMC/Geyser/issues/4172, possible fix https://github.com/GeyserMC/Geyser/issues/4122 too.