### PR TITLE
Sanity check for shulker boxes

### DIFF
--- a/core/src/main/java/org/geysermc/geyser/level/block/type/BlockState.java
+++ b/core/src/main/java/org/geysermc/geyser/level/block/type/BlockState.java
@@ -73,6 +73,15 @@ public final class BlockState {
         return (Boolean) value;
     }
 
+    public <T extends Comparable<T>> T getValue(Property<T> property, T def) {
+        var value = get(property);
+        if (value == null) {
+            return def;
+        }
+        //noinspection unchecked
+        return (T) value;
+    }
+
     @Nullable
     private Comparable<?> get(Property<?> property) {
         Property<?>[] keys = this.block.propertyKeys();

--- a/core/src/main/java/org/geysermc/geyser/translator/level/block/entity/ShulkerBoxBlockEntityTranslator.java
+++ b/core/src/main/java/org/geysermc/geyser/translator/level/block/entity/ShulkerBoxBlockEntityTranslator.java
@@ -30,6 +30,7 @@ import org.cloudburstmc.nbt.NbtMap;
 import org.cloudburstmc.nbt.NbtMapBuilder;
 import org.geysermc.geyser.level.block.property.Properties;
 import org.geysermc.geyser.level.block.type.BlockState;
+import org.geysermc.geyser.level.physics.Direction;
 import org.geysermc.geyser.session.GeyserSession;
 import org.geysermc.geyser.translator.inventory.ShulkerInventoryTranslator;
 import org.geysermc.mcprotocollib.protocol.data.game.level.block.BlockEntityType;
@@ -42,6 +43,6 @@ public class ShulkerBoxBlockEntityTranslator extends BlockEntityTranslator imple
      */
     @Override
     public void translateTag(GeyserSession session, NbtMapBuilder bedrockNbt, @Nullable NbtMap javaNbt, BlockState blockState) {
-        bedrockNbt.putByte("facing", (byte) blockState.getValue(Properties.FACING).ordinal());
+        bedrockNbt.putByte("facing", (byte) blockState.getValue(Properties.FACING, Direction.UP).ordinal());
     }
 }


### PR DESCRIPTION
Resolves https://github.com/GeyserMC/Geyser/issues/4758

It looks like the actual block that is sent is... stone!? Atleast that's what i received when i tried logging it & joined the server mentioned in the PR (where i got banned shortly as Geyser-Standalone is classified as a movement hack, oops) - so not sure what the best approach to fix it would be. It looks like a server may send a wrong block entity type for a given block; maybe we need to add some broader validation to that..!?

This fix does work though, i was able to see chunks fine.