### PR TITLE
Open advancement tab regardless of currently open tab

### DIFF
--- a/core/src/main/java/org/geysermc/geyser/session/cache/AdvancementsCache.java
+++ b/core/src/main/java/org/geysermc/geyser/session/cache/AdvancementsCache.java
@@ -91,15 +91,13 @@ public class AdvancementsCache {
         builder.validResultHandler((response) -> {
             String id = rootAdvancementIds.get(response.clickedButtonId());
             if (!id.equals("")) {
-                if (id.equals(currentAdvancementCategoryId)) {
-                    // The server thinks we are already on this tab
-                    buildAndShowListForm();
-                } else {
-                    // Send a packet indicating that we intend to open this particular advancement window
+                if (!id.equals(currentAdvancementCategoryId)) {
+                    // Send a packet indicating that we are opening this particular advancement window
                     ServerboundSeenAdvancementsPacket packet = new ServerboundSeenAdvancementsPacket(id);
                     session.sendDownstreamGamePacket(packet);
-                    // Wait for a response there
                 }
+                currentAdvancementCategoryId = id;
+                buildAndShowListForm();
             }
         });
 


### PR DESCRIPTION
The current behavior is that the form for the advancement only opens if the tab was already selected. The `currentAdvancementCategoryId` also never changed, so only the initial tab was openable. This fixes the logic by sending the (uncancellable) advancement tab switch packet when opening the tab, setting the `currentAdvancementCategoryId`, and opening the corresponding form.