### PR TITLE
Fix: Nametags are not shown (again)

### DIFF
--- a/core/src/main/java/org/geysermc/geyser/entity/type/player/PlayerEntity.java
+++ b/core/src/main/java/org/geysermc/geyser/entity/type/player/PlayerEntity.java
@@ -120,9 +120,6 @@ public class PlayerEntity extends LivingEntity implements GeyserPlayerEntity {
         super.initializeMetadata();
         // For the OptionalPack, set all bits as invisible by default as this matches Java Edition behavior
         dirtyMetadata.put(EntityDataTypes.MARK_VARIANT, 0xff);
-        // Since 1.20.60, the nametag does not show properly if this is not set :/
-        // The nametag does disappear properly when the player is invisible though.
-        dirtyMetadata.put(EntityDataTypes.NAMETAG_ALWAYS_SHOW, (byte) 1);
     }
 
     @Override
@@ -154,6 +151,10 @@ public class PlayerEntity extends LivingEntity implements GeyserPlayerEntity {
         addPlayerPacket.setGameType(GameType.SURVIVAL); //TODO
         addPlayerPacket.setAbilityLayers(BASE_ABILITY_LAYER); // Recommended to be added since 1.19.10, but only needed here for permissions viewing
         addPlayerPacket.getMetadata().putFlags(flags);
+
+        // Since 1.20.60, the nametag does not show properly if this is not set :/
+        // The nametag does disappear properly when the player is invisible though.
+        dirtyMetadata.put(EntityDataTypes.NAMETAG_ALWAYS_SHOW, (byte) 1);
         dirtyMetadata.apply(addPlayerPacket.getMetadata());
 
         setFlagsDirty(false);
@@ -377,7 +378,6 @@ public class PlayerEntity extends LivingEntity implements GeyserPlayerEntity {
 
         if (needsUpdate) {
             dirtyMetadata.put(EntityDataTypes.NAME, this.nametag);
-            dirtyMetadata.put(EntityDataTypes.NAMETAG_ALWAYS_SHOW, (byte) 1);
         }
     }
 


### PR DESCRIPTION
Moved the metadata setting from updateDisplayName and initializeMetadata to spawnEntity.

Actually fixes #4444 