### PR TITLE
Add proper text component parsing from NBT

### DIFF
--- a/core/src/main/java/org/geysermc/geyser/item/enchantment/Enchantment.java
+++ b/core/src/main/java/org/geysermc/geyser/item/enchantment/Enchantment.java
@@ -69,7 +69,7 @@ public record Enchantment(String identifier,
 
         // TODO - description is a component. So if a hardcoded literal string is given, this will display normally on Java,
         //  but Geyser will attempt to lookup the literal string as translation - and will fail, displaying an empty string as enchantment name.
-        String description = bedrockEnchantment == null ? MessageTranslator.deserializeDescription(data) : null;
+        String description = bedrockEnchantment == null ? MessageTranslator.deserializeDescription(context.session(), data) : null;
 
         return new Enchantment(context.id().asString(), effects, supportedItems, maxLevel,
                 description, anvilCost, exclusiveSet, bedrockEnchantment);

--- a/core/src/main/java/org/geysermc/geyser/level/JukeboxSong.java
+++ b/core/src/main/java/org/geysermc/geyser/level/JukeboxSong.java
@@ -44,7 +44,7 @@ public record JukeboxSong(String soundEvent, String description) {
             soundEvent = "";
             GeyserImpl.getInstance().getLogger().debug("Sound event for " + context.id() + " was of an unexpected type! Expected string or NBT map, got " + soundEventObject);
         }
-        String description = MessageTranslator.deserializeDescription(data);
+        String description = MessageTranslator.deserializeDescription(context.session(), data);
         return new JukeboxSong(soundEvent, description);
     }
 }

--- a/core/src/main/java/org/geysermc/geyser/session/cache/RegistryCache.java
+++ b/core/src/main/java/org/geysermc/geyser/session/cache/RegistryCache.java
@@ -49,7 +49,7 @@ import org.geysermc.geyser.session.GeyserSession;
 import org.geysermc.geyser.session.cache.registry.JavaRegistry;
 import org.geysermc.geyser.session.cache.registry.RegistryEntryContext;
 import org.geysermc.geyser.session.cache.registry.SimpleJavaRegistry;
-import org.geysermc.geyser.text.TextDecoration;
+import org.geysermc.geyser.text.ChatDecoration;
 import org.geysermc.geyser.translator.level.BiomeTranslator;
 import org.geysermc.geyser.util.MinecraftKey;
 import org.geysermc.mcprotocollib.protocol.MinecraftProtocol;
