### PR TITLE
Update release for preview builds

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -8,6 +8,7 @@ on:
     paths-ignore:
       - '.github/ISSUE_TEMPLATE/*.yml'
       - '.github/actions/pullrequest.yml'
+      - '.github/actions/preview.yml'
       - '.idea/copyright/*.xml'
       - '.gitignore'
       - 'CONTRIBUTING.md'
@@ -19,6 +20,8 @@ on:
 jobs:
   build:
     runs-on: ubuntu-latest
+    env:
+      PROJECT: 'geyser'
     steps:
       - name: Checkout repository and submodules
         # See https://github.com/actions/checkout/commits
@@ -103,6 +106,34 @@ jobs:
         with:
           arguments: publish
 
+      - name: Get Release Metadata
+        if: ${{ success() && github.repository == 'GeyserMC/Geyser' && github.ref_name == 'master' }}
+        uses: Kas-tle/base-release-action@b863fa0f89bd15267a96a72efb84aec25f168d4c # https://github.com/Kas-tle/base-release-action/releases/tag/main-11
+        with:
+          appID: ${{ secrets.RELEASE_APP_ID }}
+          appPrivateKey: ${{ secrets.RELEASE_APP_PK }}
+          files: |
+            bungeecord:bootstrap/bungeecord/build/libs/Geyser-BungeeCord.jar
+            fabric:bootstrap/mod/fabric/build/libs/Geyser-Fabric.jar
+            neoforge:bootstrap/mod/neoforge/build/libs/Geyser-NeoForge.jar
+            spigot:bootstrap/spigot/build/libs/Geyser-Spigot.jar
+            standalone:bootstrap/standalone/build/libs/Geyser-Standalone.jar
+            velocity:bootstrap/velocity/build/libs/Geyser-Velocity.jar
+            viaproxy:bootstrap/viaproxy/build/libs/Geyser-ViaProxy.jar
+          releaseEnabled: false
+          saveMetadata: true
+      - name: Update Generated Metadata
+        if: ${{ success() && github.repository == 'GeyserMC/Geyser' && github.ref_name == 'master' }}
+        run: |
+          cat metadata.json
+          echo
+          version=$(cat gradle.properties | grep -o "version=[0-9\\.]*" | cut -d"=" -f2)
+          cat metadata.json | jq --arg project "${PROJECT}" --arg version "${version}" '
+            .
+            | .changes |= map({"commit", "summary", "message"}) 
+            | .downloads |= map_values({"name", "sha256"})
+            | {$project, "repo", $version, "number": .build, "changes", "downloads"}
+          ' | tee metadata.json
       - name: Publish to Downloads API
         if: ${{ success() && github.repository == 'GeyserMC/Geyser' && github.ref_name == 'master' }}
         shell: bash
@@ -114,19 +145,13 @@ jobs:
           # Save the private key to a file
           echo "$DOWNLOADS_PRIVATE_KEY" > id_ecdsa
           chmod 600 id_ecdsa
-          # Set the project
-          project=geyser
-          # Get the version from gradle.properties
-          version=$(cat gradle.properties | grep -o "version=[0-9\\.]*" | cut -d"=" -f2)
           # Create the build folder
-          ssh -o StrictHostKeyChecking=no -i id_ecdsa $DOWNLOADS_USERNAME@$DOWNLOADS_SERVER_IP mkdir -p "~/uploads/$project/$GITHUB_RUN_NUMBER/"
+          ssh -o StrictHostKeyChecking=no -i id_ecdsa $DOWNLOADS_USERNAME@$DOWNLOADS_SERVER_IP mkdir -p "~/uploads/$PROJECT/$GITHUB_RUN_NUMBER/"
           # Copy over artifacts
