### PR TITLE
Fix attribute modifier tooltip

### DIFF
--- a/core/src/main/java/org/geysermc/geyser/translator/item/ItemTranslator.java
+++ b/core/src/main/java/org/geysermc/geyser/translator/item/ItemTranslator.java
@@ -52,6 +52,7 @@ import org.geysermc.geyser.text.ChatColor;
 import org.geysermc.geyser.text.MinecraftLocale;
 import org.geysermc.geyser.translator.text.MessageTranslator;
 import org.geysermc.geyser.util.InventoryUtils;
+import org.geysermc.mcprotocollib.protocol.data.game.entity.attribute.AttributeType;
 import org.geysermc.mcprotocollib.protocol.data.game.entity.attribute.ModifierOperation;
 import org.geysermc.mcprotocollib.protocol.data.game.item.ItemStack;
 import org.geysermc.mcprotocollib.protocol.data.game.item.component.*;
@@ -209,7 +210,7 @@ public final class ItemTranslator {
         Map<ItemAttributeModifiers.EquipmentSlotGroup, List<String>> slotsToModifiers = new HashMap<>();
         for (ItemAttributeModifiers.Entry entry : modifiers.getModifiers()) {
             // convert the modifier tag to a lore entry
-            String loreEntry = attributeToLore(entry.getModifier(), language);
+            String loreEntry = attributeToLore(entry.getAttribute(), entry.getModifier(), language);
             if (loreEntry == null) {
                 continue; // invalid or failed
             }
@@ -254,13 +255,13 @@ public final class ItemTranslator {
     }
 
     @Nullable
-    private static String attributeToLore(ItemAttributeModifiers.AttributeModifier modifier, String language) {
+    private static String attributeToLore(int attribute, ItemAttributeModifiers.AttributeModifier modifier, String language) {
         double amount = modifier.getAmount();
         if (amount == 0) {
             return null;
         }
 
-        String name = modifier.getId().asMinimalString();
+        String name = AttributeType.Builtin.from(attribute).getIdentifier().asMinimalString();
         // the namespace does not need to be present, but if it is, the java client ignores it as of pre-1.20.5
 
         ModifierOperation operation = modifier.getOperation();


### PR DESCRIPTION
This PR fixes the tooltip for attribute modifiers.

Before Java 1.20.5, an attribute modifier was stored with the resource location of the attribute it applies to included in the NBT tag, which Geyser used to get the translation for the attribute modifier, which is displayed in the item tooltip. With the item component changes in 1.20.5, this was changed to instead send the network ID of the attribute to the client.

However, Geyser was updated incorrectly and instead was changed to use the name of the modifier (which is arbitrary and doesn't relate to the attribute it modifies in any way) instead, and later in 1.21 to use the resource location of the modifier (which was still incorrect - it should use the resource location of the attribute).

This PR fixes this issue and looks up the resource location of the attribute that corresponds to the network ID, fixing the display of attribute modifiers. This issue *should* fix #4800, but I've only tested it with a Java 1.21 server, not using viaversion.