### PR TITLE
Gracefully handle invalid stone cutter recipes

### DIFF
--- a/ap/src/main/java/org/geysermc/geyser/processor/BlockEntityProcessor.java
+++ b/ap/src/main/java/org/geysermc/geyser/processor/BlockEntityProcessor.java
@@ -30,7 +30,7 @@ import javax.annotation.processing.SupportedSourceVersion;
 import javax.lang.model.SourceVersion;
 
 @SupportedAnnotationTypes("*")
-@SupportedSourceVersion(SourceVersion.RELEASE_16)
+@SupportedSourceVersion(SourceVersion.RELEASE_17)
 public class BlockEntityProcessor extends ClassProcessor {
     public BlockEntityProcessor() {
         super("org.geysermc.geyser.translator.level.block.entity.BlockEntity");

--- a/ap/src/main/java/org/geysermc/geyser/processor/CollisionRemapperProcessor.java
+++ b/ap/src/main/java/org/geysermc/geyser/processor/CollisionRemapperProcessor.java
@@ -30,7 +30,7 @@ import javax.annotation.processing.SupportedSourceVersion;
 import javax.lang.model.SourceVersion;
 
 @SupportedAnnotationTypes("*")
-@SupportedSourceVersion(SourceVersion.RELEASE_16)
+@SupportedSourceVersion(SourceVersion.RELEASE_17)
 public class CollisionRemapperProcessor extends ClassProcessor {
     public CollisionRemapperProcessor() {
         super("org.geysermc.geyser.translator.collision.CollisionRemapper");

--- a/ap/src/main/java/org/geysermc/geyser/processor/PacketTranslatorProcessor.java
+++ b/ap/src/main/java/org/geysermc/geyser/processor/PacketTranslatorProcessor.java
@@ -30,7 +30,7 @@ import javax.annotation.processing.SupportedSourceVersion;
 import javax.lang.model.SourceVersion;
 
 @SupportedAnnotationTypes("*")
-@SupportedSourceVersion(SourceVersion.RELEASE_16)
+@SupportedSourceVersion(SourceVersion.RELEASE_17)
 public class PacketTranslatorProcessor extends ClassProcessor {
     public PacketTranslatorProcessor() {
         super("org.geysermc.geyser.translator.protocol.Translator");

--- a/ap/src/main/java/org/geysermc/geyser/processor/SoundHandlerProcessor.java
+++ b/ap/src/main/java/org/geysermc/geyser/processor/SoundHandlerProcessor.java
@@ -30,7 +30,7 @@ import javax.annotation.processing.SupportedSourceVersion;
 import javax.lang.model.SourceVersion;
 
 @SupportedAnnotationTypes("*")
-@SupportedSourceVersion(SourceVersion.RELEASE_16)
+@SupportedSourceVersion(SourceVersion.RELEASE_17)
 public class SoundHandlerProcessor extends ClassProcessor {
     public SoundHandlerProcessor() {
         super("org.geysermc.geyser.translator.sound.SoundTranslator");

--- a/core/src/main/java/org/geysermc/geyser/text/MinecraftLocale.java
+++ b/core/src/main/java/org/geysermc/geyser/text/MinecraftLocale.java
@@ -196,7 +196,6 @@ public class MinecraftLocale {
                 Map.Entry<String, JsonNode> entry = localeIterator.next();
                 langMap.put(entry.getKey(), entry.getValue().asText());
             }
-            localeStream.close();
             return langMap;
         } catch (FileNotFoundException e){
             throw new AssertionError(GeyserLocale.getLocaleStringLog("geyser.locale.fail.file", locale, e.getMessage()));

--- a/core/src/main/java/org/geysermc/geyser/translator/protocol/java/JavaUpdateRecipesTranslator.java
+++ b/core/src/main/java/org/geysermc/geyser/translator/protocol/java/JavaUpdateRecipesTranslator.java
@@ -169,6 +169,11 @@ public class JavaUpdateRecipesTranslator extends PacketTranslator<ClientboundUpd
                 }
                 case STONECUTTING -> {
                     StoneCuttingRecipeData stoneCuttingData = (StoneCuttingRecipeData) recipe.getData();
+                    if (stoneCuttingData.getIngredient().getOptions().length == 0) {
+                        GeyserImpl.getInstance().getLogger().debug("Received broken stone cutter recipe: " + stoneCuttingData + " " +
+                                recipe.getIdentifier() + " " + Registries.JAVA_ITEMS.get().get(stoneCuttingData.getResult().getId()).javaIdentifier());
+                        continue;
+                    }
                     ItemStack ingredient = stoneCuttingData.getIngredient().getOptions()[0];
                     List<StoneCuttingRecipeData> data = unsortedStonecutterData.get(ingredient.getId());
                     if (data == null) {

--- a/core/src/main/java/org/geysermc/geyser/translator/text/MessageTranslator.java
+++ b/core/src/main/java/org/geysermc/geyser/translator/text/MessageTranslator.java
@@ -320,7 +320,7 @@ public class MessageTranslator {
             if (parameters.contains(TextDecoration.Parameter.CONTENT)) {
                 args.add(message);
             }
-            withDecoration.args(args);
+            withDecoration.arguments(args);
             textPacket.setMessage(MessageTranslator.convertMessage(withDecoration.build(), session.locale()));
         } else {
             session.getGeyser().getLogger().debug("Likely illegal chat type detection found.");


### PR DESCRIPTION
Encountered while trying to troubleshoot an issue with a user.
Error thrown: https://mclo.gs/OY4Hhgb#L501

```
Could not translate packet ClientboundUpdateRecipesPacket: java.lang.ArrayIndexOutOfBoundsException: Index 0 out of bounds for length 0
```

While caused by an invalid datapack recipe, a java client just ignores the invalid recipe; so should we.

Valid:
![image](https://github.com/GeyserMC/Geyser/assets/105284508/ed5fbacc-ca5d-4be9-9e36-d03ff1a7b531)

Invalid:
![image](https://github.com/GeyserMC/Geyser/assets/105284508/d689a3a2-b86d-4861-ba2a-f58b312589e4)

Further various little fixes:
- bump source version in AP to 17 to silence build log spam
- update args -> arguments in adventure usage
- remove unneeded close() on auto-closable resource