### PR TITLE
Update CreativeCategory none to have the correct value

### DIFF
--- a/api/src/main/java/org/geysermc/geyser/api/util/CreativeCategory.java
+++ b/api/src/main/java/org/geysermc/geyser/api/util/CreativeCategory.java
@@ -35,7 +35,7 @@ public enum CreativeCategory {
     NATURE("nature", 2),
     EQUIPMENT("equipment", 3),
     ITEMS("items", 4),
-    NONE("none", 5);
+    NONE("none", 6);
 
     private final String internalName;
     private final int id;


### PR DESCRIPTION
Correct the id for the none CreativeCategory

These are the numbers from inside the game but we cant use `All_3` or `ItemCommandOnly`

Used proxypass and BDS to confirm this was correct

Extract from decompiled BDS
```
enum CreativeItemCategory, copyof_94506, width 4 bytes
 All_3            = 0
 Construction     = 1
 Nature           = 2
 Equipment        = 3
 Items            = 4
 ItemCommandOnly  = 5
 Undefined_10     = 6
 NUM_CATEGORIES   = 7
```