### PR TITLE
Fix reading enchantments from server

### DIFF
--- a/core/src/main/java/org/geysermc/geyser/inventory/recipe/TrimRecipe.java
+++ b/core/src/main/java/org/geysermc/geyser/inventory/recipe/TrimRecipe.java
@@ -32,9 +32,8 @@ import org.cloudburstmc.protocol.bedrock.data.TrimPattern;
 import org.cloudburstmc.protocol.bedrock.data.inventory.descriptor.ItemDescriptorWithCount;
 import org.cloudburstmc.protocol.bedrock.data.inventory.descriptor.ItemTagDescriptor;
 import org.geysermc.geyser.registry.type.ItemMapping;
-import org.geysermc.geyser.session.GeyserSession;
+import org.geysermc.geyser.session.cache.registry.RegistryContext;
 import org.geysermc.geyser.translator.text.MessageTranslator;
-import org.geysermc.mcprotocollib.protocol.data.game.RegistryEntry;
 
 /**
  * Stores information on trim materials and patterns, including smithing armor hacks for pre-1.20.
@@ -46,18 +45,18 @@ public final class TrimRecipe {
     public static final ItemDescriptorWithCount ADDITION = tagDescriptor("minecraft:trim_materials");
     public static final ItemDescriptorWithCount TEMPLATE = tagDescriptor("minecraft:trim_templates");
 
-    public static TrimMaterial readTrimMaterial(GeyserSession session, RegistryEntry entry) {
-        String key = entry.getId().asMinimalString();
+    public static TrimMaterial readTrimMaterial(RegistryContext context) {
+        String key = context.id().asMinimalString();
 
         // Color is used when hovering over the item
         // Find the nearest legacy color from the RGB Java gives us to work with
         // Also yes this is a COMPLETE hack but it works ok!!!!!
-        String colorTag = entry.getData().getCompound("description").getString("color");
+        String colorTag = context.data().getCompound("description").getString("color");
         TextColor color = TextColor.fromHexString(colorTag);
         String legacy = MessageTranslator.convertMessage(Component.space().color(color));
 
-        String itemIdentifier = entry.getData().getString("ingredient");
-        ItemMapping itemMapping = session.getItemMappings().getMapping(itemIdentifier);
+        String itemIdentifier = context.data().getString("ingredient");
+        ItemMapping itemMapping = context.session().getItemMappings().getMapping(itemIdentifier);
         if (itemMapping == null) {
             // This should never happen so not sure what to do here.
             itemMapping = ItemMapping.AIR;
@@ -66,11 +65,11 @@ public final class TrimRecipe {
         return new TrimMaterial(key, legacy.substring(2).trim(), itemMapping.getBedrockIdentifier());
     }
 
-    public static TrimPattern readTrimPattern(GeyserSession session, RegistryEntry entry) {
-        String key = entry.getId().asMinimalString();
+    public static TrimPattern readTrimPattern(RegistryContext context) {
+        String key = context.id().asMinimalString();
 
-        String itemIdentifier = entry.getData().getString("template_item");
-        ItemMapping itemMapping = session.getItemMappings().getMapping(itemIdentifier);
+        String itemIdentifier = context.data().getString("template_item");
+        ItemMapping itemMapping = context.session().getItemMappings().getMapping(itemIdentifier);
         if (itemMapping == null) {
             // This should never happen so not sure what to do here.
             itemMapping = ItemMapping.AIR;

--- a/core/src/main/java/org/geysermc/geyser/inventory/recipe/TrimRecipe.java
+++ b/core/src/main/java/org/geysermc/geyser/inventory/recipe/TrimRecipe.java
@@ -32,7 +32,7 @@ import org.cloudburstmc.protocol.bedrock.data.TrimPattern;
 import org.cloudburstmc.protocol.bedrock.data.inventory.descriptor.ItemDescriptorWithCount;
 import org.cloudburstmc.protocol.bedrock.data.inventory.descriptor.ItemTagDescriptor;
 import org.geysermc.geyser.registry.type.ItemMapping;
-import org.geysermc.geyser.session.cache.registry.RegistryContext;
+import org.geysermc.geyser.session.cache.registry.RegistryEntryContext;
 import org.geysermc.geyser.translator.text.MessageTranslator;
 
 /**
@@ -45,7 +45,7 @@ public final class TrimRecipe {
     public static final ItemDescriptorWithCount ADDITION = tagDescriptor("minecraft:trim_materials");
     public static final ItemDescriptorWithCount TEMPLATE = tagDescriptor("minecraft:trim_templates");
 
-    public static TrimMaterial readTrimMaterial(RegistryContext context) {
+    public static TrimMaterial readTrimMaterial(RegistryEntryContext context) {
         String key = context.id().asMinimalString();
 
         // Color is used when hovering over the item
@@ -65,7 +65,7 @@ public final class TrimRecipe {
         return new TrimMaterial(key, legacy.substring(2).trim(), itemMapping.getBedrockIdentifier());
     }
 
-    public static TrimPattern readTrimPattern(RegistryContext context) {
+    public static TrimPattern readTrimPattern(RegistryEntryContext context) {
         String key = context.id().asMinimalString();
 
         String itemIdentifier = context.data().getString("template_item");

--- a/core/src/main/java/org/geysermc/geyser/inventory/updater/AnvilInventoryUpdater.java
+++ b/core/src/main/java/org/geysermc/geyser/inventory/updater/AnvilInventoryUpdater.java
@@ -315,11 +315,11 @@ public class AnvilInventoryUpdater extends InventoryUpdater {
             Enchantment enchantment = entry.getKey();
 
             HolderSet supportedItems = enchantment.supportedItems();
-            int[] supportedItemIds = supportedItems.resolve(key -> session.getTagCache().get(ItemTag.ALL_ITEM_TAGS.get(key)));
+            int[] supportedItemIds = supportedItems.resolve(tagId -> session.getTagCache().get(ItemTag.ALL_ITEM_TAGS.get(tagId)));
             boolean canApply = isEnchantedBook(input) || IntStream.of(supportedItemIds).anyMatch(id -> id == input.getJavaId());
 
             HolderSet exclusiveSet = enchantment.exclusiveSet();
-            int[] incompatibleEnchantments = exclusiveSet.resolve(key -> session.getTagCache().get(EnchantmentTag.ALL_ENCHANTMENT_TAGS.get(key)));
+            int[] incompatibleEnchantments = exclusiveSet.resolve(tagId -> session.getTagCache().get(EnchantmentTag.ALL_ENCHANTMENT_TAGS.get(tagId)));
             for (int i : incompatibleEnchantments) {
                 Enchantment incompatible = session.getRegistryCache().enchantments().byId(i);
                 if (combinedEnchantments.containsKey(incompatible)) {

--- a/core/src/main/java/org/geysermc/geyser/inventory/updater/AnvilInventoryUpdater.java
+++ b/core/src/main/java/org/geysermc/geyser/inventory/updater/AnvilInventoryUpdater.java
@@ -27,6 +27,7 @@ package org.geysermc.geyser.inventory.updater;
 
 import it.unimi.dsi.fastutil.objects.Object2IntMap;
 import it.unimi.dsi.fastutil.objects.Object2IntOpenHashMap;
+import java.util.stream.IntStream;
 import net.kyori.adventure.text.Component;
 import org.cloudburstmc.nbt.NbtMap;
 import org.cloudburstmc.nbt.NbtMapBuilder;
@@ -41,11 +42,14 @@ import org.geysermc.geyser.inventory.item.BedrockEnchantment;
 import org.geysermc.geyser.item.enchantment.Enchantment;
 import org.geysermc.geyser.item.Items;
 import org.geysermc.geyser.session.GeyserSession;
+import org.geysermc.geyser.session.cache.tags.EnchantmentTag;
+import org.geysermc.geyser.session.cache.tags.ItemTag;
 import org.geysermc.geyser.translator.inventory.InventoryTranslator;
 import org.geysermc.geyser.translator.text.MessageTranslator;
 import org.geysermc.geyser.util.ItemUtils;
 import org.geysermc.mcprotocollib.protocol.data.game.entity.player.GameMode;
 import org.geysermc.mcprotocollib.protocol.data.game.item.component.DataComponentType;
+import org.geysermc.mcprotocollib.protocol.data.game.item.component.HolderSet;
 import org.geysermc.mcprotocollib.protocol.data.game.item.component.ItemEnchantments;
 import org.geysermc.mcprotocollib.protocol.packet.ingame.serverbound.inventory.ServerboundRenameItemPacket;
 
@@ -310,17 +314,18 @@ public class AnvilInventoryUpdater extends InventoryUpdater {
         for (Object2IntMap.Entry<Enchantment> entry : getEnchantments(session, material).object2IntEntrySet()) {
             Enchantment enchantment = entry.getKey();
 
-            boolean canApply = isEnchantedBook(input) || session.getTagCache().is(enchantment.supportedItems(), input);
-            var exclusiveSet = enchantment.exclusiveSet();
-            if (exclusiveSet != null) {
-                int[] incompatibleEnchantments = session.getTagCache().get(exclusiveSet);
-                for (int i : incompatibleEnchantments) {
-                    Enchantment incompatible = session.getRegistryCache().enchantments().byId(i);
-                    if (combinedEnchantments.containsKey(incompatible)) {
-                        canApply = false;
-                        if (!bedrock) {
-                            cost++;
-                        }
+            HolderSet supportedItems = enchantment.supportedItems();
+            int[] supportedItemIds = supportedItems.resolve(key -> session.getTagCache().get(ItemTag.ALL_ITEM_TAGS.get(key)));
+            boolean canApply = isEnchantedBook(input) || IntStream.of(supportedItemIds).anyMatch(id -> id == input.getJavaId());
+
+            HolderSet exclusiveSet = enchantment.exclusiveSet();
+            int[] incompatibleEnchantments = exclusiveSet.resolve(key -> session.getTagCache().get(EnchantmentTag.ALL_ENCHANTMENT_TAGS.get(key)));
+            for (int i : incompatibleEnchantments) {
+                Enchantment incompatible = session.getRegistryCache().enchantments().byId(i);
+                if (combinedEnchantments.containsKey(incompatible)) {
+                    canApply = false;
+                    if (!bedrock) {
+                        cost++;
                     }
                 }
             }

--- a/core/src/main/java/org/geysermc/geyser/item/enchantment/Enchantment.java
+++ b/core/src/main/java/org/geysermc/geyser/item/enchantment/Enchantment.java
@@ -31,6 +31,8 @@ import net.kyori.adventure.key.Key;
 import org.checkerframework.checker.nullness.qual.Nullable;
 import org.cloudburstmc.nbt.NbtMap;
 import org.geysermc.geyser.inventory.item.BedrockEnchantment;
+import org.geysermc.geyser.item.type.Item;
+import org.geysermc.geyser.registry.Registries;
 import org.geysermc.geyser.translator.text.MessageTranslator;
 import org.geysermc.mcprotocollib.protocol.data.game.RegistryEntry;
 
@@ -56,7 +58,10 @@ public record Enchantment(String identifier,
         NbtMap data = entry.getData();
         Set<EnchantmentComponent> effects = readEnchantmentComponents(data.getCompound("effects"));
 
-        HolderSet supportedItems = readHolderSet(data.get("supported_items"), keyIdMapping);
+        HolderSet supportedItems = readHolderSet(data.get("supported_items"), itemId -> {
+            Item item = Registries.JAVA_ITEM_IDENTIFIERS.get(itemId.asString());
+            return Registries.JAVA_ITEMS.get().indexOf(item);
+        });
 
         int maxLevel = data.getInt("max_level");
         int anvilCost = data.getInt("anvil_cost");

--- a/core/src/main/java/org/geysermc/geyser/item/enchantment/Enchantment.java
+++ b/core/src/main/java/org/geysermc/geyser/item/enchantment/Enchantment.java
@@ -33,7 +33,7 @@ import org.cloudburstmc.nbt.NbtMap;
 import org.geysermc.geyser.inventory.item.BedrockEnchantment;
 import org.geysermc.geyser.item.Items;
 import org.geysermc.geyser.registry.Registries;
-import org.geysermc.geyser.session.cache.registry.RegistryContext;
+import org.geysermc.geyser.session.cache.registry.RegistryEntryContext;
 import org.geysermc.geyser.translator.text.MessageTranslator;
 
 import java.util.HashSet;
@@ -54,7 +54,7 @@ public record Enchantment(String identifier,
                           HolderSet exclusiveSet,
                           @Nullable BedrockEnchantment bedrockEnchantment) {
 
-    public static Enchantment read(RegistryContext context) {
+    public static Enchantment read(RegistryEntryContext context) {
         NbtMap data = context.data();
         Set<EnchantmentComponent> effects = readEnchantmentComponents(data.getCompound("effects"));
 

--- a/core/src/main/java/org/geysermc/geyser/item/enchantment/Enchantment.java
+++ b/core/src/main/java/org/geysermc/geyser/item/enchantment/Enchantment.java
@@ -25,18 +25,19 @@
 
 package org.geysermc.geyser.item.enchantment;
 
+import java.util.List;
+import java.util.function.Function;
+import net.kyori.adventure.key.Key;
 import org.checkerframework.checker.nullness.qual.Nullable;
 import org.cloudburstmc.nbt.NbtMap;
 import org.geysermc.geyser.inventory.item.BedrockEnchantment;
-import org.geysermc.geyser.session.cache.tags.EnchantmentTag;
-import org.geysermc.geyser.session.cache.tags.ItemTag;
 import org.geysermc.geyser.translator.text.MessageTranslator;
-import org.geysermc.geyser.util.MinecraftKey;
 import org.geysermc.mcprotocollib.protocol.data.game.RegistryEntry;
 
 import java.util.HashSet;
 import java.util.Map;
 import java.util.Set;
+import org.geysermc.mcprotocollib.protocol.data.game.item.component.HolderSet;
 
 /**
  * @param description only populated if {@link #bedrockEnchantment()} is not null.
@@ -44,28 +45,32 @@ import java.util.Set;
  */
 public record Enchantment(String identifier,
                           Set<EnchantmentComponent> effects,
-                          ItemTag supportedItems,
+                          HolderSet supportedItems,
                           int maxLevel,
                           String description,
                           int anvilCost,
-                          @Nullable EnchantmentTag exclusiveSet,
+                          HolderSet exclusiveSet,
                           @Nullable BedrockEnchantment bedrockEnchantment) {
 
-    // Implementation note: I have a feeling the tags can be a list of items, because in vanilla they're HolderSet classes.
-    // I'm not sure how that's wired over the network, so we'll put it off.
-    public static Enchantment read(RegistryEntry entry) {
+    public static Enchantment read(Function<Key, Integer> keyIdMapping, RegistryEntry entry) {
         NbtMap data = entry.getData();
         Set<EnchantmentComponent> effects = readEnchantmentComponents(data.getCompound("effects"));
-        String supportedItems = data.getString("supported_items").substring(1); // Remove '#' at beginning that indicates tag
+
+        HolderSet supportedItems = readHolderSet(data.get("supported_items"), keyIdMapping);
+
         int maxLevel = data.getInt("max_level");
         int anvilCost = data.getInt("anvil_cost");
-        String exclusiveSet = data.getString("exclusive_set", null);
-        EnchantmentTag exclusiveSetTag = exclusiveSet == null ? null : EnchantmentTag.ALL_ENCHANTMENT_TAGS.get(MinecraftKey.key(exclusiveSet.substring(1)));
+
+        HolderSet exclusiveSet = readHolderSet(data.getOrDefault("exclusive_set", null), keyIdMapping);
+
         BedrockEnchantment bedrockEnchantment = BedrockEnchantment.getByJavaIdentifier(entry.getId().asString());
+
+        // TODO - description is a component. So if a hardcoded literal string is given, this will display normally on Java,
+        //  but Geyser will attempt to lookup the literal string as translation - and will fail, displaying an empty string as enchantment name.
         String description = bedrockEnchantment == null ? MessageTranslator.deserializeDescription(data) : null;
 
-        return new Enchantment(entry.getId().asString(), effects, ItemTag.ALL_ITEM_TAGS.get(MinecraftKey.key(supportedItems)), maxLevel,
-                description, anvilCost, exclusiveSetTag, bedrockEnchantment);
+        return new Enchantment(entry.getId().asString(), effects, supportedItems, maxLevel,
+                description, anvilCost, exclusiveSet, bedrockEnchantment);
     }
 
     private static Set<EnchantmentComponent> readEnchantmentComponents(NbtMap effects) {
@@ -76,5 +81,25 @@ public record Enchantment(String identifier,
             }
         }
         return Set.copyOf(components); // Also ensures any empty sets are consolidated
+    }
+
+    // TODO holder set util?
+    private static HolderSet readHolderSet(@Nullable Object holderSet, Function<Key, Integer> keyIdMapping) {
+        if (holderSet == null) {
+            return new HolderSet(new int[]{});
+        }
+
+        if (holderSet instanceof String stringTag) {
+            // Tag
+            if (stringTag.startsWith("#")) {
+                return new HolderSet(Key.key(stringTag.substring(1))); // Remove '#' at beginning that indicates tag
+            } else {
+                return new HolderSet(new int[]{keyIdMapping.apply(Key.key(stringTag))});
+            }
+        } else if (holderSet instanceof List<?> list) {
+            // Assume the list is a list of strings
+            return new HolderSet(list.stream().map(o -> (String) o).map(Key::key).map(keyIdMapping).mapToInt(Integer::intValue).toArray());
+        }
+        throw new IllegalArgumentException("Holder set must either be a tag, a string ID or a list of string IDs");
     }
 }

