### PR TITLE
Somewhat fix: firework recipe not showing up in recipe book

### DIFF
--- a/core/src/main/java/org/geysermc/geyser/item/type/BedrockRequiresTagItem.java
+++ b/core/src/main/java/org/geysermc/geyser/item/type/BedrockRequiresTagItem.java
@@ -1,0 +1,36 @@
+/*
+ * Copyright (c) 2024 GeyserMC. http://geysermc.org
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ *
+ * @author GeyserMC
+ * @link https://github.com/GeyserMC/Geyser
+ */
+
+package org.geysermc.geyser.item.type;
+
+import org.checkerframework.checker.nullness.qual.Nullable;
+import org.geysermc.geyser.session.GeyserSession;
+import org.geysermc.geyser.translator.item.BedrockItemBuilder;
+import org.geysermc.mcprotocollib.protocol.data.game.item.component.DataComponents;
+
+public interface BedrockRequiresTagItem {
+
+    void addRequiredNbt(GeyserSession session, @Nullable DataComponents components, BedrockItemBuilder builder);
+}

--- a/core/src/main/java/org/geysermc/geyser/translator/item/ItemTranslator.java
+++ b/core/src/main/java/org/geysermc/geyser/translator/item/ItemTranslator.java
@@ -45,6 +45,7 @@ import org.geysermc.geyser.inventory.GeyserItemStack;
 import org.geysermc.geyser.item.Items;
 import org.geysermc.geyser.item.components.Rarity;
 import org.geysermc.geyser.item.type.Item;
+import org.geysermc.geyser.item.type.BedrockRequiresTagItem;
 import org.geysermc.geyser.level.block.type.Block;
 import org.geysermc.geyser.registry.BlockRegistries;
 import org.geysermc.geyser.registry.Registries;