-          rsync -P -e "ssh -o StrictHostKeyChecking=no -i id_ecdsa" bootstrap/**/build/libs/Geyser-*.jar $DOWNLOADS_USERNAME@$DOWNLOADS_SERVER_IP:~/uploads/$project/$GITHUB_RUN_NUMBER/
-          rsync -P -e "ssh -o StrictHostKeyChecking=no -i id_ecdsa" bootstrap/mod/**/build/libs/Geyser-*.jar $DOWNLOADS_USERNAME@$DOWNLOADS_SERVER_IP:~/uploads/$project/$GITHUB_RUN_NUMBER/
+          rsync -P -e "ssh -o StrictHostKeyChecking=no -i id_ecdsa" bootstrap/**/build/libs/Geyser-*.jar $DOWNLOADS_USERNAME@$DOWNLOADS_SERVER_IP:~/uploads/$PROJECT/$GITHUB_RUN_NUMBER/
+          rsync -P -e "ssh -o StrictHostKeyChecking=no -i id_ecdsa" bootstrap/mod/**/build/libs/Geyser-*.jar $DOWNLOADS_USERNAME@$DOWNLOADS_SERVER_IP:~/uploads/$PROJECT/$GITHUB_RUN_NUMBER/
           # Run the build script
-          # Push the metadata
-          echo "{\"project\": \"$project\", \"version\": \"$version\", \"id\": $GITHUB_RUN_NUMBER, \"commit\": \"$GITHUB_SHA\"}" > metadata.json
-          rsync -P -e "ssh -o StrictHostKeyChecking=no -i id_ecdsa" metadata.json $DOWNLOADS_USERNAME@$DOWNLOADS_SERVER_IP:~/uploads/$project/$GITHUB_RUN_NUMBER/
+          rsync -P -e "ssh -o StrictHostKeyChecking=no -i id_ecdsa" metadata.json $DOWNLOADS_USERNAME@$DOWNLOADS_SERVER_IP:~/uploads/$PROJECT/$GITHUB_RUN_NUMBER/
 
       - name: Publish to Modrinth (Fabric)
         uses: gradle/actions/setup-gradle@417ae3ccd767c252f5661f1ace9f835f9654f2b5

--- a/.github/workflows/preview.yml
+++ b/.github/workflows/preview.yml
@@ -1,0 +1,73 @@
+name: Upload Preview
+
+on:
+  workflow_dispatch:
+    inputs:
+      runId:
+        required: true
+        description: 'ID of the action to pull artifacts from'
+      build:
+        required: true
+        description: 'Build number for the release'
+      version:
+        required: true
+        description: 'Version under which to upload to the Downloads API'
+
+jobs:
+  upload:
+    runs-on: ubuntu-latest
+    env:
+      PROJECT: 'geyser-preview'
+      BUILD: ${{ github.event.inputs.build }}
+      VERSION: ${{ github.event.inputs.version }}
+    steps:
+      - uses: actions/download-artifact@c850b930e6ba138125429b7e5c93fc707a7f8427 # https://github.com/actions/download-artifact/releases/tag/v4.1.4
+        with:
+          run-id: ${{ github.event.inputs.runId }}
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          merge-multiple: true
+      - name: Get Preview Metadata
+        if: success()
+        uses: Kas-tle/base-release-action@b863fa0f89bd15267a96a72efb84aec25f168d4c # https://github.com/Kas-tle/base-release-action/releases/tag/main-11
+        with:
+          appID: ${{ secrets.RELEASE_APP_ID }}
+          appPrivateKey: ${{ secrets.RELEASE_APP_PK }}
+          files: |
+            bungeecord:Geyser-BungeeCord.jar
+            fabric:Geyser-Fabric.jar
+            neoforge:Geyser-NeoForge.jar
+            spigot:Geyser-Spigot.jar
+            standalone:Geyser-Standalone.jar
+            velocity:Geyser-Velocity.jar
+            viaproxy:Geyser-ViaProxy.jar
+          releaseEnabled: false
+          saveMetadata: true
+          updateReleaseData: false
+      - name: Update Generated Metadata
+        if: success()
+        run: |
+          cat metadata.json
+          echo
+          cat metadata.json | jq --arg project "${PROJECT}" --arg version "${VERSION}" --arg number "${BUILD}" '
+            .
+            | .downloads |= map_values({"name", "sha256"})
+            | {$project, "repo", $version, "number": $number | tonumber, "changes": [], "downloads"}
+          ' | tee metadata.json
+      - name: Publish to Downloads API
+        if: success()
+        shell: bash
+        env:
+          DOWNLOADS_USERNAME: ${{ vars.DOWNLOADS_USERNAME }}
+          DOWNLOADS_PRIVATE_KEY: ${{ secrets.DOWNLOADS_PRIVATE_KEY }}
+          DOWNLOADS_SERVER_IP: ${{ secrets.DOWNLOADS_SERVER_IP }}
+        run: |
+          # Save the private key to a file
+          echo "$DOWNLOADS_PRIVATE_KEY" > id_ecdsa
+          chmod 600 id_ecdsa
+          # Create the build folder
+          ssh -o StrictHostKeyChecking=no -i id_ecdsa $DOWNLOADS_USERNAME@$DOWNLOADS_SERVER_IP mkdir -p "~/uploads/$PROJECT/$BUILD/"
+          # Copy over artifacts
+          rsync -P -e "ssh -o StrictHostKeyChecking=no -i id_ecdsa" Geyser-*.jar $DOWNLOADS_USERNAME@$DOWNLOADS_SERVER_IP:~/uploads/$PROJECT/$BUILD/
+          # Run the build script
+          # Push the metadata
+          rsync -P -e "ssh -o StrictHostKeyChecking=no -i id_ecdsa" metadata.json $DOWNLOADS_USERNAME@$DOWNLOADS_SERVER_IP:~/uploads/$PROJECT/$BUILD/

