### PR TITLE
Fix reading custom jukebox songs

### DIFF
--- a/core/src/main/java/org/geysermc/geyser/level/JukeboxSong.java
+++ b/core/src/main/java/org/geysermc/geyser/level/JukeboxSong.java
@@ -26,6 +26,7 @@
 package org.geysermc.geyser.level;
 
 import org.cloudburstmc.nbt.NbtMap;
+import org.geysermc.geyser.GeyserImpl;
 import org.geysermc.geyser.translator.text.MessageTranslator;
 import org.geysermc.mcprotocollib.protocol.data.game.RegistryEntry;
 
@@ -34,11 +35,14 @@ public record JukeboxSong(String soundEvent, String description) {
     public static JukeboxSong read(RegistryEntry entry) {
         NbtMap data = entry.getData();
         Object soundEventObject = data.get("sound_event");
-        String soundEvent = "";
+        String soundEvent;
         if (soundEventObject instanceof NbtMap map) {
             soundEvent = map.getString("sound_id");
-        } else if (soundEventObject instanceof String string){
+        } else if (soundEventObject instanceof String string) {
             soundEvent = string;
+        } else {
+            soundEvent = "";
+            GeyserImpl.getInstance().getLogger().debug("Sound event for " + entry.getId() + " was of an unexpected type! Expected string or NBT map, got " + soundEventObject);
         }
         String description = MessageTranslator.deserializeDescription(data);
         return new JukeboxSong(soundEvent, description);

--- a/core/src/main/java/org/geysermc/geyser/level/JukeboxSong.java
+++ b/core/src/main/java/org/geysermc/geyser/level/JukeboxSong.java
@@ -33,7 +33,13 @@ public record JukeboxSong(String soundEvent, String description) {
 
     public static JukeboxSong read(RegistryEntry entry) {
         NbtMap data = entry.getData();
-        String soundEvent = data.getString("sound_event");
+        Object soundEventObject = data.get("sound_event");
+        String soundEvent = "";
+        if (soundEventObject instanceof NbtMap map) {
+            soundEvent = map.getString("sound_id");
+        } else if (soundEventObject instanceof String string){
+            soundEvent = string;
+        }
         String description = MessageTranslator.deserializeDescription(data);
         return new JukeboxSong(soundEvent, description);
     }


### PR DESCRIPTION
Sound events of custom jukebox songs can be sent over as a NBT compound map instead of as a string, containing the sound ID and the range of the music disc. This PR accommodates for that in the read method of the `JukeboxSong` record, so that sound events of custom music discs are correctly loaded.