### PR TITLE
Fix: Manually translated item names for block items not showing up properly 

### DIFF
--- a/core/src/main/java/org/geysermc/geyser/registry/populator/ItemRegistryPopulator.java
+++ b/core/src/main/java/org/geysermc/geyser/registry/populator/ItemRegistryPopulator.java
@@ -59,6 +59,7 @@ import org.geysermc.geyser.inventory.item.StoredItemMappings;
 import org.geysermc.geyser.item.GeyserCustomMappingData;
 import org.geysermc.geyser.item.Items;
 import org.geysermc.geyser.item.components.Rarity;
+import org.geysermc.geyser.item.type.BlockItem;
 import org.geysermc.geyser.item.type.Item;
 import org.geysermc.geyser.registry.BlockRegistries;
 import org.geysermc.geyser.registry.Registries;
@@ -403,7 +404,7 @@ public class ItemRegistryPopulator {
                 if (javaOnlyItems.contains(javaItem) || javaItem.rarity() != Rarity.COMMON) {
                     // These items don't exist on Bedrock, so set up a variable that indicates they should have custom names
                     // Or, ensure that we are translating these at all times to account for rarity colouring
-                    mappingBuilder = mappingBuilder.translationString((bedrockBlock != null ? "block." : "item.") + entry.getKey().replace(":", "."));
+                    mappingBuilder = mappingBuilder.translationString((javaItem instanceof BlockItem ? "block." : "item.") + entry.getKey().replace(":", "."));
                     GeyserImpl.getInstance().getLogger().debug("Adding " + entry.getKey() + " as an item that needs to be translated.");
                 }
 


### PR DESCRIPTION
Fixes a regression introduced in https://github.com/GeyserMC/Geyser/commit/b0c7ddb68dbf3141f9710ea970e5f06fd246c2a4 - some items. Based on the creative items registry, it seems like heads do not have a block state by default, and instead a damage value.
This avoid that issue altogether by checking whether a given item is a BlockItem.