### PR TITLE
Set Minecraft & protocol version in Velocity ping

### DIFF
--- a/bootstrap/velocity/src/main/java/org/geysermc/geyser/platform/velocity/GeyserVelocityPingPassthrough.java
+++ b/bootstrap/velocity/src/main/java/org/geysermc/geyser/platform/velocity/GeyserVelocityPingPassthrough.java
@@ -31,8 +31,10 @@ import com.velocitypowered.api.network.ProtocolVersion;
 import com.velocitypowered.api.proxy.InboundConnection;
 import com.velocitypowered.api.proxy.ProxyServer;
 import com.velocitypowered.api.proxy.server.ServerPing;
+import com.velocitypowered.api.proxy.server.ServerPing.Version;
 import lombok.AllArgsConstructor;
 import net.kyori.adventure.text.serializer.legacy.LegacyComponentSerializer;
+import org.geysermc.geyser.network.GameProtocol;
 import org.geysermc.geyser.ping.GeyserPingInfo;
 import org.geysermc.geyser.ping.IGeyserPingPassthrough;
 
@@ -51,7 +53,9 @@ public class GeyserVelocityPingPassthrough implements IGeyserPingPassthrough {
         try {
             event = server.getEventManager().fire(new ProxyPingEvent(new GeyserInboundConnection(inetSocketAddress), ServerPing.builder()
                     .description(server.getConfiguration().getMotd()).onlinePlayers(server.getPlayerCount())
-                    .maximumPlayers(server.getConfiguration().getShowMaxPlayers()).build())).get();
+                    .maximumPlayers(server.getConfiguration().getShowMaxPlayers())
+                    .version(new Version(GameProtocol.getJavaProtocolVersion(), GameProtocol.getJavaMinecraftVersion())) 
+                    .build())).get();
         } catch (ExecutionException | InterruptedException e) {
             throw new RuntimeException(e);
         }


### PR DESCRIPTION
This fixes issues caused by plugins which use the version in the ping, such as [OneVersionRemake](https://modrinth.com/plugin/oneversionremake).
Example before merge request:
![Screenshot_20241106_183859](https://github.com/user-attachments/assets/eee94e21-84d3-4295-9258-9b4a28e5d2fe)
Example after:
![image](https://github.com/user-attachments/assets/ce54d42e-7c0d-4f90-a334-cc8426c2853f)
