### PR TITLE
Fix: Geyser-Velocity compression disabler due to packet name changes

### DIFF
--- a/bootstrap/velocity/src/main/java/org/geysermc/geyser/platform/velocity/GeyserVelocityCompressionDisabler.java
+++ b/bootstrap/velocity/src/main/java/org/geysermc/geyser/platform/velocity/GeyserVelocityCompressionDisabler.java
@@ -47,8 +47,14 @@ public class GeyserVelocityCompressionDisabler extends ChannelDuplexHandler {
         Method setCompressionMethod = null;
 
         try {
-            compressionPacketClass = Class.forName("com.velocitypowered.proxy.protocol.packet.SetCompression");
-            loginSuccessPacketClass = Class.forName("com.velocitypowered.proxy.protocol.packet.ServerLoginSuccess");
+            try {
+                compressionPacketClass = Class.forName("com.velocitypowered.proxy.protocol.packet.SetCompressionPacket");
+                loginSuccessPacketClass = Class.forName("com.velocitypowered.proxy.protocol.packet.ServerLoginSuccessPacket");
+            } catch (Exception ignored) {
+                // Velocity renamed packet classes in https://github.com/PaperMC/Velocity/commit/2ac8751337befd04f4663575f5d752c748384110
+                compressionPacketClass = Class.forName("com.velocitypowered.proxy.protocol.packet.SetCompression");
+                loginSuccessPacketClass = Class.forName("com.velocitypowered.proxy.protocol.packet.ServerLoginSuccess");
+            }
             compressionEnabledEvent = Class.forName("com.velocitypowered.proxy.protocol.VelocityConnectionEvent")
                     .getDeclaredField("COMPRESSION_ENABLED").get(null);
             setCompressionMethod = Class.forName("com.velocitypowered.proxy.connection.MinecraftConnection")


### PR DESCRIPTION
https://github.com/PaperMC/Velocity/commit/2ac8751337befd04f4663575f5d752c748384110 was a very cool commit

Tested alongside latest version of floodgate on velocity, seems to work again.

Fixes errors such as:
```
[23:59:45 ERROR]: java.lang.ClassNotFoundException: com.velocitypowered.proxy.protocol.packet.Handshake
[23:59:45 ERROR]:       at com.velocitypowered.proxy.plugin.PluginClassLoader.loadClass0(PluginClassLoader.java:87)
[23:59:45 ERROR]:       at com.velocitypowered.proxy.plugin.PluginClassLoader.loadClass(PluginClassLoader.java:64)
[23:59:45 ERROR]:       at java.base/java.lang.ClassLoader.loadClass(ClassLoader.java:520)
[23:59:45 ERROR]:       at java.base/java.lang.Class.forName0(Native Method)
[23:59:45 ERROR]:       at java.base/java.lang.Class.forName(Class.java:375)
[23:59:45 ERROR]:       at org.geysermc.floodgate.util.ReflectionUtils.getClass(ReflectionUtils.java:87)
[23:59:45 ERROR]:       at org.geysermc.floodgate.util.ReflectionUtils.getPrefixedClass(ReflectionUtils.java:63)
[23:59:45 ERROR]:       at org.geysermc.floodgate.addon.data.VelocityProxyDataHandler.<clinit>(VelocityProxyDataHandler.java:66)
[23:59:45 ERROR]:       at org.geysermc.floodgate.addon.data.VelocityDataAddon.onInject(VelocityDataAddon.java:83)
[23:59:45 ERROR]:       at org.geysermc.floodgate.inject.CommonPlatformInjector.injectAddonsCall(CommonPlatformInjector.java:77)
[23:59:45 ERROR]:       at org.geysermc.floodgate.inject.velocity.VelocityInjector$VelocityChannelInitializer.initChannel(VelocityInjector.java:105)
[23:59:45 ERROR]:       at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
[23:59:45 ERROR]:       at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:77)
[23:59:45 ERROR]:       at java.base/jdk.internal.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
[23:59:45 ERROR]:       at java.base/java.lang.reflect.Method.invoke(Method.java:568)
[23:59:45 ERROR]:       at org.geysermc.geyser.platform.velocity.GeyserVelocityInjector$1.initChannel(GeyserVelocityInjector.java:81)
[23:59:45 ERROR]:       at io.netty.channel.ChannelInitializer.initChannel(ChannelInitializer.java:129)
[23:59:45 ERROR]:       at io.netty.channel.ChannelInitializer.handlerAdded(ChannelInitializer.java:112)
[23:59:45 ERROR]:       at io.netty.channel.AbstractChannelHandlerContext.callHandlerAdded(AbstractChannelHandlerContext.java:1114)
[23:59:45 ERROR]:       at io.netty.channel.DefaultChannelPipeline.callHandlerAdded0(DefaultChannelPipeline.java:609)
[23:59:45 ERROR]:       at io.netty.channel.DefaultChannelPipeline.access$100(DefaultChannelPipeline.java:46)
[23:59:45 ERROR]:       at io.netty.channel.DefaultChannelPipeline$PendingHandlerAddedTask.execute(DefaultChannelPipeline.java:1463)
[23:59:45 ERROR]:       at io.netty.channel.DefaultChannelPipeline.callHandlerAddedForAllHandlers(DefaultChannelPipeline.java:1115)
[23:59:45 ERROR]:       at io.netty.channel.DefaultChannelPipeline.invokeHandlerAddedIfNeeded(DefaultChannelPipeline.java:650)
[23:59:45 ERROR]:       at io.netty.channel.AbstractChannel$AbstractUnsafe.register0(AbstractChannel.java:514)
[23:59:45 ERROR]:       at io.netty.channel.AbstractChannel$AbstractUnsafe.access$200(AbstractChannel.java:429)
[23:59:45 ERROR]:       at io.netty.channel.AbstractChannel$AbstractUnsafe$1.run(AbstractChannel.java:486)
[23:59:45 ERROR]:       at io.netty.util.concurrent.AbstractEventExecutor.runTask(AbstractEventExecutor.java:173)
[23:59:45 ERROR]:       at io.netty.util.concurrent.AbstractEventExecutor.safeExecute(AbstractEventExecutor.java:166)
[23:59:45 ERROR]:       at io.netty.util.concurrent.SingleThreadEventExecutor.runAllTasks(SingleThreadEventExecutor.java:470)
[23:59:45 ERROR]:       at io.netty.channel.nio.NioEventLoop.run(NioEventLoop.java:569)
[23:59:45 ERROR]:       at io.netty.util.concurrent.SingleThreadEventExecutor$4.run(SingleThreadEventExecutor.java:997)
[23:59:45 ERROR]:       at io.netty.util.internal.ThreadExecutorMap$2.run(ThreadExecutorMap.java:74)
[23:59:45 ERROR]:       at io.netty.util.concurrent.FastThreadLocalRunnable.run(FastThreadLocalRunnable.java:30)
[23:59:45 ERROR]:       at java.base/java.lang.Thread.run(Thread.java:833)
```