--- a/.github/workflows/pullrequest.yml
+++ b/.github/workflows/pullrequest.yml
@@ -102,3 +102,21 @@ jobs:
           name: Geyser ViaProxy
           path: geyser/bootstrap/viaproxy/build/libs/Geyser-ViaProxy.jar
           if-no-files-found: error
+
+      - name: Trigger Preview Deployment
+        if: >-
+          contains(github.event.pull_request.labels.*.name, 'PR: Needs Testing')
+        uses: actions/github-script@60a0d83039c74a4aee543508d2ffcb1c3799cdea
+        with:
+          script: |
+            github.rest.actions.createWorkflowDispatch({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              workflow_id: 'preview.yml',
+              ref: 'master',
+              inputs: {
+                runId: '${{ github.run_id }}',
+                build: '${{ github.run_number }}',
+                version: 'pr.${{ github.event.pull_request.number }}'
+              }
+            });


### PR DESCRIPTION
## Needs
- Merge of https://github.com/GeyserMC/bibliothek-build-monitor/pull/2 and deployment to Downloads API box
- Creation of a GitHub bot on the organization per https://github.com/Kas-tle/base-release-action?tab=readme-ov-file#usage
  - Create a GH app with the scopes Contents (Read & Write), Metadata (Read-only), Variables (Read & Write), and Actions (Read-only) and grant it access to all repos from which builds are deployed:
    - GeyserMC/Geyser
    - GeyserMC/Floodgate
    - GeyserMC/GeyserConnect
    - GeyserMC/GeyserOptionalPack
    - GeyserMC/Hydraulic
    - GeyserMC/Erosion
  - On all repos, in order to give the action the required info to generate changelogs, set a repository level variable named `RELEASEACTION_PREVRELEASE` where the format is `{"master":{"c":"b863fa0f89bd15267a96a72efb84aec25f168d4c","t":"11"}}`, using the branch name, last commit sha (`c`), and last build number (`t`)
- Make build action changes on all other repos

## Usage
- Builds will now use sequential build numbers
- PRs with the tag `PR: Needs Testing` will now be deployed to the downloads api under the project `geyser-testing` and version `pr.NUMBER`