### PR TITLE
Fix: Nametags not showing up after respawn

### DIFF
--- a/core/src/main/java/org/geysermc/geyser/entity/type/player/PlayerEntity.java
+++ b/core/src/main/java/org/geysermc/geyser/entity/type/player/PlayerEntity.java
@@ -377,6 +377,7 @@ public class PlayerEntity extends LivingEntity implements GeyserPlayerEntity {
 
         if (needsUpdate) {
             dirtyMetadata.put(EntityDataTypes.NAME, this.nametag);
+            dirtyMetadata.put(EntityDataTypes.NAMETAG_ALWAYS_SHOW, (byte) 1);
         }
     }
 


### PR DESCRIPTION
Resetting the NAMETAG_ALWAYS_SHOW metadata in updateDisplayName seems to fix the issue.

Fixes https://github.com/GeyserMC/Geyser/issues/4444