### PR TITLE
Use uuid for bukkit api permission checks

### DIFF
--- a/bootstrap/spigot/src/main/java/org/geysermc/geyser/platform/spigot/world/manager/GeyserSpigotWorldManager.java
+++ b/bootstrap/spigot/src/main/java/org/geysermc/geyser/platform/spigot/world/manager/GeyserSpigotWorldManager.java
@@ -197,7 +197,7 @@ public class GeyserSpigotWorldManager extends WorldManager {
 
     @Override
     public boolean hasPermission(GeyserSession session, String permission) {
-        Player player = Bukkit.getPlayer(session.getPlayerEntity().getUuid());
+        Player player = Bukkit.getPlayer(session.javaUuid());
         if (player != null) {
             return player.hasPermission(permission);
         }

--- a/bootstrap/spigot/src/main/java/org/geysermc/geyser/platform/spigot/world/manager/GeyserSpigotWorldManager.java
+++ b/bootstrap/spigot/src/main/java/org/geysermc/geyser/platform/spigot/world/manager/GeyserSpigotWorldManager.java
@@ -197,7 +197,11 @@ public class GeyserSpigotWorldManager extends WorldManager {
 
     @Override
     public boolean hasPermission(GeyserSession session, String permission) {
-        return Objects.requireNonNull(Bukkit.getPlayer(session.getPlayerEntity().getUuid())).hasPermission(permission);
+        Player player = Bukkit.getPlayer(session.getPlayerEntity().getUuid());
+        if (player != null) {
+            return player.hasPermission(permission);
+        }
+        return false;
     }
 
     @Override

--- a/bootstrap/spigot/src/main/java/org/geysermc/geyser/platform/spigot/world/manager/GeyserSpigotWorldManager.java
+++ b/bootstrap/spigot/src/main/java/org/geysermc/geyser/platform/spigot/world/manager/GeyserSpigotWorldManager.java
@@ -197,7 +197,7 @@ public class GeyserSpigotWorldManager extends WorldManager {
 
     @Override
     public boolean hasPermission(GeyserSession session, String permission) {
-        return Objects.requireNonNull(Bukkit.getPlayer(session.getPlayerEntity().getUsername())).hasPermission(permission);
+        return Objects.requireNonNull(Bukkit.getPlayer(session.getPlayerEntity().getUuid())).hasPermission(permission);
     }
 
     @Override


### PR DESCRIPTION
Additionally, don't assume a non-null player, and just return false instead.

Should fix e.g.: https://mclo.gs/kSI6ziq