### PR TITLE
Indicate 1.21.1 Java support

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ The ultimate goal of this project is to allow Minecraft: Bedrock Edition users t
 Special thanks to the DragonProxy project for being a trailblazer in protocol translation and for all the team members who have joined us here!
 
 ## Supported Versions
-Geyser is currently supporting Minecraft Bedrock 1.20.80 - 1.21.3 and Minecraft Java Server 1.21. For more info please see [here](https://geysermc.org/wiki/geyser/supported-versions/).
+Geyser is currently supporting Minecraft Bedrock 1.20.80 - 1.21.3 and Minecraft Java Server 1.21/1.21.1. For more info please see [here](https://geysermc.org/wiki/geyser/supported-versions/).
 
 ## Setting Up
 Take a look [here](https://geysermc.org/wiki/geyser/setup/) for how to set up Geyser.

--- a/bootstrap/spigot/build.gradle.kts
+++ b/bootstrap/spigot/build.gradle.kts
@@ -81,5 +81,7 @@ tasks.withType<com.github.jengelman.gradle.plugins.shadow.tasks.ShadowJar> {
 
 modrinth {
     uploadFile.set(tasks.getByPath("shadowJar"))
+    gameVersions.addAll("1.16.5", "1.17", "1.17.1", "1.18", "1.18.1", "1.18.2", "1.19",
+        "1.19.1", "1.19.2", "1.19.3", "1.19.4", "1.20", "1.20.1", "1.20.2", "1.20.3", "1.20.4", "1.20.5", "1.20.6")
     loaders.addAll("spigot", "paper")
 }

--- a/build-logic/src/main/kotlin/geyser.modrinth-uploading-conventions.gradle.kts
+++ b/build-logic/src/main/kotlin/geyser.modrinth-uploading-conventions.gradle.kts
@@ -11,7 +11,7 @@ modrinth {
     versionNumber.set(project.version as String + "-" + System.getenv("BUILD_NUMBER"))
     versionType.set("beta")
     changelog.set(System.getenv("CHANGELOG") ?: "")
-    gameVersions.add(libs.minecraft.get().version as String)
+    gameVersions.addAll("1.21", libs.minecraft.get().version as String)
     failSilently.set(true)
 
     syncBodyFrom.set(rootProject.file("README.md").readText())

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -33,10 +33,10 @@ velocity = "3.3.0-SNAPSHOT"
 viaproxy = "3.3.2-SNAPSHOT"
 fabric-loader = "0.15.11"
 fabric-api = "0.100.1+1.21"
-neoforge-minecraft = "21.0.0-beta"
+neoforge-minecraft = "21.1.1"
 mixin = "0.8.5"
 mixinextras = "0.3.5"
-minecraft = "1.21"
+minecraft = "1.21.1"
 
 # plugin versions
 indra = "3.1.3"


### PR DESCRIPTION
- Indicate 1.21.1 support on modrinth/in the README.md
- Add all supported versions of Geyser-Spigot to modrinth - this will prevent modrinth from auto-pinning older e.g. 1.20.4 builds as the "latest" build for said version. 