### PR TITLE
Fix painting offset on versions older than 1.19

### DIFF
--- a/core/src/main/java/org/geysermc/geyser/entity/type/PaintingEntity.java
+++ b/core/src/main/java/org/geysermc/geyser/entity/type/PaintingEntity.java
@@ -86,7 +86,11 @@ public class PaintingEntity extends Entity {
 
     private Vector3f fixOffset(PaintingType paintingName) {
         Vector3f position = super.position;
-        position = position.add(0.5, 0.5, 0.5);
+        // ViaVersion already adds the offset for us on older versions,
+        // so no need to do it then otherwise it will be spaced
+        if (session.isEmulatePost1_18Logic()) {
+            position = position.add(0.5, 0.5, 0.5);
+        }
         double widthOffset = paintingName.getWidth() > 1 && paintingName.getWidth() != 3 ? 0.5 : 0;
         double heightOffset = paintingName.getHeight() > 1 && paintingName.getHeight() != 3 ? 0.5 : 0;
 


### PR DESCRIPTION
Resolves https://github.com/GeyserMC/Geyser/issues/3014.

This happens because ViaVersion adds the offset of 0.5, and then Geyser adds the offset of 0.5, resulting in the buggy positioning.
https://github.com/ViaVersion/ViaVersion/blob/dd1fad2dd736b3385f74ce375ebd47ea2d23daba/common/src/main/java/com/viaversion/viaversion/protocols/v1_18_2to1_19/rewriter/EntityPacketRewriter1_19.java#L104

Tested on Latest Bungeecord -> Paper 1.8.8 and on Paper 1.21