### PR TITLE
Fix lecterns on 1.20.60, add support for virtual books

### DIFF
--- a/core/src/main/java/org/geysermc/geyser/inventory/item/StoredItemMappings.java
+++ b/core/src/main/java/org/geysermc/geyser/inventory/item/StoredItemMappings.java
@@ -53,6 +53,7 @@ public class StoredItemMappings {
     private final ItemMapping upgradeTemplate;
     private final ItemMapping wheat;
     private final ItemMapping writableBook;
+    private final ItemMapping writtenBook;
 
     public StoredItemMappings(Map<Item, ItemMapping> itemMappings) {
         this.bamboo = load(itemMappings, Items.BAMBOO);
@@ -68,6 +69,7 @@ public class StoredItemMappings {
         this.upgradeTemplate = load(itemMappings, Items.NETHERITE_UPGRADE_SMITHING_TEMPLATE);
         this.wheat = load(itemMappings, Items.WHEAT);
         this.writableBook = load(itemMappings, Items.WRITABLE_BOOK);
+        this.writtenBook = load(itemMappings, Items.WRITTEN_BOOK);
     }
 
     @NonNull

--- a/core/src/main/java/org/geysermc/geyser/level/GeyserWorldManager.java
+++ b/core/src/main/java/org/geysermc/geyser/level/GeyserWorldManager.java
@@ -36,14 +36,9 @@ import org.checkerframework.checker.nullness.qual.Nullable;
 import org.cloudburstmc.math.vector.Vector3i;
 import org.cloudburstmc.nbt.NbtMap;
 import org.cloudburstmc.nbt.NbtMapBuilder;
-import org.geysermc.erosion.packet.backendbound.BackendboundBatchBlockEntityPacket;
-import org.geysermc.erosion.packet.backendbound.BackendboundBatchBlockRequestPacket;
-import org.geysermc.erosion.packet.backendbound.BackendboundBlockEntityPacket;
-import org.geysermc.erosion.packet.backendbound.BackendboundBlockRequestPacket;
-import org.geysermc.erosion.packet.backendbound.BackendboundPickBlockPacket;
+import org.geysermc.erosion.packet.backendbound.*;
 import org.geysermc.erosion.util.BlockPositionIterator;
 import org.geysermc.erosion.util.LecternUtils;
-import org.geysermc.geyser.GeyserImpl;
 import org.geysermc.geyser.session.GeyserSession;
 import org.geysermc.geyser.util.BlockEntityUtils;
 
@@ -134,8 +129,6 @@ public class GeyserWorldManager extends WorldManager {
                 .build());
         lecternTag.putInt("page", -1); // I'm surprisingly glad this exists - it forces Bedrock to stop reading immediately. Usually.
         BlockEntityUtils.updateBlockEntity(session, lecternTag.build(), Vector3i.from(x, y, z));
-
-        GeyserImpl.getInstance().getLogger().error("Lectern tag:" + lecternTag.build());
     }
 
     @Override

--- a/core/src/main/java/org/geysermc/geyser/level/GeyserWorldManager.java
+++ b/core/src/main/java/org/geysermc/geyser/level/GeyserWorldManager.java
@@ -36,9 +36,14 @@ import org.checkerframework.checker.nullness.qual.Nullable;
 import org.cloudburstmc.math.vector.Vector3i;
 import org.cloudburstmc.nbt.NbtMap;
 import org.cloudburstmc.nbt.NbtMapBuilder;
-import org.geysermc.erosion.packet.backendbound.*;
+import org.geysermc.erosion.packet.backendbound.BackendboundBatchBlockEntityPacket;
+import org.geysermc.erosion.packet.backendbound.BackendboundBatchBlockRequestPacket;
+import org.geysermc.erosion.packet.backendbound.BackendboundBlockEntityPacket;
+import org.geysermc.erosion.packet.backendbound.BackendboundBlockRequestPacket;
+import org.geysermc.erosion.packet.backendbound.BackendboundPickBlockPacket;
 import org.geysermc.erosion.util.BlockPositionIterator;
 import org.geysermc.erosion.util.LecternUtils;
+import org.geysermc.geyser.GeyserImpl;
 import org.geysermc.geyser.session.GeyserSession;
 import org.geysermc.geyser.util.BlockEntityUtils;
 
@@ -126,9 +131,20 @@ public class GeyserWorldManager extends WorldManager {
                         .putString("photoname", "")
                         .putString("text", "")
                         .build())
+//               .putCompound("tag", NbtMap.builder()
+//                       .putString("author", "GeyserMC")
+//                       .putInt("generation", 0)
+//                       .putList("pages", NbtType.COMPOUND, NbtMap.builder()
+//                               .putString("photoname", "")
+//                               .putString("text", "ljhgkzcuztc")
+//                               .build())
+//                       .putString("title", "geyser is cool")
+//                       .build())
                 .build());
         lecternTag.putInt("page", -1); // I'm surprisingly glad this exists - it forces Bedrock to stop reading immediately. Usually.
         BlockEntityUtils.updateBlockEntity(session, lecternTag.build(), Vector3i.from(x, y, z));
