### PR TITLE
Fix PARTICLES_DRAGON_BLOCK_BREAK translation

### DIFF
--- a/core/src/main/java/org/geysermc/geyser/translator/protocol/java/level/JavaLevelEventTranslator.java
+++ b/core/src/main/java/org/geysermc/geyser/translator/protocol/java/level/JavaLevelEventTranslator.java
@@ -293,7 +293,7 @@ public class JavaLevelEventTranslator extends PacketTranslator<ClientboundLevelE
             }
             case PARTICLES_DRAGON_BLOCK_BREAK -> {
                 effectPacket.setType(org.cloudburstmc.protocol.bedrock.data.LevelEvent.PARTICLE_GENERIC_SPAWN);
-                effectPacket.setData(61);
+                effectPacket.setData(65);
             }
             case PARTICLES_WATER_EVAPORATING -> {
                 effectPacket.setType(org.cloudburstmc.protocol.bedrock.data.LevelEvent.PARTICLE_EVAPORATE_WATER);


### PR DESCRIPTION
Value 61 is no longer the dragon block destroy particle, but the bubble column down particle. This PR fixes the value.
![image](https://github.com/user-attachments/assets/e66da6d4-267b-43bf-9d89-9775bcf4830c)

Before:
![image](https://github.com/user-attachments/assets/0be18d07-a3a4-41ab-b92f-d698ffa943a8)
After:
![image](https://github.com/user-attachments/assets/9d828aae-9648-4ca1-b7e7-c0819f3342f9)
