### PR TITLE
Update ViaVersion api usage to be compatible with ViaVersion 4.10

### DIFF
--- a/bootstrap/spigot/src/main/java/org/geysermc/geyser/platform/spigot/world/manager/GeyserSpigotLegacyNativeWorldManager.java
+++ b/bootstrap/spigot/src/main/java/org/geysermc/geyser/platform/spigot/world/manager/GeyserSpigotLegacyNativeWorldManager.java
@@ -58,7 +58,7 @@ public class GeyserSpigotLegacyNativeWorldManager extends GeyserSpigotNativeWorl
             int newBlockId = oldBlockId;
             // protocolList should *not* be null; we checked for that before initializing this class
             for (int i = protocolList.size() - 1; i >= 0; i--) {
-                MappingData mappingData = protocolList.get(i).getProtocol().getMappingData();
+                MappingData mappingData = protocolList.get(i).protocol().getMappingData();
                 if (mappingData != null) {
                     newBlockId = mappingData.getNewBlockStateId(newBlockId);
                 }


### PR DESCRIPTION
Currently, running e.g. Geyser-Spigot on Paper 1.20.2 results in:

```
[15:53:58 INFO]: [Template] Enabling Template v1.0.0
[15:53:58 INFO]: [Geyser-Spigot] Enabling Geyser-Spigot v2.2.3-SNAPSHOT
[15:54:02 INFO]: [Geyser-Spigot] ******************************************
[15:54:02 INFO]: [Geyser-Spigot]
[15:54:02 INFO]: [Geyser-Spigot] Loading Geyser version 2.2.3-SNAPSHOT (git-master-2471de1)
[15:54:02 INFO]: [Geyser-Spigot]
[15:54:02 INFO]: [Geyser-Spigot] ******************************************
[15:54:02 INFO]: [Geyser-Spigot] Started Geyser on :::19132
[15:54:02 INFO]: [Geyser-Spigot] [pickpack] Loaded 0 default packs!
[15:54:02 INFO]: [Geyser-Spigot] [pickpack] Loaded 0 optional packs!
[15:54:02 INFO]: [Geyser-Spigot] [pickpack] PickPack extension loaded!
[15:54:02 INFO]: [Geyser-Spigot] Done (0.249s)! Run /geyser help for help!
[15:54:02 ERROR]: Could not pass event ServerLoadEvent to Geyser-Spigot v2.2.3-SNAPSHOT
java.lang.NoSuchMethodError: 'com.viaversion.viaversion.api.protocol.Protocol com.viaversion.viaversion.api.protocol.ProtocolPathEntry.getProtocol()'
        at org.geysermc.geyser.platform.spigot.world.manager.GeyserSpigotLegacyNativeWorldManager.<init>(GeyserSpigotLegacyNativeWorldManager.java:61) ~[Geyser-Spigot.jar:?]
        at org.geysermc.geyser.platform.spigot.GeyserSpigotPlugin.onGeyserEnable(GeyserSpigotPlugin.java:251) ~[Geyser-Spigot.jar:?]
        at org.geysermc.geyser.platform.spigot.GeyserSpigotPlugin$1.onServerLoaded(GeyserSpigotPlugin.java:198) ~[Geyser-Spigot.jar:?]
        at com.destroystokyo.paper.event.executor.MethodHandleEventExecutor.execute(MethodHandleEventExecutor.java:40) ~[paper-api-1.20.2-R0.1-SNAPSHOT.jar:?]
        at co.aikar.timings.TimedEventExecutor.execute(TimedEventExecutor.java:81) ~[paper-api-1.20.2-R0.1-SNAPSHOT.jar:git-Paper-217]
        at org.bukkit.plugin.RegisteredListener.callEvent(RegisteredListener.java:70) ~[paper-api-1.20.2-R0.1-SNAPSHOT.jar:?]
        at io.papermc.paper.plugin.manager.PaperEventManager.callEvent(PaperEventManager.java:54) ~[paper-1.20.2.jar:git-Paper-217]
        at io.papermc.paper.plugin.manager.PaperPluginManagerImpl.callEvent(PaperPluginManagerImpl.java:126) ~[paper-1.20.2.jar:git-Paper-217]
        at org.bukkit.plugin.SimplePluginManager.callEvent(SimplePluginManager.java:615) ~[paper-api-1.20.2-R0.1-SNAPSHOT.jar:?]
        at net.minecraft.server.MinecraftServer.loadWorld0(MinecraftServer.java:628) ~[paper-1.20.2.jar:git-Paper-217]
        at net.minecraft.server.MinecraftServer.loadLevel(MinecraftServer.java:424) ~[paper-1.20.2.jar:git-Paper-217]
        at net.minecraft.server.dedicated.DedicatedServer.initServer(DedicatedServer.java:308) ~[paper-1.20.2.jar:git-Paper-217]
        at net.minecraft.server.MinecraftServer.runServer(MinecraftServer.java:1086) ~[paper-1.20.2.jar:git-Paper-217]
        at net.minecraft.server.MinecraftServer.lambda$spin$0(MinecraftServer.java:315) ~[paper-1.20.2.jar:git-Paper-217]
        at java.lang.Thread.run(Thread.java:1583) ~[?:?]
[15:54:02 INFO]: Running delayed init tasks
[15:54:02 INFO]: [ViaVersion] Finished mapping loading,
```