### PR TITLE
API: Expose a GeyserConnection's protocol version

### DIFF
--- a/api/src/main/java/org/geysermc/geyser/api/connection/GeyserConnection.java
+++ b/api/src/main/java/org/geysermc/geyser/api/connection/GeyserConnection.java
@@ -71,6 +71,11 @@ public interface GeyserConnection extends Connection, CommandSource {
     void closeForm();
 
     /**
+     * Gets the protocol version of the player.
+     */
+    int protocolVersion();
+
+    /**
      * @param javaId the Java entity ID to look up.
      * @return a {@link GeyserEntity} if present in this connection's entity tracker.
      * @deprecated Use {@link EntityData#entityByJavaId(int)} instead

--- a/api/src/main/java/org/geysermc/geyser/api/connection/GeyserConnection.java
+++ b/api/src/main/java/org/geysermc/geyser/api/connection/GeyserConnection.java
@@ -71,7 +71,7 @@ public interface GeyserConnection extends Connection, CommandSource {
     void closeForm();
 
     /**
-     * Gets the protocol version of the player.
+     * Gets the Bedrock protocol version of the player.
      */
     int protocolVersion();
 

--- a/core/src/main/java/org/geysermc/geyser/session/GeyserSession.java
+++ b/core/src/main/java/org/geysermc/geyser/session/GeyserSession.java
@@ -2230,6 +2230,11 @@ public class GeyserSession implements GeyserConnection, GeyserCommandSource {
     }
 
     @Override
+    public int protocolVersion() {
+        return upstream.getProtocolVersion();
+    }
+
+    @Override
     public void closeForm() {
         if (!GameProtocol.isPre1_21_2(this)) {
             sendUpstreamPacket(new ClientboundCloseFormPacket());

--- a/gradle.properties
+++ b/gradle.properties
@@ -8,5 +8,5 @@ org.gradle.vfs.watch=false
 
 group=org.geysermc
 id=geyser
-version=2.4.3-SNAPSHOT
+version=2.4.4-SNAPSHOT
 description=Allows for players from Minecraft: Bedrock Edition to join Minecraft: Java Edition servers.


### PR DESCRIPTION
This method could be moved to the base api at a later point without api breakage.