### PR TITLE
Ignore PurchaseReceiptPacket instead of kicking players

### DIFF
--- a/core/src/main/java/org/geysermc/geyser/network/CodecProcessor.java
+++ b/core/src/main/java/org/geysermc/geyser/network/CodecProcessor.java
@@ -232,8 +232,8 @@ class CodecProcessor {
             .updateSerializer(CreatePhotoPacket.class, ILLEGAL_SERIALIZER)
             .updateSerializer(NpcRequestPacket.class, ILLEGAL_SERIALIZER)
             .updateSerializer(PhotoInfoRequestPacket.class, ILLEGAL_SERIALIZER)
-            // Illegal unused serverbound packets for featured servers
-            .updateSerializer(PurchaseReceiptPacket.class, ILLEGAL_SERIALIZER)
+            // Unused serverbound packets for featured servers, which is for some reason still occasionally sent
+            .updateSerializer(PurchaseReceiptPacket.class, IGNORED_SERIALIZER)
             // Illegal unused serverbound packets that are deprecated
             .updateSerializer(ClientCheatAbilityPacket.class, ILLEGAL_SERIALIZER)
             // Illegal unusued serverbound packets that relate to unused features


### PR DESCRIPTION
Seen a few reports where the packet is still sent by consoles.. so let's ignore it instead of kick players.

e.g.:
https://discord.com/channels/613163671870242838/1247610072167874570
https://discord.com/channels/613163671870242838/613168464634576897/1241155239596261429

I can only guess that consoles always send this packet as you wouldn't normally be able to join non-featured servers there.