### PR TITLE
Feature: Modrinth version names

### DIFF
--- a/build-logic/src/main/kotlin/extensions.kt
+++ b/build-logic/src/main/kotlin/extensions.kt
@@ -118,3 +118,12 @@ open class DownloadFilesTask : DefaultTask() {
 private fun calcExclusion(section: String, bit: Int, excludedOn: Int): String =
     if (excludedOn and bit > 0) section else ""
 
+fun projectVersion(project: Project): String =
+    project.version.toString().replace("SNAPSHOT", "b" + buildNumber())
+
+fun versionName(project: Project): String =
+    "Geyser-" + project.name.replaceFirstChar { it.uppercase() } + "-" + projectVersion(project)
+
+fun buildNumber(): Int =
+    (System.getenv("BUILD_NUMBER"))?.let { Integer.parseInt(it) } ?: -1
+

--- a/build-logic/src/main/kotlin/geyser.modded-conventions.gradle.kts
+++ b/build-logic/src/main/kotlin/geyser.modded-conventions.gradle.kts
@@ -87,7 +87,7 @@ tasks {
     register("remapModrinthJar", RemapJarTask::class) {
         dependsOn(shadowJar)
         inputFile.set(shadowJar.get().archiveFile)
-        archiveVersion.set(project.version.toString() + "+build."  + System.getenv("BUILD_NUMBER"))
+        archiveVersion.set(versionName(project))
         archiveClassifier.set("")
     }
 }

--- a/build-logic/src/main/kotlin/geyser.modrinth-uploading-conventions.gradle.kts
+++ b/build-logic/src/main/kotlin/geyser.modrinth-uploading-conventions.gradle.kts
@@ -8,8 +8,8 @@ tasks.modrinth.get().dependsOn(tasks.modrinthSyncBody)
 modrinth {
     token.set(System.getenv("MODRINTH_TOKEN") ?: "") // Even though this is the default value, apparently this prevents GitHub Actions caching the token?
     projectId.set("geyser")
-    versionName.set(versionName())
-    versionNumber.set(version())
+    versionName.set(versionName(project))
+    versionNumber.set(projectVersion(project))
     versionType.set("beta")
     changelog.set(System.getenv("CHANGELOG") ?: "")
     gameVersions.addAll("1.21", libs.minecraft.get().version as String)
@@ -17,9 +17,3 @@ modrinth {
 
     syncBodyFrom.set(rootProject.file("README.md").readText())
 }
-
-private fun version(): String =
-    project.version.toString().removeSuffix("SNAPSHOT") + "b" + System.getenv("BUILD_NUMBER")
-
-private fun versionName(): String =
-    "Geyser-" + project.name.replaceFirstChar { it.uppercase() } + "-" + version()

--- a/build-logic/src/main/kotlin/geyser.modrinth-uploading-conventions.gradle.kts
+++ b/build-logic/src/main/kotlin/geyser.modrinth-uploading-conventions.gradle.kts
@@ -8,7 +8,8 @@ tasks.modrinth.get().dependsOn(tasks.modrinthSyncBody)
 modrinth {
     token.set(System.getenv("MODRINTH_TOKEN") ?: "") // Even though this is the default value, apparently this prevents GitHub Actions caching the token?
     projectId.set("geyser")
-    versionNumber.set(project.version as String + "-" + System.getenv("BUILD_NUMBER"))
+    versionName.set(versionName())
+    versionNumber.set(version())
     versionType.set("beta")
     changelog.set(System.getenv("CHANGELOG") ?: "")
     gameVersions.addAll("1.21", libs.minecraft.get().version as String)
@@ -16,3 +17,9 @@ modrinth {
 
     syncBodyFrom.set(rootProject.file("README.md").readText())
 }
+
+private fun version(): String =
+    project.version.toString().removeSuffix("SNAPSHOT") + "b" + System.getenv("BUILD_NUMBER")
+
+private fun versionName(): String =
+    "Geyser-" + project.name.replaceFirstChar { it.uppercase() } + "-" + version()

--- a/core/build.gradle.kts
+++ b/core/build.gradle.kts
@@ -103,9 +103,6 @@ sourceSets {
     }
 }
 
-fun buildNumber(): Int =
-    (System.getenv("BUILD_NUMBER"))?.let { Integer.parseInt(it) } ?: -1
-
 fun isDevBuild(branch: String, repository: String): Boolean {
     return branch != "master" || repository.equals("https://github.com/GeyserMC/Geyser", ignoreCase = true).not()
 }
@@ -139,7 +136,7 @@ inner class GitInfo {
 
         buildNumber = buildNumber()
         isDev = isDevBuild(branch, repository)
-        val projectVersion = if (isDev) project.version else project.version.toString().replace("SNAPSHOT", "b${buildNumber}")
+        val projectVersion = if (isDev) project.version else projectVersion(project)
         version = "$projectVersion ($gitVersion)"
     }
 }


### PR DESCRIPTION
Hey! This PR will change how versions are shown on modrinth.
Current state:
![image](https://github.com/user-attachments/assets/4d4da1df-819c-44c2-bc44-f8a42045eb8e)
![image](https://github.com/user-attachments/assets/3c05e2c0-e779-4ea5-bc46-f738bb7f2ec8)

These changes will:
- remove `-SNAPSHOT` from the version, and replace it with `-b69` (build number)
- add the platform name to the download, making it clearer in the changelogs which build was changed.
- change the modrinth names of the fabric/neoforge builds: Geyser-Fabric-2.4.2-b69.jar instead of `geyser-fabric-2.4.2-SNAPSHOT-build.69.jar`