### PR TITLE
Fix: Text display entities only being visible when directly looked at

### DIFF
--- a/core/src/main/java/org/geysermc/geyser/entity/type/TextDisplayEntity.java
+++ b/core/src/main/java/org/geysermc/geyser/entity/type/TextDisplayEntity.java
@@ -26,6 +26,7 @@
 package org.geysermc.geyser.entity.type;
 
 import com.github.steveice10.mc.protocol.data.game.entity.metadata.EntityMetadata;
+import com.github.steveice10.mc.protocol.data.game.entity.metadata.type.BooleanEntityMetadata;
 import net.kyori.adventure.text.Component;
 import org.cloudburstmc.math.vector.Vector3f;
 import org.cloudburstmc.protocol.bedrock.data.entity.EntityDataTypes;
@@ -47,6 +48,12 @@ public class TextDisplayEntity extends Entity {
         // Remove armor stand body
         this.dirtyMetadata.put(EntityDataTypes.SCALE, 0f);
         this.dirtyMetadata.put(EntityDataTypes.NAMETAG_ALWAYS_SHOW, (byte) 1);
+    }
+
+    @Override
+    public void setDisplayNameVisible(BooleanEntityMetadata entityMetadata) {
+        // Don't allow the display name to be hidden - messes with our armor stand.
+        // On JE: Hiding the display name still shows the display entity text.
     }
 
     public void setText(EntityMetadata<Component, ?> entityMetadata) {


### PR DESCRIPTION
Fixes https://github.com/GeyserMC/Geyser/issues/4122 

E.g. FancyHolograms was sending entity metadata that would hide the custom name (id 3, boolean). This messes with our fake armorstand workaround - we need it to be set to true.
On Java edition, this value makes no difference whether the text display itself is shown or not; for Geyser players it caused this:
https://gyazo.com/47e8976b684224d6818c1530a1383345