### PR TITLE
Override forward-hostname setting if ViaProxy wildcard domain handling is enabled

### DIFF
--- a/bootstrap/viaproxy/src/main/java/org/geysermc/geyser/platform/viaproxy/GeyserViaProxyConfiguration.java
+++ b/bootstrap/viaproxy/src/main/java/org/geysermc/geyser/platform/viaproxy/GeyserViaProxyConfiguration.java
@@ -27,6 +27,7 @@ package org.geysermc.geyser.platform.viaproxy;
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import net.raphimc.vialegacy.api.LegacyProtocolVersion;
 import net.raphimc.viaproxy.ViaProxy;
+import net.raphimc.viaproxy.protocoltranslator.viaproxy.ViaProxyConfig;
 import org.geysermc.geyser.configuration.GeyserJacksonConfiguration;
 
 import java.io.File;
@@ -48,6 +49,18 @@ public class GeyserViaProxyConfiguration extends GeyserJacksonConfiguration {
             interval = 15;
         }
         return interval;
+    }
+
+    @Override
+    public RemoteConfiguration getRemote() {
+        return new RemoteConfiguration() {
+
+            @Override
+            public boolean isForwardHost() {
+                return super.isForwardHost() || !ViaProxy.getConfig().getWildcardDomainHandling().equals(ViaProxyConfig.WildcardDomainHandling.NONE);
+            }
+
+        };
     }
 
 }


### PR DESCRIPTION
Overrides the forward-hostname to passthrough the hostname the client used, so the ViaProxy wildcard domain handling works as expected