+
+        GeyserImpl.getInstance().getLogger().error("Lectern tag:" + lecternTag.build());
     }
 
     @Override

--- a/core/src/main/java/org/geysermc/geyser/level/GeyserWorldManager.java
+++ b/core/src/main/java/org/geysermc/geyser/level/GeyserWorldManager.java
@@ -131,15 +131,6 @@ public class GeyserWorldManager extends WorldManager {
                         .putString("photoname", "")
                         .putString("text", "")
                         .build())
-//               .putCompound("tag", NbtMap.builder()
-//                       .putString("author", "GeyserMC")
-//                       .putInt("generation", 0)
-//                       .putList("pages", NbtType.COMPOUND, NbtMap.builder()
-//                               .putString("photoname", "")
-//                               .putString("text", "ljhgkzcuztc")
-//                               .build())
-//                       .putString("title", "geyser is cool")
-//                       .build())
                 .build());
         lecternTag.putInt("page", -1); // I'm surprisingly glad this exists - it forces Bedrock to stop reading immediately. Usually.
         BlockEntityUtils.updateBlockEntity(session, lecternTag.build(), Vector3i.from(x, y, z));

--- a/core/src/main/java/org/geysermc/geyser/session/GeyserSession.java
+++ b/core/src/main/java/org/geysermc/geyser/session/GeyserSession.java
@@ -89,6 +89,7 @@ import org.cloudburstmc.protocol.bedrock.data.command.CommandEnumData;
 import org.cloudburstmc.protocol.bedrock.data.command.CommandPermission;
 import org.cloudburstmc.protocol.bedrock.data.command.SoftEnumUpdateType;
 import org.cloudburstmc.protocol.bedrock.data.entity.EntityFlag;
+import org.cloudburstmc.protocol.bedrock.data.inventory.ItemData;
 import org.cloudburstmc.protocol.bedrock.packet.*;
 import org.cloudburstmc.protocol.common.DefinitionRegistry;
 import org.cloudburstmc.protocol.common.util.OptionalBoolean;
