### PR TITLE
Remove Java custom armor trims when translating item to Bedrock to prevent visual issues

### DIFF
--- a/core/src/main/java/org/geysermc/geyser/item/type/ArmorItem.java
+++ b/core/src/main/java/org/geysermc/geyser/item/type/ArmorItem.java
@@ -52,6 +52,7 @@ public class ArmorItem extends Item {
             // discard custom trim patterns/materials to prevent visual glitches on bedrock
             if (!material.getValue().startsWith(MINECRAFT_NAMESPACE)
                     || !pattern.getValue().startsWith(MINECRAFT_NAMESPACE)) {
+                tag.remove("Trim");
                 return;
             }
 

--- a/core/src/main/java/org/geysermc/geyser/item/type/ArmorItem.java
+++ b/core/src/main/java/org/geysermc/geyser/item/type/ArmorItem.java
@@ -33,7 +33,6 @@ import org.geysermc.geyser.registry.type.ItemMapping;
 import org.geysermc.geyser.session.GeyserSession;
 
 public class ArmorItem extends Item {
-    private static final String MINECRAFT_NAMESPACE = "minecraft:";
     private final ArmorMaterial material;
 
     public ArmorItem(String javaIdentifier, ArmorMaterial material, Builder builder) {
@@ -50,8 +49,8 @@ public class ArmorItem extends Item {
             StringTag pattern = trim.remove("pattern");
 
             // discard custom trim patterns/materials to prevent visual glitches on bedrock
-            if (!material.getValue().startsWith(MINECRAFT_NAMESPACE)
-                    || !pattern.getValue().startsWith(MINECRAFT_NAMESPACE)) {
+            if (!material.getValue().startsWith("minecraft:")
+                    || !pattern.getValue().startsWith("minecraft:")) {
                 tag.remove("Trim");
                 return;
             }

--- a/core/src/main/java/org/geysermc/geyser/item/type/ArmorItem.java
+++ b/core/src/main/java/org/geysermc/geyser/item/type/ArmorItem.java
@@ -33,6 +33,7 @@ import org.geysermc.geyser.registry.type.ItemMapping;
 import org.geysermc.geyser.session.GeyserSession;
 
 public class ArmorItem extends Item {
+    private static final String MINECRAFT_NAMESPACE = "minecraft:";
     private final ArmorMaterial material;
 
     public ArmorItem(String javaIdentifier, ArmorMaterial material, Builder builder) {
@@ -47,6 +48,13 @@ public class ArmorItem extends Item {
         if (tag.get("Trim") instanceof CompoundTag trim) {
             StringTag material = trim.remove("material");
             StringTag pattern = trim.remove("pattern");
+
+            // discard custom trim patterns/materials to prevent visual glitches on bedrock
+            if (!material.getValue().startsWith(MINECRAFT_NAMESPACE)
+                    || !pattern.getValue().startsWith(MINECRAFT_NAMESPACE)) {
+                return;
+            }
+
             // bedrock has an uppercase first letter key, and the value is not namespaced
             trim.put(new StringTag("Material", stripNamespace(material.getValue())));
             trim.put(new StringTag("Pattern", stripNamespace(pattern.getValue())));


### PR DESCRIPTION
Hello, I've implemented a small fix regarding custom armor trims created using Java datapacks. Armor pieces with custom trims render on Bedrock as though they have a missing model/texture, and additionally, the item looks blank when in inventory.

As far as I know, Bedrock doesn't have the ability to add custom armor trims yet, so my fix was to entirely discard the armor trim NBT tag when translating a Java item to a Bedrock item.


Without fix:
![Screenshot_20240404_170829](https://github.com/GeyserMC/Geyser/assets/116838833/5b0666a5-fad3-45d5-a6d0-5ea1508f3f0d)
With fix:
![Screenshot_20240404_171221](https://github.com/GeyserMC/Geyser/assets/116838833/2171ccfe-744b-46f5-8bf9-137f501e531b)