### PR TITLE
Fix: readme not being synched to modrinth

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -103,19 +103,12 @@ jobs:
             bootstrap/viaproxy/build/libs/Geyser-ViaProxy.jar
           changelog: ${{ steps.metadata.outputs.body }}
 
-      - name: Publish to Modrinth (Fabric)
+      - name: Publish to Modrinth
         if: ${{ success() && github.repository == 'GeyserMC/Geyser' && github.ref_name == 'master' }}
         env:
           BUILD_NUMBER: ${{ steps.release-info.outputs.curentRelease }}
           MODRINTH_TOKEN: ${{ secrets.MODRINTH_TOKEN }}
-        run: ./gradlew fabric:modrinth
-
-      - name: Publish to Modrinth (NeoForge)
-        if: ${{ success() && github.repository == 'GeyserMC/Geyser' && github.ref_name == 'master' }}
-        env:
-          BUILD_NUMBER: ${{ steps.release-info.outputs.curentRelease }}
-          MODRINTH_TOKEN: ${{ secrets.MODRINTH_TOKEN }}
-        run: ./gradlew neoforge:modrinth
+        run: ./gradlew modrinth
 
       - name: Notify Discord
         if: ${{ (success() || failure()) && github.repository == 'GeyserMC/Geyser' }}

--- a/bootstrap/bungeecord/build.gradle.kts
+++ b/bootstrap/bungeecord/build.gradle.kts
@@ -34,3 +34,8 @@ tasks.withType<com.github.jengelman.gradle.plugins.shadow.tasks.ShadowJar> {
         exclude(dependency("io.netty:netty-resolver-dns:.*"))
     }
 }
+
+modrinth {
+    uploadFile.set(tasks.getByPath("shadowJar"))
+    loaders.add("bungeecord")
+}

