### PR TITLE
Update Java version in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ The ultimate goal of this project is to allow Minecraft: Bedrock Edition users t
 
 Special thanks to the DragonProxy project for being a trailblazer in protocol translation and for all the team members who have joined us here!
 
-### Currently supporting Minecraft Bedrock 1.20.40 - 1.20.80 and Minecraft Java 1.20.4
+### Currently supporting Minecraft Bedrock 1.20.40 - 1.20.80 and Minecraft Java 1.20.5
 
 ## Setting Up
 Take a look [here](https://wiki.geysermc.org/geyser/setup/) for how to set up Geyser.


### PR DESCRIPTION
I refrained from altering any other references to 1.20.4 out of concern that it might disrupt functionality. Enclosed are the files I abstained from modifying, although certain ones may necessitate an adjustment to the 1.20.4 string:
- bootstrap\mod\fabric\src\main\resources\fabric.mod.json
- build-logic\src\main\kotlin\geyser.modded-conventions.gradle.kts
- gradle\libs.versions.toml