### PR TITLE
Fix: Broadcast port system property not being read on Geyser-Standalone

### DIFF
--- a/core/src/main/java/org/geysermc/geyser/GeyserImpl.java
+++ b/core/src/main/java/org/geysermc/geyser/GeyserImpl.java
@@ -363,22 +363,6 @@ public class GeyserImpl implements GeyserApi, EventRegistrar {
                 }
             }
 
-            String broadcastPort = System.getProperty("geyserBroadcastPort", "");
-            if (!broadcastPort.isEmpty()) {
-                int parsedPort;
-                try {
-                    parsedPort = Integer.parseInt(broadcastPort);
-                    if (parsedPort < 1 || parsedPort > 65535) {
-                        throw new NumberFormatException("The broadcast port must be between 1 and 65535 inclusive!");
-                    }
-                } catch (NumberFormatException e) {
-                    logger.error(String.format("Invalid broadcast port: %s! Defaulting to configured port.", broadcastPort + " (" + e.getMessage() + ")"));
-                    parsedPort = config.getBedrock().port();
-                }
-                config.getBedrock().setBroadcastPort(parsedPort);
-                logger.info("Broadcast port set from system property: " + parsedPort);
-            }
-
             if (platformType != PlatformType.VIAPROXY) {
                 boolean floodgatePresent = bootstrap.testFloodgatePluginPresent();
                 if (config.getRemote().authType() == AuthType.FLOODGATE && !floodgatePresent) {
@@ -391,6 +375,23 @@ public class GeyserImpl implements GeyserApi, EventRegistrar {
                     config.getRemote().setAuthType(AuthType.FLOODGATE);
                 }
             }
+        }
+
+        // Now that other platforms set the Bedrock port, also check the broadcast port
+        String broadcastPort = System.getProperty("geyserBroadcastPort", "");
+        if (!broadcastPort.isEmpty()) {
+            int parsedPort;
+            try {
+                parsedPort = Integer.parseInt(broadcastPort);
+                if (parsedPort < 1 || parsedPort > 65535) {
+                    throw new NumberFormatException("The broadcast port must be between 1 and 65535 inclusive!");
+                }
+            } catch (NumberFormatException e) {
+                logger.error(String.format("Invalid broadcast port: %s! Defaulting to configured port.", broadcastPort + " (" + e.getMessage() + ")"));
+                parsedPort = config.getBedrock().port();
+            }
+            config.getBedrock().setBroadcastPort(parsedPort);
+            logger.info("Broadcast port set from system property: " + parsedPort);
         }
 
         String remoteAddress = config.getRemote().address();

--- a/core/src/main/java/org/geysermc/geyser/GeyserImpl.java
+++ b/core/src/main/java/org/geysermc/geyser/GeyserImpl.java
@@ -392,6 +392,11 @@ public class GeyserImpl implements GeyserApi, EventRegistrar {
             }
         }
 
+        // It's set to 0 only if no system property or manual config value was set
+        if (config.getBedrock().broadcastPort() == 0) {
+            config.getBedrock().setBroadcastPort(config.getBedrock().port());
+        }
+
         String remoteAddress = config.getRemote().address();
         // Filters whether it is not an IP address or localhost, because otherwise it is not possible to find out an SRV entry.
         if (!remoteAddress.matches(IP_REGEX) && !remoteAddress.equalsIgnoreCase("localhost")) {

--- a/core/src/main/java/org/geysermc/geyser/GeyserImpl.java
+++ b/core/src/main/java/org/geysermc/geyser/GeyserImpl.java
@@ -380,18 +380,16 @@ public class GeyserImpl implements GeyserApi, EventRegistrar {
         // Now that the Bedrock port may have been changed, also check the broadcast port (configurable on all platforms)
         String broadcastPort = System.getProperty("geyserBroadcastPort", "");
         if (!broadcastPort.isEmpty()) {
-            int parsedPort;
             try {
-                parsedPort = Integer.parseInt(broadcastPort);
+                int parsedPort = Integer.parseInt(broadcastPort);
                 if (parsedPort < 1 || parsedPort > 65535) {
                     throw new NumberFormatException("The broadcast port must be between 1 and 65535 inclusive!");
                 }
+                config.getBedrock().setBroadcastPort(parsedPort);
+                logger.info("Broadcast port set from system property: " + parsedPort);
             } catch (NumberFormatException e) {
-                logger.error(String.format("Invalid broadcast port: %s! Defaulting to configured port.", broadcastPort + " (" + e.getMessage() + ")"));
-                parsedPort = config.getBedrock().port();
+                logger.error(String.format("Invalid broadcast port from system property: %s! Defaulting to configured port.", broadcastPort + " (" + e.getMessage() + ")"));
             }
-            config.getBedrock().setBroadcastPort(parsedPort);
-            logger.info("Broadcast port set from system property: " + parsedPort);
         }
 
         String remoteAddress = config.getRemote().address();

--- a/core/src/main/java/org/geysermc/geyser/GeyserImpl.java
+++ b/core/src/main/java/org/geysermc/geyser/GeyserImpl.java
@@ -377,7 +377,7 @@ public class GeyserImpl implements GeyserApi, EventRegistrar {
             }
         }
 
-        // Now that other platforms set the Bedrock port, also check the broadcast port
+        // Now that the Bedrock port may have been changed, also check the broadcast port (configurable on all platforms)
         String broadcastPort = System.getProperty("geyserBroadcastPort", "");
         if (!broadcastPort.isEmpty()) {
             int parsedPort;

--- a/core/src/main/java/org/geysermc/geyser/network/netty/GeyserServer.java
+++ b/core/src/main/java/org/geysermc/geyser/network/netty/GeyserServer.java
@@ -143,11 +143,6 @@ public final class GeyserServer {
             this.proxiedAddresses = null;
         }
 
-        // It's set to 0 only if no system property or manual config value was set
-        if (geyser.getConfig().getBedrock().broadcastPort() == 0) {
-            geyser.getConfig().getBedrock().setBroadcastPort(geyser.getConfig().getBedrock().port());
-        }
-
         this.broadcastPort = geyser.getConfig().getBedrock().broadcastPort();
     }
 


### PR DESCRIPTION
This was in the block that was not running when we're on standalone. oops!

Not that i've ever seen anyone actually using this; but you never know.