### PR TITLE
Add ServerCustomPayloadEvent

### DIFF
--- a/api/src/main/java/org/geysermc/geyser/api/event/java/GeyserCustomPayloadEvent.java
+++ b/api/src/main/java/org/geysermc/geyser/api/event/java/GeyserCustomPayloadEvent.java
@@ -1,0 +1,66 @@
+/*
+ * Copyright (c) 2019-2024 GeyserMC. http://geysermc.org
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ *
+ * @author GeyserMC
+ * @link https://github.com/GeyserMC/Geyser
+ */
+
+package org.geysermc.geyser.api.event.java;
+
+import org.checkerframework.checker.nullness.qual.NonNull;
+import org.geysermc.geyser.api.connection.GeyserConnection;
+import org.geysermc.geyser.api.event.connection.ConnectionEvent;
+
+/**
+ * Called when the java server sends a custom payload to geyser.
+ * An extension/addon can use this event to translate this.
+ * This event is not called when a built-in supported custom payload
+ * such as floodgate is received.
+ */
+public class GeyserCustomPayloadEvent extends ConnectionEvent {
+
+    private final String channel;
+    private final byte[] data;
+
+    public GeyserCustomPayloadEvent(@NonNull GeyserConnection connection, @NonNull String channel, byte[] data) {
+        super(connection);
+        this.channel = channel;
+        this.data = data;
+    }
+
+    /**
+     * The channel that sent this custom payload.
+     * A channel would look something like this:
+     * <code>minecraft:register</code>.
+     * @return the channel that sent this custom payload.
+     */
+    public @NonNull String getChannel() {
+        return channel;
+    }
+
+    /**
+     * The data field of the custom payload.
+     * @return the data field of the custom payload.
+     */
+    public byte[] getData() {
+        return data;
+    }
+}

--- a/api/src/main/java/org/geysermc/geyser/api/event/java/ServerCustomPayloadEvent.java
+++ b/api/src/main/java/org/geysermc/geyser/api/event/java/ServerCustomPayloadEvent.java
@@ -35,12 +35,12 @@ import org.geysermc.geyser.api.event.connection.ConnectionEvent;
  * This event is not called when a built-in supported custom payload
  * such as floodgate is received.
  */
