### PR TITLE
Fix: Show correct port that Geyser started on with Geyser-Fabric on a LAN world

### DIFF
--- a/bootstrap/fabric/src/main/java/org/geysermc/geyser/platform/fabric/mixin/client/IntegratedServerMixin.java
+++ b/bootstrap/fabric/src/main/java/org/geysermc/geyser/platform/fabric/mixin/client/IntegratedServerMixin.java
@@ -32,6 +32,7 @@ import net.minecraft.client.server.IntegratedServer;
 import net.minecraft.network.chat.Component;
 import net.minecraft.server.MinecraftServer;
 import net.minecraft.world.level.GameType;
+import org.geysermc.geyser.GeyserImpl;
 import org.geysermc.geyser.platform.fabric.GeyserFabricMod;
 import org.geysermc.geyser.platform.fabric.GeyserServerPortGetter;
 import org.geysermc.geyser.text.GeyserLocale;
@@ -62,7 +63,7 @@ public class IntegratedServerMixin implements GeyserServerPortGetter {
             // Give indication that Geyser is loaded
             Objects.requireNonNull(this.minecraft.player);
             this.minecraft.player.displayClientMessage(Component.literal(GeyserLocale.getPlayerLocaleString("geyser.core.start",
-                    this.minecraft.options.languageCode, "localhost", String.valueOf(this.publishedPort))), false);
+                    this.minecraft.options.languageCode, "localhost", String.valueOf(GeyserImpl.getInstance().bedrockListener().port()))), false);
         }
     }
 


### PR DESCRIPTION
Fixes https://github.com/GeyserMC/Geyser/issues/3569