### PR TITLE
Fallback to GITHUB_RUN_NUMBER if RELEASEACTION_PREVRELEASE is unset

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -7,9 +7,9 @@ on:
       - 'gh-readonly-queue/**'
     paths-ignore:
       - '.github/ISSUE_TEMPLATE/*.yml'
-      - '.github/actions/workflows/build-remote.yml'
-      - '.github/actions/workflows/preview.yml'
-      - '.github/actions/workflows/pull-request.yml'
+      - '.github/workflows/build-remote.yml'
+      - '.github/workflows/preview.yml'
+      - '.github/workflows/pull-request.yml'
       - '.idea/copyright/*.xml'
       - '.gitignore'
       - 'CONTRIBUTING.md'
@@ -29,7 +29,7 @@ jobs:
           BUILD_JSON: ${{ vars.RELEASEACTION_PREVRELEASE }}
         run: |
           BUILD_NUMBER=$(echo $BUILD_JSON | jq --arg branch "${GITHUB_REF_NAME}" 'if .[$branch] == null then 1 else .[$branch] | .t | tonumber + 1 end // 1')
-          echo "BUILD_NUMBER=${BUILD_NUMBER}" >> $GITHUB_ENV
+          echo "BUILD_NUMBER=${BUILD_NUMBER:=$GITHUB_RUN_NUMBER}" >> $GITHUB_ENV
 
       - name: Checkout repository and submodules
         # See https://github.com/actions/checkout/commits


### PR DESCRIPTION
This is so there is still a build number when built on other repositories.