### PR TITLE
Don't show custom names on display entities

### DIFF
--- a/core/src/main/java/org/geysermc/geyser/entity/type/TextDisplayEntity.java
+++ b/core/src/main/java/org/geysermc/geyser/entity/type/TextDisplayEntity.java
@@ -59,7 +59,8 @@ public class TextDisplayEntity extends Entity {
 
     @Override
     public void setDisplayName(EntityMetadata<Optional<Component>, ?> entityMetadata) {
-        // Don't allow the display name to be set - messes with our armor stand.
+        // This would usually set EntityDataTypes.NAME, but we are instead using NAME for the text display.
+        // On JE: custom name does not override text display.
     }
 
     public void setText(EntityMetadata<Component, ?> entityMetadata) {

--- a/core/src/main/java/org/geysermc/geyser/entity/type/TextDisplayEntity.java
+++ b/core/src/main/java/org/geysermc/geyser/entity/type/TextDisplayEntity.java
@@ -34,6 +34,7 @@ import org.geysermc.geyser.entity.EntityDefinition;
 import org.geysermc.geyser.session.GeyserSession;
 import org.geysermc.geyser.translator.text.MessageTranslator;
 
+import java.util.Optional;
 import java.util.UUID;
 
 // Note: 1.19.4 requires that the billboard is set to something in order to show, on Java Edition
@@ -54,6 +55,11 @@ public class TextDisplayEntity extends Entity {
     public void setDisplayNameVisible(BooleanEntityMetadata entityMetadata) {
         // Don't allow the display name to be hidden - messes with our armor stand.
         // On JE: Hiding the display name still shows the display entity text.
+    }
+
+    @Override
+    public void setDisplayName(EntityMetadata<Optional<Component>, ?> entityMetadata) {
+        // Don't allow the display name to be set - messes with our armor stand.
     }
 
     public void setText(EntityMetadata<Component, ?> entityMetadata) {


### PR DESCRIPTION
This ensures that a custom text display entity name doesn't show up - it doesn't show on Java, and if we show it, the text display contents aren't shown.

Resolves https://github.com/GeyserMC/Geyser/issues/4308