### PR TITLE
Fix: Opening inventory menus in spectator mode

### DIFF
--- a/core/src/main/java/org/geysermc/geyser/util/EntityUtils.java
+++ b/core/src/main/java/org/geysermc/geyser/util/EntityUtils.java
@@ -270,7 +270,7 @@ public final class EntityUtils {
         return switch (gamemode) {
             case CREATIVE -> GameType.CREATIVE;
             case ADVENTURE -> GameType.ADVENTURE;
-            case SPECTATOR -> GameType.SPECTATOR;
+            case SPECTATOR -> GameType.SURVIVAL_VIEWER;
             default -> GameType.SURVIVAL;
         };
     }


### PR DESCRIPTION
This PR aims to revert to the `spectator_viewer` bedrock gamemode to use instead of the native Bedrock spectator game mode that we currently do. While it looks uglier - e.g. it's showing health/hunger bars; and is buggier, it allows opening menus. Hopefully, with 1.20.60 adding the ability to hide gui elements, we can make it look a bit nicer.

This change will also be needed for entity spectating, since clicking on things is not possible in bedrocks spectator mode

Fixes https://github.com/GeyserMC/Geyser/issues/4312, fixes https://github.com/GeyserMC/Geyser/issues/4341