-public class GeyserCustomPayloadEvent extends ConnectionEvent {
+public class ServerCustomPayloadEvent extends ConnectionEvent {
 
     private final String channel;
     private final byte[] data;
 
-    public GeyserCustomPayloadEvent(@NonNull GeyserConnection connection, @NonNull String channel, byte[] data) {
+    public ServerCustomPayloadEvent(@NonNull GeyserConnection connection, @NonNull String channel, byte[] data) {
         super(connection);
         this.channel = channel;
         this.data = data;

--- a/api/src/main/java/org/geysermc/geyser/api/event/java/ServerCustomPayloadEvent.java
+++ b/api/src/main/java/org/geysermc/geyser/api/event/java/ServerCustomPayloadEvent.java
@@ -31,7 +31,6 @@ import org.geysermc.geyser.api.event.connection.ConnectionEvent;
 
 /**
  * Called when the Java server sends a custom payload to Geyser.
- * An extension/addon can use this event to translate this.
  * This event is not called when a built-in supported custom payload
  * such as floodgate is received.
  */

--- a/api/src/main/java/org/geysermc/geyser/api/event/java/ServerCustomPayloadEvent.java
+++ b/api/src/main/java/org/geysermc/geyser/api/event/java/ServerCustomPayloadEvent.java
@@ -32,7 +32,7 @@ import org.geysermc.geyser.api.event.connection.ConnectionEvent;
 /**
  * Called when the Java server sends a custom payload to Geyser.
  * This event is not called when a built-in supported custom payload
- * such as floodgate is received.
+ * such as Floodgate is received.
  */
 public class ServerCustomPayloadEvent extends ConnectionEvent {
 
@@ -51,7 +51,7 @@ public class ServerCustomPayloadEvent extends ConnectionEvent {
      * <code>minecraft:register</code>.
      * @return the channel that sent this custom payload.
      */
-    public @NonNull String getChannel() {
+    public @NonNull String channel() {
         return channel;
     }
 
@@ -59,7 +59,7 @@ public class ServerCustomPayloadEvent extends ConnectionEvent {
      * The data field of the custom payload.
      * @return the data field of the custom payload.
      */
-    public byte[] getData() {
+    public byte[] data() {
         return data;
     }
 }

--- a/api/src/main/java/org/geysermc/geyser/api/event/java/ServerCustomPayloadEvent.java
+++ b/api/src/main/java/org/geysermc/geyser/api/event/java/ServerCustomPayloadEvent.java
@@ -31,7 +31,7 @@ import org.geysermc.geyser.api.event.connection.ConnectionEvent;
 
 /**
  * Called when the Java server sends a custom payload to Geyser.
- * This event is not called when a built-in supported custom payload
+ * This event is not called when a built-in custom payload
  * such as Floodgate is received.
  */
 public class ServerCustomPayloadEvent extends ConnectionEvent {

--- a/api/src/main/java/org/geysermc/geyser/api/event/java/ServerCustomPayloadEvent.java
+++ b/api/src/main/java/org/geysermc/geyser/api/event/java/ServerCustomPayloadEvent.java
@@ -30,7 +30,7 @@ import org.geysermc.geyser.api.connection.GeyserConnection;
 import org.geysermc.geyser.api.event.connection.ConnectionEvent;
 
 /**
- * Called when the java server sends a custom payload to geyser.
+ * Called when the Java server sends a custom payload to Geyser.
  * An extension/addon can use this event to translate this.
  * This event is not called when a built-in supported custom payload
  * such as floodgate is received.

--- a/core/src/main/java/org/geysermc/geyser/translator/protocol/java/JavaCustomPayloadTranslator.java
+++ b/core/src/main/java/org/geysermc/geyser/translator/protocol/java/JavaCustomPayloadTranslator.java
@@ -141,9 +141,7 @@ public class JavaCustomPayloadTranslator extends PacketTranslator<ClientboundCus
             });
         } else {
             var eventBus = session.getGeyser().eventBus();
-
-            var event = new ServerCustomPayloadEvent(session, channel, packet.getData());
-            eventBus.fire(event);
+            eventBus.fire(new ServerCustomPayloadEvent(session, channel, packet.getData()));
         }
     }
 

--- a/core/src/main/java/org/geysermc/geyser/translator/protocol/java/JavaCustomPayloadTranslator.java
+++ b/core/src/main/java/org/geysermc/geyser/translator/protocol/java/JavaCustomPayloadTranslator.java
@@ -42,6 +42,7 @@ import org.geysermc.erosion.packet.geyserbound.GeyserboundPacket;
 import org.geysermc.floodgate.pluginmessage.PluginMessageChannels;
 import org.geysermc.geyser.GeyserImpl;
 import org.geysermc.geyser.GeyserLogger;
+import org.geysermc.geyser.api.event.EventBus;
 import org.geysermc.geyser.api.event.java.ServerCustomPayloadEvent;
 import org.geysermc.geyser.session.GeyserSession;
 import org.geysermc.geyser.translator.protocol.PacketTranslator;
@@ -140,7 +141,7 @@ public class JavaCustomPayloadTranslator extends PacketTranslator<ClientboundCus
                 session.sendUpstreamPacket(toSend);
             });
         } else {
-            var eventBus = session.getGeyser().eventBus();
+            EventBus eventBus = session.getGeyser().eventBus();
             eventBus.fire(new ServerCustomPayloadEvent(session, channel, packet.getData()));
         }
     }

--- a/core/src/main/java/org/geysermc/geyser/translator/protocol/java/JavaCustomPayloadTranslator.java
+++ b/core/src/main/java/org/geysermc/geyser/translator/protocol/java/JavaCustomPayloadTranslator.java
@@ -141,8 +141,10 @@ public class JavaCustomPayloadTranslator extends PacketTranslator<ClientboundCus
                 session.sendUpstreamPacket(toSend);
             });
         } else {
-            EventBus eventBus = session.getGeyser().eventBus();
-            eventBus.fire(new ServerCustomPayloadEvent(session, channel, packet.getData()));
+            session.ensureInEventLoop(() -> {
+                EventBus eventBus = session.getGeyser().eventBus();
+                eventBus.fire(new ServerCustomPayloadEvent(session, channel, packet.getData()));
+            });
         }
     }
 

--- a/core/src/main/java/org/geysermc/geyser/translator/protocol/java/JavaCustomPayloadTranslator.java
+++ b/core/src/main/java/org/geysermc/geyser/translator/protocol/java/JavaCustomPayloadTranslator.java
@@ -42,7 +42,7 @@ import org.geysermc.erosion.packet.geyserbound.GeyserboundPacket;
 import org.geysermc.floodgate.pluginmessage.PluginMessageChannels;
 import org.geysermc.geyser.GeyserImpl;
 import org.geysermc.geyser.GeyserLogger;
-import org.geysermc.geyser.api.event.java.GeyserCustomPayloadEvent;
+import org.geysermc.geyser.api.event.java.ServerCustomPayloadEvent;
 import org.geysermc.geyser.session.GeyserSession;
 import org.geysermc.geyser.translator.protocol.PacketTranslator;
 import org.geysermc.geyser.translator.protocol.Translator;
@@ -142,7 +142,7 @@ public class JavaCustomPayloadTranslator extends PacketTranslator<ClientboundCus
         } else {
             var eventBus = session.getGeyser().eventBus();
 
-            var event = new GeyserCustomPayloadEvent(session, channel, packet.getData());
+            var event = new ServerCustomPayloadEvent(session, channel, packet.getData());
             eventBus.fire(event);
         }
     }

--- a/core/src/main/java/org/geysermc/geyser/translator/protocol/java/JavaCustomPayloadTranslator.java
+++ b/core/src/main/java/org/geysermc/geyser/translator/protocol/java/JavaCustomPayloadTranslator.java
@@ -42,6 +42,7 @@ import org.geysermc.erosion.packet.geyserbound.GeyserboundPacket;
 import org.geysermc.floodgate.pluginmessage.PluginMessageChannels;
 import org.geysermc.geyser.GeyserImpl;
 import org.geysermc.geyser.GeyserLogger;
+import org.geysermc.geyser.api.event.java.GeyserCustomPayloadEvent;
 import org.geysermc.geyser.session.GeyserSession;
 import org.geysermc.geyser.translator.protocol.PacketTranslator;
 import org.geysermc.geyser.translator.protocol.Translator;
@@ -138,6 +139,11 @@ public class JavaCustomPayloadTranslator extends PacketTranslator<ClientboundCus
 
                 session.sendUpstreamPacket(toSend);
             });
+        } else {
+            var eventBus = session.getGeyser().eventBus();
+
+            var event = new GeyserCustomPayloadEvent(session, channel, packet.getData());
+            eventBus.fire(event);
         }
     }
 


### PR DESCRIPTION
This pull request adds `ServerCustomPayloadEvent` to the plugin's API. This allows extensions/addons to understand some special custom payloads (also known as plugin messages) and act accordingly. This event is not called when floodgate custom payloads are received.