@@ -146,6 +147,12 @@ public final class ItemTranslator {
         if (components != null) {
             javaItem.translateComponentsToBedrock(session, components, nbtBuilder);
             if (components.get(DataComponentType.HIDE_TOOLTIP) != null) hideTooltips = true;
+        }
+
+        // Fixes fireworks crafting recipe: they always contain a tag
+        // TODO remove once all items have their default components
+        if (javaItem instanceof BedrockRequiresTagItem) {
+            ((BedrockRequiresTagItem) javaItem).addRequiredNbt(session, components, nbtBuilder);
         }
 
         Rarity rarity = javaItem.rarity();

--- a/core/src/main/java/org/geysermc/geyser/translator/item/ItemTranslator.java
+++ b/core/src/main/java/org/geysermc/geyser/translator/item/ItemTranslator.java
@@ -151,8 +151,8 @@ public final class ItemTranslator {
 
         // Fixes fireworks crafting recipe: they always contain a tag
         // TODO remove once all items have their default components
-        if (javaItem instanceof BedrockRequiresTagItem) {
-            ((BedrockRequiresTagItem) javaItem).addRequiredNbt(session, components, nbtBuilder);
+        if (javaItem instanceof BedrockRequiresTagItem requiresTagItem) {
+            requiresTagItem.addRequiredNbt(session, components, nbtBuilder);
         }
 
         Rarity rarity = javaItem.rarity();

--- a/core/src/main/java/org/geysermc/geyser/translator/protocol/java/JavaUpdateRecipesTranslator.java
+++ b/core/src/main/java/org/geysermc/geyser/translator/protocol/java/JavaUpdateRecipesTranslator.java
@@ -25,7 +25,11 @@
 
 package org.geysermc.geyser.translator.protocol.java;
 
-import it.unimi.dsi.fastutil.ints.*;
+import it.unimi.dsi.fastutil.ints.Int2ObjectMap;
+import it.unimi.dsi.fastutil.ints.Int2ObjectOpenHashMap;
+import it.unimi.dsi.fastutil.ints.IntIterator;
+import it.unimi.dsi.fastutil.ints.IntOpenHashSet;
+import it.unimi.dsi.fastutil.ints.IntSet;
 import lombok.AllArgsConstructor;
 import lombok.EqualsAndHashCode;
 import org.cloudburstmc.protocol.bedrock.data.definitions.ItemDefinition;
@@ -40,7 +44,11 @@ import org.cloudburstmc.protocol.bedrock.data.inventory.descriptor.ItemTagDescri
 import org.cloudburstmc.protocol.bedrock.packet.CraftingDataPacket;
 import org.cloudburstmc.protocol.bedrock.packet.TrimDataPacket;
 import org.geysermc.geyser.GeyserImpl;
-import org.geysermc.geyser.inventory.recipe.*;
+import org.geysermc.geyser.inventory.recipe.GeyserRecipe;
+import org.geysermc.geyser.inventory.recipe.GeyserShapedRecipe;
+import org.geysermc.geyser.inventory.recipe.GeyserShapelessRecipe;
+import org.geysermc.geyser.inventory.recipe.GeyserStonecutterData;
+import org.geysermc.geyser.inventory.recipe.TrimRecipe;
 import org.geysermc.geyser.registry.Registries;
 import org.geysermc.geyser.registry.type.ItemMapping;
 import org.geysermc.geyser.session.GeyserSession;
@@ -58,7 +66,17 @@ import org.geysermc.mcprotocollib.protocol.data.game.recipe.data.SmithingTransfo
 import org.geysermc.mcprotocollib.protocol.data.game.recipe.data.StoneCuttingRecipeData;
 import org.geysermc.mcprotocollib.protocol.packet.ingame.clientbound.ClientboundUpdateRecipesPacket;
 
-import java.util.*;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.Comparator;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Set;
+import java.util.UUID;
 import java.util.stream.Collectors;
 
 import static org.geysermc.geyser.util.InventoryUtils.LAST_RECIPE_NET_ID;
@@ -190,6 +208,9 @@ public class JavaUpdateRecipesTranslator extends PacketTranslator<ClientboundUpd
                 }
                 case CRAFTING_SPECIAL_MAPCLONING -> {
                     craftingDataPacket.getCraftingData().add(MultiRecipeData.of(UUID.fromString("85939755-ba10-4d9d-a4cc-efb7a8e943c4"), context.getAndIncrementNetId()));
+                }
+                case CRAFTING_SPECIAL_FIREWORK_ROCKET -> {
+                    craftingDataPacket.getCraftingData().add(MultiRecipeData.of(UUID.fromString("00000000-0000-0000-0000-000000000002"), context.getAndIncrementNetId()));
                 }
                 default -> {
                     List<GeyserRecipe> recipes = Registries.RECIPES.get(recipe.getType());
@@ -427,7 +448,7 @@ public class JavaUpdateRecipesTranslator extends PacketTranslator<ClientboundUpd
                 return null;
             }
             // Strip NBT - tools won't appear in the recipe book otherwise
-            output = output.toBuilder().tag(null).build();
+            // output = output.toBuilder().tag(null).build(); // TODO confirm???
             ItemDescriptorWithCount[][] inputCombinations = combinations(session, recipe.ingredients());
             if (inputCombinations == null) {
                 return null;
@@ -451,7 +472,7 @@ public class JavaUpdateRecipesTranslator extends PacketTranslator<ClientboundUpd
                 return null;
             }
             // Strip NBT - tools won't appear in the recipe book otherwise
-            output = output.toBuilder().tag(null).build();
+            //output = output.toBuilder().tag(null).build(); // TODO confirm this is still true???
             ItemDescriptorWithCount[][] inputCombinations = combinations(session, recipe.ingredients());
             if (inputCombinations == null) {
                 return null;
@@ -475,7 +496,7 @@ public class JavaUpdateRecipesTranslator extends PacketTranslator<ClientboundUpd
                 return null;
             }
             // See above
-            output = output.toBuilder().tag(null).build();
+            //output = output.toBuilder().tag(null).build();
             ItemDescriptorWithCount[][] inputCombinations = combinations(session, recipe.ingredients());
             if (inputCombinations == null) {
                 return null;


### PR DESCRIPTION
Fixes https://github.com/GeyserMC/Geyser/issues/4301 - the proper long term fix would be to:
- add default components to all items, which would ensure that fireworks always have their component
- re-add hardcoded recipes for fireworks/firework stars :)

While i was able to craft tools just fine without nbt tags being stripped, this is no guarantee - hence why i left in todo's for now.