### PR TITLE
Gracefully fail on older spigot builds due to outdated netty

### DIFF
--- a/bootstrap/spigot/src/main/java/org/geysermc/geyser/platform/spigot/GeyserSpigotPlugin.java
+++ b/bootstrap/spigot/src/main/java/org/geysermc/geyser/platform/spigot/GeyserSpigotPlugin.java
@@ -140,7 +140,7 @@ public class GeyserSpigotPlugin extends JavaPlugin implements GeyserBootstrap {
         } catch (ClassNotFoundException e) {
             getLogger().severe("*********************************************");
             getLogger().severe("");
-            getLogger().severe("This version of spigot is using an outdated version of netty, please use paper!");
+            getLogger().severe("This version of Spigot is using an outdated version of netty. Please update, or use Paper!");
             getLogger().severe("");
             getLogger().severe("*********************************************");
             return;

--- a/bootstrap/spigot/src/main/java/org/geysermc/geyser/platform/spigot/GeyserSpigotPlugin.java
+++ b/bootstrap/spigot/src/main/java/org/geysermc/geyser/platform/spigot/GeyserSpigotPlugin.java
@@ -135,6 +135,17 @@ public class GeyserSpigotPlugin extends JavaPlugin implements GeyserBootstrap {
             }
         }
 
+        try {
+            Class.forName("io.netty.util.internal.ObjectPool.ObjectCreator");
+        } catch (ClassNotFoundException e) {
+            getLogger().severe("*********************************************");
+            getLogger().severe("");
+            getLogger().severe("This version of spigot is using an outdated version of netty, please use paper!");
+            getLogger().severe("");
+            getLogger().severe("*********************************************");
+            return;
+        }
+
         // This is manually done instead of using Bukkit methods to save the config because otherwise comments get removed
         try {
             if (!getDataFolder().exists()) {

--- a/bootstrap/spigot/src/main/java/org/geysermc/geyser/platform/spigot/GeyserSpigotPlugin.java
+++ b/bootstrap/spigot/src/main/java/org/geysermc/geyser/platform/spigot/GeyserSpigotPlugin.java
@@ -140,7 +140,7 @@ public class GeyserSpigotPlugin extends JavaPlugin implements GeyserBootstrap {
         } catch (ClassNotFoundException e) {
             getLogger().severe("*********************************************");
             getLogger().severe("");
-            getLogger().severe("This version of Spigot is using an outdated version of netty. Please update, or use Paper!");
+            getLogger().severe("This version of Spigot is using an outdated version of netty. Please use Paper instead!");
             getLogger().severe("");
             getLogger().severe("*********************************************");
             return;


### PR DESCRIPTION
Should resolve https://github.com/GeyserMC/Geyser/issues/3814 by just not starting and telling people to use paper. We also can't shade netty, see https://github.com/GeyserMC/Geyser/blob/3da94efbe7eec9fd4c7cde4264f050a743d942c7/bootstrap/spigot/build.gradle.kts#L49-L64 for reference