### PR TITLE
Revert inventory "fix" that's causing issues with quickly opening & closing inventories

### DIFF
--- a/core/src/main/java/org/geysermc/geyser/translator/protocol/bedrock/entity/player/BedrockInteractTranslator.java
+++ b/core/src/main/java/org/geysermc/geyser/translator/protocol/bedrock/entity/player/BedrockInteractTranslator.java
@@ -126,12 +126,7 @@ public class BedrockInteractTranslator extends PacketTranslator<InteractPacket> 
                     } else {
                         InventoryUtils.openInventory(session, session.getPlayerInventory());
                     }
-                } else {
-                    // Case: Player tries to open a player inventory, while we think it should be in a different inventory
-                    // Now: Open the inventory that we're supposed to be in.
-                    InventoryUtils.openInventory(session, session.getOpenInventory());
                 }
-                break;
         }
     }
 }


### PR DESCRIPTION
temporary fix for https://github.com/GeyserMC/Geyser/issues/4517 - seems like Geyser sometimes still thinks we're in an inventory when we don't actually are in one. Yikes.

Not able to look into the root cause of the issue at the moment, but this should, at the very least, undo the problematic change for now. 