### PR TITLE
Feature: Subpack loading

### DIFF
--- a/api/src/main/java/org/geysermc/geyser/api/pack/ResourcePack.java
+++ b/api/src/main/java/org/geysermc/geyser/api/pack/ResourcePack.java
@@ -29,10 +29,9 @@ import org.checkerframework.checker.nullness.qual.NonNull;
 import org.checkerframework.checker.nullness.qual.Nullable;
 
 /**
- * Represents a resource pack sent to Bedrock clients
+ * Represents a resource pack sent to Bedrock clients.
  * <p>
- * This representation of a resource pack only contains what
- * Geyser requires to send it to the client.
+ * This representation of a resource pack tends to be minimal.
  * <p>
  * Optionally, a content key and/or a subpack name to load can be provided.
  */

--- a/api/src/main/java/org/geysermc/geyser/api/pack/ResourcePack.java
+++ b/api/src/main/java/org/geysermc/geyser/api/pack/ResourcePack.java
@@ -65,7 +65,7 @@ public interface ResourcePack {
     /**
      * Sets the content key of the resource pack. Lack of a content key can be represented by an empty string.
      */
-    void contentKey(@NonNull String contentKey);
+    void contentKey(@Nullable String contentKey);
 
     /**
      * The subpack to tell Bedrock clients to load. Lack of a subpack to load is represented by an empty string.

--- a/api/src/main/java/org/geysermc/geyser/api/pack/ResourcePack.java
+++ b/api/src/main/java/org/geysermc/geyser/api/pack/ResourcePack.java
@@ -26,12 +26,15 @@
 package org.geysermc.geyser.api.pack;
 
 import org.checkerframework.checker.nullness.qual.NonNull;
+import org.checkerframework.checker.nullness.qual.Nullable;
 
 /**
  * Represents a resource pack sent to Bedrock clients
  * <p>
  * This representation of a resource pack only contains what
  * Geyser requires to send it to the client.
+ * <p>
+ * Optionally, a content key and/or a subpack name to load can be provided.
  */
 public interface ResourcePack {
 
@@ -58,6 +61,25 @@ public interface ResourcePack {
      */
     @NonNull
     String contentKey();
+
+    /**
+     * Sets the content key of the resource pack. Lack of a content key can be represented by an empty string.
+     */
+    void contentKey(@NonNull String contentKey);
+
+    /**
+     * The subpack to tell Bedrock clients to load. Lack of a subpack to load is represented by an empty string.
+     *
+     * @return the subpack name, or an empty string if not set.
+     */
+    @NonNull
+    String subpackName();
+
+    /**
+     * Sets the subpack name that clients should load.
+     * It must match one of the subpacks that can be found in the manifest.
+     */
+    void subpackName(@Nullable String subpackName);
 
     /**
      * Creates a resource pack with the given {@link PackCodec}.

--- a/api/src/main/java/org/geysermc/geyser/api/pack/ResourcePackManifest.java
+++ b/api/src/main/java/org/geysermc/geyser/api/pack/ResourcePackManifest.java
@@ -26,6 +26,7 @@
 package org.geysermc.geyser.api.pack;
 
 import org.checkerframework.checker.nullness.qual.NonNull;
+import org.checkerframework.checker.nullness.qual.Nullable;
 
 import java.util.Collection;
 import java.util.UUID;
@@ -78,6 +79,7 @@ public interface ResourcePackManifest {
      * Gets the settings of the resource pack.
      * This is the text shown in the settings menu of a resource pack.
      */
+    @NonNull
     Collection<? extends Setting> settings();
 
     /**
@@ -196,6 +198,7 @@ public interface ResourcePackManifest {
          *
          * @return the folder name
          */
+        @NonNull
         String folderName();
 
         /**
@@ -205,6 +208,7 @@ public interface ResourcePackManifest {
          *
          * @return the subpack name
          */
+        @NonNull
         String name();
 
         /**
@@ -214,7 +218,7 @@ public interface ResourcePackManifest {
          *
          * @return the memory tier
          */
-
+        @Nullable
         Float memoryTier();
     }
 
@@ -229,6 +233,7 @@ public interface ResourcePackManifest {
          *
          * @return the type
          */
+        @NonNull
         String type();
 
         /**
@@ -236,6 +241,7 @@ public interface ResourcePackManifest {
          *
          * @return the text content
          */
+        @NonNull
         String text();
     }
 

--- a/api/src/main/java/org/geysermc/geyser/api/pack/ResourcePackManifest.java
+++ b/api/src/main/java/org/geysermc/geyser/api/pack/ResourcePackManifest.java
@@ -75,6 +75,12 @@ public interface ResourcePackManifest {
     Collection<? extends Subpack> subpacks();
 
     /**
+     * Gets the settings of the resource pack.
+     * This is the text shown in the settings menu of a resource pack.
+     */
+    Collection<? extends Setting> settings();
+
+    /**
      * Represents the header of a resource pack.
      */
     interface Header {
@@ -203,11 +209,34 @@ public interface ResourcePackManifest {
 
         /**
          * Gets the memory tier of the subpack.
+         * One memory tier requires 0.25 GB of free memory
+         * that a device must have to run a sub-pack.
          *
          * @return the memory tier
          */
 
         Float memoryTier();
+    }
+
+    /**
+     * Represents a setting that is shown client-side that describe what a pack does.
+     * Multiple setting entries are shown in separate paragraphs.
+     */
+    interface Setting {
+
+        /**
+         * The type of the setting. Usually just "label".
+         *
+         * @return the type
+         */
+        String type();
+
+        /**
+         * The text shown for the setting.
+         *
+         * @return the text content
+         */
+        String text();
     }
 
     /**

--- a/api/src/main/java/org/geysermc/geyser/api/pack/ResourcePackManifest.java
+++ b/api/src/main/java/org/geysermc/geyser/api/pack/ResourcePackManifest.java
@@ -67,6 +67,14 @@ public interface ResourcePackManifest {
     Collection<? extends Dependency> dependencies();
 
     /**
+     * Gets the subpacks of the resource pack.
+     *
+     * @return the subpacks
+     */
+    @NonNull
+    Collection<? extends Subpack> subpacks();
+
+    /**
      * Represents the header of a resource pack.
      */
     interface Header {
@@ -170,6 +178,36 @@ public interface ResourcePackManifest {
          */
         @NonNull
         Version version();
+    }
+
+    /**
+     * Represents a subpack of a resource pack
+     */
+    interface Subpack {
+
+        /**
+         * Gets the folder name of the subpack.
+         *
+         * @return the folder name
+         */
+        String folderName();
+
+        /**
+         * Gets the name of the subpack.
+         * It can be sent to the Bedrock client alongside the pack
+         * to load a particular subpack within a resource pack.
+         *
+         * @return the subpack name
+         */
+        String name();
+
+        /**
+         * Gets the memory tier of the subpack.
+         *
+         * @return the memory tier
+         */
+
+        Float memoryTier();
     }
 
     /**

--- a/core/src/main/java/org/geysermc/geyser/network/UpstreamPacketHandler.java
+++ b/core/src/main/java/org/geysermc/geyser/network/UpstreamPacketHandler.java
@@ -205,11 +205,10 @@ public class UpstreamPacketHandler extends LoggingPacketHandler {
 
         ResourcePacksInfoPacket resourcePacksInfo = new ResourcePacksInfoPacket();
         for (ResourcePack pack : this.resourcePackLoadEvent.resourcePacks()) {
-            PackCodec codec = pack.codec();
             ResourcePackManifest.Header header = pack.manifest().header();
             resourcePacksInfo.getResourcePackInfos().add(new ResourcePacksInfoPacket.Entry(
-                    header.uuid().toString(), header.version().toString(), codec.size(), pack.contentKey(),
-                    "", header.uuid().toString(), false, false));
+                    header.uuid().toString(), header.version().toString(), pack.codec().size(), pack.contentKey(),
+                    pack.subpackName(), header.uuid().toString(), false, false));
         }
         resourcePacksInfo.setForcedToAccept(GeyserImpl.getInstance().getConfig().isForceResourcePacks());
         session.sendUpstreamPacket(resourcePacksInfo);

--- a/core/src/main/java/org/geysermc/geyser/pack/GeyserResourcePack.java
+++ b/core/src/main/java/org/geysermc/geyser/pack/GeyserResourcePack.java
@@ -25,14 +25,62 @@
 
 package org.geysermc.geyser.pack;
 
+import lombok.RequiredArgsConstructor;
+import org.checkerframework.checker.nullness.qual.NonNull;
+import org.checkerframework.checker.nullness.qual.Nullable;
 import org.geysermc.geyser.api.pack.PackCodec;
 import org.geysermc.geyser.api.pack.ResourcePack;
 import org.geysermc.geyser.api.pack.ResourcePackManifest;
 
-public record GeyserResourcePack(PackCodec codec, ResourcePackManifest manifest, String contentKey) implements ResourcePack {
+@RequiredArgsConstructor
+public class GeyserResourcePack implements ResourcePack {
 
     /**
      * The size of each chunk to use when sending the resource packs to clients in bytes
      */
     public static final int CHUNK_SIZE = 102400;
+
+    private final PackCodec codec;
+    private final ResourcePackManifest manifest;
+    private String contentKey;
+    private String subpackName;
+
+    public GeyserResourcePack(PackCodec codec, ResourcePackManifest manifest, String contentKey) {
+        this(codec, manifest);
+        this.contentKey = contentKey;
+    }
+
+    @Override
+    public @NonNull PackCodec codec() {
+        return this.codec;
+    }
+
+    @Override
+    public @NonNull ResourcePackManifest manifest() {
+        return this.manifest;
+    }
+
+    @Override
+    public @NonNull String contentKey() {
+        return this.contentKey == null ? "" : this.contentKey;
+    }
+
+    @Override
+    public void contentKey(@Nullable String contentKey) {
+        this.contentKey = contentKey;
+    }
+
+    @Override
+    public @NonNull String subpackName() {
+        return this.subpackName == null ? "" : this.subpackName;
+    }
+
+    @Override
+    public void subpackName(@Nullable String subpackName) {
+        if (manifest.subpacks().stream().anyMatch(subpack -> subpack.name().equals(subpackName))) {
+            this.subpackName = subpackName;
+        } else {
+            throw new IllegalArgumentException("A subpack with the name '" + subpackName + "' does not exist!");
+        }
+    }
 }

--- a/core/src/main/java/org/geysermc/geyser/pack/GeyserResourcePackManifest.java
+++ b/core/src/main/java/org/geysermc/geyser/pack/GeyserResourcePackManifest.java
@@ -37,13 +37,21 @@ import java.io.IOException;
 import java.util.Collection;
 import java.util.UUID;
 
-public record GeyserResourcePackManifest(@JsonProperty("format_version") int formatVersion, Header header, Collection<Module> modules, Collection<Dependency> dependencies) implements ResourcePackManifest {
+public record GeyserResourcePackManifest(
+    @JsonProperty("format_version") int formatVersion,
+    Header header,
+    Collection<Module> modules,
+    Collection<Dependency> dependencies,
+    Collection<Subpack> subpacks
+) implements ResourcePackManifest {
 
     public record Header(UUID uuid, Version version, String name, String description, @JsonProperty("min_engine_version") Version minimumSupportedMinecraftVersion) implements ResourcePackManifest.Header { }
 
     public record Module(UUID uuid, Version version, String type, String description) implements ResourcePackManifest.Module { }
 
     public record Dependency(UUID uuid, Version version) implements ResourcePackManifest.Dependency { }
+
+    public record Subpack(@JsonProperty("folder_name") String folderName, String name, @JsonProperty("memory_tier") Float memoryTier) implements ResourcePackManifest.Subpack { }
 
     @JsonDeserialize(using = Version.VersionDeserializer.class)
     public record Version(int major, int minor, int patch) implements ResourcePackManifest.Version {

--- a/core/src/main/java/org/geysermc/geyser/pack/GeyserResourcePackManifest.java
+++ b/core/src/main/java/org/geysermc/geyser/pack/GeyserResourcePackManifest.java
@@ -42,7 +42,8 @@ public record GeyserResourcePackManifest(
     Header header,
     Collection<Module> modules,
     Collection<Dependency> dependencies,
-    Collection<Subpack> subpacks
+    Collection<Subpack> subpacks,
+    Collection<Setting> settings
 ) implements ResourcePackManifest {
 
     public record Header(UUID uuid, Version version, String name, String description, @JsonProperty("min_engine_version") Version minimumSupportedMinecraftVersion) implements ResourcePackManifest.Header { }
@@ -52,6 +53,8 @@ public record GeyserResourcePackManifest(
     public record Dependency(UUID uuid, Version version) implements ResourcePackManifest.Dependency { }
 
     public record Subpack(@JsonProperty("folder_name") String folderName, String name, @JsonProperty("memory_tier") Float memoryTier) implements ResourcePackManifest.Subpack { }
+
+    public record Setting(String type, String text) implements ResourcePackManifest.Setting { }
 
     @JsonDeserialize(using = Version.VersionDeserializer.class)
     public record Version(int major, int minor, int patch) implements ResourcePackManifest.Version {


### PR DESCRIPTION
Implements https://github.com/GeyserMC/Geyser/issues/4939

Potential usages:
- different textures/animations depending on platform to e.g. account for different performance levels
- shipping one pack for different servers

Further, this also adds setters for `contentKey` and the `subpackName` to the `ResourcePack` interface. These would, imo, also benefit remote resource pack - those values cannot be read directly from the resource pack, so it makes sense to allow these to be modifies after reading the pack.