### PR TITLE
Update ViaVersion api usage

### DIFF
--- a/bootstrap/spigot/src/main/java/org/geysermc/geyser/platform/spigot/GeyserSpigotPlugin.java
+++ b/bootstrap/spigot/src/main/java/org/geysermc/geyser/platform/spigot/GeyserSpigotPlugin.java
@@ -433,7 +433,7 @@ public class GeyserSpigotPlugin extends JavaPlugin implements GeyserBootstrap {
             return false;
         }
         for (int i = protocolList.size() - 1; i >= 0; i--) {
-            MappingData mappingData = protocolList.get(i).getProtocol().getMappingData();
+            MappingData mappingData = protocolList.get(i).protocol().getMappingData();
             if (mappingData != null) {
                 return true;
             }


### PR DESCRIPTION
Should still work with older versions of ViaVersion - `getProtocol()` was marked deprecated 3 years ago:
https://github.com/ViaVersion/ViaVersion/commit/f2147179c2bcf9bd53affc36d0596088742d3725#diff-1491b08ad3ccf74fc5bf4ebdfb8f5113e3dd5add96ea1ad7289804ee39a956a0

4.10.0 dev removes these: https://github.com/ViaVersion/ViaVersion/commit/302716054de78de956d56a854e1657d665cc85ef#diff-1491b08ad3ccf74fc5bf4ebdfb8f5113e3dd5add96ea1ad7289804ee39a956a0

Should resolve issues such as https://mclo.gs/aNYUT60#L993