### PR TITLE
Weapon component is deprecated

### DIFF
--- a/core/src/main/java/org/geysermc/geyser/registry/populator/CustomItemRegistryPopulator.java
+++ b/core/src/main/java/org/geysermc/geyser/registry/populator/CustomItemRegistryPopulator.java
@@ -348,7 +348,6 @@ public class CustomItemRegistryPopulator {
         if (toolType.equals("sword")) {
             miningSpeed = 1.5f;
             canDestroyInCreative = false;
-            componentBuilder.putCompound("minecraft:weapon", NbtMap.EMPTY);
         }
 
         itemProperties.putBoolean("hand_equipped", true);


### PR DESCRIPTION
Fix client throwing a fir because weapon component is deprecated. As far as I know it hasn't done anything for a while anyways on the client side... and of course this is preferable to the client disconnecting...