### PR TITLE
Fix: Geyser-NeoForge not booting due to duplicate module

### DIFF
--- a/bootstrap/mod/fabric/build.gradle.kts
+++ b/bootstrap/mod/fabric/build.gradle.kts
@@ -25,10 +25,7 @@ dependencies {
     shadow(libs.protocol.connection) { isTransitive = false }
     shadow(libs.protocol.common) { isTransitive = false }
     shadow(libs.protocol.codec) { isTransitive = false }
-    shadow(libs.minecraftauth) { isTransitive = false }
     shadow(libs.raknet) { isTransitive = false }
-
-    // Consequences of shading + relocating mcauthlib: shadow/relocate mcpl!
     shadow(libs.mcprotocollib) { isTransitive = false }
 
     // Since we also relocate cloudburst protocol: shade erosion common

--- a/bootstrap/mod/neoforge/build.gradle.kts
+++ b/bootstrap/mod/neoforge/build.gradle.kts
@@ -5,6 +5,7 @@ plugins {
 // This is provided by "org.cloudburstmc.math.mutable" too, so yeet.
 // NeoForge's class loader is *really* annoying.
 provided("org.cloudburstmc.math", "api")
+provided("com.google.errorprone", "error_prone_annotations")
 
 architectury {
     platformSetupLoomIde()


### PR DESCRIPTION
Further - there's no reason to JiJ MinecraftAuth on Fabric, since it's using a semver compliant version. 