### PR TITLE
Various entity fixes: Ensure TNT doesn't bug into the ground, reset player entity flags properly

### DIFF
--- a/core/src/main/java/org/geysermc/geyser/entity/EntityDefinitions.java
+++ b/core/src/main/java/org/geysermc/geyser/entity/EntityDefinitions.java
@@ -235,7 +235,7 @@ public final class EntityDefinitions {
                     .addTranslator(MetadataType.BOOLEAN,
                             (enderCrystalEntity, entityMetadata) -> enderCrystalEntity.setFlag(EntityFlag.SHOW_BOTTOM, ((BooleanEntityMetadata) entityMetadata).getPrimitiveValue())) // There is a base located on the ender crystal
                     .build();
-            EXPERIENCE_ORB = EntityDefinition.<ExpOrbEntity>inherited(null, entityBase)
+            EXPERIENCE_ORB = EntityDefinition.inherited(ExpOrbEntity::new, entityBase)
                     .type(EntityType.EXPERIENCE_ORB)
                     .identifier("minecraft:xp_orb")
                     .build();
@@ -297,6 +297,7 @@ public final class EntityDefinitions {
             TNT = EntityDefinition.inherited(TNTEntity::new, entityBase)
                     .type(EntityType.TNT)
                     .heightAndWidth(0.98f)
+                    .offset(0.49f)
                     .addTranslator(MetadataType.INT, TNTEntity::setFuseLength)
                     .build();
 

--- a/core/src/main/java/org/geysermc/geyser/entity/type/Entity.java
+++ b/core/src/main/java/org/geysermc/geyser/entity/type/Entity.java
@@ -59,6 +59,9 @@ import java.util.*;
 @Getter
 @Setter
 public class Entity implements GeyserEntity {
+
+    private static final boolean PRINT_ENTITY_SPAWN_DEBUG = Boolean.parseBoolean(System.getProperty("Geyser.PrintEntitySpawnDebug", "true"));
+
     protected final GeyserSession session;
 
     protected int entityId;
@@ -181,7 +184,7 @@ public class Entity implements GeyserEntity {
 
         flagsDirty = false;
 
-        if (session.getGeyser().getConfig().isDebugMode()) {
+        if (session.getGeyser().getConfig().isDebugMode() && PRINT_ENTITY_SPAWN_DEBUG) {
             EntityType type = definition.entityType();
             String name = type != null ? type.name() : getClass().getSimpleName();
             session.getGeyser().getLogger().debug("Spawned entity " + name + " at location " + position + " with id " + geyserId + " (java id " + entityId + ")");

--- a/core/src/main/java/org/geysermc/geyser/entity/type/Entity.java
+++ b/core/src/main/java/org/geysermc/geyser/entity/type/Entity.java
@@ -60,7 +60,7 @@ import java.util.*;
 @Setter
 public class Entity implements GeyserEntity {
 
-    private static final boolean PRINT_ENTITY_SPAWN_DEBUG = Boolean.parseBoolean(System.getProperty("Geyser.PrintEntitySpawnDebug", "true"));
+    private static final boolean PRINT_ENTITY_SPAWN_DEBUG = Boolean.parseBoolean(System.getProperty("Geyser.PrintEntitySpawnDebug", "false"));
 
     protected final GeyserSession session;
 

--- a/core/src/main/java/org/geysermc/geyser/entity/type/ExpOrbEntity.java
+++ b/core/src/main/java/org/geysermc/geyser/entity/type/ExpOrbEntity.java
@@ -27,10 +27,17 @@ package org.geysermc.geyser.entity.type;
 
 import org.cloudburstmc.math.vector.Vector3f;
 import org.cloudburstmc.protocol.bedrock.data.entity.EntityDataTypes;
+import org.geysermc.geyser.entity.EntityDefinition;
 import org.geysermc.geyser.entity.EntityDefinitions;
 import org.geysermc.geyser.session.GeyserSession;
 
+import java.util.UUID;
+
 public class ExpOrbEntity extends Entity {
+
+    public ExpOrbEntity(GeyserSession session, int entityId, long geyserId, UUID uuid, EntityDefinition<?> entityDefinition, Vector3f position, Vector3f motion, float yaw, float pitch, float headYaw) {
+        this(session, 1, entityId, geyserId, position);
+    }
 
     public ExpOrbEntity(GeyserSession session, int amount, int entityId, long geyserId, Vector3f position) {
         super(session, entityId, geyserId, null, EntityDefinitions.EXPERIENCE_ORB, position, Vector3f.ZERO, 0, 0, 0);

--- a/core/src/main/java/org/geysermc/geyser/entity/type/TNTEntity.java
+++ b/core/src/main/java/org/geysermc/geyser/entity/type/TNTEntity.java
@@ -39,7 +39,17 @@ public class TNTEntity extends Entity implements Tickable {
     private int currentTick;
 
     public TNTEntity(GeyserSession session, int entityId, long geyserId, UUID uuid, EntityDefinition<?> definition, Vector3f position, Vector3f motion, float yaw, float pitch, float headYaw) {
-        super(session, entityId, geyserId, uuid, definition, position, motion, yaw, pitch, headYaw);
+        super(session, entityId, geyserId, uuid, definition, position.add(0, definition.offset(), 0), motion, yaw, pitch, headYaw);
+    }
+
+    @Override
+    public void moveRelative(double relX, double relY, double relZ, float yaw, float pitch, boolean isOnGround) {
+        super.moveRelative(relX, relY + definition.offset(), relZ, yaw, pitch, isOnGround);
+    }
+
+    @Override
+    public void moveAbsolute(Vector3f position, float yaw, float pitch, float headYaw, boolean isOnGround, boolean teleported) {
+        super.moveAbsolute(position.add(Vector3f.from(0, definition.offset(), 0)), yaw, pitch, headYaw, isOnGround, teleported);
     }
 
     public void setFuseLength(IntEntityMetadata entityMetadata) {

--- a/core/src/main/java/org/geysermc/geyser/entity/type/player/PlayerEntity.java
+++ b/core/src/main/java/org/geysermc/geyser/entity/type/player/PlayerEntity.java
@@ -41,6 +41,7 @@ import org.cloudburstmc.protocol.bedrock.data.command.CommandPermission;
 import org.cloudburstmc.protocol.bedrock.data.entity.EntityDataTypes;
 import org.cloudburstmc.protocol.bedrock.data.entity.EntityFlag;
 import org.cloudburstmc.protocol.bedrock.data.entity.EntityLinkData;
+import org.cloudburstmc.protocol.bedrock.data.inventory.ItemData;
 import org.cloudburstmc.protocol.bedrock.packet.*;
 import org.geysermc.geyser.api.entity.type.player.GeyserPlayerEntity;
 import org.geysermc.geyser.entity.EntityDefinitions;
@@ -164,6 +165,31 @@ public class PlayerEntity extends LivingEntity implements GeyserPlayerEntity {
 
         valid = true;
         session.sendUpstreamPacket(addPlayerPacket);
+    }
+
+    @Override
+    public void despawnEntity() {
+        super.despawnEntity();
+
+        // Since we re-use player entities: Clear flags, held item, etc
+        this.resetMetadata();
+        this.hand = ItemData.AIR;
+        this.offhand = ItemData.AIR;
+        this.boots = ItemData.AIR;
+        this.leggings = ItemData.AIR;
+        this.chestplate = ItemData.AIR;
+        this.helmet = ItemData.AIR;
+    }
+
+    public void resetMetadata() {
+        // Reset all metadata to their default values
+        // This is used when a player respawns
+        this.flags.clear();
+        this.initializeMetadata();
+
+        // Explicitly reset all metadata not handled by initializeMetadata
+        setParrot(null, true);
+        setParrot(null, false);
     }
 
     public void sendPlayer() {

--- a/core/src/main/java/org/geysermc/geyser/entity/type/player/SessionPlayerEntity.java
+++ b/core/src/main/java/org/geysermc/geyser/entity/type/player/SessionPlayerEntity.java
@@ -264,18 +264,12 @@ public class SessionPlayerEntity extends PlayerEntity {
         super.setAbsorptionHearts(entityMetadata);
     }
 
+    @Override
     public void resetMetadata() {
-        // Reset all metadata to their default values
-        // This is used when a player respawns
-        this.flags.clear();
-        this.initializeMetadata();
+        super.resetMetadata();
 
         // Reset air
         this.resetAir();
-
-        // Explicitly reset all metadata not handled by initializeMetadata
-        setParrot(null, true);
-        setParrot(null, false);
 
         // Absorption is metadata in java edition
         attributes.remove(GeyserAttributeType.ABSORPTION);

--- a/core/src/main/java/org/geysermc/geyser/translator/protocol/java/entity/spawn/JavaAddEntityTranslator.java
+++ b/core/src/main/java/org/geysermc/geyser/translator/protocol/java/entity/spawn/JavaAddEntityTranslator.java
@@ -82,6 +82,8 @@ public class JavaAddEntityTranslator extends PacketTranslator<ClientboundAddEnti
                 entity.setPitch(pitch);
                 entity.setHeadYaw(headYaw);
                 entity.setMotion(motion);
+
+
             }
             session.getEntityCache().cacheEntity(entity);
 

--- a/core/src/main/java/org/geysermc/geyser/translator/protocol/java/entity/spawn/JavaAddEntityTranslator.java
+++ b/core/src/main/java/org/geysermc/geyser/translator/protocol/java/entity/spawn/JavaAddEntityTranslator.java
@@ -82,8 +82,6 @@ public class JavaAddEntityTranslator extends PacketTranslator<ClientboundAddEnti
                 entity.setPitch(pitch);
                 entity.setHeadYaw(headYaw);
                 entity.setMotion(motion);
-
-
             }
             session.getEntityCache().cacheEntity(entity);
 


### PR DESCRIPTION
Other fixes not mentioned in title:
- Made entity spawn debug messages opt-in (using the new system property `-DGeyser.PrintEntitySpawnDebug`
- Added a factory method for experience orbs - e.g. Hypixel uses those, which otherwise causes NPE's
- TNT entities no longer bug into the ground, and stay on top (as they do on Java too)
- Attempts to fix https://github.com/GeyserMC/Geyser/issues/4430