### PR TITLE
Feat: Add changelog to modrinth releases

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -56,7 +56,6 @@ jobs:
         run: ./gradlew publish
         env:
           BUILD_NUMBER: ${{ steps.release-info.outputs.curentRelease }}
-          CHANGELOG: ${{ steps.metadata.outputs.body }}
           ORG_GRADLE_PROJECT_geysermcUsername: ${{ vars.DEPLOY_USER }}
           ORG_GRADLE_PROJECT_geysermcPassword: ${{ secrets.DEPLOY_PASS }}
         
@@ -107,6 +106,7 @@ jobs:
       - name: Publish to Modrinth
         if: ${{ success() && github.repository == 'GeyserMC/Geyser' && github.ref_name == 'master' }}
         env:
+          CHANGELOG: ${{ steps.metadata.outputs.body }}
           BUILD_NUMBER: ${{ steps.release-info.outputs.curentRelease }}
           MODRINTH_TOKEN: ${{ secrets.MODRINTH_TOKEN }}
         run: ./gradlew modrinth

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -56,6 +56,7 @@ jobs:
         run: ./gradlew publish
         env:
           BUILD_NUMBER: ${{ steps.release-info.outputs.curentRelease }}
+          CHANGELOG: ${{ steps.metadata.outputs.body }}
           ORG_GRADLE_PROJECT_geysermcUsername: ${{ vars.DEPLOY_USER }}
           ORG_GRADLE_PROJECT_geysermcPassword: ${{ secrets.DEPLOY_PASS }}
         

--- a/build-logic/src/main/kotlin/geyser.modrinth-uploading-conventions.gradle.kts
+++ b/build-logic/src/main/kotlin/geyser.modrinth-uploading-conventions.gradle.kts
@@ -10,7 +10,7 @@ modrinth {
     projectId.set("geyser")
     versionNumber.set(project.version as String + "-" + System.getenv("BUILD_NUMBER"))
     versionType.set("beta")
-    changelog.set("A changelog can be found at https://github.com/GeyserMC/Geyser/commits")
+    changelog.set(System.getenv("CHANGELOG") ?: "")
     gameVersions.add(libs.minecraft.get().version as String)
     failSilently.set(true)
 


### PR DESCRIPTION
This *should* add the changelog that's currently also being sent to the discord build messages/the downloads page to modrinth release descriptions.