### PR TITLE
Match Advancement Packet Behavior Towards Java

### DIFF
--- a/core/src/main/java/org/geysermc/geyser/session/cache/AdvancementsCache.java
+++ b/core/src/main/java/org/geysermc/geyser/session/cache/AdvancementsCache.java
@@ -186,6 +186,10 @@ public class AdvancementsCache {
                         .content(content)
                         .button(GeyserLocale.getPlayerLocaleString("gui.back", language))
                         .validResultHandler((response) -> buildAndShowListForm())
+                        .closedResultHandler(() -> {
+                            // Indicate that we have closed the current advancement tab
+                            session.sendDownstreamGamePacket(new ServerboundSeenAdvancementsPacket());
+                        })
         );
     }
 

--- a/core/src/main/java/org/geysermc/geyser/session/cache/AdvancementsCache.java
+++ b/core/src/main/java/org/geysermc/geyser/session/cache/AdvancementsCache.java
@@ -91,11 +91,9 @@ public class AdvancementsCache {
         builder.validResultHandler((response) -> {
             String id = rootAdvancementIds.get(response.clickedButtonId());
             if (!id.equals("")) {
-                if (!id.equals(currentAdvancementCategoryId)) {
-                    // Send a packet indicating that we are opening this particular advancement window
-                    ServerboundSeenAdvancementsPacket packet = new ServerboundSeenAdvancementsPacket(id);
-                    session.sendDownstreamGamePacket(packet);
-                }
+                // Send a packet indicating that we are opening this particular advancement window
+                ServerboundSeenAdvancementsPacket packet = new ServerboundSeenAdvancementsPacket(id);
+                session.sendDownstreamGamePacket(packet);
                 currentAdvancementCategoryId = id;
                 buildAndShowListForm();
             }


### PR DESCRIPTION
The client sends a "advancement tab open" packet whenever any tab is opened, not necessarily when a new one is switched to. This removes the if statement and sends the packet to the server regardless.