### PR TITLE
Map new Mace enchantments for Bedrock clients

### DIFF
--- a/core/src/main/java/org/geysermc/geyser/item/type/Item.java
+++ b/core/src/main/java/org/geysermc/geyser/item/type/Item.java
@@ -228,7 +228,23 @@ public class Item {
         // TODO streamline Enchantment process
         Enchantment.JavaEnchantment enchantment = Enchantment.JavaEnchantment.of(enchantId);
         if (enchantment == Enchantment.JavaEnchantment.SWEEPING_EDGE) {
-            addSweeping(session, builder, level);
+            String sweepingTranslation = MinecraftLocale.getLocaleString("enchantment.minecraft.sweeping", session.locale());
+            addJavaOnlyEnchantment(session, builder, sweepingTranslation, level);
+            return null;
+        }
+        if (enchantment == Enchantment.JavaEnchantment.DENSITY) {
+            String densityTranslation = MinecraftLocale.getLocaleString("enchantment.minecraft.density", session.locale());
+            addJavaOnlyEnchantment(session, builder, densityTranslation, level);
+            return null;
+        }
+        if (enchantment == Enchantment.JavaEnchantment.BREACH) {
+            String breachTranslation = MinecraftLocale.getLocaleString("enchantment.minecraft.breach", session.locale());
+            addJavaOnlyEnchantment(session, builder, breachTranslation, level);
+            return null;
+        }
+        if (enchantment == Enchantment.JavaEnchantment.WIND_BURST) {
+            String windBurstTranslation = MinecraftLocale.getLocaleString("enchantment.minecraft.wind_burst", session.locale());
+            addJavaOnlyEnchantment(session, builder, windBurstTranslation, level);
             return null;
         }
         if (enchantment == null) {
@@ -242,11 +258,10 @@ public class Item {
                 .build();
     }
 
-    private void addSweeping(GeyserSession session, BedrockItemBuilder builder, int level) {
-        String sweepingTranslation = MinecraftLocale.getLocaleString("enchantment.minecraft.sweeping", session.locale());
+    private void addJavaOnlyEnchantment(GeyserSession session, BedrockItemBuilder builder, String enchantmentName, int level) {
         String lvlTranslation = MinecraftLocale.getLocaleString("enchantment.level." + level, session.locale());
 
-        builder.getOrCreateLore().add(ChatColor.RESET + ChatColor.GRAY + sweepingTranslation + " " + lvlTranslation);
+        builder.getOrCreateLore().add(ChatColor.RESET + ChatColor.GRAY + enchantmentName + " " + lvlTranslation);
     }
 
     /* Translation methods end */

--- a/core/src/main/java/org/geysermc/geyser/item/type/Item.java
+++ b/core/src/main/java/org/geysermc/geyser/item/type/Item.java
@@ -53,6 +53,16 @@ import java.util.List;
 import java.util.Map;
 
 public class Item {
+    /**
+     * This is a map from Java-only enchantments to their translation keys so that we can
+     * map these enchantments to Bedrock clients, since they don't actually exist there.
+     */
+    private static final Map<Enchantment.JavaEnchantment, String> ENCHANTMENT_TRANSLATION_KEYS = Map.of(
+            Enchantment.JavaEnchantment.SWEEPING_EDGE, "enchantment.minecraft.sweeping",
+            Enchantment.JavaEnchantment.DENSITY, "enchantment.minecraft.density",
+            Enchantment.JavaEnchantment.BREACH, "enchantment.minecraft.breach",
+            Enchantment.JavaEnchantment.WIND_BURST, "enchantment.minecraft.wind_burst");
+
     private final String javaIdentifier;
     private int javaId = -1;
     private final int stackSize;
@@ -227,25 +237,10 @@ public class Item {
         // TODO verify
         // TODO streamline Enchantment process
         Enchantment.JavaEnchantment enchantment = Enchantment.JavaEnchantment.of(enchantId);
-        if (enchantment == Enchantment.JavaEnchantment.SWEEPING_EDGE) {
-            String sweepingTranslation = MinecraftLocale.getLocaleString("enchantment.minecraft.sweeping", session.locale());
-            addJavaOnlyEnchantment(session, builder, sweepingTranslation, level);
-            return null;
-        }
-        if (enchantment == Enchantment.JavaEnchantment.DENSITY) {
-            String densityTranslation = MinecraftLocale.getLocaleString("enchantment.minecraft.density", session.locale());
-            addJavaOnlyEnchantment(session, builder, densityTranslation, level);
-            return null;
-        }
-        if (enchantment == Enchantment.JavaEnchantment.BREACH) {
-            String breachTranslation = MinecraftLocale.getLocaleString("enchantment.minecraft.breach", session.locale());
-            addJavaOnlyEnchantment(session, builder, breachTranslation, level);
-            return null;
-        }
-        if (enchantment == Enchantment.JavaEnchantment.WIND_BURST) {
-            String windBurstTranslation = MinecraftLocale.getLocaleString("enchantment.minecraft.wind_burst", session.locale());
-            addJavaOnlyEnchantment(session, builder, windBurstTranslation, level);
-            return null;
+        if (ENCHANTMENT_TRANSLATION_KEYS.containsKey(enchantment)) {
+            String translationKey = ENCHANTMENT_TRANSLATION_KEYS.get(enchantment);
+            String enchantmentTranslation = MinecraftLocale.getLocaleString(translationKey, session.locale());
+            addJavaOnlyEnchantment(session, builder, enchantmentTranslation, level);
         }
         if (enchantment == null) {
             GeyserImpl.getInstance().getLogger().debug("Unknown Java enchantment while NBT item translating: " + enchantId);

--- a/core/src/main/java/org/geysermc/geyser/item/type/Item.java
+++ b/core/src/main/java/org/geysermc/geyser/item/type/Item.java
@@ -237,10 +237,11 @@ public class Item {
         // TODO verify
         // TODO streamline Enchantment process
         Enchantment.JavaEnchantment enchantment = Enchantment.JavaEnchantment.of(enchantId);
-        if (ENCHANTMENT_TRANSLATION_KEYS.containsKey(enchantment)) {
-            String translationKey = ENCHANTMENT_TRANSLATION_KEYS.get(enchantment);
+        String translationKey = ENCHANTMENT_TRANSLATION_KEYS.get(enchantment);
+        if (translationKey != null) {
             String enchantmentTranslation = MinecraftLocale.getLocaleString(translationKey, session.locale());
             addJavaOnlyEnchantment(session, builder, enchantmentTranslation, level);
+            return null;
         }
         if (enchantment == null) {
             GeyserImpl.getInstance().getLogger().debug("Unknown Java enchantment while NBT item translating: " + enchantId);


### PR DESCRIPTION
This PR fixes the new Mace enchantments, Breach, Density and Wind Burst not being mapped to Bedrock clients, causing users to be unable to see the contents of their inventory.

Prior to this PR, this would get spammed in console whenever a Bedrock user had one of these enchantments in their inventory:
```
[16:00:18 WARN]: [Geyser-Spigot] Could not translate packet ClientboundContainerSetContentPacket
java.lang.IllegalArgumentException: No enum constant org.geysermc.geyser.inventory.item.Enchantment.WIND_BURST
        at java.base/java.lang.Enum.valueOf(Enum.java:293) ~[?:?]
        at Geyser-Spigot.jar/org.geysermc.geyser.inventory.item.Enchantment.valueOf(Enchantment.java:33) ~[Geyser-Spigot.jar:?]
        at Geyser-Spigot.jar/org.geysermc.geyser.item.type.Item.remapEnchantment(Item.java:240) ~[Geyser-Spigot.jar:?]
        at Geyser-Spigot.jar/org.geysermc.geyser.item.type.EnchantedBookItem.translateComponentsToBedrock(EnchantedBookItem.java:59) ~[Geyser-Spigot.jar:?]
        at Geyser-Spigot.jar/org.geysermc.geyser.translator.item.ItemTranslator.translateToBedrock(ItemTranslator.java:148) ~[Geyser-Spigot.jar:?]
        at Geyser-Spigot.jar/org.geysermc.geyser.translator.item.ItemTranslator.translateToBedrock(ItemTranslator.java:125) ~[Geyser-Spigot.jar:?]
        at Geyser-Spigot.jar/org.geysermc.geyser.inventory.GeyserItemStack.getItemData(GeyserItemStack.java:156) ~[Geyser-Spigot.jar:?]
        at Geyser-Spigot.jar/org.geysermc.geyser.translator.inventory.PlayerInventoryTranslator.updateInventory(PlayerInventoryTranslator.java:79) ~[Geyser-Spigot.jar:?]
        at Geyser-Spigot.jar/org.geysermc.geyser.translator.protocol.java.inventory.JavaContainerSetContentTranslator.updateInventory(JavaContainerSetContentTranslator.java:86) ~[Geyser-Spigot.jar:?]
        at Geyser-Spigot.jar/org.geysermc.geyser.translator.protocol.java.inventory.JavaContainerSetContentTranslator.translate(JavaContainerSetContentTranslator.java:70) ~[Geyser-Spigot.jar:?]
        at Geyser-Spigot.jar/org.geysermc.geyser.translator.protocol.java.inventory.JavaContainerSetContentTranslator.translate(JavaContainerSetContentTranslator.java:40) ~[Geyser-Spigot.jar:?]
        at Geyser-Spigot.jar/org.geysermc.geyser.registry.PacketTranslatorRegistry.translate0(PacketTranslatorRegistry.java:89) ~[Geyser-Spigot.jar:?]
        at Geyser-Spigot.jar/org.geysermc.geyser.registry.PacketTranslatorRegistry.lambda$translate$0(PacketTranslatorRegistry.java:69) ~[Geyser-Spigot.jar:?]
        at io.netty.util.concurrent.AbstractEventExecutor.runTask(AbstractEventExecutor.java:174) ~[netty-common-4.1.97.Final.jar:4.1.97.Final]
        at io.netty.channel.DefaultEventLoop.run(DefaultEventLoop.java:54) ~[netty-transport-4.1.97.Final.jar:4.1.97.Final]
        at io.netty.util.concurrent.SingleThreadEventExecutor$4.run(SingleThreadEventExecutor.java:997) ~[netty-common-4.1.97.Final.jar:4.1.97.Final]
        at io.netty.util.internal.ThreadExecutorMap$2.run(ThreadExecutorMap.java:74) ~[netty-common-4.1.97.Final.jar:4.1.97.Final]
        at io.netty.util.concurrent.FastThreadLocalRunnable.run(FastThreadLocalRunnable.java:30) ~[netty-common-4.1.97.Final.jar:4.1.97.Final]
        at java.base/java.lang.Thread.run(Thread.java:1583) ~[?:?]
```