### PR TITLE
Fix crafting output not updating sometimes

### DIFF
--- a/core/src/main/java/org/geysermc/geyser/translator/protocol/java/inventory/JavaContainerSetSlotTranslator.java
+++ b/core/src/main/java/org/geysermc/geyser/translator/protocol/java/inventory/JavaContainerSetSlotTranslator.java
@@ -71,10 +71,6 @@ public class JavaContainerSetSlotTranslator extends PacketTranslator<Clientbound
 
         InventoryTranslator translator = session.getInventoryTranslator();
         if (translator != null) {
-            if (session.getCraftingGridFuture() != null) {
-                session.getCraftingGridFuture().cancel(false);
-            }
-
             int slot = packet.getSlot();
             if (slot >= inventory.getSize()) {
                 GeyserLogger logger = session.getGeyser().getLogger();
@@ -113,6 +109,9 @@ public class JavaContainerSetSlotTranslator extends PacketTranslator<Clientbound
     private static void updateCraftingGrid(GeyserSession session, int slot, ItemStack item, Inventory inventory, InventoryTranslator translator) {
         if (slot != 0) {
             return;
+        }
+        if (session.getCraftingGridFuture() != null) {
+            session.getCraftingGridFuture().cancel(false);
         }
         int gridSize = translator.getGridSize();
         if (gridSize == -1) {

--- a/core/src/main/java/org/geysermc/geyser/translator/protocol/java/inventory/JavaContainerSetSlotTranslator.java
+++ b/core/src/main/java/org/geysermc/geyser/translator/protocol/java/inventory/JavaContainerSetSlotTranslator.java
@@ -107,15 +107,20 @@ public class JavaContainerSetSlotTranslator extends PacketTranslator<Clientbound
      * Checks for a changed output slot in the crafting grid, and ensures Bedrock sees the recipe.
      */
     private static void updateCraftingGrid(GeyserSession session, int slot, ItemStack item, Inventory inventory, InventoryTranslator translator) {
+        // Check if it's the crafting grid result slot.
         if (slot != 0) {
             return;
         }
-        if (session.getCraftingGridFuture() != null) {
-            session.getCraftingGridFuture().cancel(false);
-        }
+
+        // Check if there is any crafting grid.
         int gridSize = translator.getGridSize();
         if (gridSize == -1) {
             return;
+        }
+
+        // Only process the most recent crafting grid result, and cancel the previous one.
+        if (session.getCraftingGridFuture() != null) {
+            session.getCraftingGridFuture().cancel(false);
         }
 
         if (InventoryUtils.isEmpty(item)) {


### PR DESCRIPTION
Crafting recipes are updated within a future, but this future is canceled on any ContainerSetSlotPacket, it should be enough to only cancel the future when the output slot is directly affected.

As on our server the input slots are sent after the output slot is updated which causes that the recipe is never sent. (non-registered/procedural custom recipe)