### PR TITLE
Fix abstract arrow entity metadata

### DIFF
--- a/core/src/main/java/org/geysermc/geyser/entity/EntityDefinitions.java
+++ b/core/src/main/java/org/geysermc/geyser/entity/EntityDefinitions.java
@@ -492,6 +492,7 @@ public final class EntityDefinitions {
             EntityDefinition<AbstractArrowEntity> abstractArrowBase = EntityDefinition.inherited(AbstractArrowEntity::new, entityBase)
                     .addTranslator(MetadataType.BYTE, AbstractArrowEntity::setArrowFlags)
                     .addTranslator(null) // "Piercing level"
+                    .addTranslator(null) // If the arrow is in the ground
                     .build();
             ARROW = EntityDefinition.inherited(ArrowEntity::new, abstractArrowBase)
                     .type(EntityType.ARROW)


### PR DESCRIPTION
A very small PR to fix the metadata parsing of abstract arrow entities (arrows, tridents, etc.)

In 1.21.2 a new boolean (`inGround`) was added to the metadata of these entities. This PR updates Geyser to load this boolean, although it doesn't do anything with it. This mostly just fixes warning logs.

PR has had some basic testing, I tested if arrows still work fine and if the warning logs disappeared, and they did.