### PR TITLE
Fix NPEs caused by custom head blocks from Polymer

### DIFF
--- a/core/src/main/java/org/geysermc/geyser/entity/type/player/SkullPlayerEntity.java
+++ b/core/src/main/java/org/geysermc/geyser/entity/type/player/SkullPlayerEntity.java
@@ -141,7 +141,7 @@ public class SkullPlayerEntity extends PlayerEntity {
         float rotation;
 
         BlockState blockState = skull.getBlockState();
-        if (blockState.block() instanceof WallSkullBlock) {
+        if (blockState != null && blockState.block() instanceof WallSkullBlock) {
             y += 0.25f;
             Direction direction = blockState.getValue(Properties.HORIZONTAL_FACING);
             rotation = WallSkullBlock.getDegrees(direction);
@@ -152,7 +152,7 @@ public class SkullPlayerEntity extends PlayerEntity {
                 case EAST -> x -= 0.24f;
             }
         } else {
-            rotation = (180f + (blockState.getValue(Properties.ROTATION_16) * 22.5f)) % 360;
+            rotation = (180f + (blockState != null ? blockState.getValue(Properties.ROTATION_16) * 22.5f : 0.0f)) % 360;
         }
 
         moveAbsolute(Vector3f.from(x, y, z), rotation, 0, rotation, true, true);

--- a/core/src/main/java/org/geysermc/geyser/level/WorldManager.java
+++ b/core/src/main/java/org/geysermc/geyser/level/WorldManager.java
@@ -33,6 +33,7 @@ import org.checkerframework.checker.nullness.qual.NonNull;
 import org.checkerframework.checker.nullness.qual.Nullable;
 import org.cloudburstmc.math.vector.Vector3i;
 import org.geysermc.erosion.util.BlockPositionIterator;
+import org.geysermc.geyser.level.block.type.Block;
 import org.geysermc.geyser.level.block.type.BlockState;
 import org.geysermc.geyser.session.GeyserSession;
 import org.geysermc.mcprotocollib.protocol.data.game.entity.player.GameMode;
@@ -64,7 +65,11 @@ public abstract class WorldManager {
 
     @NonNull
     public BlockState blockAt(GeyserSession session, int x, int y, int z) {
-        return BlockState.of(this.getBlockAt(session, x, y, z));
+        BlockState block = BlockState.of(this.getBlockAt(session, x, y, z));
+        if (block == null) {
+            return BlockState.of(Block.JAVA_AIR_ID);
+        }
+        return block;
     }
 
     /**

--- a/core/src/main/java/org/geysermc/geyser/session/cache/SkullCache.java
+++ b/core/src/main/java/org/geysermc/geyser/session/cache/SkullCache.java
@@ -254,10 +254,10 @@ public class SkullCache {
         CustomSkull customSkull = BlockRegistries.CUSTOM_SKULLS.get(skinHash);
         if (customSkull != null) {
             CustomBlockState customBlockState;
-            if (blockState.block() instanceof WallSkullBlock) {
+            if (blockState != null && blockState.block() instanceof WallSkullBlock) {
                 customBlockState = customSkull.getWallBlockState(WallSkullBlock.getDegrees(blockState));
             } else {
-                customBlockState = customSkull.getFloorBlockState(blockState.getValue(Properties.ROTATION_16));
+                customBlockState = customSkull.getFloorBlockState(blockState != null ? blockState.getValue(Properties.ROTATION_16) : 0);
             }
 
             return session.getBlockMappings().getCustomBlockStateDefinitions().get(customBlockState);

--- a/core/src/main/java/org/geysermc/geyser/translator/level/block/entity/SkullBlockEntityTranslator.java
+++ b/core/src/main/java/org/geysermc/geyser/translator/level/block/entity/SkullBlockEntityTranslator.java
@@ -53,6 +53,10 @@ public class SkullBlockEntityTranslator extends BlockEntityTranslator implements
 
     @Override
     public void translateTag(GeyserSession session, NbtMapBuilder bedrockNbt, NbtMap javaNbt, BlockState blockState) {
+        if (blockState == null) {
+            bedrockNbt.putByte("SkullType", (byte) 0);
+            return;
+        }
         Integer rotation = blockState.getValue(Properties.ROTATION_16);
         if (rotation != null) {
             // Could be a wall skull block otherwise, which has rotation in its Bedrock state


### PR DESCRIPTION
This PR fixes a bunch of NPE exceptions similar to the one fixed by #4557, caused by custom head blocks added by Polymer.

These NPEs are caused by block states that are unexpectedly `null`. As said in #4557, I think this is caused because Geyser retrieves the block state ID from the world and tries to look this up in the JAVA_BLOCKS registry, which returns null because Geyser is looking the block up in the server side world, which will return the actual modded block and not a player head.

The block is not registered in said registry, and thus it returns null.

The method changed in `WorldManager` didn't cause an NPE on itself, however [this](https://github.com/GeyserMC/Geyser/blob/77fa37ff828cf31fc09710a5f4c9e57ab2c88944/core/src/main/java/org/geysermc/geyser/translator/protocol/bedrock/entity/player/BedrockActionTranslator.java#L333) line did, and since the method in `WorldManager` is marked as non null I thought I should implement the fix there.