--- a/core/src/main/java/org/geysermc/geyser/level/JavaDimension.java
+++ b/core/src/main/java/org/geysermc/geyser/level/JavaDimension.java
@@ -26,7 +26,7 @@
 package org.geysermc.geyser.level;
 
 import org.cloudburstmc.nbt.NbtMap;
-import org.geysermc.geyser.session.cache.registry.RegistryContext;
+import org.geysermc.geyser.session.cache.registry.RegistryEntryContext;
 
 /**
  * Represents the information we store from the current Java dimension
@@ -35,7 +35,7 @@ import org.geysermc.geyser.session.cache.registry.RegistryContext;
  */
 public record JavaDimension(int minY, int maxY, boolean piglinSafe, double worldCoordinateScale) {
 
-    public static JavaDimension read(RegistryContext entry) {
+    public static JavaDimension read(RegistryEntryContext entry) {
         NbtMap dimension = entry.data();
         int minY = dimension.getInt("min_y");
         int maxY = dimension.getInt("height");

--- a/core/src/main/java/org/geysermc/geyser/level/JukeboxSong.java
+++ b/core/src/main/java/org/geysermc/geyser/level/JukeboxSong.java
@@ -27,13 +27,13 @@ package org.geysermc.geyser.level;
 
 import org.cloudburstmc.nbt.NbtMap;
 import org.geysermc.geyser.GeyserImpl;
+import org.geysermc.geyser.session.cache.registry.RegistryContext;
 import org.geysermc.geyser.translator.text.MessageTranslator;
-import org.geysermc.mcprotocollib.protocol.data.game.RegistryEntry;
 
 public record JukeboxSong(String soundEvent, String description) {
 
-    public static JukeboxSong read(RegistryEntry entry) {
-        NbtMap data = entry.getData();
+    public static JukeboxSong read(RegistryContext context) {
+        NbtMap data = context.data();
         Object soundEventObject = data.get("sound_event");
         String soundEvent;
         if (soundEventObject instanceof NbtMap map) {
@@ -42,7 +42,7 @@ public record JukeboxSong(String soundEvent, String description) {
             soundEvent = string;
         } else {
             soundEvent = "";
-            GeyserImpl.getInstance().getLogger().debug("Sound event for " + entry.getId() + " was of an unexpected type! Expected string or NBT map, got " + soundEventObject);
+            GeyserImpl.getInstance().getLogger().debug("Sound event for " + context.id() + " was of an unexpected type! Expected string or NBT map, got " + soundEventObject);
         }
         String description = MessageTranslator.deserializeDescription(data);
         return new JukeboxSong(soundEvent, description);

--- a/core/src/main/java/org/geysermc/geyser/level/JukeboxSong.java
+++ b/core/src/main/java/org/geysermc/geyser/level/JukeboxSong.java
@@ -27,12 +27,12 @@ package org.geysermc.geyser.level;
 
 import org.cloudburstmc.nbt.NbtMap;
 import org.geysermc.geyser.GeyserImpl;
-import org.geysermc.geyser.session.cache.registry.RegistryContext;
+import org.geysermc.geyser.session.cache.registry.RegistryEntryContext;
 import org.geysermc.geyser.translator.text.MessageTranslator;
 
 public record JukeboxSong(String soundEvent, String description) {
 
-    public static JukeboxSong read(RegistryContext context) {
+    public static JukeboxSong read(RegistryEntryContext context) {
         NbtMap data = context.data();
         Object soundEventObject = data.get("sound_event");
         String soundEvent;

--- a/core/src/main/java/org/geysermc/geyser/session/cache/RegistryCache.java
+++ b/core/src/main/java/org/geysermc/geyser/session/cache/RegistryCache.java
@@ -45,7 +45,7 @@ import org.geysermc.geyser.level.JukeboxSong;
 import org.geysermc.geyser.level.PaintingType;
 import org.geysermc.geyser.session.GeyserSession;
 import org.geysermc.geyser.session.cache.registry.JavaRegistry;
-import org.geysermc.geyser.session.cache.registry.RegistryContext;
+import org.geysermc.geyser.session.cache.registry.RegistryEntryContext;
 import org.geysermc.geyser.session.cache.registry.SimpleJavaRegistry;
 import org.geysermc.geyser.text.TextDecoration;
 import org.geysermc.geyser.translator.level.BiomeTranslator;
@@ -149,7 +149,7 @@ public final class RegistryCache {
      * @param reader converts the RegistryEntry NBT into a class file
      * @param <T> the class that represents these entries.
      */
-    private static <T> void register(String registry, Function<RegistryCache, JavaRegistry<T>> localCacheFunction, Function<RegistryContext, T> reader) {
+    private static <T> void register(String registry, Function<RegistryCache, JavaRegistry<T>> localCacheFunction, Function<RegistryEntryContext, T> reader) {
         Key registryKey = MinecraftKey.key(registry);
         REGISTRIES.put(registryKey, (registryCache, entries) -> {
             Map<Key, NbtMap> localRegistry = null;
@@ -175,7 +175,7 @@ public final class RegistryCache {
                     entry = new RegistryEntry(entry.getId(), localRegistry.get(entry.getId()));
                 }
 
-                RegistryContext context = new RegistryContext(entry, entryIdMap, registryCache.session);
+                RegistryEntryContext context = new RegistryEntryContext(entry, entryIdMap, registryCache.session);
                 // This is what Geyser wants to keep as a value for this registry.
                 T cacheEntry = reader.apply(context);
                 builder.add(i, cacheEntry);

--- a/core/src/main/java/org/geysermc/geyser/session/cache/RegistryCache.java
+++ b/core/src/main/java/org/geysermc/geyser/session/cache/RegistryCache.java
@@ -27,6 +27,8 @@ package org.geysermc.geyser.session.cache;
 
 import it.unimi.dsi.fastutil.ints.Int2IntMap;
 import it.unimi.dsi.fastutil.ints.Int2IntOpenHashMap;
+import it.unimi.dsi.fastutil.objects.Object2IntMap;
+import it.unimi.dsi.fastutil.objects.Object2IntOpenHashMap;
 import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.experimental.Accessors;
@@ -159,7 +161,7 @@ public final class RegistryCache {
 
             // Store each of the entries resource location IDs and their respective network ID,
             // used for the key mapper that's currently only used by the Enchantment class
-            Map<Key, Integer> entryIdMap = new HashMap<>();
+            Object2IntMap<Key> entryIdMap = new Object2IntOpenHashMap<>();
             for (int i = 0; i < entries.size(); i++) {
                 entryIdMap.put(entries.get(i).getId(), i);
             }

--- a/core/src/main/java/org/geysermc/geyser/session/cache/RegistryCache.java
+++ b/core/src/main/java/org/geysermc/geyser/session/cache/RegistryCache.java
@@ -173,10 +173,7 @@ public final class RegistryCache {
                     entry = new RegistryEntry(entry.getId(), localRegistry.get(entry.getId()));
                 }
                 // This is what Geyser wants to keep as a value for this registry.
-                T cacheEntry = reader.apply(registryCache.session, key -> entryIdMap.getOrDefault(key, 0), entry);
-                if (cacheEntry instanceof Enchantment) {
-                    System.out.println(cacheEntry);
-                }
+                T cacheEntry = reader.apply(registryCache.session, entryId -> entryIdMap.getOrDefault(entryId, 0), entry);
                 builder.add(i, cacheEntry);
             }
             localCache.reset(builder);

--- a/core/src/main/java/org/geysermc/geyser/session/cache/TagCache.java
+++ b/core/src/main/java/org/geysermc/geyser/session/cache/TagCache.java
@@ -130,8 +130,12 @@ public final class TagCache {
         return contains(values, item.javaId());
     }
 
-    public int[] get(EnchantmentTag tag) {
-        return this.enchantments[tag.ordinal()];
+    public int[] get(ItemTag itemTag) {
+        return this.items[itemTag.ordinal()];
+    }
+
+    public int[] get(EnchantmentTag enchantmentTag) {
+        return this.enchantments[enchantmentTag.ordinal()];
     }
 
     private static boolean contains(int[] array, int i) {

--- a/core/src/main/java/org/geysermc/geyser/session/cache/registry/RegistryContext.java
+++ b/core/src/main/java/org/geysermc/geyser/session/cache/registry/RegistryContext.java
@@ -31,6 +31,13 @@ import org.cloudburstmc.nbt.NbtMap;
 import org.geysermc.geyser.session.GeyserSession;
 import org.geysermc.mcprotocollib.protocol.data.game.RegistryEntry;
 
+/**
+ * Used to store context around a single registry entry when reading said entry's NBT.
+ *
+ * @param entry the registry entry being read.
+ * @param keyIdMap a map for each of the resource location's in the registry and their respective network IDs.
+ * @param session the Geyser session.
+ */
 public record RegistryContext(RegistryEntry entry, Map<Key, Integer> keyIdMap, GeyserSession session) {
 
     public int getNetworkId(Key registryKey) {

--- a/core/src/main/java/org/geysermc/geyser/session/cache/registry/RegistryContext.java
+++ b/core/src/main/java/org/geysermc/geyser/session/cache/registry/RegistryContext.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019-2022 GeyserMC. http://geysermc.org
+ * Copyright (c) 2024 GeyserMC. http://geysermc.org
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -23,29 +23,26 @@
  * @link https://github.com/GeyserMC/Geyser
  */
 
-package org.geysermc.geyser.level;
+package org.geysermc.geyser.session.cache.registry;
 
+import java.util.Map;
+import net.kyori.adventure.key.Key;
 import org.cloudburstmc.nbt.NbtMap;
-import org.geysermc.geyser.session.cache.registry.RegistryContext;
+import org.geysermc.geyser.session.GeyserSession;
+import org.geysermc.mcprotocollib.protocol.data.game.RegistryEntry;
 
-/**
- * Represents the information we store from the current Java dimension
- * @param piglinSafe Whether piglins and hoglins are safe from conversion in this dimension.
- *      This controls if they have the shaking effect applied in the dimension.
- */
-public record JavaDimension(int minY, int maxY, boolean piglinSafe, double worldCoordinateScale) {
+public record RegistryContext(RegistryEntry entry, Map<Key, Integer> keyIdMap, GeyserSession session) {
 
-    public static JavaDimension read(RegistryContext entry) {
-        NbtMap dimension = entry.data();
-        int minY = dimension.getInt("min_y");
-        int maxY = dimension.getInt("height");
-        // Logical height can be ignored probably - seems to be for artificial limits like the Nether.
+    public int getNetworkId(Key registryKey) {
+        return keyIdMap.getOrDefault(registryKey, 0);
+    }
 
-        // Set if piglins/hoglins should shake
-        boolean piglinSafe = dimension.getBoolean("piglin_safe");
-        // Load world coordinate scale for the world border
-        double coordinateScale = dimension.getDouble("coordinate_scale");
+    public Key id() {
+        return entry.getId();
+    }
 
-        return new JavaDimension(minY, maxY, piglinSafe, coordinateScale);
+    // Not annotated as nullable because data should never be null here
+    public NbtMap data() {
+        return entry.getData();
     }
 }

--- a/core/src/main/java/org/geysermc/geyser/session/cache/registry/RegistryEntryContext.java
+++ b/core/src/main/java/org/geysermc/geyser/session/cache/registry/RegistryEntryContext.java
@@ -38,7 +38,7 @@ import org.geysermc.mcprotocollib.protocol.data.game.RegistryEntry;
  * @param keyIdMap a map for each of the resource location's in the registry and their respective network IDs.
  * @param session the Geyser session.
  */
-public record RegistryContext(RegistryEntry entry, Map<Key, Integer> keyIdMap, GeyserSession session) {
+public record RegistryEntryContext(RegistryEntry entry, Map<Key, Integer> keyIdMap, GeyserSession session) {
 
     public int getNetworkId(Key registryKey) {
         return keyIdMap.getOrDefault(registryKey, 0);

--- a/core/src/main/java/org/geysermc/geyser/session/cache/registry/RegistryEntryContext.java
+++ b/core/src/main/java/org/geysermc/geyser/session/cache/registry/RegistryEntryContext.java
@@ -25,6 +25,7 @@
 
 package org.geysermc.geyser.session.cache.registry;
 
+import it.unimi.dsi.fastutil.objects.Object2IntMap;
 import java.util.Map;
 import net.kyori.adventure.key.Key;
 import org.cloudburstmc.nbt.NbtMap;
@@ -38,7 +39,7 @@ import org.geysermc.mcprotocollib.protocol.data.game.RegistryEntry;
  * @param keyIdMap a map for each of the resource location's in the registry and their respective network IDs.
  * @param session the Geyser session.
  */
-public record RegistryEntryContext(RegistryEntry entry, Map<Key, Integer> keyIdMap, GeyserSession session) {
+public record RegistryEntryContext(RegistryEntry entry, Object2IntMap<Key> keyIdMap, GeyserSession session) {
 
     public int getNetworkId(Key registryKey) {
         return keyIdMap.getOrDefault(registryKey, 0);

--- a/core/src/main/java/org/geysermc/geyser/text/TextDecoration.java
+++ b/core/src/main/java/org/geysermc/geyser/text/TextDecoration.java
@@ -29,7 +29,7 @@ import net.kyori.adventure.text.format.NamedTextColor;
 import net.kyori.adventure.text.format.Style;
 import org.cloudburstmc.nbt.NbtMap;
 import org.cloudburstmc.nbt.NbtType;
-import org.geysermc.mcprotocollib.protocol.data.game.RegistryEntry;
+import org.geysermc.geyser.session.cache.registry.RegistryContext;
 import org.geysermc.mcprotocollib.protocol.data.game.chat.ChatType;
 import org.geysermc.mcprotocollib.protocol.data.game.chat.ChatTypeDecoration;
 
@@ -43,11 +43,11 @@ public record TextDecoration(String translationKey, List<Parameter> parameters, 
         throw new UnsupportedOperationException();
     }
 
-    public static ChatType readChatType(RegistryEntry entry) {
+    public static ChatType readChatType(RegistryContext context) {
         // Note: The ID is NOT ALWAYS THE SAME! ViaVersion as of 1.19 adds two registry entries that do NOT match vanilla.
         // (This note has been passed around through several classes and iterations. It stays as a warning
         // to anyone that dares to try and hardcode registry IDs.)
-        NbtMap tag = entry.getData();
+        NbtMap tag = context.data();
         NbtMap chat = tag.getCompound("chat", null);
         if (chat != null) {
             String translationKey = chat.getString("translation_key");

--- a/core/src/main/java/org/geysermc/geyser/text/TextDecoration.java
+++ b/core/src/main/java/org/geysermc/geyser/text/TextDecoration.java
@@ -29,7 +29,7 @@ import net.kyori.adventure.text.format.NamedTextColor;
 import net.kyori.adventure.text.format.Style;
 import org.cloudburstmc.nbt.NbtMap;
 import org.cloudburstmc.nbt.NbtType;
-import org.geysermc.geyser.session.cache.registry.RegistryContext;
+import org.geysermc.geyser.session.cache.registry.RegistryEntryContext;
 import org.geysermc.mcprotocollib.protocol.data.game.chat.ChatType;
 import org.geysermc.mcprotocollib.protocol.data.game.chat.ChatTypeDecoration;
 
@@ -43,7 +43,7 @@ public record TextDecoration(String translationKey, List<Parameter> parameters, 
         throw new UnsupportedOperationException();
     }
 
-    public static ChatType readChatType(RegistryContext context) {
+    public static ChatType readChatType(RegistryEntryContext context) {
         // Note: The ID is NOT ALWAYS THE SAME! ViaVersion as of 1.19 adds two registry entries that do NOT match vanilla.
         // (This note has been passed around through several classes and iterations. It stays as a warning
         // to anyone that dares to try and hardcode registry IDs.)


### PR DESCRIPTION
This PR implements proper reading of data driven enchantments from the server. As of right now, Geyser assumes the `supported_items` and `exclusive_set` tags in enchantments are item and enchantment tags respectively - but this isn't always the case. These tags are holder sets, and can therefore be an item/enchantment ID, an item/enchantment tag, or a list of item/enchantment IDs. This PR properly accommodates for this when reading enchantments.

The PR required a change to how registries are read in `RegistryCache`. A mapper method has been added that maps resource locations of a registry that's being read to their network IDs.

This PR *should* fix #4834, but I haven't tested it in their exact environment. I have created a simple datapack that reproduces the bug, available [here](https://github.com/user-attachments/files/16127214/geyser_bug.zip), which I have tested this fix with.

Additionally, the PR also slightly cleans up the read methods for data-driven registries, by using a simple new `RegistryEntryContext` record object (containing the Geyser session, the registry entry and more) instead of passing these as multiple arguments.