### PR TITLE
Enable PurchaseReceiptPacket and RefreshEntitlementsPacket

### DIFF
--- a/core/src/main/java/org/geysermc/geyser/network/CodecProcessor.java
+++ b/core/src/main/java/org/geysermc/geyser/network/CodecProcessor.java
@@ -74,8 +74,6 @@ import org.cloudburstmc.protocol.bedrock.packet.PhotoTransferPacket;
 import org.cloudburstmc.protocol.bedrock.packet.PlayerAuthInputPacket;
 import org.cloudburstmc.protocol.bedrock.packet.PlayerHotbarPacket;
 import org.cloudburstmc.protocol.bedrock.packet.PlayerSkinPacket;
-import org.cloudburstmc.protocol.bedrock.packet.PurchaseReceiptPacket;
-import org.cloudburstmc.protocol.bedrock.packet.RefreshEntitlementsPacket;
 import org.cloudburstmc.protocol.bedrock.packet.ScriptMessagePacket;
 import org.cloudburstmc.protocol.bedrock.packet.SetEntityDataPacket;
 import org.cloudburstmc.protocol.bedrock.packet.SetEntityLinkPacket;
@@ -312,8 +310,6 @@ class CodecProcessor {
             .updateSerializer(CreatePhotoPacket.class, ILLEGAL_SERIALIZER)
             .updateSerializer(NpcRequestPacket.class, ILLEGAL_SERIALIZER)
             .updateSerializer(PhotoInfoRequestPacket.class, ILLEGAL_SERIALIZER)
-            // Unused serverbound packets for featured servers, which is for some reason still occasionally sent
-            .updateSerializer(PurchaseReceiptPacket.class, IGNORED_SERIALIZER)
             // Illegal unused serverbound packets that are deprecated
             .updateSerializer(ClientCheatAbilityPacket.class, ILLEGAL_SERIALIZER)
             .updateSerializer(CraftingEventPacket.class, ILLEGAL_SERIALIZER)
@@ -330,7 +326,6 @@ class CodecProcessor {
             .updateSerializer(MapInfoRequestPacket.class, IGNORED_SERIALIZER)
             .updateSerializer(SettingsCommandPacket.class, IGNORED_SERIALIZER)
             .updateSerializer(AnvilDamagePacket.class, IGNORED_SERIALIZER)
-            .updateSerializer(RefreshEntitlementsPacket.class, IGNORED_SERIALIZER)
             // Illegal when serverbound due to Geyser specific setup
             .updateSerializer(InventoryContentPacket.class, inventoryContentSerializer)
             .updateSerializer(InventorySlotPacket.class, inventorySlotSerializer)


### PR DESCRIPTION
These packets are still sent by the client and exclusively used by featured servers. This might be out of scope for Geyser to support though.