### PR TITLE
Fix: Lecterns not opening when there is no lectern cache

### DIFF
--- a/core/src/main/java/org/geysermc/geyser/session/GeyserSession.java
+++ b/core/src/main/java/org/geysermc/geyser/session/GeyserSession.java
@@ -285,7 +285,7 @@ public class GeyserSession implements GeyserConnection, GeyserCommandSource {
      * See {@link WorldManager#sendLecternData(GeyserSession, int, int, int)}
      * for more information.
      */
-    private final Set<Vector3i> lecternCache;
+    private final @Nullable Set<Vector3i> lecternCache;
 
     /**
      * A list of all players that have a player head on with a custom texture.

--- a/core/src/main/java/org/geysermc/geyser/translator/inventory/LecternInventoryTranslator.java
+++ b/core/src/main/java/org/geysermc/geyser/translator/inventory/LecternInventoryTranslator.java
@@ -193,9 +193,11 @@ public class LecternInventoryTranslator extends AbstractBlockInventoryTranslator
             lecternContainer.setPosition(position);
 
             BlockEntityUtils.updateBlockEntity(session, blockEntityTag, position);
-            session.getLecternCache().add(position);
 
             if (shouldRefresh) {
+                // the lectern cache doesn't always exist; only when we must refresh
+                session.getLecternCache().add(position);
+
                 // Close the window - we will reopen it once the client has this data synced
                 ServerboundContainerClosePacket closeWindowPacket = new ServerboundContainerClosePacket(lecternContainer.getJavaId());
                 session.sendDownstreamGamePacket(closeWindowPacket);


### PR DESCRIPTION
... the LecternCache doesn't always exist. Oops. Also marked the lectern cache as nullable to hopefully avoid similar issues in the future :p

Results in the following:
```
[23:18:01] [Geyser player thread-5-1/WARN]: [Geyser-Spigot] Could not translate packet ClientboundContainerSetContentPacket
java.lang.NullPointerException: Cannot invoke "java.util.Set.add(Object)" because the return value of "org.geysermc.geyser.session.GeyserSession.getLecternCache()" is null
	at org.geysermc.geyser.translator.inventory.LecternInventoryTranslator.updateBook(LecternInventoryTranslator.java:202) ~[Geyser-Spigot.jar:?]
	at org.geysermc.geyser.translator.inventory.LecternInventoryTranslator.updateInventory(LecternInventoryTranslator.java:125) ~[Geyser-Spigot.jar:?]
	at org.geysermc.geyser.translator.protocol.java.inventory.JavaContainerSetContentTranslator.updateInventory(JavaContainerSetContentTranslator.java:86) ~[Geyser-Spigot.jar:?]
	at org.geysermc.geyser.translator.protocol.java.inventory.JavaContainerSetContentTranslator.translate(JavaContainerSetContentTranslator.java:70) ~[Geyser-Spigot.jar:?]
	at org.geysermc.geyser.translator.protocol.java.inventory.JavaContainerSetContentTranslator.translate(JavaContainerSetContentTranslator.java:40) ~[Geyser-Spigot.jar:?]
	at org.geysermc.geyser.registry.PacketTranslatorRegistry.translate0(PacketTranslatorRegistry.java:89) ~[Geyser-Spigot.jar:?]
	at org.geysermc.geyser.registry.PacketTranslatorRegistry.lambda$translate$0(PacketTranslatorRegistry.java:69) ~[Geyser-Spigot.jar:?]
	at io.netty.util.concurrent.AbstractEventExecutor.runTask(AbstractEventExecutor.java:174) ~[netty-common-4.1.97.Final.jar:4.1.97.Final]
	at io.netty.channel.DefaultEventLoop.run(DefaultEventLoop.java:54) ~[netty-transport-4.1.97.Final.jar:4.1.97.Final]
	at io.netty.util.concurrent.SingleThreadEventExecutor$4.run(SingleThreadEventExecutor.java:997) ~[netty-common-4.1.97.Final.jar:4.1.97.Final]
	at io.netty.util.internal.ThreadExecutorMap$2.run(ThreadExecutorMap.java:74) ~[netty-common-4.1.97.Final.jar:4.1.97.Final]
	at io.netty.util.concurrent.FastThreadLocalRunnable.run(FastThreadLocalRunnable.java:30) ~[netty-common-4.1.97.Final.jar:4.1.97.Final]
	at java.lang.Thread.run(Thread.java:840) ~[?:?]
[23:18:01] [Geyser player thread-5-1/WARN]: java.lang.NullPointerException: Cannot invoke "java.util.Set.add(Object)" because the return value of "org.geysermc.geyser.session.GeyserSession.getLecternCache()" is null
[23:18:01] [Geyser player thread-5-1/WARN]: 	at Geyser-Spigot.jar//org.geysermc.geyser.translator.inventory.LecternInventoryTranslator.updateBook(LecternInventoryTranslator.java:202)
[23:18:01] [Geyser player thread-5-1/WARN]: 	at Geyser-Spigot.jar//org.geysermc.geyser.translator.inventory.LecternInventoryTranslator.updateInventory(LecternInventoryTranslator.java:125)
[23:18:01] [Geyser player thread-5-1/WARN]: 	at Geyser-Spigot.jar//org.geysermc.geyser.translator.protocol.java.inventory.JavaContainerSetContentTranslator.updateInventory(JavaContainerSetContentTranslator.java:86)
[23:18:01] [Geyser player thread-5-1/WARN]: 	at Geyser-Spigot.jar//org.geysermc.geyser.translator.protocol.java.inventory.JavaContainerSetContentTranslator.translate(JavaContainerSetContentTranslator.java:70)
[23:18:01] [Geyser player thread-5-1/WARN]: 	at Geyser-Spigot.jar//org.geysermc.geyser.translator.protocol.java.inventory.JavaContainerSetContentTranslator.translate(JavaContainerSetContentTranslator.java:40)
[23:18:01] [Geyser player thread-5-1/WARN]: 	at Geyser-Spigot.jar//org.geysermc.geyser.registry.PacketTranslatorRegistry.translate0(PacketTranslatorRegistry.java:89)
[23:18:01] [Geyser player thread-5-1/WARN]: 	at Geyser-Spigot.jar//org.geysermc.geyser.registry.PacketTranslatorRegistry.lambda$translate$0(PacketTranslatorRegistry.java:69)
[23:18:01] [Geyser player thread-5-1/WARN]: 	at io.netty.util.concurrent.AbstractEventExecutor.runTask(AbstractEventExecutor.java:174)
[23:18:01] [Geyser player thread-5-1/WARN]: 	at io.netty.channel.DefaultEventLoop.run(DefaultEventLoop.java:54)
[23:18:01] [Geyser player thread-5-1/WARN]: 	at io.netty.util.concurrent.SingleThreadEventExecutor$4.run(SingleThreadEventExecutor.java:997)
[23:18:01] [Geyser player thread-5-1/WARN]: 	at io.netty.util.internal.ThreadExecutorMap$2.run(ThreadExecutorMap.java:74)
[23:18:01] [Geyser player thread-5-1/WARN]: 	at io.netty.util.concurrent.FastThreadLocalRunnable.run(FastThreadLocalRunnable.java:30)
[23:18:01] [Geyser player thread-5-1/WARN]: 	at java.base/java.lang.Thread.run(Thread.java:840)
```