### PR TITLE
Add basic support for the 1.21.2 minecart experiment

### DIFF
--- a/core/src/main/java/org/geysermc/geyser/translator/protocol/java/entity/JavaMoveMinecartTranslator.java
+++ b/core/src/main/java/org/geysermc/geyser/translator/protocol/java/entity/JavaMoveMinecartTranslator.java
@@ -26,7 +26,6 @@
 package org.geysermc.geyser.translator.protocol.java.entity;
 
 import org.cloudburstmc.math.vector.Vector3d;
-import org.cloudburstmc.math.vector.Vector3f;
 import org.cloudburstmc.protocol.bedrock.packet.SetEntityMotionPacket;
 import org.geysermc.geyser.entity.type.Entity;
 import org.geysermc.geyser.session.GeyserSession;
@@ -44,12 +43,11 @@ public class JavaMoveMinecartTranslator extends PacketTranslator<ClientboundMove
             Entity entity = session.getEntityCache().getEntityByJavaId(packet.getEntityId());
 
             MinecartStep lastStep = packet.getLerpSteps().get(packet.getLerpSteps().size() - 1);
-            Vector3d relativePosition = lastStep.position();
+            Vector3d position = lastStep.position();
+            entity.moveAbsolute(position.toFloat(), lastStep.yRot(), lastStep.xRot(), entity.isOnGround(), false);
+
             Vector3d movement = lastStep.movement();
-            entity.moveAbsolute(Vector3f.from(relativePosition.getX(), relativePosition.getY(), relativePosition.getZ()), lastStep.yRot(), lastStep.xRot(), false, false);
-
-
-            entity.setMotion(Vector3f.from(movement.getX(), movement.getY(), movement.getZ()));
+            entity.setMotion(movement.toFloat());
 
             SetEntityMotionPacket entityMotionPacket = new SetEntityMotionPacket();
             entityMotionPacket.setRuntimeEntityId(entity.getGeyserId());

--- a/core/src/main/java/org/geysermc/geyser/translator/protocol/java/entity/JavaMoveMinecartTranslator.java
+++ b/core/src/main/java/org/geysermc/geyser/translator/protocol/java/entity/JavaMoveMinecartTranslator.java
@@ -1,0 +1,60 @@
+/*
+ * Copyright (c) 2024 GeyserMC. http://geysermc.org
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ *
+ * @author GeyserMC
+ * @link https://github.com/GeyserMC/Geyser
+ */
+
+package org.geysermc.geyser.translator.protocol.java.entity;
+
+import org.cloudburstmc.math.vector.Vector3d;
+import org.cloudburstmc.math.vector.Vector3f;
+import org.cloudburstmc.protocol.bedrock.packet.SetEntityMotionPacket;
+import org.geysermc.geyser.entity.type.Entity;
+import org.geysermc.geyser.session.GeyserSession;
+import org.geysermc.geyser.translator.protocol.PacketTranslator;
+import org.geysermc.geyser.translator.protocol.Translator;
+import org.geysermc.mcprotocollib.protocol.data.game.entity.MinecartStep;
+import org.geysermc.mcprotocollib.protocol.packet.ingame.clientbound.entity.ClientboundMoveMinecartPacket;
+
+@Translator(packet = ClientboundMoveMinecartPacket.class)
+public class JavaMoveMinecartTranslator extends PacketTranslator<ClientboundMoveMinecartPacket> {
+
+    @Override
+    public void translate(GeyserSession session, ClientboundMoveMinecartPacket packet) {
+        if (!packet.getLerpSteps().isEmpty()) {
+            Entity entity = session.getEntityCache().getEntityByJavaId(packet.getEntityId());
+
+            MinecartStep lastStep = packet.getLerpSteps().get(packet.getLerpSteps().size() - 1);
+            Vector3d relativePosition = lastStep.position();
+            Vector3d movement = lastStep.movement();
+            entity.moveAbsolute(Vector3f.from(relativePosition.getX(), relativePosition.getY(), relativePosition.getZ()), lastStep.yRot(), lastStep.xRot(), false, false);
+
+
+            entity.setMotion(Vector3f.from(movement.getX(), movement.getY(), movement.getZ()));
+
+            SetEntityMotionPacket entityMotionPacket = new SetEntityMotionPacket();
+            entityMotionPacket.setRuntimeEntityId(entity.getGeyserId());
+            entityMotionPacket.setMotion(entity.getMotion());
+            session.sendUpstreamPacket(entityMotionPacket);
+        }
+    }
+}

--- a/core/src/main/java/org/geysermc/geyser/translator/protocol/java/entity/JavaMoveMinecartTranslator.java
+++ b/core/src/main/java/org/geysermc/geyser/translator/protocol/java/entity/JavaMoveMinecartTranslator.java
@@ -25,7 +25,6 @@
 
 package org.geysermc.geyser.translator.protocol.java.entity;
 
-import org.cloudburstmc.math.vector.Vector3d;
 import org.cloudburstmc.protocol.bedrock.packet.SetEntityMotionPacket;
 import org.geysermc.geyser.entity.type.Entity;
 import org.geysermc.geyser.session.GeyserSession;
@@ -43,12 +42,9 @@ public class JavaMoveMinecartTranslator extends PacketTranslator<ClientboundMove
             Entity entity = session.getEntityCache().getEntityByJavaId(packet.getEntityId());
 
             MinecartStep lastStep = packet.getLerpSteps().get(packet.getLerpSteps().size() - 1);
-            Vector3d position = lastStep.position();
-            entity.moveAbsolute(position.toFloat(), lastStep.yRot(), lastStep.xRot(), entity.isOnGround(), false);
+            entity.moveAbsolute(lastStep.position().toFloat(), lastStep.yRot(), lastStep.xRot(), entity.isOnGround(), false);
 
-            Vector3d movement = lastStep.movement();
-            entity.setMotion(movement.toFloat());
-
+            entity.setMotion(lastStep.movement().toFloat());
             SetEntityMotionPacket entityMotionPacket = new SetEntityMotionPacket();
             entityMotionPacket.setRuntimeEntityId(entity.getGeyserId());
             entityMotionPacket.setMotion(entity.getMotion());


### PR DESCRIPTION
This PR adds a simple packet translator for the `ClientboundMoveMinecartPacket`. This packet, introduced in Minecraft 1.21.2, is used to move minecarts around when the new minecart experiment is enabled. Without this PR, minecarts using the new minecart behaviour don't move at all on Bedrock.

Since Bedrock doesn't have a similar minecart experiment and doesn't support entity interpolation steps in the way they are described in this packet, the translator simply takes the last interpolation step and sends its data to the Bedrock client. This isn't a perfect solution, and especially in turns minecarts don't move perfectly along the rails, but it seems this is the best it gets for now.

Note: I've also tried interpolating between the steps on Geyser, which didn't work much better since I was unable to interpolate between ticks, and I tried sending the step with the biggest weight instead of the last interpolation step, which also didn't work much better.