--- a/bootstrap/mod/build.gradle.kts
+++ b/bootstrap/mod/build.gradle.kts
@@ -11,9 +11,6 @@ afterEvaluate {
     tasks.named("remapModrinthJar").configure {
         enabled = false
     }
-    tasks.named("modrinth").configure {
-        enabled = false
-    }
 }
 
 dependencies {

--- a/bootstrap/mod/build.gradle.kts
+++ b/bootstrap/mod/build.gradle.kts
@@ -6,6 +6,16 @@ loom {
     mixin.defaultRefmapName.set("geyser-refmap.json")
 }
 
+afterEvaluate {
+    // We don't need these
+    tasks.named("remapModrinthJar").configure {
+        enabled = false
+    }
+    tasks.named("modrinth").configure {
+        enabled = false
+    }
+}
+
 dependencies {
     api(projects.core)
     compileOnly(libs.mixin)

--- a/bootstrap/mod/fabric/build.gradle.kts
+++ b/bootstrap/mod/fabric/build.gradle.kts
@@ -63,6 +63,7 @@ tasks {
 
 modrinth {
     loaders.add("fabric")
+    uploadFile.set(tasks.getByPath("remapModrinthJar"))
     dependencies {
         required.project("fabric-api")
     }

--- a/bootstrap/mod/neoforge/build.gradle.kts
+++ b/bootstrap/mod/neoforge/build.gradle.kts
@@ -55,4 +55,5 @@ tasks {
 
 modrinth {
     loaders.add("neoforge")
+    uploadFile.set(tasks.getByPath("remapModrinthJar"))
 }

--- a/bootstrap/spigot/build.gradle.kts
+++ b/bootstrap/spigot/build.gradle.kts
@@ -76,3 +76,8 @@ tasks.withType<com.github.jengelman.gradle.plugins.shadow.tasks.ShadowJar> {
         exclude(dependency("com.mojang:.*"))
     }
 }
+
+modrinth {
+    uploadFile.set(tasks.getByPath("shadowJar"))
+    loaders.addAll("spigot", "paper")
+}

--- a/bootstrap/velocity/build.gradle.kts
+++ b/bootstrap/velocity/build.gradle.kts
@@ -70,3 +70,8 @@ tasks.withType<com.github.jengelman.gradle.plugins.shadow.tasks.ShadowJar> {
         exclude(dependency("net.kyori:adventure-nbt:.*"))
     }
 }
+
+modrinth {
+    uploadFile.set(tasks.getByPath("shadowJar"))
+    loaders.addAll("velocity")
+}

--- a/build-logic/build.gradle.kts
+++ b/build-logic/build.gradle.kts
@@ -12,6 +12,9 @@ repositories {
 }
 
 dependencies {
+    // this is OK as long as the same version catalog is used in the main build and build-logic
+    // see https://github.com/gradle/gradle/issues/15383#issuecomment-779893192
+    implementation(files(libs.javaClass.superclass.protectionDomain.codeSource.location))
     implementation(libs.indra)
     implementation(libs.shadow)
     implementation(libs.architectury.plugin)

--- a/build-logic/src/main/kotlin/LibsAccessor.kt
+++ b/build-logic/src/main/kotlin/LibsAccessor.kt
@@ -1,0 +1,6 @@
+import org.gradle.accessors.dm.LibrariesForLibs
+import org.gradle.api.Project
+import org.gradle.kotlin.dsl.getByType
+
+val Project.libs: LibrariesForLibs
+    get() = rootProject.extensions.getByType()

--- a/build-logic/src/main/kotlin/geyser.modded-conventions.gradle.kts
+++ b/build-logic/src/main/kotlin/geyser.modded-conventions.gradle.kts
@@ -6,7 +6,6 @@ import org.gradle.kotlin.dsl.maven
 
 plugins {
     id("geyser.publish-conventions")
-    id("geyser.modrinth-uploading")
     id("architectury-plugin")
     id("dev.architectury.loom")
 }
@@ -107,10 +106,6 @@ afterEvaluate {
             //println("Not including ${dep.id} for ${project.name}!")
         }
     }
-}
-
-modrinth {
-    uploadFile.set(tasks.getByPath("remapModrinthJar"))
 }
 
 dependencies {

--- a/build-logic/src/main/kotlin/geyser.modded-conventions.gradle.kts
+++ b/build-logic/src/main/kotlin/geyser.modded-conventions.gradle.kts
@@ -6,9 +6,9 @@ import org.gradle.kotlin.dsl.maven
 
 plugins {
     id("geyser.publish-conventions")
+    id("geyser.modrinth-uploading")
     id("architectury-plugin")
     id("dev.architectury.loom")
-    id("com.modrinth.minotaur")
 }
 
 // These are provided by Minecraft/modded platforms already, no need to include them
@@ -39,7 +39,7 @@ provided("io.netty", "netty-resolver-dns-native-macos")
 provided("org.ow2.asm", "asm")
 
 architectury {
-    minecraft = "1.20.5"
+    minecraft = libs.minecraft.get().version as String
 }
 
 loom {
@@ -83,7 +83,7 @@ tasks {
     register("remapModrinthJar", RemapJarTask::class) {
         dependsOn(shadowJar)
         inputFile.set(shadowJar.get().archiveFile)
-        archiveVersion.set(project.version.toString() + "+build."  + System.getenv("GITHUB_RUN_NUMBER"))
+        archiveVersion.set(project.version.toString() + "+build."  + System.getenv("BUILD_NUMBER"))
         archiveClassifier.set("")
     }
 }
@@ -93,7 +93,7 @@ afterEvaluate {
 
     // These are shaded, no need to JiJ them
     configurations["shadow"].dependencies.forEach {shadowed ->
-        println("Not including shadowed dependency: ${shadowed.group}:${shadowed.name}")
+        //println("Not including shadowed dependency: ${shadowed.group}:${shadowed.name}")
         providedDependencies.add("${shadowed.group}:${shadowed.name}")
     }
 
@@ -101,16 +101,20 @@ afterEvaluate {
     configurations["includeTransitive"].resolvedConfiguration.resolvedArtifacts.forEach { dep ->
         if (!providedDependencies.contains("${dep.moduleVersion.id.group}:${dep.moduleVersion.id.name}")
             and !providedDependencies.contains("${dep.moduleVersion.id.group}:.*")) {
-            println("Including dependency via JiJ: ${dep.id}")
+            //println("Including dependency via JiJ: ${dep.id}")
             dependencies.add("include", dep.moduleVersion.id.toString())
         } else {
-            println("Not including ${dep.id} for ${project.name}!")
+            //println("Not including ${dep.id} for ${project.name}!")
         }
     }
 }
 
+modrinth {
+    uploadFile.set(tasks.getByPath("remapModrinthJar"))
+}
+
 dependencies {
-    minecraft("com.mojang:minecraft:1.21")
+    minecraft(libs.minecraft)
     mappings(loom.officialMojangMappings())
 }
 
@@ -121,18 +125,4 @@ repositories {
     maven("https://oss.sonatype.org/content/repositories/snapshots/")
     maven("https://s01.oss.sonatype.org/content/repositories/snapshots/")
     maven("https://maven.neoforged.net/releases")
-}
-
-modrinth {
-    token.set(System.getenv("MODRINTH_TOKEN")) // Even though this is the default value, apparently this prevents GitHub Actions caching the token?
-    projectId.set("wKkoqHrH")
-    versionNumber.set(project.version as String + "-" + System.getenv("GITHUB_RUN_NUMBER"))
-    versionType.set("beta")
-    changelog.set("A changelog can be found at https://github.com/GeyserMC/Geyser/commits")
-
-    syncBodyFrom.set(rootProject.file("README.md").readText())
-
-    uploadFile.set(tasks.getByPath("remapModrinthJar"))
-    gameVersions.addAll("1.21")
-    failSilently.set(true)
 }

--- a/build-logic/src/main/kotlin/geyser.modrinth-uploading-conventions.gradle.kts
+++ b/build-logic/src/main/kotlin/geyser.modrinth-uploading-conventions.gradle.kts
@@ -13,6 +13,7 @@ modrinth {
     changelog.set("A changelog can be found at https://github.com/GeyserMC/Geyser/commits")
     gameVersions.add(libs.minecraft.get().version as String)
     failSilently.set(true)
+    debugMode.set(true)
 
     syncBodyFrom.set(rootProject.file("README.md").readText())
 }

--- a/build-logic/src/main/kotlin/geyser.modrinth-uploading-conventions.gradle.kts
+++ b/build-logic/src/main/kotlin/geyser.modrinth-uploading-conventions.gradle.kts
@@ -13,7 +13,6 @@ modrinth {
     changelog.set("A changelog can be found at https://github.com/GeyserMC/Geyser/commits")
     gameVersions.add(libs.minecraft.get().version as String)
     failSilently.set(true)
-    debugMode.set(true)
 
     syncBodyFrom.set(rootProject.file("README.md").readText())
 }

--- a/build-logic/src/main/kotlin/geyser.modrinth-uploading.gradle.kts
+++ b/build-logic/src/main/kotlin/geyser.modrinth-uploading.gradle.kts
@@ -6,7 +6,7 @@ plugins {
 tasks.modrinth.get().dependsOn(tasks.modrinthSyncBody)
 
 modrinth {
-    token.set(System.getenv("MODRINTH_TOKEN")) // Even though this is the default value, apparently this prevents GitHub Actions caching the token?
+    token.set(System.getenv("MODRINTH_TOKEN") ?: "") // Even though this is the default value, apparently this prevents GitHub Actions caching the token?
     projectId.set("geyser")
     versionNumber.set(project.version as String + "-" + System.getenv("BUILD_NUMBER"))
     versionType.set("beta")

--- a/build-logic/src/main/kotlin/geyser.modrinth-uploading.gradle.kts
+++ b/build-logic/src/main/kotlin/geyser.modrinth-uploading.gradle.kts
@@ -8,7 +8,7 @@ tasks.modrinth.get().dependsOn(tasks.modrinthSyncBody)
 modrinth {
     token.set(System.getenv("MODRINTH_TOKEN")) // Even though this is the default value, apparently this prevents GitHub Actions caching the token?
     projectId.set("geyser")
-    versionNumber.set(project.version as String + "-" + System.getenv("GITHUB_RUN_NUMBER"))
+    versionNumber.set(project.version as String + "-" + System.getenv("BUILD_NUMBER"))
     versionType.set("beta")
     changelog.set("A changelog can be found at https://github.com/GeyserMC/Geyser/commits")
     gameVersions.add(libs.minecraft.get().version as String)

--- a/build-logic/src/main/kotlin/geyser.modrinth-uploading.gradle.kts
+++ b/build-logic/src/main/kotlin/geyser.modrinth-uploading.gradle.kts
@@ -1,0 +1,18 @@
+plugins {
+    id("com.modrinth.minotaur")
+}
+
+// Ensure that the readme is synched
+tasks.modrinth.get().dependsOn(tasks.modrinthSyncBody)
+
+modrinth {
+    token.set(System.getenv("MODRINTH_TOKEN")) // Even though this is the default value, apparently this prevents GitHub Actions caching the token?
+    projectId.set("geyser")
+    versionNumber.set(project.version as String + "-" + System.getenv("GITHUB_RUN_NUMBER"))
+    versionType.set("beta")
+    changelog.set("A changelog can be found at https://github.com/GeyserMC/Geyser/commits")
+    gameVersions.add(libs.minecraft.get().version as String)
+    failSilently.set(true)
+
+    syncBodyFrom.set(rootProject.file("README.md").readText())
+}

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -26,6 +26,14 @@ val moddedPlatforms = setOf(
     projects.mod
 ).map { it.dependencyProject }
 
+val modrinthPlatforms = setOf(
+    projects.bungeecord,
+    projects.fabric,
+    projects.neoforge,
+    projects.spigot,
+    projects.velocity
+).map { it.dependencyProject }
+
 subprojects {
     apply {
         plugin("java-library")
@@ -37,5 +45,11 @@ subprojects {
         in basePlatforms -> plugins.apply("geyser.platform-conventions")
         in moddedPlatforms -> plugins.apply("geyser.modded-conventions")
         else -> plugins.apply("geyser.base-conventions")
+    }
+
+    // Not combined with platform-conventions as that
+    // also contains viaproxy and standalone; both of which we cant publish to modrinth
+    if (modrinthPlatforms.contains(this)) {
+        plugins.apply("geyser.modrinth-uploading")
     }
 }

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -47,9 +47,9 @@ subprojects {
         else -> plugins.apply("geyser.base-conventions")
     }
 
-    // Not combined with platform-conventions as that
-    // also contains viaproxy and standalone; both of which we cant publish to modrinth
+    // Not combined with platform-conventions as that also contains
+    // platforms which we cant publish to modrinth
     if (modrinthPlatforms.contains(this)) {
-        plugins.apply("geyser.modrinth-uploading")
+        plugins.apply("geyser.modrinth-uploading-conventions")
     }
 }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -28,12 +28,12 @@ commodore = "2.2"
 bungeecord = "a7c6ede"
 velocity = "3.3.0-SNAPSHOT"
 viaproxy = "3.2.1"
-fabric-minecraft = "1.21"
 fabric-loader = "0.15.11"
 fabric-api = "0.100.1+1.21"
 fabric-permissions = "0.2-SNAPSHOT"
 neoforge-minecraft = "21.0.0-beta"
 mixin = "0.8.5"
+minecraft = "1.21"
 
 # plugin versions
 indra = "3.1.3"
@@ -90,8 +90,9 @@ paper-mojangapi = { group = "io.papermc.paper", name = "paper-mojangapi", versio
 
 mixin = { group = "org.spongepowered", name = "mixin", version.ref = "mixin" }
 
+minecraft = { group = "com.mojang", name = "minecraft", version.ref = "minecraft" }
+
 # Check these on https://modmuss50.me/fabric.html
-fabric-minecraft = { group = "com.mojang", name = "minecraft", version.ref = "fabric-minecraft" }
 fabric-loader = { group = "net.fabricmc", name = "fabric-loader", version.ref = "fabric-loader" }
 fabric-api = { group = "net.fabricmc.fabric-api", name = "fabric-api", version.ref = "fabric-api" }
 fabric-permissions = { group = "me.lucko", name = "fabric-permissions-api", version.ref = "fabric-permissions" }


### PR DESCRIPTION
This PR would resolve https://github.com/GeyserMC/Geyser/issues/4755 by ensuring that the `modrinthSyncBody` is ran when we're publishing to modrinth.

This also separates the modrinth uploading task into a separate plugin, which could be further expanded to support uploading velocity/bungeecord/spigot builds too.