### PR TITLE
Default to nb_NO when system locale is set to no_NO or nn_NO

### DIFF
--- a/core/src/main/java/org/geysermc/geyser/text/GeyserLocale.java
+++ b/core/src/main/java/org/geysermc/geyser/text/GeyserLocale.java
@@ -259,6 +259,13 @@ public class GeyserLocale {
             // Invalid locale
             return locale;
         }
+
+        // See https://en.wikipedia.org/wiki/List_of_ISO_639_language_codes - covers the special case that is norwegian
+        String lowerCaseLocale = locale.toLowerCase(Locale.ROOT);
+        if (lowerCaseLocale.equals("nn_no") || lowerCaseLocale.equals("no_no")) {
+            locale = "nb_NO";
+        }
+
         String language = locale.substring(0, 2);
         String country = locale.substring(3);
         return language.toLowerCase(Locale.ENGLISH) + "_" + country.toUpperCase(Locale.ENGLISH);


### PR DESCRIPTION
See https://github.com/GeyserMC/GeyserWiki/issues/276 and https://en.wikipedia.org/wiki/List_of_ISO_639_language_codes 

![image](https://github.com/GeyserMC/Geyser/assets/105284508/73222527-7678-4fdb-a827-9552bf029070)

Ideally, we could rename our language file name and match nb_NO and nn_NO to no_NO; but this seems easier for now considering cloud blocks changes in the languages submodule.