### PR TITLE
Fix: Improper detection of virtual double chests

### DIFF
--- a/core/src/main/java/org/geysermc/geyser/translator/inventory/chest/DoubleChestInventoryTranslator.java
+++ b/core/src/main/java/org/geysermc/geyser/translator/inventory/chest/DoubleChestInventoryTranslator.java
@@ -64,7 +64,7 @@ public class DoubleChestInventoryTranslator extends ChestInventoryTranslator {
         if (session.getLastInteractionPlayerPosition().equals(session.getPlayerEntity().getPosition())) {
             BlockState state = session.getGeyser().getWorldManager().blockAt(session, session.getLastInteractionBlockPosition());
             if (!BlockRegistries.CUSTOM_BLOCK_STATE_OVERRIDES.get().containsKey(state.javaId())) {
-                if (state.block() == Blocks.CHEST || state.block() == Blocks.TRAPPED_CHEST
+                if ((state.block() == Blocks.CHEST || state.block() == Blocks.TRAPPED_CHEST)
                         && state.getValue(Properties.CHEST_TYPE) != ChestType.SINGLE) {
                     inventory.setHolderPosition(session.getLastInteractionBlockPosition());
                     ((Container) inventory).setUsingRealBlock(true, state.block());


### PR DESCRIPTION
Closes https://github.com/GeyserMC/Geyser/issues/4737 
The missing brackets caused the logic to trip and falsely open a single chest inventory when the block we're interacting with is a single chest, while the Java server sent us instructions to open a (for us virtual) double chest inventory.