### PR TITLE
Clear bossbars & entity attributes on server switching

### DIFF
--- a/core/src/main/java/org/geysermc/geyser/entity/type/TextDisplayEntity.java
+++ b/core/src/main/java/org/geysermc/geyser/entity/type/TextDisplayEntity.java
@@ -26,6 +26,7 @@
 package org.geysermc.geyser.entity.type;
 
 import com.github.steveice10.mc.protocol.data.game.entity.metadata.EntityMetadata;
+import com.github.steveice10.mc.protocol.data.game.entity.metadata.type.BooleanEntityMetadata;
 import net.kyori.adventure.text.Component;
 import org.cloudburstmc.math.vector.Vector3f;
 import org.cloudburstmc.protocol.bedrock.data.entity.EntityDataTypes;
@@ -47,6 +48,12 @@ public class TextDisplayEntity extends Entity {
         // Remove armor stand body
         this.dirtyMetadata.put(EntityDataTypes.SCALE, 0f);
         this.dirtyMetadata.put(EntityDataTypes.NAMETAG_ALWAYS_SHOW, (byte) 1);
+    }
+
+    @Override
+    public void setDisplayNameVisible(BooleanEntityMetadata entityMetadata) {
+        // Don't allow the display name to be hidden - messes with our armor stand.
+        // On JE: Hiding the display name still shows the display entity text.
     }
 
     public void setText(EntityMetadata<Component, ?> entityMetadata) {

--- a/core/src/main/java/org/geysermc/geyser/entity/type/player/SessionPlayerEntity.java
+++ b/core/src/main/java/org/geysermc/geyser/entity/type/player/SessionPlayerEntity.java
@@ -254,4 +254,17 @@ public class SessionPlayerEntity extends PlayerEntity {
     public UUID getTabListUuid() {
         return session.getAuthData().uuid();
     }
+
+    public void resetMetadata() {
+        // Reset all metadata to their default values
+        // This is used when a player respawns
+        this.initializeMetadata();
+
+        // Reset air
+        this.resetAir();
+    }
+
+    public void resetAir() {
+        this.setAirSupply(getMaxAir());
+    }
 }

--- a/core/src/main/java/org/geysermc/geyser/session/cache/EntityCache.java
+++ b/core/src/main/java/org/geysermc/geyser/session/cache/EntityCache.java
@@ -162,4 +162,9 @@ public class EntityCache {
     public List<Tickable> getTickableEntities() {
         return tickableEntities;
     }
+
+    public void removeAllBossBars() {
+        bossBars.values().forEach(BossBar::removeBossBar);
+        bossBars.clear();
+    }
 }

--- a/core/src/main/java/org/geysermc/geyser/translator/protocol/java/JavaLoginTranslator.java
+++ b/core/src/main/java/org/geysermc/geyser/translator/protocol/java/JavaLoginTranslator.java
@@ -64,6 +64,10 @@ public class JavaLoginTranslator extends PacketTranslator<ClientboundLoginPacket
             DimensionUtils.switchDimension(session, fakeDim);
 
             session.getWorldCache().removeScoreboard();
+
+            // Remove all bossbars
+            session.getEntityCache().removeAllBossBars();
+            session.getEntityCache().removeAllEntities();
         }
         session.setWorldName(spawnInfo.getWorldName());
         session.setLevels(packet.getWorldNames());

--- a/core/src/main/java/org/geysermc/geyser/translator/protocol/java/JavaLoginTranslator.java
+++ b/core/src/main/java/org/geysermc/geyser/translator/protocol/java/JavaLoginTranslator.java
@@ -67,13 +67,14 @@ public class JavaLoginTranslator extends PacketTranslator<ClientboundLoginPacket
 
             // Remove all bossbars
             session.getEntityCache().removeAllBossBars();
-            session.getEntityCache().removeAllEntities();
+            // Remove extra hearts, hunger, etc.
+            entity.getAttributes().clear();
+            entity.resetMetadata();
         }
+
         session.setWorldName(spawnInfo.getWorldName());
         session.setLevels(packet.getWorldNames());
-
         session.setGameMode(spawnInfo.getGameMode());
-
         String newDimension = spawnInfo.getDimension();
 
         boolean needsSpawnPacket = !session.isSentSpawnPacket();
@@ -85,9 +86,7 @@ public class JavaLoginTranslator extends PacketTranslator<ClientboundLoginPacket
 
             // It is now safe to send these packets
             session.getUpstream().sendPostStartGamePackets();
-        }
-
-        if (!needsSpawnPacket) {
+        } else {
             SetPlayerGameTypePacket playerGameTypePacket = new SetPlayerGameTypePacket();
             playerGameTypePacket.setGamemode(EntityUtils.toBedrockGamemode(spawnInfo.getGameMode()).ordinal());
             session.sendUpstreamPacket(playerGameTypePacket);


### PR DESCRIPTION
This fix should ensure that BossBars don't persist when switching servers - the same for e.g. air supply. 
Behavior on Java:
- Bossbars are not cleared during dimension switching, only on server switching 
- Attributes are cleared - we now do the same 

Should fix https://github.com/GeyserMC/Geyser/issues/4220, fix https://github.com/GeyserMC/Geyser/issues/4273, fix https://github.com/GeyserMC/Geyser/issues/4096