### PR TITLE
Fix: Don't mistakingly assume that Geyser-Velocity initialized 

### DIFF
--- a/bootstrap/velocity/src/main/java/org/geysermc/geyser/platform/velocity/GeyserVelocityPlugin.java
+++ b/bootstrap/velocity/src/main/java/org/geysermc/geyser/platform/velocity/GeyserVelocityPlugin.java
@@ -154,7 +154,6 @@ public class GeyserVelocityPlugin implements GeyserBootstrap {
         }
 
         proxyServer.getEventManager().register(this, new GeyserVelocityUpdateListener());
-        INITIALIZED = true;
     }
 
     @Override
@@ -207,6 +206,8 @@ public class GeyserVelocityPlugin implements GeyserBootstrap {
                 // After this bound, we know that the channel initializer cannot change without it being ineffective for Velocity, too
                 geyserInjector.initializeLocalChannel(this);
             }
+
+            INITIALIZED = true;
         }
     }
 

--- a/bootstrap/velocity/src/main/java/org/geysermc/geyser/platform/velocity/GeyserVelocityPlugin.java
+++ b/bootstrap/velocity/src/main/java/org/geysermc/geyser/platform/velocity/GeyserVelocityPlugin.java
@@ -154,6 +154,7 @@ public class GeyserVelocityPlugin implements GeyserBootstrap {
         }
 
         proxyServer.getEventManager().register(this, new GeyserVelocityUpdateListener());
+        INITIALIZED = true;
     }
 
     @Override
@@ -207,8 +208,6 @@ public class GeyserVelocityPlugin implements GeyserBootstrap {
                 geyserInjector.initializeLocalChannel(this);
             }
         }
-
-        INITIALIZED = true;
     }
 
     @Override


### PR DESCRIPTION
Should fix https://github.com/GeyserMC/Geyser/issues/4275

Suspected issue:
- Query initialized, which fired a ListenerBoundEvent, which caused `INITIALIZED` to be set to true 
- After the proxy started accepting connections, a new ListenerBoundEvent was fired with the `ListenerType.MINECRAFT` - which is when geyser's post startup occurs. However, since `INITIALIZED` was set to true due to the query binding, no injector is created... sorry, my mistake.

This fix should now ensure that `INITIALIZED` is only set after we initialized, and not every time the ListenerBoundEvent was fired.