### PR TITLE
We only need to use recipe tags when there actually are more than one…

### DIFF
--- a/core/src/main/java/org/geysermc/geyser/translator/protocol/java/JavaUpdateRecipesTranslator.java
+++ b/core/src/main/java/org/geysermc/geyser/translator/protocol/java/JavaUpdateRecipesTranslator.java
@@ -337,7 +337,7 @@ public class JavaUpdateRecipesTranslator extends PacketTranslator<ClientboundUpd
                     GroupedItem groupedItem = entry.getKey();
 
                     String recipeTag = RECIPE_TAGS.get(groupedItem.id.getIdentifier());
-                    if (recipeTag != null) {
+                    if (recipeTag != null && ingredients.length > 1) {
                         optionSet.add(new ItemDescriptorWithCount(new ItemTagDescriptor(recipeTag), groupedItem.count));
                         continue;
                     }


### PR DESCRIPTION
We only need to use recipe tags when there actually is more than one possible ingredient option. For example, currently, we apply a logs item tag to the planks recipe, which causes an issue with plank type suggestions.

Fixes https://github.com/GeyserMC/Geyser/issues/4300