### PR TITLE
Properly fix hanging sign recipes

### DIFF
--- a/core/src/main/java/org/geysermc/geyser/registry/populator/CreativeItemRegistryPopulator.java
+++ b/core/src/main/java/org/geysermc/geyser/registry/populator/CreativeItemRegistryPopulator.java
@@ -80,7 +80,6 @@ public class CreativeItemRegistryPopulator {
     private static ItemData.@Nullable Builder createItemData(JsonNode itemNode, BlockMappings blockMappings, Map<String, ItemDefinition> definitions) {
         int count = 1;
         int damage = 0;
-        int bedrockBlockRuntimeId;
         NbtMap tag = null;
 
         String identifier = itemNode.get("id").textValue();

--- a/core/src/main/java/org/geysermc/geyser/registry/populator/ItemRegistryPopulator.java
+++ b/core/src/main/java/org/geysermc/geyser/registry/populator/ItemRegistryPopulator.java
@@ -167,6 +167,7 @@ public class ItemRegistryPopulator {
             Map<Item, ItemMapping> javaItemToMapping = new Object2ObjectOpenHashMap<>();
 
             List<ItemData> creativeItems = new ArrayList<>();
+            Set<String> noBlockDefinitions = new ObjectOpenHashSet<>();
 
             AtomicInteger creativeNetId = new AtomicInteger();
             CreativeItemRegistryPopulator.populate(palette, definitions, itemBuilder -> {
@@ -187,6 +188,9 @@ public class ItemRegistryPopulator {
                             bedrockBlockIdOverrides.put(identifier, item.getBlockDefinition());
                         }
                     }
+                } else {
+                    // Item mappings should also NOT have a block definition for these.
+                    noBlockDefinitions.add(item.getDefinition().getIdentifier());
                 }
             });
 
@@ -254,7 +258,12 @@ public class ItemRegistryPopulator {
                     } else {
                         // Try to get an example block runtime ID from the creative contents packet, for Bedrock identifier obtaining
                         int aValidBedrockBlockId = blacklistedIdentifiers.getOrDefault(bedrockIdentifier, customBlockItemOverride != null ? customBlockItemOverride.getRuntimeId() : -1);
-                        if (aValidBedrockBlockId != -1 || customBlockItemOverride != null) {
+                        if (aValidBedrockBlockId == -1 && customBlockItemOverride == null) {
+                            // Fallback
+                            if (!noBlockDefinitions.contains(entry.getValue().getBedrockIdentifier())) {
+                                bedrockBlock = blockMappings.getBedrockBlock(firstBlockRuntimeId);
+                            }
+                        } else {
                             // As of 1.16.220, every item requires a block runtime ID attached to it.
                             // This is mostly for identifying different blocks with the same item ID - wool, slabs, some walls.
                             // However, in order for some visuals and crafting to work, we need to send the first matching block state

--- a/core/src/main/java/org/geysermc/geyser/registry/type/ItemMapping.java
+++ b/core/src/main/java/org/geysermc/geyser/registry/type/ItemMapping.java
@@ -28,6 +28,7 @@ package org.geysermc.geyser.registry.type;
 import it.unimi.dsi.fastutil.Pair;
 import lombok.Builder;
 import lombok.EqualsAndHashCode;
+import lombok.ToString;
 import lombok.Value;
 import org.checkerframework.checker.nullness.qual.NonNull;
 import org.cloudburstmc.protocol.bedrock.data.definitions.BlockDefinition;
@@ -42,6 +43,7 @@ import java.util.List;
 @Value
 @Builder
 @EqualsAndHashCode
+@ToString
 public class ItemMapping {
     public static final ItemMapping AIR = new ItemMapping(
             "minecraft:air",


### PR DESCRIPTION
The hunch for https://github.com/GeyserMC/Geyser/commit/93b0a612659d026a293a53f632f89d1c5775eacf was correct; not the execution. Instead of removing all "fallback" block definition setting, only items that dont have a block definition sent in the creative contents packet also shouldnt have one in the mappings. Tested with BDS; this seems now to properly follow BDS behavior.