### PR TITLE
Ensure we send commands/chat the same way a Java client would

### DIFF
--- a/core/src/main/java/org/geysermc/geyser/translator/protocol/bedrock/BedrockCommandRequestTranslator.java
+++ b/core/src/main/java/org/geysermc/geyser/translator/protocol/bedrock/BedrockCommandRequestTranslator.java
@@ -26,8 +26,8 @@
 package org.geysermc.geyser.translator.protocol.bedrock;
 
 import org.cloudburstmc.protocol.bedrock.packet.CommandRequestPacket;
-import org.geysermc.geyser.api.util.PlatformType;
 import org.geysermc.geyser.GeyserImpl;
+import org.geysermc.geyser.api.util.PlatformType;
 import org.geysermc.geyser.session.GeyserSession;
 import org.geysermc.geyser.translator.protocol.PacketTranslator;
 import org.geysermc.geyser.translator.protocol.Translator;
@@ -39,15 +39,17 @@ public class BedrockCommandRequestTranslator extends PacketTranslator<CommandReq
     @Override
     public void translate(GeyserSession session, CommandRequestPacket packet) {
         String command = MessageTranslator.convertToPlainText(packet.getCommand());
+        handleCommand(session, MessageTranslator.normalizeSpace(command).substring(1));
+    }
+
+    public static void handleCommand(GeyserSession session, String command) {
         if (!(session.getGeyser().getPlatformType() == PlatformType.STANDALONE
-                && GeyserImpl.getInstance().commandManager().runCommand(session, command.substring(1)))) {
+                && GeyserImpl.getInstance().commandManager().runCommand(session, command))) {
             if (MessageTranslator.isTooLong(command, session)) {
                 return;
             }
 
-            // running commands via Bedrock's command select menu adds a trailing whitespace which Java doesn't like
-            // https://github.com/GeyserMC/Geyser/issues/3877
-            session.sendCommand(command.substring(1).stripTrailing());
+            session.sendCommand(command);
         }
     }
 }

--- a/core/src/main/java/org/geysermc/geyser/translator/protocol/bedrock/BedrockTextTranslator.java
+++ b/core/src/main/java/org/geysermc/geyser/translator/protocol/bedrock/BedrockTextTranslator.java
@@ -31,24 +31,24 @@ import org.geysermc.geyser.translator.protocol.PacketTranslator;
 import org.geysermc.geyser.translator.protocol.Translator;
 import org.geysermc.geyser.translator.text.MessageTranslator;
 
-import static org.geysermc.geyser.translator.text.MessageTranslator.normalizeSpace;
-
 @Translator(packet = TextPacket.class)
 public class BedrockTextTranslator extends PacketTranslator<TextPacket> {
 
     @Override
     public void translate(GeyserSession session, TextPacket packet) {
         // Java trims all messages, and then checks for the leading slash
-        String message = MessageTranslator.convertToPlainText(normalizeSpace(packet.getMessage()));
+        String message = MessageTranslator.convertToPlainText(
+                MessageTranslator.normalizeSpace(packet.getMessage())
+        );
+
+        if (message.isBlank()) {
+            // Java Edition (as of 1.17.1) just doesn't pass on these messages, so... we won't either!
+            return;
+        }
 
         if (message.startsWith("/")) {
             // Yes, Java actually allows whitespaces before commands and will still see those as valid
             BedrockCommandRequestTranslator.handleCommand(session, message.substring(1));
-            return;
-        }
-
-        if (message.isBlank()) {
-            // Java Edition (as of 1.17.1) just doesn't pass on these messages, so... we won't either!
             return;
         }
 

--- a/core/src/main/java/org/geysermc/geyser/translator/protocol/bedrock/BedrockTextTranslator.java
+++ b/core/src/main/java/org/geysermc/geyser/translator/protocol/bedrock/BedrockTextTranslator.java
@@ -31,12 +31,21 @@ import org.geysermc.geyser.translator.protocol.PacketTranslator;
 import org.geysermc.geyser.translator.protocol.Translator;
 import org.geysermc.geyser.translator.text.MessageTranslator;
 
+import static org.geysermc.geyser.translator.text.MessageTranslator.normalizeSpace;
+
 @Translator(packet = TextPacket.class)
 public class BedrockTextTranslator extends PacketTranslator<TextPacket> {
 
     @Override
     public void translate(GeyserSession session, TextPacket packet) {
-        String message = MessageTranslator.convertToPlainText(packet.getMessage());
+        // Java trims all messages, and then checks for the leading slash
+        String message = MessageTranslator.convertToPlainText(normalizeSpace(packet.getMessage()));
+
+        if (message.startsWith("/")) {
+            // Yes, Java actually allows whitespaces before commands and will still see those as valid
+            BedrockCommandRequestTranslator.handleCommand(session, message.substring(1));
+            return;
+        }
 
         if (message.isBlank()) {
             // Java Edition (as of 1.17.1) just doesn't pass on these messages, so... we won't either!

--- a/core/src/main/java/org/geysermc/geyser/translator/text/MessageTranslator.java
+++ b/core/src/main/java/org/geysermc/geyser/translator/text/MessageTranslator.java
@@ -387,6 +387,38 @@ public class MessageTranslator {
         return false;
     }
 
+    /**
+     * Normalizes whitespaces - a thing a vanilla client apparently does with commands and chat messages.
+     */
+    public static String normalizeSpace(String string) {
+        if (string == null || string.isEmpty()) {
+            return string;
+        }
+        final int size = string.length();
+        final char[] newChars = new char[size];
+        int count = 0;
+        int whitespacesCount = 0;
+        boolean startWhitespaces = true;
+        for (int i = 0; i < size; i++) {
+            final char actualChar = string.charAt(i);
+            final boolean isWhitespace = Character.isWhitespace(actualChar);
+            if (isWhitespace) {
+                if (whitespacesCount == 0 && !startWhitespaces) {
+                    newChars[count++] = ' ';
+                }
+                whitespacesCount++;
+            } else {
+                startWhitespaces = false;
+                newChars[count++] = (actualChar == 160 ? 32 : actualChar);
+                whitespacesCount = 0;
+            }
+        }
+        if (startWhitespaces) {
+            return "";
+        }
+        return new String(newChars, 0, count - (whitespacesCount > 0 ? 1 : 0)).trim();
+    }
+
     public static void init() {
         // no-op
     }


### PR DESCRIPTION
Fixes https://github.com/GeyserMC/Geyser/issues/4700

So, interestingly enough, a vanilla Java client is quite.. lenient with whitespaces. Specifically:
- More than one whitespace between words will be normalized to one
- leading/tailing whitespaces are always stripped.

This leads to the interesting case where Bedrock sends a chat packet for the input `   /give @s diamond`, where Java would actually make that a command. Fun!

![image](https://github.com/GeyserMC/Geyser/assets/105284508/3bf6b135-8e4a-41a9-8cd9-90f553f9c7df)
