### PR TITLE
Fix issues with the ConnectionTestCommand

### DIFF
--- a/core/src/main/java/org/geysermc/geyser/command/defaults/ConnectionTestCommand.java
+++ b/core/src/main/java/org/geysermc/geyser/command/defaults/ConnectionTestCommand.java
@@ -36,6 +36,8 @@ import org.geysermc.geyser.text.GeyserLocale;
 import org.geysermc.geyser.util.LoopbackUtil;
 import org.geysermc.geyser.util.WebUtils;
 
+import java.net.URLEncoder;
+import java.nio.charset.StandardCharsets;
 import java.util.Random;
 import java.util.concurrent.CompletableFuture;
 
@@ -104,6 +106,12 @@ public class ConnectionTestCommand extends GeyserCommand {
             return;
         }
 
+        // Issue: port out of bounds
+        if (port <= 0 || port >= 65535) {
+            sender.sendMessage("The port you specified is invalid! Please specify a valid port.");
+            return;
+        }
+
         // Issue: do the ports not line up?
         if (port != geyser.getConfig().getBedrock().port()) {
             if (fullAddress.length == 2) {
@@ -161,20 +169,21 @@ public class ConnectionTestCommand extends GeyserCommand {
                 sender.sendMessage("Testing server connection now. Please wait...");
                 JsonNode output;
                 try {
-                    output = WebUtils.getJson("https://checker.geysermc.org/ping?hostname=" + ip + "&port=" + port);
+                    String hostname = URLEncoder.encode(ip, StandardCharsets.UTF_8);
+                    output = WebUtils.getJson("https://checker.geysermc.org/ping?hostname=" + hostname + "&port=" + port);
                 } finally {
                     CONNECTION_TEST_MOTD = null;
                 }
 
-                JsonNode cache = output.get("cache");
-                String when;
-                if (cache.get("fromCache").asBoolean()) {
-                    when = cache.get("secondsSince").asInt() + " seconds ago";
-                } else {
-                    when = "now";
-                }
-
                 if (output.get("success").asBoolean()) {
+                    JsonNode cache = output.get("cache");
+                    String when;
+                    if (cache.get("fromCache").asBoolean()) {
+                        when = cache.get("secondsSince").asInt() + " seconds ago";
+                    } else {
+                        when = "now";
+                    }
+
                     JsonNode ping = output.get("ping");
                     JsonNode pong = ping.get("pong");
                     String remoteMotd = pong.get("motd").asText();
@@ -196,7 +205,11 @@ public class ConnectionTestCommand extends GeyserCommand {
                     return;
                 }
 
-                sender.sendMessage("Your server is likely unreachable from outside the network as of " + when + ".");
+                sender.sendMessage("Your server is likely unreachable from outside the network!");
+                JsonNode message = output.get("message");
+                if (message != null && !message.asText().isEmpty()) {
+                    sender.sendMessage("Got the error message: " + message.asText());
+                }
                 sendLinks(sender);
             } catch (Exception e) {
                 sender.sendMessage("An error occurred while trying to check your connection! Check the console for more information.");


### PR DESCRIPTION
- Port out of bounds checking
- Proper encoding of ip's to check
- Don't assume "cache" response is nonnull; it is null when there's an error
- Send users the error message that we get when server is unreachable