### PR TITLE
Update for 2024

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 The MIT License
 
-Copyright (c) 2019-2023 GeyserMC. http://geysermc.org
+Copyright (c) 2019-2024 GeyserMC. http://geysermc.org
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/licenseheader.txt
+++ b/licenseheader.txt
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019-2022 GeyserMC. http://geysermc.org
+ * Copyright (c) 2019-2024 GeyserMC. http://geysermc.org
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal


### PR DESCRIPTION
changed "Copyright (c) 2019-2022 GeyserMC. http://geysermc.org" (line 2) to "Copyright (c) 2019-2024 GeyserMC. http://geysermc.org"