@@ -78,7 +78,7 @@ public final class RegistryCache {
     private static final Map<Key, BiConsumer<RegistryCache, List<RegistryEntry>>> REGISTRIES = new HashMap<>();
 
     static {
-        register("chat_type", cache -> cache.chatTypes, TextDecoration::readChatType);
+        register("chat_type", cache -> cache.chatTypes, ChatDecoration::readChatType);
         register("dimension_type", cache -> cache.dimensions, JavaDimension::read);
         register("enchantment", cache -> cache.enchantments, Enchantment::read);
         register("jukebox_song", cache -> cache.jukeboxSongs, JukeboxSong::read);

--- a/core/src/main/java/org/geysermc/geyser/text/ChatDecoration.java
+++ b/core/src/main/java/org/geysermc/geyser/text/ChatDecoration.java
@@ -55,7 +55,7 @@ public record ChatDecoration(String translationKey, List<Parameter> parameters, 
             String translationKey = chat.getString("translation_key");
 
             NbtMap styleTag = chat.getCompound("style");
-            Style style = deserializeStyle(styleTag);
+            Style style = MessageTranslator.getStyleFromNbtMap(styleTag);
 
             List<ChatTypeDecoration.Parameter> parameters = new ArrayList<>();
             List<String> parametersNbt = chat.getList("parameters", NbtType.STRING);
@@ -71,10 +71,6 @@ public record ChatDecoration(String translationKey, List<Parameter> parameters, 
         if (decoration instanceof ChatDecoration chatDecoration) {
             return chatDecoration.deserializedStyle();
         }
-        return deserializeStyle(decoration.style());
-    }
-
-    private static Style deserializeStyle(NbtMap styleTag) {
-        return MessageTranslator.getStyleFromNbtMap(styleTag);
+        return MessageTranslator.getStyleFromNbtMap(decoration.style());
     }
 }

--- a/core/src/main/java/org/geysermc/geyser/text/ChatDecoration.java
+++ b/core/src/main/java/org/geysermc/geyser/text/ChatDecoration.java
@@ -25,17 +25,19 @@
 
 package org.geysermc.geyser.text;
 
-import net.kyori.adventure.text.format.NamedTextColor;
 import net.kyori.adventure.text.format.Style;
 import org.cloudburstmc.nbt.NbtMap;
 import org.cloudburstmc.nbt.NbtType;
 import org.geysermc.geyser.session.cache.registry.RegistryEntryContext;
+import org.geysermc.geyser.translator.text.MessageTranslator;
 import org.geysermc.mcprotocollib.protocol.data.game.chat.ChatType;
 import org.geysermc.mcprotocollib.protocol.data.game.chat.ChatTypeDecoration;
 
-import java.util.*;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Locale;
 
-public record TextDecoration(String translationKey, List<Parameter> parameters, Style deserializedStyle) implements ChatTypeDecoration {
+public record ChatDecoration(String translationKey, List<Parameter> parameters, Style deserializedStyle) implements ChatTypeDecoration {
 
     @Override
     public NbtMap style() {
@@ -60,31 +62,19 @@ public record TextDecoration(String translationKey, List<Parameter> parameters, 
             for (String parameter : parametersNbt) {
                 parameters.add(ChatTypeDecoration.Parameter.valueOf(parameter.toUpperCase(Locale.ROOT)));
             }
-            return new ChatType(new TextDecoration(translationKey, parameters, style), null);
+            return new ChatType(new ChatDecoration(translationKey, parameters, style), null);
         }
         return new ChatType(null, null);
     }
 
     public static Style getStyle(ChatTypeDecoration decoration) {
-        if (decoration instanceof TextDecoration textDecoration) {
-            return textDecoration.deserializedStyle();
+        if (decoration instanceof ChatDecoration chatDecoration) {
+            return chatDecoration.deserializedStyle();
         }
         return deserializeStyle(decoration.style());
     }
 
     private static Style deserializeStyle(NbtMap styleTag) {
-        Style.Builder builder = Style.style();
-        if (!styleTag.isEmpty()) {
-            String color = styleTag.getString("color", null);
-            if (color != null) {
-                builder.color(NamedTextColor.NAMES.value(color));
-            }
-            //TODO implement the rest
-            boolean italic = styleTag.getBoolean("italic");
-            if (italic) {
-                builder.decorate(net.kyori.adventure.text.format.TextDecoration.ITALIC);
-            }
-        }
-        return builder.build();
+        return MessageTranslator.getStyleFromNbtMap(styleTag);
     }
 }

--- a/core/src/main/java/org/geysermc/geyser/translator/text/MessageTranslator.java
+++ b/core/src/main/java/org/geysermc/geyser/translator/text/MessageTranslator.java
@@ -431,7 +431,7 @@ public class MessageTranslator {
     }
 
     /**
-     * Deserialize an NbtMap provided from a registry into a string.
+     * Deserialize an NbtMap with a description text component (usually provided from a registry) into a Bedrock-formatted string.
      */
     public static String deserializeDescription(GeyserSession session, NbtMap tag) {
         NbtMap description = tag.getCompound("description");
@@ -447,39 +447,42 @@ public class MessageTranslator {
         if (nbtTag instanceof String literal) {
             return Component.text(literal).style(style);
         } else if (nbtTag instanceof List<?> list) {
-            return Component.join(JoinConfiguration.builder(), componentsFromNbtList(list, style));
+            return Component.join(JoinConfiguration.noSeparators(), componentsFromNbtList(list, style));
         } else if (nbtTag instanceof NbtMap map) {
-            Component component = Component.empty();
-            if (map.containsKey("text")) {
-                component = Component.text(map.getString("text"));
-            } else if (map.containsKey("translate")) {
-                String key = map.getString("translate");
-                String fallback = map.getString("fallback", "");
-                List<Component> args = new ArrayList<>();
+            Component component = null;
+            String text = map.getString("text", null);
+            if (text != null) {
+                component = Component.text(text);
+            } else {
+                String translateKey = map.getString("translate", null);
+                if (translateKey != null) {
+                    String fallback = map.getString("fallback", "");
+                    List<Component> args = new ArrayList<>();
 
-                if (map.containsKey("with")) {
                     Object with = map.get("with");
                     if (with instanceof List<?> list) {
                         args = componentsFromNbtList(list, style);
-                    } else {
+                    } else if (with != null) {
                         args.add(componentFromNbtTag(with, style));
                     }
+                    component = Component.translatable(translateKey, fallback, args);
                 }
-                component = Component.translatable(key, fallback, args);
             }
 
-            Style newStyle = getStyleFromNbtMap(map, style);
-            component = component.style(newStyle);
+            if (component != null) {
+                Style newStyle = getStyleFromNbtMap(map, style);
+                component = component.style(newStyle);
 
-            Object extra = map.get("extra");
-            if (extra != null) {
-                component = component.append(componentFromNbtTag(extra, newStyle));
+                Object extra = map.get("extra");
+                if (extra != null) {
+                    component = component.append(componentFromNbtTag(extra, newStyle));
+                }
+
+                return component;
             }
-
-            return component;
         }
 
-        throw new IllegalArgumentException("Expected tag to be a literal string, a list of components, or a component");
+        throw new IllegalArgumentException("Expected tag to be a literal string, a list of components, or a component object with a text/translate key");
     }
 
     private static List<Component> componentsFromNbtList(List<?> list, Style style) {
@@ -491,37 +494,28 @@ public class MessageTranslator {
     }
 
     public static Style getStyleFromNbtMap(NbtMap map) {
-        return getStyleFromNbtMap(map, Style.empty());
+        Style.Builder style = Style.style();
+
+        String colorString = map.getString("color", null);
+        if (colorString != null) {
+            if (colorString.startsWith(TextColor.HEX_PREFIX)) {
+                style.color(TextColor.fromHexString(colorString));
+            } else {
+                style.color(NamedTextColor.NAMES.value(colorString));
+            }
+        }
+
+        map.listenForBoolean("bold", value -> style.decoration(TextDecoration.BOLD, value));
+        map.listenForBoolean("italic", value -> style.decoration(TextDecoration.ITALIC, value));
+        map.listenForBoolean("underlined", value -> style.decoration(TextDecoration.UNDERLINED, value));
+        map.listenForBoolean("strikethrough", value -> style.decoration(TextDecoration.STRIKETHROUGH, value));
+        map.listenForBoolean("obfuscated", value -> style.decoration(TextDecoration.OBFUSCATED, value));
+
+        return style.build();
     }
 
     public static Style getStyleFromNbtMap(NbtMap map, Style base) {
-        Style.Builder newStyle = Style.style().merge(base);
-
-        if (map.containsKey("color", NbtType.STRING)) {
-            String colorString = map.getString("color");
-            if (colorString.startsWith(TextColor.HEX_PREFIX)) {
-                newStyle.color(TextColor.fromHexString(colorString));
-            } else {
-                newStyle.color(NamedTextColor.NAMES.value(colorString));
-            }
-        }
-        if (map.containsKey("bold", NbtType.BYTE)) {
-            newStyle.decoration(TextDecoration.BOLD, map.getBoolean("bold"));
-        }
-        if (map.containsKey("italic", NbtType.BYTE)) {
-            newStyle.decoration(TextDecoration.ITALIC, map.getBoolean("italic"));
-        }
-        if (map.containsKey("underlined", NbtType.BYTE)) {
-            newStyle.decoration(TextDecoration.UNDERLINED, map.getBoolean("underlined"));
-        }
-        if (map.containsKey("strikethrough", NbtType.BYTE)) {
-            newStyle.decoration(TextDecoration.STRIKETHROUGH, map.getBoolean("strikethrough"));
-        }
-        if (map.containsKey("obfuscated", NbtType.BYTE)) {
-            newStyle.decoration(TextDecoration.OBFUSCATED, map.getBoolean("obfuscated"));
-        }
-
-        return newStyle.build();
+        return base.merge(getStyleFromNbtMap(map));
     }
 
     public static void init() {

--- a/core/src/main/java/org/geysermc/geyser/translator/text/MessageTranslator.java
+++ b/core/src/main/java/org/geysermc/geyser/translator/text/MessageTranslator.java
@@ -433,18 +433,9 @@ public class MessageTranslator {
     /**
      * Deserialize an NbtMap provided from a registry into a string.
      */
-    // This may be a Component in the future.
     public static String deserializeDescription(GeyserSession session, NbtMap tag) {
         NbtMap description = tag.getCompound("description");
         Component parsed = componentFromNbtTag(description);
-        /*
-        String translate = description.getString("translate", null);
-        if (translate == null) {
-            GeyserImpl.getInstance().getLogger().debug("Don't know how to read description! " + tag);
-            return "";
-        }
-        */
-
         return convertMessage(session, parsed);
     }
 

--- a/core/src/main/java/org/geysermc/geyser/translator/text/MessageTranslator.java
+++ b/core/src/main/java/org/geysermc/geyser/translator/text/MessageTranslator.java
@@ -33,6 +33,7 @@ import net.kyori.adventure.text.flattener.ComponentFlattener;
 import net.kyori.adventure.text.format.NamedTextColor;
 import net.kyori.adventure.text.format.Style;
 import net.kyori.adventure.text.format.TextColor;
+import net.kyori.adventure.text.format.TextDecoration;
 import net.kyori.adventure.text.renderer.TranslatableComponentRenderer;
 import net.kyori.adventure.text.serializer.gson.GsonComponentSerializer;
 import net.kyori.adventure.text.serializer.legacy.CharacterAndFormat;
@@ -345,16 +346,16 @@ public class MessageTranslator {
             // Though, Bedrock cannot care about the signed stuff.
             TranslatableComponent.Builder withDecoration = Component.translatable()
                     .key(chat.translationKey())
-                    .style(TextDecoration.getStyle(chat));
+                    .style(ChatDecoration.getStyle(chat));
             List<ChatTypeDecoration.Parameter> parameters = chat.parameters();
             List<Component> args = new ArrayList<>(3);
-            if (parameters.contains(TextDecoration.Parameter.TARGET)) {
+            if (parameters.contains(ChatDecoration.Parameter.TARGET)) {
                 args.add(targetName);
             }
-            if (parameters.contains(TextDecoration.Parameter.SENDER)) {
+            if (parameters.contains(ChatDecoration.Parameter.SENDER)) {
                 args.add(sender);
             }
-            if (parameters.contains(TextDecoration.Parameter.CONTENT)) {
+            if (parameters.contains(ChatDecoration.Parameter.CONTENT)) {
                 args.add(message);
             }
             withDecoration.arguments(args);
@@ -476,37 +477,12 @@ public class MessageTranslator {
                 component = Component.translatable(key, fallback, args);
             }
 
-            Style.Builder newStyle = Style.style().merge(style);
-
-            if (map.containsKey("color", NbtType.STRING)) {
-                String colorString = map.getString("color");
-                if (colorString.startsWith(TextColor.HEX_PREFIX)) {
-                    newStyle.color(TextColor.fromHexString(colorString));
-                } else {
-                    newStyle.color(NamedTextColor.NAMES.value(colorString));
-                }
-            }
-            if (map.containsKey("bold", NbtType.BYTE)) {
-                newStyle.decoration(net.kyori.adventure.text.format.TextDecoration.BOLD, map.getBoolean("bold"));
-            }
-            if (map.containsKey("italic", NbtType.BYTE)) {
-                newStyle.decoration(net.kyori.adventure.text.format.TextDecoration.ITALIC, map.getBoolean("italic"));
-            }
-            if (map.containsKey("underlined", NbtType.BYTE)) {
-                newStyle.decoration(net.kyori.adventure.text.format.TextDecoration.UNDERLINED, map.getBoolean("underlined"));
-            }
-            if (map.containsKey("strikethrough", NbtType.BYTE)) {
-                newStyle.decoration(net.kyori.adventure.text.format.TextDecoration.STRIKETHROUGH, map.getBoolean("strikethrough"));
-            }
-            if (map.containsKey("obfuscated", NbtType.BYTE)) {
-                newStyle.decoration(net.kyori.adventure.text.format.TextDecoration.OBFUSCATED, map.getBoolean("obfuscated"));
-            }
-
+            Style newStyle = getStyleFromNbtMap(map, style);
             component = component.style(newStyle);
 
             Object extra = map.get("extra");
             if (extra != null) {
-                component = component.append(componentFromNbtTag(extra, newStyle.build()));
+                component = component.append(componentFromNbtTag(extra, newStyle));
             }
 
             return component;
@@ -521,6 +497,40 @@ public class MessageTranslator {
             components.add(componentFromNbtTag(entry, style));
         }
         return components;
+    }
+
+    public static Style getStyleFromNbtMap(NbtMap map) {
+        return getStyleFromNbtMap(map, Style.empty());
+    }
+
+    public static Style getStyleFromNbtMap(NbtMap map, Style base) {
+        Style.Builder newStyle = Style.style().merge(base);
+
+        if (map.containsKey("color", NbtType.STRING)) {
+            String colorString = map.getString("color");
+            if (colorString.startsWith(TextColor.HEX_PREFIX)) {
+                newStyle.color(TextColor.fromHexString(colorString));
+            } else {
+                newStyle.color(NamedTextColor.NAMES.value(colorString));
+            }
+        }
+        if (map.containsKey("bold", NbtType.BYTE)) {
+            newStyle.decoration(TextDecoration.BOLD, map.getBoolean("bold"));
+        }
+        if (map.containsKey("italic", NbtType.BYTE)) {
+            newStyle.decoration(TextDecoration.ITALIC, map.getBoolean("italic"));
+        }
+        if (map.containsKey("underlined", NbtType.BYTE)) {
+            newStyle.decoration(TextDecoration.UNDERLINED, map.getBoolean("underlined"));
+        }
+        if (map.containsKey("strikethrough", NbtType.BYTE)) {
+            newStyle.decoration(TextDecoration.STRIKETHROUGH, map.getBoolean("strikethrough"));
+        }
+        if (map.containsKey("obfuscated", NbtType.BYTE)) {
+            newStyle.decoration(TextDecoration.OBFUSCATED, map.getBoolean("obfuscated"));
+        }
+
+        return newStyle.build();
     }
 
     public static void init() {

--- a/core/src/main/java/org/geysermc/geyser/translator/text/MessageTranslator.java
+++ b/core/src/main/java/org/geysermc/geyser/translator/text/MessageTranslator.java
@@ -39,6 +39,7 @@ import net.kyori.adventure.text.serializer.legacy.CharacterAndFormat;
 import net.kyori.adventure.text.serializer.legacy.LegacyComponentSerializer;
 import net.kyori.adventure.text.serializer.plain.PlainTextComponentSerializer;
 import org.cloudburstmc.nbt.NbtMap;
+import org.cloudburstmc.nbt.NbtType;
 import org.cloudburstmc.protocol.bedrock.packet.TextPacket;
 import org.geysermc.geyser.GeyserImpl;
 import org.geysermc.geyser.session.GeyserSession;
@@ -475,35 +476,37 @@ public class MessageTranslator {
                 component = Component.translatable(key, fallback, args);
             }
 
-            String colorString = map.getString("color", "");
-            TextColor color = null;
-            if (!colorString.isEmpty()) {
+            Style.Builder newStyle = Style.style().merge(style);
+
+            if (map.containsKey("color", NbtType.STRING)) {
+                String colorString = map.getString("color");
                 if (colorString.startsWith(TextColor.HEX_PREFIX)) {
-                    color = TextColor.fromHexString(colorString);
+                    newStyle.color(TextColor.fromHexString(colorString));
                 } else {
-                    color = NamedTextColor.NAMES.value(colorString);
+                    newStyle.color(NamedTextColor.NAMES.value(colorString));
                 }
             }
-
-            boolean bold = map.getBoolean("bold", false);
-            boolean italic = map.getBoolean("italic", false);
-            boolean underlined = map.getBoolean("underlined", false);
-            boolean strikethrough = map.getBoolean("strikethrough", false);
-            boolean obfuscated = map.getBoolean("obfuscated", false);
-
-            Style newStyle = style
-                    .color(color)
-                    .decoration(net.kyori.adventure.text.format.TextDecoration.BOLD, bold)
-                    .decoration(net.kyori.adventure.text.format.TextDecoration.ITALIC, italic)
-                    .decoration(net.kyori.adventure.text.format.TextDecoration.UNDERLINED, underlined)
-                    .decoration(net.kyori.adventure.text.format.TextDecoration.STRIKETHROUGH, strikethrough)
-                    .decoration(net.kyori.adventure.text.format.TextDecoration.OBFUSCATED, obfuscated);
+            if (map.containsKey("bold", NbtType.BYTE)) {
+                newStyle.decoration(net.kyori.adventure.text.format.TextDecoration.BOLD, map.getBoolean("bold"));
+            }
+            if (map.containsKey("italic", NbtType.BYTE)) {
+                newStyle.decoration(net.kyori.adventure.text.format.TextDecoration.ITALIC, map.getBoolean("italic"));
+            }
+            if (map.containsKey("underlined", NbtType.BYTE)) {
+                newStyle.decoration(net.kyori.adventure.text.format.TextDecoration.UNDERLINED, map.getBoolean("underlined"));
+            }
+            if (map.containsKey("strikethrough", NbtType.BYTE)) {
+                newStyle.decoration(net.kyori.adventure.text.format.TextDecoration.STRIKETHROUGH, map.getBoolean("strikethrough"));
+            }
+            if (map.containsKey("obfuscated", NbtType.BYTE)) {
+                newStyle.decoration(net.kyori.adventure.text.format.TextDecoration.OBFUSCATED, map.getBoolean("obfuscated"));
+            }
 
             component = component.style(newStyle);
 
             Object extra = map.get("extra");
             if (extra != null) {
-                component = component.append(componentFromNbtTag(extra, newStyle));
+                component = component.append(componentFromNbtTag(extra, newStyle.build()));
             }
 
             return component;


### PR DESCRIPTION
This PR adds methods to Geyser to properly parse Java text components from NBT sent by the server. This is used in the `MessageTranslator.deserializeDescription` method, which is responsible for parsing descriptions for jukebox songs and enchantments.

- A `componentFromNbtTag` method has been added to the `MessageTranslator` class, which is used in the `deserializeDescription` method and can also be used elsewhere in the future.
- Two `getStyleFromNbtMap` methods have been added to the `MessageTranslator` class, which are used when parsing text components from NBT, as well as proper parsing of styles for data driven chat types, whereas before only hardcoded colours and italic styles where parsed there.
- The Geyser `TextDecoration` record has been renamed to `ChatDecoration` to solve conflicts with the `TextDecoration` class from the Adventure library.

Basic testing has been performed and all seems to work now, however further testing might be nice. This PR should fix #5024, but I haven't tested it in their setup.