### PR TITLE
Deprecate unit cube in block components

### DIFF
--- a/api/src/main/java/org/geysermc/geyser/api/block/custom/component/CustomBlockComponents.java
+++ b/api/src/main/java/org/geysermc/geyser/api/block/custom/component/CustomBlockComponents.java
@@ -129,8 +129,11 @@ public interface CustomBlockComponents {
      * Gets the unit cube component
      * Equivalent to "minecraft:unit_cube"
      *
+     * @deprecated Use {@link #geometry()} and compare with `minecraft:geometry.full_block` instead.
+     *
      * @return The rotation.
      */
+    @Deprecated
     boolean unitCube();
 
     /**
@@ -181,6 +184,10 @@ public interface CustomBlockComponents {
 
         Builder transformation(TransformationComponent transformation);
 
+        /**
+         * @deprecated Use {@link #geometry(GeometryComponent)} with `minecraft:geometry.full_block` instead.
+         */
+        @Deprecated
         Builder unitCube(boolean unitCube);
 
         Builder placeAir(boolean placeAir);

--- a/core/src/main/java/org/geysermc/geyser/level/block/GeyserCustomBlockComponents.java
+++ b/core/src/main/java/org/geysermc/geyser/level/block/GeyserCustomBlockComponents.java
@@ -58,7 +58,6 @@ public class GeyserCustomBlockComponents implements CustomBlockComponents {
     Integer lightEmission;
     Integer lightDampening;
     TransformationComponent transformation;
-    boolean unitCube;
     boolean placeAir;
     Set<String> tags;
 
@@ -66,7 +65,13 @@ public class GeyserCustomBlockComponents implements CustomBlockComponents {
         this.selectionBox = builder.selectionBox;
         this.collisionBox = builder.collisionBox;
         this.displayName = builder.displayName;
-        this.geometry = builder.geometry;
+        GeometryComponent geo = builder.geometry;
+        if (builder.unitCube && geo == null) {
+            geo = GeometryComponent.builder()
+                .identifier("minecraft:geometry.full_block")
+                .build();
+        }
+        this.geometry = geo;
         if (builder.materialInstances.isEmpty()) {
             this.materialInstances = Object2ObjectMaps.emptyMap();
         } else {
@@ -78,7 +83,6 @@ public class GeyserCustomBlockComponents implements CustomBlockComponents {
         this.lightEmission = builder.lightEmission;
         this.lightDampening = builder.lightDampening;
         this.transformation = builder.transformation;
-        this.unitCube = builder.unitCube;
         this.placeAir = builder.placeAir;
         if (builder.tags.isEmpty()) {
             this.tags = Set.of();
@@ -144,7 +148,7 @@ public class GeyserCustomBlockComponents implements CustomBlockComponents {
 
     @Override
     public boolean unitCube() {
-        return unitCube;
+        return geometry.identifier().equals("minecraft:geometry.full_block");
     }
 
     @Override
@@ -169,7 +173,6 @@ public class GeyserCustomBlockComponents implements CustomBlockComponents {
         protected Integer lightEmission;
         protected Integer lightDampening;
         protected TransformationComponent transformation;
-        protected boolean unitCube = false;
         protected boolean placeAir = false;
         protected Set<String> tags = new HashSet<>();
 
@@ -282,7 +285,11 @@ public class GeyserCustomBlockComponents implements CustomBlockComponents {
 
         @Override
         public Builder unitCube(boolean unitCube) {
-            this.unitCube = unitCube;
+            if (unitCube) {
+                this.geometry = GeometryComponent.builder()
+                    .identifier("minecraft:geometry.full_block")
+                    .build();
+            }
             return this;
         }
 

--- a/core/src/main/java/org/geysermc/geyser/level/block/GeyserCustomBlockComponents.java
+++ b/core/src/main/java/org/geysermc/geyser/level/block/GeyserCustomBlockComponents.java
@@ -173,6 +173,7 @@ public class GeyserCustomBlockComponents implements CustomBlockComponents {
         protected Integer lightEmission;
         protected Integer lightDampening;
         protected TransformationComponent transformation;
+        protected boolean unitCube = false;
         protected boolean placeAir = false;
         protected Set<String> tags = new HashSet<>();
 
@@ -285,11 +286,7 @@ public class GeyserCustomBlockComponents implements CustomBlockComponents {
 
         @Override
         public Builder unitCube(boolean unitCube) {
-            if (unitCube) {
-                this.geometry = GeometryComponent.builder()
-                    .identifier("minecraft:geometry.full_block")
-                    .build();
-            }
+            this.unitCube = unitCube;
             return this;
         }
 

--- a/core/src/main/java/org/geysermc/geyser/registry/mappings/versions/MappingsReader_v1.java
+++ b/core/src/main/java/org/geysermc/geyser/registry/mappings/versions/MappingsReader_v1.java
@@ -488,7 +488,9 @@ public class MappingsReader_v1 extends MappingsReader {
         }
 
         if (node.has("unit_cube")) {
-            builder.unitCube(node.get("unit_cube").asBoolean());
+            builder.geometry(GeometryComponent.builder()
+                .identifier("minecraft:geometry.full_block")
+                .build());
         }
 
         if (node.has("material_instances")) {

--- a/core/src/main/java/org/geysermc/geyser/registry/populator/CustomBlockRegistryPopulator.java
+++ b/core/src/main/java/org/geysermc/geyser/registry/populator/CustomBlockRegistryPopulator.java
@@ -422,10 +422,6 @@ public class CustomBlockRegistryPopulator {
                     .build());
         }
 
-        if (components.unitCube()) {
-            builder.putCompound("minecraft:unit_cube", NbtMap.EMPTY);
-        }
-
         // place_air is not an actual component
         // We just apply a dummy event to prevent the client from trying to place a block
         // This mitigates the issue with the client sometimes double placing blocks


### PR DESCRIPTION
`minecraft:unit_cube` is deprecated and no longer works in the client so we now need to use `minecraft:geometry.full_block` as a geometry identifier.
Most functions are masked over to support this and mark old unit cube stuff as deprecated.
Thanks to @Kas-tle for coming up with the fix to use `minecraft:geometry.full_block`