### PR TITLE
Fix discarding of custom trim patterns/materials

### DIFF
--- a/core/src/main/java/org/geysermc/geyser/inventory/recipe/TrimRecipe.java
+++ b/core/src/main/java/org/geysermc/geyser/inventory/recipe/TrimRecipe.java
@@ -47,7 +47,7 @@ public final class TrimRecipe {
     public static final ItemDescriptorWithCount TEMPLATE = tagDescriptor("minecraft:trim_templates");
 
     public static TrimMaterial readTrimMaterial(GeyserSession session, RegistryEntry entry) {
-        String key = stripNamespace(entry.getId());
+        String key = stripMinecraftNamespace(entry.getId());
 
         // Color is used when hovering over the item
         // Find the nearest legacy color from the RGB Java gives us to work with
@@ -67,7 +67,7 @@ public final class TrimRecipe {
     }
 
     public static TrimPattern readTrimPattern(GeyserSession session, RegistryEntry entry) {
-        String key = stripNamespace(entry.getId());
+        String key = stripMinecraftNamespace(entry.getId());
 
         String itemIdentifier = entry.getData().getString("template_item");
         ItemMapping itemMapping = session.getItemMappings().getMapping(itemIdentifier);
@@ -79,7 +79,7 @@ public final class TrimRecipe {
     }
 
     // TODO find a good place for a stripNamespace util method
-    private static String stripNamespace(String identifier) {
+    private static String stripMinecraftNamespace(String identifier) {
         int i = identifier.indexOf(':');
         if (i >= 0) {
             String namespace = identifier.substring(0, i);

--- a/core/src/main/java/org/geysermc/geyser/inventory/recipe/TrimRecipe.java
+++ b/core/src/main/java/org/geysermc/geyser/inventory/recipe/TrimRecipe.java
@@ -82,7 +82,11 @@ public final class TrimRecipe {
     private static String stripNamespace(String identifier) {
         int i = identifier.indexOf(':');
         if (i >= 0) {
-            return identifier.substring(i + 1);
+            String namespace = identifier.substring(0, i);
+            // Only strip minecraft namespace
+            if (namespace.equals("minecraft")) {
+                return identifier.substring(i + 1);
+            }
         }
         return identifier;
     }

--- a/core/src/main/java/org/geysermc/geyser/item/type/ArmorItem.java
+++ b/core/src/main/java/org/geysermc/geyser/item/type/ArmorItem.java
@@ -51,13 +51,14 @@ public class ArmorItem extends Item {
 
         ArmorTrim trim = components.get(DataComponentType.TRIM);
         if (trim != null) {
-            // discard custom trim patterns/materials to prevent visual glitches on bedrock
-            if (trim.material().isCustom() || trim.pattern().isCustom()) {
-                return;
-            }
-
             TrimMaterial material = session.getRegistryCache().trimMaterials().byId(trim.material().id());
             TrimPattern pattern = session.getRegistryCache().trimPatterns().byId(trim.pattern().id());
+
+            // discard custom trim patterns/materials to prevent visual glitches on bedrock
+            if (!getNamespace(material.getMaterialId()).equals("minecraft")
+                    || !getNamespace(pattern.getPatternId()).equals("minecraft")) {
+                return;
+            }
 
             NbtMapBuilder trimBuilder = NbtMap.builder();
             // bedrock has an uppercase first letter key, and the value is not namespaced
@@ -70,5 +71,14 @@ public class ArmorItem extends Item {
     @Override
     public boolean isValidRepairItem(Item other) {
         return material.getRepairIngredient() == other;
+    }
+
+    // TODO maybe some kind of namespace util?
+    private static String getNamespace(String identifier) {
+        int i = identifier.indexOf(':');
+        if (i >= 0) {
+            return identifier.substring(0, i);
+        }
+        return "minecraft";
     }
 }


### PR DESCRIPTION
This PR fixes discarding of custom trim patterns/materials by checking for the namespace of the trim pattern/material and discarding it if the namespace is not `minecraft`.

Previously, the `Holder#isCustom` method was used, but this doesn't work since the Minecraft server sends the trim patterns and materials registries to the client and then sends holders with int IDs instead of direct objects.

Note: I added a `getNamespace(String identifier)` method to the `ArmorItem` class. I'm not sure if there's already a similar method available, or if there's a better class it should go in, please do let me know.