### PR TITLE
Fix: Invalid heads blocking inventory transactions

### DIFF
--- a/core/src/main/java/org/geysermc/geyser/skin/FakeHeadProvider.java
+++ b/core/src/main/java/org/geysermc/geyser/skin/FakeHeadProvider.java
@@ -112,7 +112,13 @@ public class FakeHeadProvider {
             return;
         }
 
-        Map<TextureType, Texture> textures = profile.getTextures(false);
+        Map<TextureType, Texture> textures;
+        try {
+            textures = profile.getTextures(false);
+        } catch (IllegalStateException e) {
+            GeyserImpl.getInstance().getLogger().debug("Could not decode player head from profile %s, got: %s".formatted(profile, e.getMessage()));
+            textures = null;
+        }
 
         if (textures == null || textures.isEmpty()) {
             loadHead(session, entity, profile.getName());

--- a/core/src/main/java/org/geysermc/geyser/translator/item/ItemTranslator.java
+++ b/core/src/main/java/org/geysermc/geyser/translator/item/ItemTranslator.java
@@ -25,9 +25,6 @@
 
 package org.geysermc.geyser.translator.item;
 
-import org.geysermc.mcprotocollib.auth.GameProfile;
-import org.geysermc.mcprotocollib.auth.GameProfile.Texture;
-import org.geysermc.mcprotocollib.auth.GameProfile.TextureType;
 import net.kyori.adventure.text.Component;
 import net.kyori.adventure.text.format.NamedTextColor;
 import org.checkerframework.checker.nullness.qual.NonNull;
@@ -43,8 +40,8 @@ import org.geysermc.geyser.api.block.custom.CustomBlockData;
 import org.geysermc.geyser.inventory.GeyserItemStack;
 import org.geysermc.geyser.item.Items;
 import org.geysermc.geyser.item.components.Rarity;
-import org.geysermc.geyser.item.type.Item;
 import org.geysermc.geyser.item.type.BedrockRequiresTagItem;
+import org.geysermc.geyser.item.type.Item;
 import org.geysermc.geyser.level.block.type.Block;
 import org.geysermc.geyser.registry.BlockRegistries;
 import org.geysermc.geyser.registry.Registries;
@@ -55,13 +52,24 @@ import org.geysermc.geyser.text.ChatColor;
 import org.geysermc.geyser.text.MinecraftLocale;
 import org.geysermc.geyser.translator.text.MessageTranslator;
 import org.geysermc.geyser.util.InventoryUtils;
+import org.geysermc.mcprotocollib.auth.GameProfile;
+import org.geysermc.mcprotocollib.auth.GameProfile.Texture;
+import org.geysermc.mcprotocollib.auth.GameProfile.TextureType;
 import org.geysermc.mcprotocollib.protocol.data.game.entity.attribute.AttributeType;
 import org.geysermc.mcprotocollib.protocol.data.game.entity.attribute.ModifierOperation;
 import org.geysermc.mcprotocollib.protocol.data.game.item.ItemStack;
-import org.geysermc.mcprotocollib.protocol.data.game.item.component.*;
+import org.geysermc.mcprotocollib.protocol.data.game.item.component.AdventureModePredicate;
+import org.geysermc.mcprotocollib.protocol.data.game.item.component.DataComponentType;
+import org.geysermc.mcprotocollib.protocol.data.game.item.component.DataComponents;
+import org.geysermc.mcprotocollib.protocol.data.game.item.component.HolderSet;
+import org.geysermc.mcprotocollib.protocol.data.game.item.component.ItemAttributeModifiers;
 
 import java.text.DecimalFormat;
-import java.util.*;
+import java.util.ArrayList;
+import java.util.EnumMap;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
 
 public final class ItemTranslator {
 
@@ -486,7 +494,13 @@ public final class ItemTranslator {
         
         GameProfile profile = components.get(DataComponentType.PROFILE);
         if (profile != null) {
-            Map<TextureType, Texture> textures = profile.getTextures(false);
+            Map<TextureType, Texture> textures;
+            try {
+                textures = profile.getTextures(false);
+            } catch (IllegalStateException e) {
+                GeyserImpl.getInstance().getLogger().debug("Could not decode player head from profile %s, got: %s".formatted(profile, e.getMessage()));
+                return null;
+            }
 
             if (textures == null || textures.isEmpty()) {
                 return null;


### PR DESCRIPTION
fixes e.g. https://mclo.gs/SJOYKgZ - an invalid texture will result in a default player head, but not block java packets from being translated