### PR TITLE
Only apply door fix when we can actually access the old blockstate

### DIFF
--- a/core/src/main/java/org/geysermc/geyser/level/block/type/DoorBlock.java
+++ b/core/src/main/java/org/geysermc/geyser/level/block/type/DoorBlock.java
@@ -40,7 +40,7 @@ public class DoorBlock extends Block {
         // Needed to check whether we must force the client to update the door state.
         String doubleBlockHalf = state.getValue(Properties.DOUBLE_BLOCK_HALF);
 
-        if (doubleBlockHalf.equals("lower")) {
+        if (!session.getGeyser().getWorldManager().hasOwnChunkCache() && doubleBlockHalf.equals("lower")) {
             BlockState oldBlockState = session.getGeyser().getWorldManager().blockAt(session, position);
             // If these are the same, it means that we already updated the lower door block (manually in the workaround below),
             // and we do not need to update the block in the cache/on the client side using the super.updateBlock() method again.


### PR DESCRIPTION
Should resolve https://github.com/GeyserMC/Geyser/issues/4826 - i should've seen this one coming :(

To explain why i added this in the first place:
This check ensures that door flickering isnt happening anymore by checking whether we already updated the block state on bedrock (by checking the current block state vs the old one). It is caused by us updating the lower door part twice, which was added in https://github.com/GeyserMC/Geyser/commit/b0ccf45cd47f797eca2f62e5716170bc80074b86 