### PR TITLE
Add system property Geyser.RakSendCookie to allow disabling cookie send

### DIFF
--- a/core/src/main/java/org/geysermc/geyser/network/netty/GeyserServer.java
+++ b/core/src/main/java/org/geysermc/geyser/network/netty/GeyserServer.java
@@ -228,6 +228,9 @@ public final class GeyserServer {
         int rakGlobalPacketLimit = positivePropOrDefault("Geyser.RakGlobalPacketLimit", DEFAULT_GLOBAL_PACKET_LIMIT);
         this.geyser.getLogger().debug("Setting RakNet global packet limit to " + rakGlobalPacketLimit);
 
+        boolean rakSendCookie = Boolean.parseBoolean(System.getProperty("Geyser.RakSendCookie", "true"));
+        this.geyser.getLogger().debug("Setting RakNet send cookie to " + rakSendCookie);
+
         return new ServerBootstrap()
                 .channelFactory(RakChannelFactory.server(TRANSPORT.datagramChannel()))
                 .group(group, childGroup)
@@ -235,7 +238,7 @@ public final class GeyserServer {
                 .option(RakChannelOption.RAK_MAX_MTU, this.geyser.getConfig().getMtu())
                 .option(RakChannelOption.RAK_PACKET_LIMIT, rakPacketLimit)
                 .option(RakChannelOption.RAK_GLOBAL_PACKET_LIMIT, rakGlobalPacketLimit)
-                .option(RakChannelOption.RAK_SEND_COOKIE, true)
+                .option(RakChannelOption.RAK_SEND_COOKIE, rakSendCookie)
                 .childHandler(serverInitializer);
     }
 


### PR DESCRIPTION
Adds the system property Geyser.RakSendCookie to allow disabling of sending RakNet cookies in environments where it is not supported (e.g. running Geyser behind an older bedrock proxy).

This is meant as a temporary mitigation as we would rather bedrock proxies update to support this. Ideally, this should not be set to `false` unless Geyser is running behind a reverse proxy that is also sending a challenge to prevent IP spoofing.