### PR TITLE
Unify repository definition

### DIFF
--- a/build-logic/src/main/kotlin/geyser.build-logic.gradle.kts
+++ b/build-logic/src/main/kotlin/geyser.build-logic.gradle.kts
@@ -30,7 +30,6 @@ repositories {
         mavenContent { releasesOnly() }
     }
 
-
     // ViaVersion
     maven("https://repo.viaversion.com") {
         name = "viaversion"

--- a/build-logic/src/main/kotlin/geyser.build-logic.gradle.kts
+++ b/build-logic/src/main/kotlin/geyser.build-logic.gradle.kts
@@ -3,9 +3,6 @@ repositories {
 
     mavenCentral()
 
-    // Opencollab repo
-    maven("https://repo.opencollab.dev/main")
-
     // Floodgate, Cumulus etc.
     maven("https://repo.opencollab.dev/main")
 

--- a/build-logic/src/main/kotlin/geyser.build-logic.gradle.kts
+++ b/build-logic/src/main/kotlin/geyser.build-logic.gradle.kts
@@ -1,0 +1,49 @@
+repositories {
+    // mavenLocal()
+
+    mavenCentral()
+
+    // Opencollab repo
+    maven("https://repo.opencollab.dev/main")
+
+    // Floodgate, Cumulus etc.
+    maven("https://repo.opencollab.dev/main")
+
+    // Paper, Velocity
+    maven("https://repo.papermc.io/repository/maven-public")
+
+    // Spigot
+    maven("https://hub.spigotmc.org/nexus/content/repositories/snapshots") {
+        mavenContent { snapshotsOnly() }
+    }
+
+    // BungeeCord
+    maven("https://oss.sonatype.org/content/repositories/snapshots") {
+        mavenContent { snapshotsOnly() }
+    }
+
+    // NeoForge
+    maven("https://maven.neoforged.net/releases") {
+        mavenContent { releasesOnly() }
+    }
+
+    // Minecraft
+    maven("https://libraries.minecraft.net") {
+        name = "minecraft"
+        mavenContent { releasesOnly() }
+    }
+
+
+    // ViaVersion
+    maven("https://repo.viaversion.com") {
+        name = "viaversion"
+    }
+
+    // Jitpack for e.g. MCPL
+    maven("https://jitpack.io") {
+        content { includeGroupByRegex("com\\.github\\..*") }
+    }
+
+    // For Adventure snapshots
+    maven("https://s01.oss.sonatype.org/content/repositories/snapshots/")
+}

--- a/build-logic/src/main/kotlin/geyser.modded-conventions.gradle.kts
+++ b/build-logic/src/main/kotlin/geyser.modded-conventions.gradle.kts
@@ -5,6 +5,7 @@ import org.gradle.kotlin.dsl.dependencies
 import org.gradle.kotlin.dsl.maven
 
 plugins {
+    id("geyser.build-logic")
     id("geyser.publish-conventions")
     id("architectury-plugin")
     id("dev.architectury.loom")
@@ -115,13 +116,4 @@ afterEvaluate {
 dependencies {
     minecraft(libs.minecraft)
     mappings(loom.officialMojangMappings())
-}
-
-repositories {
-    // mavenLocal()
-    maven("https://repo.opencollab.dev/main")
-    maven("https://jitpack.io")
-    maven("https://oss.sonatype.org/content/repositories/snapshots/")
-    maven("https://s01.oss.sonatype.org/content/repositories/snapshots/")
-    maven("https://maven.neoforged.net/releases")
 }

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -2,52 +2,6 @@
 
 enableFeaturePreview("TYPESAFE_PROJECT_ACCESSORS")
 
-dependencyResolutionManagement {
-    repositories {
-        // mavenLocal()
-        
-        // Floodgate, Cumulus etc.
-        maven("https://repo.opencollab.dev/main")
-
-        // Paper, Velocity
-        maven("https://repo.papermc.io/repository/maven-public")
-        // Spigot
-        maven("https://hub.spigotmc.org/nexus/content/repositories/snapshots") {
-            mavenContent { snapshotsOnly() }
-        }
-
-        // BungeeCord
-        maven("https://oss.sonatype.org/content/repositories/snapshots") {
-            mavenContent { snapshotsOnly() }
-        }
-
-        // NeoForge
-        maven("https://maven.neoforged.net/releases") {
-            mavenContent { releasesOnly() }
-        }
-
-        // Minecraft
-        maven("https://libraries.minecraft.net") {
-            name = "minecraft"
-            mavenContent { releasesOnly() }
-        }
-
-        mavenCentral()
-
-        // ViaVersion
-        maven("https://repo.viaversion.com") {
-            name = "viaversion"
-        }
-
-        maven("https://jitpack.io") {
-            content { includeGroupByRegex("com\\.github\\..*") }
-        }
-
-        // For Adventure snapshots
-        maven("https://s01.oss.sonatype.org/content/repositories/snapshots/")
-    }
-}
-
 pluginManagement {
     repositories {
         gradlePluginPortal()


### PR DESCRIPTION
These changes ensure that there is a single point where we define maven repos - instead of multiple. Done similarly in the floodgate-neoforge PR; works like a charm there. 
Unfortunately, the build-logic's build.gradle.kts will have it's own repo section, but to my knowledge that is unavoidable (and not a huge issue, as that specifically affects the plugins used in there)