@@ -594,6 +595,12 @@ public class GeyserSession implements GeyserConnection, GeyserCommandSource {
      * Only used if {@link GeyserConfiguration#isForwardPlayerPing()} is enabled.
      */
     private final Queue<Long> keepAliveCache = new ConcurrentLinkedQueue<>();
+
+    /**
+     * Stores the book that is currently being read. Used in {@link org.geysermc.geyser.translator.protocol.java.inventory.JavaOpenBookTranslator}
+     */
+    @Setter
+    private @Nullable ItemData currentBook = null;
 
     private final GeyserCameraData cameraData;
 

--- a/core/src/main/java/org/geysermc/geyser/translator/inventory/LecternInventoryTranslator.java
+++ b/core/src/main/java/org/geysermc/geyser/translator/inventory/LecternInventoryTranslator.java
@@ -54,7 +54,7 @@ public class LecternInventoryTranslator extends AbstractBlockInventoryTranslator
 
     /**
      * Hack: Java opens a lectern first, and then follows it up with a ClientboundContainerSetContentPacket
-     * to actually send the book contents. We delay opening the inventory until the book was sent.
+     * to actually send the book's contents. We delay opening the inventory until the book was sent.
      */
     private boolean initialized = false;
 
@@ -66,9 +66,9 @@ public class LecternInventoryTranslator extends AbstractBlockInventoryTranslator
     public boolean prepareInventory(GeyserSession session, Inventory inventory) {
         super.prepareInventory(session, inventory);
         if (((Container) inventory).isUsingRealBlock()) {
-            initialized = false; // We have to wait until we get the Book to show to the client
+            initialized = false; // We have to wait until we get the book to show to the client
         } else {
-            updateBook(session, inventory, inventory.getItem(0)); // See JavaOpenBookTranslator; set there manually
+            updateBook(session, inventory, inventory.getItem(0)); // See JavaOpenBookTranslator; placed here manually
             initialized = true;
         }
         return true;
@@ -89,13 +89,13 @@ public class LecternInventoryTranslator extends AbstractBlockInventoryTranslator
     public void closeInventory(GeyserSession session, Inventory inventory) {
         // Of course, sending a simple ContainerClosePacket, or even breaking the block doesn't work to close a lectern.
         // Heck, the latter crashes the client xd
-        // BDS just sends an empty base lectern tag...
+        // BDS just sends an empty base lectern tag... that kicks out the client. Fine. Let's do that!
         LecternContainer lecternContainer = (LecternContainer) inventory;
         Vector3i position = lecternContainer.isUsingRealBlock() ? session.getLastInteractionBlockPosition() : inventory.getHolderPosition();
         var baseLecternTag = LecternUtils.getBaseLecternTag(position.getX(), position.getY(), position.getZ(), 0);
         BlockEntityUtils.updateBlockEntity(session, baseLecternTag.build(), position);
 
-        super.closeInventory(session, inventory); // Removes the fake blocks, if exist#
+        super.closeInventory(session, inventory); // Removes the fake blocks if need be
 
         // Now: Restore the lectern, if it actually exists
         if (lecternContainer.isUsingRealBlock()) {

--- a/core/src/main/java/org/geysermc/geyser/translator/inventory/LecternInventoryTranslator.java
+++ b/core/src/main/java/org/geysermc/geyser/translator/inventory/LecternInventoryTranslator.java
@@ -148,11 +148,11 @@ public class LecternInventoryTranslator extends AbstractBlockInventoryTranslator
             InventoryUtils.closeInventory(session, inventory.getJavaId(), false);
         } else if (lecternContainer.getBlockEntityTag() == null) {
             CompoundTag tag = book.getNbt();
-
             Vector3i position = lecternContainer.isUsingRealBlock() ? session.getLastInteractionBlockPosition() : inventory.getHolderPosition();
 
             // If shouldExpectLecternHandled returns true, this is already handled for us
             // shouldRefresh means that we should boot out the client on our side because their lectern GUI isn't updated yet
+            // TODO: yeet after 1.20.60 is minimum supported version
             boolean shouldRefresh = !session.getGeyser().getWorldManager().shouldExpectLecternHandled(session)
                     && !session.getLecternCache().contains(position)
                     && !GameProtocol.is1_20_60orHigher(session.getUpstream().getProtocolVersion());

--- a/core/src/main/java/org/geysermc/geyser/translator/protocol/bedrock/BedrockInventoryTransactionTranslator.java
+++ b/core/src/main/java/org/geysermc/geyser/translator/protocol/bedrock/BedrockInventoryTransactionTranslator.java
@@ -380,6 +380,8 @@ public class BedrockInventoryTransactionTranslator extends PacketTranslator<Inve
                             } else if (packet.getItemInHand().getDefinition() == session.getItemMappings().getStoredItems().glassBottle().getBedrockDefinition()) {
                                 // Handled in case 0
                                 break;
+                            } else if (packet.getItemInHand().getDefinition() == session.getItemMappings().getStoredItems().writtenBook().getBedrockDefinition()) {
+                                session.setCurrentBook(packet.getItemInHand());
                             }
                         }
 
@@ -387,7 +389,7 @@ public class BedrockInventoryTransactionTranslator extends PacketTranslator<Inve
                         session.sendDownstreamGamePacket(useItemPacket);
 
                         List<LegacySetItemSlotData> legacySlots = packet.getLegacySlots();
-                        if (packet.getActions().size() == 1 && legacySlots.size() > 0) {
+                        if (packet.getActions().size() == 1 && !legacySlots.isEmpty()) {
                             InventoryActionData actionData = packet.getActions().get(0);
                             LegacySetItemSlotData slotData = legacySlots.get(0);
                             if (slotData.getContainerId() == 6 && !actionData.getFromItem().isNull()) {

--- a/core/src/main/java/org/geysermc/geyser/translator/protocol/bedrock/BedrockLecternUpdateTranslator.java
+++ b/core/src/main/java/org/geysermc/geyser/translator/protocol/bedrock/BedrockLecternUpdateTranslator.java
@@ -31,8 +31,10 @@ import com.github.steveice10.mc.protocol.packet.ingame.serverbound.inventory.Ser
 import com.github.steveice10.mc.protocol.packet.ingame.serverbound.inventory.ServerboundContainerClosePacket;
 import com.github.steveice10.mc.protocol.packet.ingame.serverbound.player.ServerboundUseItemOnPacket;
 import org.cloudburstmc.protocol.bedrock.packet.LecternUpdatePacket;
+import org.geysermc.geyser.inventory.Inventory;
 import org.geysermc.geyser.inventory.LecternContainer;
 import org.geysermc.geyser.session.GeyserSession;
+import org.geysermc.geyser.translator.inventory.LecternInventoryTranslator;
 import org.geysermc.geyser.translator.protocol.PacketTranslator;
 import org.geysermc.geyser.translator.protocol.Translator;
 import org.geysermc.geyser.util.InventoryUtils;
@@ -62,7 +64,7 @@ public class BedrockLecternUpdateTranslator extends PacketTranslator<LecternUpda
         } else {
             // Bedrock wants to either move a page or exit
             if (!(session.getOpenInventory() instanceof LecternContainer lecternContainer)) {
-                session.getGeyser().getLogger().debug("Expected lectern but it wasn't open!");
+                session.getGeyser().getLogger().error("Expected lectern but it wasn't open!");
                 return;
             }
 
@@ -76,6 +78,15 @@ public class BedrockLecternUpdateTranslator extends PacketTranslator<LecternUpda
                 // Each "page" on Java is just one page (think a spiral notebook folded back to only show one page)
                 int newJavaPage = (packet.getPage() * 2);
                 int currentJavaPage = (lecternContainer.getCurrentBedrockPage() * 2);
+
+                // So, fun fact: We need to separately handle fake lecterns!
+                // Since those are not actually a real lectern... the Java client won't respond to our requests.
+                if (!lecternContainer.isUsingRealBlock()) {
+                    LecternInventoryTranslator translator = (LecternInventoryTranslator) session.getInventoryTranslator();
+                    Inventory inventory = session.getOpenInventory();
+                    translator.updateProperty(session, inventory, 0, newJavaPage);
+                    return;
+                }
 
                 // Send as many click button packets as we need to
                 // Java has the option to specify exact page numbers by adding 100 to the number, but buttonId variable

--- a/core/src/main/java/org/geysermc/geyser/translator/protocol/bedrock/BedrockLecternUpdateTranslator.java
+++ b/core/src/main/java/org/geysermc/geyser/translator/protocol/bedrock/BedrockLecternUpdateTranslator.java
@@ -64,7 +64,7 @@ public class BedrockLecternUpdateTranslator extends PacketTranslator<LecternUpda
         } else {
             // Bedrock wants to either move a page or exit
             if (!(session.getOpenInventory() instanceof LecternContainer lecternContainer)) {
-                session.getGeyser().getLogger().error("Expected lectern but it wasn't open!");
+                session.getGeyser().getLogger().debug("Expected lectern but it wasn't open!");
                 return;
             }
 
@@ -80,7 +80,7 @@ public class BedrockLecternUpdateTranslator extends PacketTranslator<LecternUpda
                 int currentJavaPage = (lecternContainer.getCurrentBedrockPage() * 2);
 
                 // So, fun fact: We need to separately handle fake lecterns!
-                // Since those are not actually a real lectern... the Java client won't respond to our requests.
+                // Since those are not actually a real lectern... the Java server won't respond to our requests.
                 if (!lecternContainer.isUsingRealBlock()) {
                     LecternInventoryTranslator translator = (LecternInventoryTranslator) session.getInventoryTranslator();
                     Inventory inventory = session.getOpenInventory();

--- a/core/src/main/java/org/geysermc/geyser/translator/protocol/bedrock/entity/player/BedrockInteractTranslator.java
+++ b/core/src/main/java/org/geysermc/geyser/translator/protocol/bedrock/entity/player/BedrockInteractTranslator.java
@@ -37,12 +37,14 @@ import org.cloudburstmc.protocol.bedrock.data.inventory.ContainerType;
 import org.cloudburstmc.protocol.bedrock.packet.ContainerOpenPacket;
 import org.cloudburstmc.protocol.bedrock.packet.InteractPacket;
 import org.cloudburstmc.protocol.bedrock.packet.SetEntityLinkPacket;
+import org.geysermc.geyser.GeyserImpl;
 import org.geysermc.geyser.entity.type.Entity;
 import org.geysermc.geyser.entity.type.living.animal.horse.AbstractHorseEntity;
 import org.geysermc.geyser.item.Items;
 import org.geysermc.geyser.session.GeyserSession;
 import org.geysermc.geyser.translator.protocol.PacketTranslator;
 import org.geysermc.geyser.translator.protocol.Translator;
+import org.geysermc.geyser.util.InventoryUtils;
 
 import java.util.concurrent.TimeUnit;
 
@@ -134,6 +136,10 @@ public class BedrockInteractTranslator extends PacketTranslator<InteractPacket> 
                         containerOpenPacket.setBlockPosition(entity.getPosition().toInt());
                         session.sendUpstreamPacket(containerOpenPacket);
                     }
+                } else {
+                    // Case: Player opens a player inventory, while we think it shouldnt have!
+                    // Close all inventories, reset to player inventory.
+                    InventoryUtils.closeInventory(session, session.getOpenInventory().getJavaId(), true);
                 }
                 break;
         }

--- a/core/src/main/java/org/geysermc/geyser/translator/protocol/bedrock/entity/player/BedrockInteractTranslator.java
+++ b/core/src/main/java/org/geysermc/geyser/translator/protocol/bedrock/entity/player/BedrockInteractTranslator.java
@@ -37,7 +37,6 @@ import org.cloudburstmc.protocol.bedrock.data.inventory.ContainerType;
 import org.cloudburstmc.protocol.bedrock.packet.ContainerOpenPacket;
 import org.cloudburstmc.protocol.bedrock.packet.InteractPacket;
 import org.cloudburstmc.protocol.bedrock.packet.SetEntityLinkPacket;
-import org.geysermc.geyser.GeyserImpl;
 import org.geysermc.geyser.entity.type.Entity;
 import org.geysermc.geyser.entity.type.living.animal.horse.AbstractHorseEntity;
 import org.geysermc.geyser.item.Items;
@@ -137,9 +136,9 @@ public class BedrockInteractTranslator extends PacketTranslator<InteractPacket> 
                         session.sendUpstreamPacket(containerOpenPacket);
                     }
                 } else {
-                    // Case: Player opens a player inventory, while we think it shouldnt have!
+                    // Case: Player opens a player inventory, while we think it shouldn't have!
                     // Close all inventories, reset to player inventory.
-                    InventoryUtils.closeInventory(session, session.getOpenInventory().getJavaId(), true);
+                    InventoryUtils.closeInventory(session, session.getOpenInventory().getJavaId(), false);
                 }
                 break;
         }

--- a/core/src/main/java/org/geysermc/geyser/translator/protocol/java/inventory/JavaContainerSetContentTranslator.java
+++ b/core/src/main/java/org/geysermc/geyser/translator/protocol/java/inventory/JavaContainerSetContentTranslator.java
@@ -27,6 +27,7 @@ package org.geysermc.geyser.translator.protocol.java.inventory;
 
 import com.github.steveice10.mc.protocol.packet.ingame.clientbound.inventory.ClientboundContainerSetContentPacket;
 import org.geysermc.geyser.GeyserImpl;
+import org.geysermc.geyser.GeyserLogger;
 import org.geysermc.geyser.inventory.GeyserItemStack;
 import org.geysermc.geyser.inventory.Inventory;
 import org.geysermc.geyser.session.GeyserSession;
@@ -48,12 +49,12 @@ public class JavaContainerSetContentTranslator extends PacketTranslator<Clientbo
         int inventorySize = inventory.getSize();
         for (int i = 0; i < packet.getItems().length; i++) {
             if (i >= inventorySize) {
-                GeyserImpl geyser = session.getGeyser();
-                geyser.getLogger().warning("ClientboundContainerSetContentPacket sent to " + session.bedrockUsername()
+                GeyserLogger logger = session.getGeyser().getLogger();
+                logger.warning("ClientboundContainerSetContentPacket sent to " + session.bedrockUsername()
                         + " that exceeds inventory size!");
-                if (geyser.getConfig().isDebugMode()) {
-                    geyser.getLogger().debug(packet);
-                    geyser.getLogger().debug(inventory);
+                if (logger.isDebug()) {
+                    logger.debug(packet);
+                    logger.debug(inventory);
                 }
                 updateInventory(session, inventory, packet.getContainerId());
                 // 1.18.1 behavior: the previous items will be correctly set, but the state ID and carried item will not

--- a/core/src/main/java/org/geysermc/geyser/translator/protocol/java/inventory/JavaContainerSetSlotTranslator.java
+++ b/core/src/main/java/org/geysermc/geyser/translator/protocol/java/inventory/JavaContainerSetSlotTranslator.java
@@ -34,7 +34,7 @@ import org.cloudburstmc.protocol.bedrock.data.inventory.crafting.recipe.ShapedRe
 import org.cloudburstmc.protocol.bedrock.data.inventory.descriptor.ItemDescriptorWithCount;
 import org.cloudburstmc.protocol.bedrock.packet.CraftingDataPacket;
 import org.cloudburstmc.protocol.bedrock.packet.InventorySlotPacket;
-import org.geysermc.geyser.GeyserImpl;
+import org.geysermc.geyser.GeyserLogger;
 import org.geysermc.geyser.inventory.GeyserItemStack;
 import org.geysermc.geyser.inventory.Inventory;
 import org.geysermc.geyser.inventory.recipe.GeyserShapedRecipe;
@@ -77,12 +77,12 @@ public class JavaContainerSetSlotTranslator extends PacketTranslator<Clientbound
 
             int slot = packet.getSlot();
             if (slot >= inventory.getSize()) {
-                GeyserImpl geyser = session.getGeyser();
-                geyser.getLogger().warning("ClientboundContainerSetSlotPacket sent to " + session.bedrockUsername()
+                GeyserLogger logger = session.getGeyser().getLogger();
+                logger.warning("ClientboundContainerSetSlotPacket sent to " + session.bedrockUsername()
                         + " that exceeds inventory size!");
-                if (geyser.getLogger().isDebug()) {
-                    geyser.getLogger().info(packet.toString());
-                    geyser.getLogger().info(inventory.toString());
+                if (logger.isDebug()) {
+                    logger.debug(packet.toString());
+                    logger.debug(inventory.toString());
                 }
                 // 1.19.0 behavior: the state ID will not be set due to exception
                 return;

--- a/core/src/main/java/org/geysermc/geyser/translator/protocol/java/inventory/JavaContainerSetSlotTranslator.java
+++ b/core/src/main/java/org/geysermc/geyser/translator/protocol/java/inventory/JavaContainerSetSlotTranslator.java
@@ -65,8 +65,9 @@ public class JavaContainerSetSlotTranslator extends PacketTranslator<Clientbound
 
         //TODO: support window id -2, should update player inventory
         Inventory inventory = InventoryUtils.getInventory(session, packet.getContainerId());
-        if (inventory == null)
+        if (inventory == null) {
             return;
+        }
 
         InventoryTranslator translator = session.getInventoryTranslator();
         if (translator != null) {
@@ -79,9 +80,9 @@ public class JavaContainerSetSlotTranslator extends PacketTranslator<Clientbound
                 GeyserImpl geyser = session.getGeyser();
                 geyser.getLogger().warning("ClientboundContainerSetSlotPacket sent to " + session.bedrockUsername()
                         + " that exceeds inventory size!");
-                if (geyser.getConfig().isDebugMode()) {
-                    geyser.getLogger().debug(packet);
-                    geyser.getLogger().debug(inventory);
+                if (geyser.getLogger().isDebug()) {
+                    geyser.getLogger().info(packet.toString());
+                    geyser.getLogger().info(inventory.toString());
                 }
                 // 1.19.0 behavior: the state ID will not be set due to exception
                 return;

--- a/core/src/main/java/org/geysermc/geyser/translator/protocol/java/inventory/JavaOpenBookTranslator.java
+++ b/core/src/main/java/org/geysermc/geyser/translator/protocol/java/inventory/JavaOpenBookTranslator.java
@@ -1,0 +1,70 @@
+/*
+ * Copyright (c) 2019-2024 GeyserMC. http://geysermc.org
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ *
+ * @author GeyserMC
+ * @link https://github.com/GeyserMC/Geyser
+ */
+
+package org.geysermc.geyser.translator.protocol.java.inventory;
+
+import com.github.steveice10.mc.protocol.data.game.inventory.ContainerType;
+import com.github.steveice10.mc.protocol.packet.ingame.clientbound.inventory.ClientboundOpenBookPacket;
+import com.github.steveice10.mc.protocol.packet.ingame.serverbound.inventory.ServerboundContainerClosePacket;
+import org.geysermc.geyser.GeyserImpl;
+import org.geysermc.geyser.inventory.GeyserItemStack;
+import org.geysermc.geyser.inventory.Inventory;
+import org.geysermc.geyser.item.Items;
+import org.geysermc.geyser.session.GeyserSession;
+import org.geysermc.geyser.translator.inventory.InventoryTranslator;
+import org.geysermc.geyser.translator.protocol.PacketTranslator;
+import org.geysermc.geyser.translator.protocol.Translator;
+import org.geysermc.geyser.util.InventoryUtils;
+
+@Translator(packet = ClientboundOpenBookPacket.class)
+public class JavaOpenBookTranslator extends PacketTranslator<ClientboundOpenBookPacket> {
+
+    @Override
+    public void translate(GeyserSession session, ClientboundOpenBookPacket packet) {
+        GeyserItemStack stack = session.getPlayerInventory().getItemInHand();
+
+        GeyserImpl.getInstance().getLogger().info("Got request to open book: " + packet.toString() + " holding: " + stack.asItem().javaIdentifier());
+
+        if (stack.asItem().equals(Items.WRITTEN_BOOK)) {
+            Inventory openInventory = session.getOpenInventory();
+            if (openInventory != null) {
+                InventoryUtils.closeInventory(session, openInventory.getJavaId(), true);
+
+                ServerboundContainerClosePacket closeWindowPacket = new ServerboundContainerClosePacket(openInventory.getJavaId());
+                session.sendDownstreamGamePacket(closeWindowPacket);
+            }
+
+            InventoryTranslator translator = InventoryTranslator.inventoryTranslator(ContainerType.LECTERN);
+            session.setInventoryTranslator(translator);
+
+            // Should never be null
+            assert translator != null;
+
+            Inventory inventory = translator.createInventory("", 69, ContainerType.LECTERN , session.getPlayerInventory());
+            inventory.setItem(0, stack, session);
+            InventoryUtils.openInventory(session, inventory);
+        }
+    }
+}

--- a/core/src/main/java/org/geysermc/geyser/translator/protocol/java/inventory/JavaOpenBookTranslator.java
+++ b/core/src/main/java/org/geysermc/geyser/translator/protocol/java/inventory/JavaOpenBookTranslator.java
@@ -38,8 +38,17 @@ import org.geysermc.geyser.translator.protocol.PacketTranslator;
 import org.geysermc.geyser.translator.protocol.Translator;
 import org.geysermc.geyser.util.InventoryUtils;
 
+import java.util.Objects;
+
 @Translator(packet = ClientboundOpenBookPacket.class)
 public class JavaOpenBookTranslator extends PacketTranslator<ClientboundOpenBookPacket> {
+
+    /**
+     * Unlike other fake inventories that rely on placing blocks in the world;
+     * the virtual lectern workaround for books isn't triggered the same way.
+     * Specifically, we don't get a window id - hence, we just use our own!
+     */
+    private final static int FAKE_LECTERN_WINDOW_ID = -69;
 
     @Override
     public void translate(GeyserSession session, ClientboundOpenBookPacket packet) {
@@ -69,8 +78,8 @@ public class JavaOpenBookTranslator extends PacketTranslator<ClientboundOpenBook
             session.setInventoryTranslator(translator);
 
             // Should never be null
-            assert translator != null;
-            Inventory inventory = translator.createInventory("", 69, ContainerType.LECTERN , session.getPlayerInventory());
+            Objects.requireNonNull(translator, "lectern translator must exist");
+            Inventory inventory = translator.createInventory("", FAKE_LECTERN_WINDOW_ID, ContainerType.LECTERN , session.getPlayerInventory());
             inventory.setItem(0, stack, session);
             InventoryUtils.openInventory(session, inventory);
         }

--- a/core/src/main/java/org/geysermc/geyser/translator/protocol/java/inventory/JavaOpenBookTranslator.java
+++ b/core/src/main/java/org/geysermc/geyser/translator/protocol/java/inventory/JavaOpenBookTranslator.java
@@ -31,6 +31,7 @@ import com.github.steveice10.mc.protocol.packet.ingame.serverbound.inventory.Ser
 import org.geysermc.geyser.inventory.GeyserItemStack;
 import org.geysermc.geyser.inventory.Inventory;
 import org.geysermc.geyser.item.Items;
+import org.geysermc.geyser.network.GameProtocol;
 import org.geysermc.geyser.session.GeyserSession;
 import org.geysermc.geyser.translator.inventory.InventoryTranslator;
 import org.geysermc.geyser.translator.protocol.PacketTranslator;
@@ -47,6 +48,11 @@ public class JavaOpenBookTranslator extends PacketTranslator<ClientboundOpenBook
         // Don't spawn a fake lectern for books already opened "normally" by the client.
         if (stack.getItemData(session).equals(session.getCurrentBook())) {
             session.setCurrentBook(null);
+            return;
+        }
+
+        // Only post 1.20.60 is it possible to tell the client to open a lectern.
+        if (!GameProtocol.is1_20_60orHigher(session.getUpstream().getProtocolVersion())) {
             return;
         }
 

--- a/core/src/main/java/org/geysermc/geyser/translator/protocol/java/inventory/JavaOpenBookTranslator.java
+++ b/core/src/main/java/org/geysermc/geyser/translator/protocol/java/inventory/JavaOpenBookTranslator.java
@@ -28,7 +28,6 @@ package org.geysermc.geyser.translator.protocol.java.inventory;
 import com.github.steveice10.mc.protocol.data.game.inventory.ContainerType;
 import com.github.steveice10.mc.protocol.packet.ingame.clientbound.inventory.ClientboundOpenBookPacket;
 import com.github.steveice10.mc.protocol.packet.ingame.serverbound.inventory.ServerboundContainerClosePacket;
-import org.geysermc.geyser.GeyserImpl;
 import org.geysermc.geyser.inventory.GeyserItemStack;
 import org.geysermc.geyser.inventory.Inventory;
 import org.geysermc.geyser.item.Items;
@@ -45,7 +44,11 @@ public class JavaOpenBookTranslator extends PacketTranslator<ClientboundOpenBook
     public void translate(GeyserSession session, ClientboundOpenBookPacket packet) {
         GeyserItemStack stack = session.getPlayerInventory().getItemInHand();
 
-        GeyserImpl.getInstance().getLogger().info("Got request to open book: " + packet.toString() + " holding: " + stack.asItem().javaIdentifier());
+        // Don't spawn a fake lectern for books already opened "normally" by the client.
+        if (stack.getItemData(session).equals(session.getCurrentBook())) {
+            session.setCurrentBook(null);
+            return;
+        }
 
         if (stack.asItem().equals(Items.WRITTEN_BOOK)) {
             Inventory openInventory = session.getOpenInventory();
@@ -61,7 +64,6 @@ public class JavaOpenBookTranslator extends PacketTranslator<ClientboundOpenBook
 
             // Should never be null
             assert translator != null;
-
             Inventory inventory = translator.createInventory("", 69, ContainerType.LECTERN , session.getPlayerInventory());
             inventory.setItem(0, stack, session);
             InventoryUtils.openInventory(session, inventory);

--- a/core/src/main/java/org/geysermc/geyser/util/InventoryUtils.java
+++ b/core/src/main/java/org/geysermc/geyser/util/InventoryUtils.java
@@ -45,6 +45,7 @@ import org.geysermc.geyser.GeyserImpl;
 import org.geysermc.geyser.inventory.Container;
 import org.geysermc.geyser.inventory.GeyserItemStack;
 import org.geysermc.geyser.inventory.Inventory;
+import org.geysermc.geyser.inventory.LecternContainer;
 import org.geysermc.geyser.inventory.PlayerInventory;
 import org.geysermc.geyser.inventory.click.Click;
 import org.geysermc.geyser.inventory.recipe.GeyserRecipe;
@@ -123,7 +124,9 @@ public class InventoryUtils {
         if (inventory != null) {
             InventoryTranslator translator = session.getInventoryTranslator();
             translator.closeInventory(session, inventory);
-            if (confirm && inventory.isDisplayed() && !inventory.isPending() && !(translator instanceof LecternInventoryTranslator)) {
+            if (confirm && inventory.isDisplayed() && !inventory.isPending()
+                    && !(translator instanceof LecternInventoryTranslator) // TODO: double-check
+            ) {
                 session.setClosingInventory(true);
             }
         }
@@ -133,6 +136,10 @@ public class InventoryUtils {
 
     public static @Nullable Inventory getInventory(GeyserSession session, int javaId) {
         if (javaId == 0) {
+            // ugly hack: lecterns aren't their own inventory on Java, and can hence be closed with e.g. an id of 0
+            if (session.getOpenInventory() instanceof LecternContainer) {
+                return session.getOpenInventory();
+            }
             return session.getPlayerInventory();
         } else {
             Inventory openInventory = session.getOpenInventory();


### PR DESCRIPTION
Turns out, the Bedrock client now expects to be told when to open a lectern. Neat! This means that we can finally start using fake lecterns to forcibly open books on a client. Fixes https://github.com/GeyserMC/Geyser/issues/1351 (for 1.20.60+ clients)!

Sadly, the lectern code is still ugly. But it's lecterns we're dealing with; they're never pretty. At the very least we don't have to re-open lecterns now. Actually, you do need to if you're not on 1.20.60 - below that version, clients are a bit... stubborn on opening lecterns. Compatibility has been kept, so 1.20.40-1.20.50 are still able to open lecterns.

Other, really *fun* things:
- Simply deleting a lectern that the player has currently open causes it to crash. Heck, sending an "pls close lectern" packet is also ignored! The only thing that works is sending an empty lectern, that kicks them out of the book menu.
- Old lectern workarounds weren't removed, and will still be needed to some extent even after 1.20.60+ is supported. Bedrock clients won't try to open a lectern if no book is on them :(

Fixes https://github.com/GeyserMC/Geyser/issues/4426 , adds more debugging (and a potential fix; see `BedrockInteractTranslator`) for https://github.com/GeyserMC/Geyser/issues/4141 - that apparently can occur when a client decides to open a chest, quickly closes it, and opens the player inventory instead; leading to some fun deadlock. At the very least; that should give us more information to resolve that little issue.