### PR TITLE
Fix moving items from output slot over multiple actions

### DIFF
--- a/core/src/main/java/org/geysermc/geyser/inventory/click/ClickPlan.java
+++ b/core/src/main/java/org/geysermc/geyser/inventory/click/ClickPlan.java
@@ -162,6 +162,27 @@ public final class ClickPlan {
         finished = true;
     }
 
+    public Inventory getInventory() {
+        return inventory;
+    }
+
+    /**
+     * Test if the item stacks with another item in the specified slot.
+     * This will check the simulated inventory without copying.
+     */
+    public boolean canStack(int slot, GeyserItemStack item) {
+        GeyserItemStack slotItem = simulatedItems.getOrDefault(slot, inventory.getItem(slot));
+        return InventoryUtils.canStack(slotItem, item);
+    }
+
+    /**
+     * Test if the specified slot is empty.
+     * This will check the simulated inventory without copying.
+     */
+    public boolean isEmpty(int slot) {
+        return simulatedItems.getOrDefault(slot, inventory.getItem(slot)).isEmpty();
+    }
+
     public GeyserItemStack getItem(int slot) {
         return simulatedItems.computeIfAbsent(slot, k -> inventory.getItem(slot).copy());
     }

--- a/core/src/main/java/org/geysermc/geyser/translator/inventory/InventoryTranslator.java
+++ b/core/src/main/java/org/geysermc/geyser/translator/inventory/InventoryTranslator.java
@@ -245,7 +245,8 @@ public abstract class InventoryTranslator {
                     }
 
                     // Handle partial transfer of output slot
-                    if (pendingOutput == 0 && getSlotType(sourceSlot) == SlotType.OUTPUT && transferAction.getCount() < plan.getItem(sourceSlot).getAmount()) {
+                    if (pendingOutput == 0 && !isSourceCursor && getSlotType(sourceSlot) == SlotType.OUTPUT
+                        && transferAction.getCount() < plan.getItem(sourceSlot).getAmount()) {
                         // Cursor as dest should always be full transfer.
                         if (isDestCursor) {
                             return rejectRequest(request);
@@ -266,7 +267,7 @@ public abstract class InventoryTranslator {
 
                     // Continue transferring items from output that is currently stored in the cursor
                     if (pendingOutput > 0) {
-                        if (getSlotType(sourceSlot) != SlotType.OUTPUT
+                        if (isSourceCursor || getSlotType(sourceSlot) != SlotType.OUTPUT
                             || transferAction.getCount() > pendingOutput
                             || destSlot == savedTempSlot
                             || isDestCursor) {


### PR DESCRIPTION
Should fix #4984

Certain requests with an item in the cursor are intentionally rejected with this PR so it might give the impression that something is glitching, but this is still an improvement over the translator shuffling items around. Will try to find a good solution

An easy way to test is to spawn a villager like this 
```/summon villager ~ ~1 ~ {VillagerData:{profession:farmer,level:2,type:plains},PersistenceRequired:1,Offers:{Recipes:[{buy:{id:emerald,count:1},sell:{id:cobblestone,count:54},rewardExp:0b,maxUses:9999999}]}}```