### PR TITLE
Fix client crash issue if empty recipe is sent

### DIFF
--- a/core/src/main/java/org/geysermc/geyser/translator/protocol/java/JavaClientboundRecipesTranslator.java
+++ b/core/src/main/java/org/geysermc/geyser/translator/protocol/java/JavaClientboundRecipesTranslator.java
@@ -27,7 +27,6 @@ package org.geysermc.geyser.translator.protocol.java;
 
 import com.github.steveice10.mc.protocol.packet.ingame.clientbound.ClientboundRecipePacket;
 import org.cloudburstmc.protocol.bedrock.packet.UnlockedRecipesPacket;
-import org.geysermc.geyser.network.GameProtocol;
 import org.geysermc.geyser.session.GeyserSession;
 import org.geysermc.geyser.translator.protocol.PacketTranslator;
 import org.geysermc.geyser.translator.protocol.Translator;
@@ -48,10 +47,20 @@ public class JavaClientboundRecipesTranslator extends PacketTranslator<Clientbou
             }
             case ADD -> {
                 recipesPacket.setAction(UnlockedRecipesPacket.ActionType.NEWLY_UNLOCKED);
-                recipesPacket.getUnlockedRecipes().addAll(getBedrockRecipes(session, packet.getRecipes()));
+                List<String> recipes = getBedrockRecipes(session, packet.getRecipes());
+                if (recipes.isEmpty()) {
+                    // Sending an empty list here packet will crash the client as of 1.20.60
+                    return;
+                }
+                recipesPacket.getUnlockedRecipes().addAll(recipes);
             }
             case REMOVE -> {
                 recipesPacket.setAction(UnlockedRecipesPacket.ActionType.REMOVE_UNLOCKED);
+                List<String> recipes = getBedrockRecipes(session, packet.getRecipes());
+                if (recipes.isEmpty()) {
+                    // Sending an empty list here will crash the client as of 1.20.60
+                    return;
+                }
                 recipesPacket.getUnlockedRecipes().addAll(getBedrockRecipes(session, packet.getRecipes()));
             }
         }
@@ -71,4 +80,3 @@ public class JavaClientboundRecipesTranslator extends PacketTranslator<Clientbou
         return recipes;
     }
 }
-

--- a/core/src/main/java/org/geysermc/geyser/translator/protocol/java/JavaClientboundRecipesTranslator.java
+++ b/core/src/main/java/org/geysermc/geyser/translator/protocol/java/JavaClientboundRecipesTranslator.java
@@ -61,7 +61,7 @@ public class JavaClientboundRecipesTranslator extends PacketTranslator<Clientbou
                     return;
                 }
                 recipesPacket.setAction(UnlockedRecipesPacket.ActionType.REMOVE_UNLOCKED);
-                recipesPacket.getUnlockedRecipes().addAll(getBedrockRecipes(session, packet.getRecipes()));
+                recipesPacket.getUnlockedRecipes().addAll(recipes);
             }
         }
         session.sendUpstreamPacket(recipesPacket);

--- a/core/src/main/java/org/geysermc/geyser/translator/protocol/java/JavaClientboundRecipesTranslator.java
+++ b/core/src/main/java/org/geysermc/geyser/translator/protocol/java/JavaClientboundRecipesTranslator.java
@@ -46,21 +46,21 @@ public class JavaClientboundRecipesTranslator extends PacketTranslator<Clientbou
                 recipesPacket.getUnlockedRecipes().addAll(getBedrockRecipes(session, packet.getAlreadyKnownRecipes()));
             }
             case ADD -> {
-                recipesPacket.setAction(UnlockedRecipesPacket.ActionType.NEWLY_UNLOCKED);
                 List<String> recipes = getBedrockRecipes(session, packet.getRecipes());
                 if (recipes.isEmpty()) {
                     // Sending an empty list here packet will crash the client as of 1.20.60
                     return;
                 }
+                recipesPacket.setAction(UnlockedRecipesPacket.ActionType.NEWLY_UNLOCKED);
                 recipesPacket.getUnlockedRecipes().addAll(recipes);
             }
             case REMOVE -> {
-                recipesPacket.setAction(UnlockedRecipesPacket.ActionType.REMOVE_UNLOCKED);
                 List<String> recipes = getBedrockRecipes(session, packet.getRecipes());
                 if (recipes.isEmpty()) {
                     // Sending an empty list here will crash the client as of 1.20.60
                     return;
                 }
+                recipesPacket.setAction(UnlockedRecipesPacket.ActionType.REMOVE_UNLOCKED);
                 recipesPacket.getUnlockedRecipes().addAll(getBedrockRecipes(session, packet.getRecipes()));
             }
         }


### PR DESCRIPTION
It seems the client now crashes if we send an empty list for `UnlockedRecipesPacket.ActionType.NEWLY_UNLOCKED` or `UnlockedRecipesPacket.ActionType.REMOVE_UNLOCKED`