### PR TITLE
Allow commands with xbox achievements enabled

### DIFF
--- a/core/src/main/java/org/geysermc/geyser/configuration/GeyserJacksonConfiguration.java
+++ b/core/src/main/java/org/geysermc/geyser/configuration/GeyserJacksonConfiguration.java
@@ -137,7 +137,7 @@ public abstract class GeyserJacksonConfiguration implements GeyserConfiguration 
     private boolean forceResourcePacks = true;
 
     @JsonProperty("xbox-achievements-enabled")
-    private boolean xboxAchievementsEnabled = true;
+    private boolean xboxAchievementsEnabled = false;
 
     @JsonProperty("log-player-ip-addresses")
     private boolean logPlayerIpAddresses = true;

--- a/core/src/main/java/org/geysermc/geyser/configuration/GeyserJacksonConfiguration.java
+++ b/core/src/main/java/org/geysermc/geyser/configuration/GeyserJacksonConfiguration.java
@@ -137,7 +137,7 @@ public abstract class GeyserJacksonConfiguration implements GeyserConfiguration 
     private boolean forceResourcePacks = true;
 
     @JsonProperty("xbox-achievements-enabled")
-    private boolean xboxAchievementsEnabled = false;
+    private boolean xboxAchievementsEnabled = true;
 
     @JsonProperty("log-player-ip-addresses")
     private boolean logPlayerIpAddresses = true;

--- a/core/src/main/java/org/geysermc/geyser/translator/protocol/java/JavaCommandsTranslator.java
+++ b/core/src/main/java/org/geysermc/geyser/translator/protocol/java/JavaCommandsTranslator.java
@@ -449,7 +449,7 @@ public class JavaCommandsTranslator extends PacketTranslator<ClientboundCommands
                         type = (CommandParam) mappedType;
                         // Bedrock throws a fit if an optional message comes after a string or target
                         // Example vanilla commands: ban-ip, ban, and kick
-                        if (optional && type == CommandParam.MESSAGE && (paramData.getType() == CommandParam.STRING || paramData.getType() == CommandParam.TARGET)) {
+                        if (optional && type == CommandParam.MESSAGE && paramData != null && (paramData.getType() == CommandParam.STRING || paramData.getType() == CommandParam.TARGET)) {
                             optional = false;
                         }
                     }

--- a/core/src/main/java/org/geysermc/geyser/translator/protocol/java/JavaCommandsTranslator.java
+++ b/core/src/main/java/org/geysermc/geyser/translator/protocol/java/JavaCommandsTranslator.java
@@ -169,8 +169,8 @@ public class JavaCommandsTranslator extends PacketTranslator<ClientboundCommands
             return;
         }
 
-        // The command flags, not sure what these do apart from break things
-        Set<CommandData.Flag> flags = Set.of();
+        // The command flags, set to NOT_CHEAT, so we can enable achievements by default
+        Set<CommandData.Flag> flags = Set.of(CommandData.Flag.NOT_CHEAT);
 
         // Loop through all the found commands
         for (Map.Entry<BedrockCommandInfo, Set<String>> entry : commands.entrySet()) {

--- a/core/src/main/java/org/geysermc/geyser/translator/protocol/java/JavaCommandsTranslator.java
+++ b/core/src/main/java/org/geysermc/geyser/translator/protocol/java/JavaCommandsTranslator.java
@@ -169,7 +169,7 @@ public class JavaCommandsTranslator extends PacketTranslator<ClientboundCommands
             return;
         }
 
-        // The command flags, set to NOT_CHEAT, so we can enable achievements by default
+        // The command flags, set to NOT_CHEAT so known commands can be used while achievements are enabled.
         Set<CommandData.Flag> flags = Set.of(CommandData.Flag.NOT_CHEAT);
 
         // Loop through all the found commands

--- a/core/src/main/resources/config.yml
+++ b/core/src/main/resources/config.yml
@@ -168,7 +168,7 @@ above-bedrock-nether-building: false
 force-resource-packs: true
 
 # Allows Xbox achievements to be unlocked.
-xbox-achievements-enabled: true
+xbox-achievements-enabled: false
 
 # Whether player IP addresses will be logged by the server.
 log-player-ip-addresses: true

--- a/core/src/main/resources/config.yml
+++ b/core/src/main/resources/config.yml
@@ -168,8 +168,7 @@ above-bedrock-nether-building: false
 force-resource-packs: true
 
 # Allows Xbox achievements to be unlocked.
-# THIS DISABLES ALL COMMANDS FROM SUCCESSFULLY RUNNING FOR BEDROCK IN-GAME, as otherwise Bedrock thinks you are cheating.
-xbox-achievements-enabled: false
+xbox-achievements-enabled: true
 
 # Whether player IP addresses will be logged by the server.
 log-player-ip-addresses: true


### PR DESCRIPTION
Apparently after all this time its that easy to make commands work while Xbox achievements are enabled

There is one side effect, commands not registered with the client just print a message saying cheats are not enabled. But that happened before so we are definitely still better.

Also fixes #4793

![image](https://github.com/user-attachments/assets/4f1f9d36-6a91-451a-9ec7-07bdd4303b1c)

![image](https://github.com/user-attachments/assets/9be687d1-626f-4740-ab94-5334f0b4b962)