### PR TITLE
Empty player list on phase transition, despawn skulls, always reset weather

### DIFF
--- a/core/src/main/java/org/geysermc/geyser/session/GeyserSession.java
+++ b/core/src/main/java/org/geysermc/geyser/session/GeyserSession.java
@@ -87,7 +87,6 @@ import org.geysermc.geyser.entity.attribute.GeyserAttributeType;
 import org.geysermc.geyser.entity.type.Entity;
 import org.geysermc.geyser.entity.type.ItemFrameEntity;
 import org.geysermc.geyser.entity.type.Tickable;
-import org.geysermc.geyser.entity.type.player.PlayerEntity;
 import org.geysermc.geyser.entity.type.player.SessionPlayerEntity;
 import org.geysermc.geyser.erosion.AbstractGeyserboundPacketHandler;
 import org.geysermc.geyser.erosion.GeyserboundHandshakePacketHandler;
@@ -888,18 +887,8 @@ public class GeyserSession implements GeyserConnection, GeyserCommandSource {
             public void packetReceived(Session session, Packet packet) {
                 if (protocol.getState() == ProtocolState.CONFIGURATION) {
                     if (packet instanceof ClientboundFinishConfigurationPacket) {
-                        GeyserSession.this.ensureInEventLoop(() -> {
-                            // Clear the player list, as on Java the player list is cleared after transitioning from config to play phase
-                            PlayerListPacket playerListPacket = new PlayerListPacket();
-                            playerListPacket.setAction(PlayerListPacket.Action.REMOVE);
-                            for (PlayerEntity otherEntity : GeyserSession.this.getEntityCache().getAllPlayerEntities()) {
-                                playerListPacket.getEntries().add(new PlayerListPacket.Entry(otherEntity.getTabListUuid()));
-                                GeyserSession.this.getEntityCache().removePlayerEntity(otherEntity.getUuid());
-                            }
-                            GeyserSession.this.sendUpstreamPacket(playerListPacket);
-
-                            GeyserSession.this.sendDownstreamPacket(new ServerboundFinishConfigurationPacket());
-                        });
+                        // Prevent
+                        GeyserSession.this.ensureInEventLoop(() -> GeyserSession.this.sendDownstreamPacket(new ServerboundFinishConfigurationPacket()));
                         return;
                     }
                 }

--- a/core/src/main/java/org/geysermc/geyser/session/cache/EntityCache.java
+++ b/core/src/main/java/org/geysermc/geyser/session/cache/EntityCache.java
@@ -32,7 +32,6 @@ import it.unimi.dsi.fastutil.longs.Long2ObjectOpenHashMap;
 import it.unimi.dsi.fastutil.objects.Object2ObjectOpenHashMap;
 import it.unimi.dsi.fastutil.objects.ObjectArrayList;
 import lombok.Getter;
-import org.cloudburstmc.protocol.bedrock.packet.PlayerListPacket;
 import org.geysermc.geyser.entity.type.Entity;
 import org.geysermc.geyser.entity.type.Tickable;
 import org.geysermc.geyser.entity.type.player.PlayerEntity;
@@ -143,12 +142,6 @@ public class EntityCache {
     }
 
     public void removeAllPlayerEntities() {
-        PlayerListPacket playerListPacket = new PlayerListPacket();
-        playerListPacket.setAction(PlayerListPacket.Action.REMOVE);
-        for (PlayerEntity otherEntity : playerEntities.values()) {
-            playerListPacket.getEntries().add(new PlayerListPacket.Entry(otherEntity.getTabListUuid()));
-        }
-        session.sendUpstreamPacket(playerListPacket);
         playerEntities.clear();
     }
 

--- a/core/src/main/java/org/geysermc/geyser/session/cache/EntityCache.java
+++ b/core/src/main/java/org/geysermc/geyser/session/cache/EntityCache.java
@@ -32,6 +32,7 @@ import it.unimi.dsi.fastutil.longs.Long2ObjectOpenHashMap;
 import it.unimi.dsi.fastutil.objects.Object2ObjectOpenHashMap;
 import it.unimi.dsi.fastutil.objects.ObjectArrayList;
 import lombok.Getter;
+import org.cloudburstmc.protocol.bedrock.packet.PlayerListPacket;
 import org.geysermc.geyser.entity.type.Entity;
 import org.geysermc.geyser.entity.type.Tickable;
 import org.geysermc.geyser.entity.type.player.PlayerEntity;
@@ -139,6 +140,16 @@ public class EntityCache {
 
     public Collection<PlayerEntity> getAllPlayerEntities() {
         return playerEntities.values();
+    }
+
+    public void removeAllPlayerEntities() {
+        PlayerListPacket playerListPacket = new PlayerListPacket();
+        playerListPacket.setAction(PlayerListPacket.Action.REMOVE);
+        for (PlayerEntity otherEntity : playerEntities.values()) {
+            playerListPacket.getEntries().add(new PlayerListPacket.Entry(otherEntity.getTabListUuid()));
+        }
+        session.sendUpstreamPacket(playerListPacket);
+        playerEntities.clear();
     }
 
     public void addBossBar(UUID uuid, BossBar bossBar) {

--- a/core/src/main/java/org/geysermc/geyser/session/cache/SkullCache.java
+++ b/core/src/main/java/org/geysermc/geyser/session/cache/SkullCache.java
@@ -243,8 +243,16 @@ public class SkullCache {
     }
 
     public void clear() {
+        for (Skull skull : skulls.values()) {
+            if (skull.entity != null) {
+                skull.entity.despawnEntity();
+            }
+        }
         skulls.clear();
         inRangeSkulls.clear();
+        for (SkullPlayerEntity skull : unusedSkullEntities) {
+            skull.despawnEntity();
+        }
         unusedSkullEntities.clear();
         totalSkullEntities = 0;
         lastPlayerPosition = null;

--- a/core/src/main/java/org/geysermc/geyser/translator/protocol/java/JavaFinishConfigurationPacketTranslator.java
+++ b/core/src/main/java/org/geysermc/geyser/translator/protocol/java/JavaFinishConfigurationPacketTranslator.java
@@ -25,6 +25,8 @@
 
 package org.geysermc.geyser.translator.protocol.java;
 
+import org.cloudburstmc.protocol.bedrock.packet.PlayerListPacket;
+import org.geysermc.geyser.entity.type.player.PlayerEntity;
 import org.geysermc.geyser.session.GeyserSession;
 import org.geysermc.geyser.translator.protocol.PacketTranslator;
 import org.geysermc.geyser.translator.protocol.Translator;
@@ -36,6 +38,12 @@ public class JavaFinishConfigurationPacketTranslator extends PacketTranslator<Cl
     @Override
     public void translate(GeyserSession session, ClientboundFinishConfigurationPacket packet) {
         // Clear the player list, as on Java the player list is cleared after transitioning from config to play phase
+        PlayerListPacket playerListPacket = new PlayerListPacket();
+        playerListPacket.setAction(PlayerListPacket.Action.REMOVE);
+        for (PlayerEntity otherEntity : session.getEntityCache().getAllPlayerEntities()) {
+            playerListPacket.getEntries().add(new PlayerListPacket.Entry(otherEntity.getTabListUuid()));
+        }
+        session.sendUpstreamPacket(playerListPacket);
         session.getEntityCache().removeAllPlayerEntities();
     }
 }

--- a/core/src/main/java/org/geysermc/geyser/translator/protocol/java/JavaFinishConfigurationPacketTranslator.java
+++ b/core/src/main/java/org/geysermc/geyser/translator/protocol/java/JavaFinishConfigurationPacketTranslator.java
@@ -1,0 +1,41 @@
+/*
+ * Copyright (c) 2024 GeyserMC. http://geysermc.org
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ *
+ * @author GeyserMC
+ * @link https://github.com/GeyserMC/Geyser
+ */
+
+package org.geysermc.geyser.translator.protocol.java;
+
+import org.geysermc.geyser.session.GeyserSession;
+import org.geysermc.geyser.translator.protocol.PacketTranslator;
+import org.geysermc.geyser.translator.protocol.Translator;
+import org.geysermc.mcprotocollib.protocol.packet.configuration.clientbound.ClientboundFinishConfigurationPacket;
+
+@Translator(packet = ClientboundFinishConfigurationPacket.class)
+public class JavaFinishConfigurationPacketTranslator extends PacketTranslator<ClientboundFinishConfigurationPacket> {
+
+    @Override
+    public void translate(GeyserSession session, ClientboundFinishConfigurationPacket packet) {
+        // Clear the player list, as on Java the player list is cleared after transitioning from config to play phase
+        session.getEntityCache().removeAllPlayerEntities();
+    }
+}

--- a/core/src/main/java/org/geysermc/geyser/translator/protocol/java/JavaLoginTranslator.java
+++ b/core/src/main/java/org/geysermc/geyser/translator/protocol/java/JavaLoginTranslator.java
@@ -79,25 +79,6 @@ public class JavaLoginTranslator extends PacketTranslator<ClientboundLoginPacket
             // Remove extra hearts, hunger, etc.
             entity.resetAttributes();
             entity.resetMetadata();
-
-            // Reset weather
-            if (session.isRaining()) {
-                LevelEventPacket stopRainPacket = new LevelEventPacket();
-                stopRainPacket.setType(LevelEvent.STOP_RAINING);
-                stopRainPacket.setData(0);
-                stopRainPacket.setPosition(Vector3f.ZERO);
-                session.sendUpstreamPacket(stopRainPacket);
-                session.setRaining(false);
-            }
-
-            if (session.isThunder()) {
-                LevelEventPacket stopThunderPacket = new LevelEventPacket();
-                stopThunderPacket.setType(LevelEvent.STOP_THUNDERSTORM);
-                stopThunderPacket.setData(0);
-                stopThunderPacket.setPosition(Vector3f.ZERO);
-                session.sendUpstreamPacket(stopThunderPacket);
-                session.setThunder(false);
-            }
         }
 
         session.setWorldName(spawnInfo.getWorldName());

--- a/core/src/main/java/org/geysermc/geyser/util/DimensionUtils.java
+++ b/core/src/main/java/org/geysermc/geyser/util/DimensionUtils.java
@@ -27,6 +27,7 @@ package org.geysermc.geyser.util;
 
 import org.cloudburstmc.math.vector.Vector3f;
 import org.cloudburstmc.math.vector.Vector3i;
+import org.cloudburstmc.protocol.bedrock.data.LevelEvent;
 import org.cloudburstmc.protocol.bedrock.data.PlayerActionType;
 import org.cloudburstmc.protocol.bedrock.packet.*;
 import org.geysermc.geyser.entity.type.Entity;
@@ -109,6 +110,20 @@ public class DimensionUtils {
         }
         // Effects are re-sent from server
         entityEffects.clear();
+
+        // Always reset weather, as it sometimes suddenly starts raining. See https://github.com/GeyserMC/Geyser/issues/3679
+        LevelEventPacket stopRainPacket = new LevelEventPacket();
+        stopRainPacket.setType(LevelEvent.STOP_RAINING);
+        stopRainPacket.setData(0);
+        stopRainPacket.setPosition(Vector3f.ZERO);
+        session.sendUpstreamPacket(stopRainPacket);
+        session.setRaining(false);
+        LevelEventPacket stopThunderPacket = new LevelEventPacket();
+        stopThunderPacket.setType(LevelEvent.STOP_THUNDERSTORM);
+        stopThunderPacket.setData(0);
+        stopThunderPacket.setPosition(Vector3f.ZERO);
+        session.sendUpstreamPacket(stopThunderPacket);
+        session.setThunder(false);
 
         //let java server handle portal travel sound
         StopSoundPacket stopSoundPacket = new StopSoundPacket();


### PR DESCRIPTION
When the Java Client transitions between config to play, it resets the player list, and Velocity seems to not send player list remove packets. Resolves https://github.com/GeyserMC/Geyser/issues/4785

While I'm already there, skulls now despawn, for parity with normal entities, which also get despawned in Geyser when switching worlds/servers.

Improve https://github.com/GeyserMC/Geyser/issues/3679 as now at least the weather gets reset between dimension switches.
