### PR TITLE
Catch EOFExceptions when the remote server is misconfigured/not online

### DIFF
--- a/core/src/main/java/org/geysermc/geyser/ping/GeyserLegacyPingPassthrough.java
+++ b/core/src/main/java/org/geysermc/geyser/ping/GeyserLegacyPingPassthrough.java
@@ -35,10 +35,7 @@ import org.cloudburstmc.nbt.util.VarInts;
 import org.geysermc.geyser.GeyserImpl;
 import org.geysermc.geyser.network.GameProtocol;
 
-import java.io.ByteArrayOutputStream;
-import java.io.DataInputStream;
-import java.io.DataOutputStream;
-import java.io.IOException;
+import java.io.*;
 import java.net.*;
 import java.util.concurrent.TimeUnit;
 
@@ -139,6 +136,9 @@ public class GeyserLegacyPingPassthrough implements IGeyserPingPassthrough, Runn
             this.geyser.getLogger().debug("Connection timeout for ping passthrough.");
         } catch (JsonParseException | JsonMappingException ex) {
             this.geyser.getLogger().error("Failed to parse json when pinging server!", ex);
+        } catch (EOFException e) {
+            this.pingInfo = null;
+            this.geyser.getLogger().warning("Failed to ping the remote Java server! Is it online and configured in Geysers config?");
         } catch (UnknownHostException ex) {
             // Don't reset pingInfo, as we want to keep the last known value
             this.geyser.getLogger().warning("Unable to resolve remote host! Is the remote server down or invalid?");

--- a/core/src/main/java/org/geysermc/geyser/ping/GeyserLegacyPingPassthrough.java
+++ b/core/src/main/java/org/geysermc/geyser/ping/GeyserLegacyPingPassthrough.java
@@ -138,7 +138,7 @@ public class GeyserLegacyPingPassthrough implements IGeyserPingPassthrough, Runn
             this.geyser.getLogger().error("Failed to parse json when pinging server!", ex);
         } catch (EOFException e) {
             this.pingInfo = null;
-            this.geyser.getLogger().warning("Failed to ping the remote Java server! Is it online and configured in Geysers config?");
+            this.geyser.getLogger().warning("Failed to ping the remote Java server! Is it online and configured in Geyser's config?");
         } catch (UnknownHostException ex) {
             // Don't reset pingInfo, as we want to keep the last known value
             this.geyser.getLogger().warning("Unable to resolve remote host! Is the remote server down or invalid?");


### PR DESCRIPTION
Otherwise, this causes the following to get spammed:
```
[13:59:23 ERROR] IO error while trying to use legacy ping passthrough
java.io.EOFException: null
        at java.io.DataInputStream.readByte(DataInputStream.java:273) ~[?:?]
        at org.cloudburstmc.nbt.util.VarInts.decode(VarInts.java:149) ~[Geyser-Standalone.jar:?]
        at org.cloudburstmc.nbt.util.VarInts.readUnsignedInt(VarInts.java:25) ~[Geyser-Standalone.jar:?]
        at org.geysermc.geyser.ping.GeyserLegacyPingPassthrough.run(GeyserLegacyPingPassthrough.java:123) [Geyser-Standalone.jar:?]
        at java.util.concurrent.Executors$RunnableAdapter.call(Executors.java:539) [?:?]
        at java.util.concurrent.FutureTask.runAndReset(FutureTask.java:305) [?:?]
        at java.util.concurrent.ScheduledThreadPoolExecutor$ScheduledFutureTask.run(ScheduledThreadPoolExecutor.java:305) [?:?]
        at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1136) [?:?]
        at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:635) [?:?]
        at io.netty.util.concurrent.FastThreadLocalRunnable.run(FastThreadLocalRunnable.java:30) [Geyser-Standalone.jar:?]
        at java.lang.Thread.run(Thread.java:833) [?:?]
        ```