### PR TITLE
Feature: Username dialog when joining offline servers

### DIFF
--- a/core/src/main/java/org/geysermc/geyser/network/UpstreamPacketHandler.java
+++ b/core/src/main/java/org/geysermc/geyser/network/UpstreamPacketHandler.java
@@ -216,9 +216,10 @@ public class UpstreamPacketHandler extends LoggingPacketHandler {
     public PacketSignal handle(ResourcePackClientResponsePacket packet) {
         switch (packet.getStatus()) {
             case COMPLETED:
-                if (geyser.getConfig().getRemote().authType() != AuthType.ONLINE) {
+                AuthType authType = geyser.getConfig().getRemote().authType();
+                if (authType == AuthType.FLOODGATE) {
                     session.authenticate(session.getAuthData().name());
-                } else if (!couldLoginUserByName(session.getAuthData().name())) {
+                } else if (!couldLoginUserByName(session.getAuthData().name()) || authType == AuthType.OFFLINE) {
                     // We must spawn the white world
                     session.connect();
                 }

--- a/core/src/main/java/org/geysermc/geyser/translator/protocol/bedrock/BedrockSetLocalPlayerAsInitializedTranslator.java
+++ b/core/src/main/java/org/geysermc/geyser/translator/protocol/bedrock/BedrockSetLocalPlayerAsInitializedTranslator.java
@@ -59,6 +59,11 @@ public class BedrockSetLocalPlayerAsInitializedTranslator extends PacketTranslat
                     }
                     // else we were able to log the user in
                 }
+
+                if (session.remoteServer().authType() == AuthType.OFFLINE) {
+                    LoginEncryptionUtils.buildAndShowOfflineLoginWindow(session);
+                }
+
                 if (session.isLoggedIn()) {
                     // Sigh - as of Bedrock 1.18
                     session.getEntityCache().updateBossBars();

--- a/core/src/main/java/org/geysermc/geyser/util/LoginEncryptionUtils.java
+++ b/core/src/main/java/org/geysermc/geyser/util/LoginEncryptionUtils.java
@@ -34,6 +34,7 @@ import org.cloudburstmc.protocol.bedrock.packet.ServerToClientHandshakePacket;
 import org.cloudburstmc.protocol.bedrock.util.ChainValidationResult;
 import org.cloudburstmc.protocol.bedrock.util.ChainValidationResult.IdentityData;
 import org.cloudburstmc.protocol.bedrock.util.EncryptionUtils;
+import org.geysermc.cumulus.form.CustomForm;
 import org.geysermc.cumulus.form.ModalForm;
 import org.geysermc.cumulus.form.SimpleForm;
 import org.geysermc.cumulus.response.SimpleFormResponse;
@@ -150,6 +151,26 @@ public class LoginEncryptionUtils {
                             }
 
                             session.disconnect(GeyserLocale.getPlayerLocaleString("geyser.auth.login.form.disconnect", session.locale()));
+                        }));
+    }
+
+    public static void buildAndShowOfflineLoginWindow(GeyserSession session) {
+        if (session.isLoggedIn()) {
+            // Can happen if a window is1 cancelled during dimension switch
+            return;
+        }
+
+        // Set DoDaylightCycle to false so the time doesn't accelerate while we're here
+        session.setDaylightCycle(false);
+
+        session.sendForm(
+                CustomForm.builder()
+                        .translator(GeyserLocale::getPlayerLocaleString, session.locale())
+                        .title("geyser.auth.login.form.details.title")
+                        .input("geyser.auth.login.form.details.email", "", session.bedrockUsername())
+                        .closedOrInvalidResultHandler(() -> buildAndShowOfflineLoginWindow(session))
+                        .validResultHandler((response) -> {
+                            session.authenticate(response.asInput(0));
                         }));
     }
 


### PR DESCRIPTION
Implements https://github.com/GeyserMC/Geyser/issues/1096#issuecomment-670284755 to make players able to join with a different name than their Xbox gamertag in offline mode. The functionality is similar to the Microsoft login for online mode, where players are placed into a blank world and prompted to submit their login details.

<details>
<summary>Screenshots</summary>

![Screenshot 2024-04-01 210517](https://github.com/GeyserMC/Geyser/assets/57678928/ebdecbde-a4df-4218-8d2e-56392c315268)
![Screenshot 2024-04-01 210537](https://github.com/GeyserMC/Geyser/assets/57678928/5307fca5-4a77-40c9-90ab-3da613226697)
</details>
 
Since mojang login was removed, I think https://github.com/GeyserMC/Geyser/issues/1096#issuecomment-670285248 is not possible anymore. Thus, I believe these changes are small yet significant, addressing an important user need. Thank you for considering this pull request.