### PR TITLE
Ensure proper Geyser starting/disabling when Geyser is used on a client

### DIFF
--- a/bootstrap/mod/fabric/src/main/java/org/geysermc/geyser/platform/fabric/GeyserFabricBootstrap.java
+++ b/bootstrap/mod/fabric/src/main/java/org/geysermc/geyser/platform/fabric/GeyserFabricBootstrap.java
@@ -46,7 +46,7 @@ public class GeyserFabricBootstrap extends GeyserModBootstrap implements ModInit
 
     @Override
     public void onInitialize() {
-        if (FabricLoader.getInstance().getEnvironmentType() == EnvType.SERVER) {
+        if (isServer()) {
             // Set as an event, so we can get the proper IP and port if needed
             ServerLifecycleEvents.SERVER_STARTED.register((server) -> {
                 this.setServer(server);
@@ -60,7 +60,7 @@ public class GeyserFabricBootstrap extends GeyserModBootstrap implements ModInit
 
         // These are only registered once
         ServerLifecycleEvents.SERVER_STOPPING.register((server) -> {
-            if (FabricLoader.getInstance().getEnvironmentType() == EnvType.SERVER) {
+            if (isServer()) {
                 onGeyserShutdown();
             } else {
                 onGeyserDisable();
@@ -70,6 +70,11 @@ public class GeyserFabricBootstrap extends GeyserModBootstrap implements ModInit
         ServerPlayConnectionEvents.JOIN.register((handler, $, $$) -> GeyserModUpdateListener.onPlayReady(handler.getPlayer()));
 
         this.onGeyserInitialize();
+    }
+
+    @Override
+    public boolean isServer() {
+        return FabricLoader.getInstance().getEnvironmentType().equals(EnvType.SERVER);
     }
 
     @Override

--- a/bootstrap/mod/neoforge/src/main/java/org/geysermc/geyser/platform/neoforge/GeyserNeoForgeBootstrap.java
+++ b/bootstrap/mod/neoforge/src/main/java/org/geysermc/geyser/platform/neoforge/GeyserNeoForgeBootstrap.java
@@ -27,7 +27,6 @@ package org.geysermc.geyser.platform.neoforge;
 
 import net.minecraft.commands.CommandSourceStack;
 import net.minecraft.world.entity.player.Player;
-import net.neoforged.api.distmarker.Dist;
 import net.neoforged.fml.common.Mod;
 import net.neoforged.fml.loading.FMLLoader;
 import net.neoforged.neoforge.common.NeoForge;
@@ -47,7 +46,7 @@ public class GeyserNeoForgeBootstrap extends GeyserModBootstrap {
     public GeyserNeoForgeBootstrap() {
         super(new GeyserNeoForgePlatform());
 
-        if (FMLLoader.getDist() == Dist.DEDICATED_SERVER) {
+        if (isServer()) {
             // Set as an event so we can get the proper IP and port if needed
             NeoForge.EVENT_BUS.addListener(this::onServerStarted);
         } else {
@@ -67,7 +66,7 @@ public class GeyserNeoForgeBootstrap extends GeyserModBootstrap {
     }
 
     private void onServerStopping(ServerStoppingEvent event) {
-        if (FMLLoader.getDist() == Dist.DEDICATED_SERVER) {
+        if (isServer()) {
             this.onGeyserShutdown();
         } else {
             this.onGeyserDisable();
@@ -80,6 +79,11 @@ public class GeyserNeoForgeBootstrap extends GeyserModBootstrap {
 
     private void onPlayerJoin(PlayerEvent.PlayerLoggedInEvent event) {
         GeyserModUpdateListener.onPlayReady(event.getEntity());
+    }
+
+    @Override
+    public boolean isServer() {
+        return FMLLoader.getDist().isDedicatedServer();
     }
 
     @Override

--- a/bootstrap/mod/neoforge/src/main/java/org/geysermc/geyser/platform/neoforge/GeyserNeoForgeBootstrap.java
+++ b/bootstrap/mod/neoforge/src/main/java/org/geysermc/geyser/platform/neoforge/GeyserNeoForgeBootstrap.java
@@ -31,6 +31,7 @@ import net.neoforged.api.distmarker.Dist;
 import net.neoforged.fml.common.Mod;
 import net.neoforged.fml.loading.FMLLoader;
 import net.neoforged.neoforge.common.NeoForge;
+import net.neoforged.neoforge.event.GameShuttingDownEvent;
 import net.neoforged.neoforge.event.entity.player.PlayerEvent;
 import net.neoforged.neoforge.event.server.ServerStartedEvent;
 import net.neoforged.neoforge.event.server.ServerStoppingEvent;
@@ -49,6 +50,8 @@ public class GeyserNeoForgeBootstrap extends GeyserModBootstrap {
         if (FMLLoader.getDist() == Dist.DEDICATED_SERVER) {
             // Set as an event so we can get the proper IP and port if needed
             NeoForge.EVENT_BUS.addListener(this::onServerStarted);
+        } else {
+            NeoForge.EVENT_BUS.addListener(this::onClientStopping);
         }
 
         NeoForge.EVENT_BUS.addListener(this::onServerStopping);
@@ -64,6 +67,14 @@ public class GeyserNeoForgeBootstrap extends GeyserModBootstrap {
     }
 
     private void onServerStopping(ServerStoppingEvent event) {
+        if (FMLLoader.getDist() == Dist.DEDICATED_SERVER) {
+            this.onGeyserShutdown();
+        } else {
+            this.onGeyserDisable();
+        }
+    }
+
+    private void onClientStopping(GameShuttingDownEvent ignored) {
         this.onGeyserShutdown();
     }
 

--- a/bootstrap/mod/src/main/java/org/geysermc/geyser/platform/mod/GeyserModBootstrap.java
+++ b/bootstrap/mod/src/main/java/org/geysermc/geyser/platform/mod/GeyserModBootstrap.java
@@ -58,6 +58,7 @@ import org.geysermc.geyser.util.FileUtils;
 import java.io.File;
 import java.io.IOException;
 import java.io.InputStream;
+import java.net.SocketAddress;
 import java.nio.file.Path;
 import java.util.Map;
 import java.util.UUID;
@@ -127,7 +128,9 @@ public abstract class GeyserModBootstrap implements GeyserBootstrap {
         // We want to do this late in the server startup process to allow other mods
         // To do their job injecting, then connect into *that*
         this.geyserInjector = new GeyserModInjector(server, this.platform);
-        this.geyserInjector.initializeLocalChannel(this);
+        if (isServer()) {
+            this.geyserInjector.initializeLocalChannel(this);
+        }
 
         // Start command building
         // Set just "geyser" as the help command
@@ -242,7 +245,19 @@ public abstract class GeyserModBootstrap implements GeyserBootstrap {
 
     @Override
     public int getServerPort() {
-        return ((GeyserServerPortGetter) server).geyser$getServerPort();
+        if (isServer()) {
+            return ((GeyserServerPortGetter) server).geyser$getServerPort();
+        } else {
+            // Set in the IntegratedServerMixin
+            return geyserConfig.getRemote().port();
+        }
+    }
+
+    public abstract boolean isServer();
+
+    @Override
+    public @Nullable SocketAddress getSocketAddress() {
+        return this.geyserInjector.getServerSocketAddress();
     }
 
     @Override

--- a/bootstrap/mod/src/main/java/org/geysermc/geyser/platform/mod/mixin/client/IntegratedServerMixin.java
+++ b/bootstrap/mod/src/main/java/org/geysermc/geyser/platform/mod/mixin/client/IntegratedServerMixin.java
@@ -54,8 +54,10 @@ public class IntegratedServerMixin implements GeyserServerPortGetter {
     private void onOpenToLan(GameType gameType, boolean cheatsAllowed, int port, CallbackInfoReturnable<Boolean> cir) {
         if (cir.getReturnValueZ()) {
             // If the LAN is opened, starts Geyser.
-            GeyserModBootstrap.getInstance().setServer((MinecraftServer) (Object) this);
-            GeyserModBootstrap.getInstance().onGeyserEnable();
+            GeyserModBootstrap instance = GeyserModBootstrap.getInstance();
+            instance.setServer((MinecraftServer) (Object) this);
+            instance.getGeyserConfig().getRemote().setPort(port);
+            instance.onGeyserEnable();
             // Ensure player locale has been loaded, in case it's different from Java system language
             GeyserLocale.loadGeyserLocale(this.minecraft.options.languageCode);
             // Give indication that Geyser is loaded


### PR DESCRIPTION
Essentially, we were treating `ServerLifecycleEvents.SERVER_STOPPING` as the event to shutdown Geyser on. While true for servers, the client will call this event multiple times.

Hence, this ensures that we only shut down Geyser when the client is being shut down, and otherwise disable Geyser instead.