### PR TITLE
Don't warn if clients send subchunkrequest packets

### DIFF
--- a/core/src/main/java/org/geysermc/geyser/network/LoggingPacketHandler.java
+++ b/core/src/main/java/org/geysermc/geyser/network/LoggingPacketHandler.java
@@ -286,6 +286,11 @@ public class LoggingPacketHandler implements BedrockPacketHandler {
     }
 
     @Override
+    public PacketSignal handle(SubChunkRequestPacket packet) {
+        return defaultHandler(packet);
+    }
+
+    @Override
     public PacketSignal handle(SubClientLoginPacket packet) {
         return defaultHandler(packet);
     }


### PR DESCRIPTION
Should resolve https://github.com/GeyserMC/Geyser/issues/4391 for now; however, it might be worth thinking about forcefully disconnecting clients sending bad packets or similar, since this could happen for any number of packets