### PR TITLE
Fix for plugins that use display entities as nametag

### DIFF
--- a/core/src/main/java/org/geysermc/geyser/entity/type/TextDisplayEntity.java
+++ b/core/src/main/java/org/geysermc/geyser/entity/type/TextDisplayEntity.java
@@ -34,6 +34,8 @@ import org.geysermc.geyser.entity.EntityDefinition;
 import org.geysermc.geyser.session.GeyserSession;
 import org.geysermc.geyser.translator.text.MessageTranslator;
 import org.geysermc.mcprotocollib.protocol.data.game.entity.metadata.EntityMetadata;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
 
 import java.util.UUID;
 
@@ -41,7 +43,6 @@ import java.util.UUID;
 @Getter
 public class TextDisplayEntity extends DisplayBaseEntity {
 
-    private Component text;
     private int lines;
 
     public TextDisplayEntity(GeyserSession session, int entityId, long geyserId, UUID uuid, EntityDefinition<?> definition, Vector3f position, Vector3f motion, float yaw, float pitch, float headYaw) {
@@ -67,12 +68,11 @@ public class TextDisplayEntity extends DisplayBaseEntity {
     }
 
     public void setText(EntityMetadata<Component, ?> entityMetadata) {
-        this.text = entityMetadata.getValue();
         this.dirtyMetadata.put(EntityDataTypes.NAME, MessageTranslator.convertMessage(entityMetadata.getValue()));
-        calculateLines();
+        calculateLines(entityMetadata.getValue());
     }
 
-    private void calculateLines() {
+    private void calculateLines(@Nullable Component text) {
         if (text == null) {
             lines = 0;
             return;

--- a/core/src/main/java/org/geysermc/geyser/entity/type/TextDisplayEntity.java
+++ b/core/src/main/java/org/geysermc/geyser/entity/type/TextDisplayEntity.java
@@ -25,7 +25,9 @@
 
 package org.geysermc.geyser.entity.type;
 
+import lombok.Getter;
 import net.kyori.adventure.text.Component;
+import net.kyori.adventure.text.serializer.plain.PlainTextComponentSerializer;
 import org.cloudburstmc.math.vector.Vector3f;
 import org.cloudburstmc.protocol.bedrock.data.entity.EntityDataTypes;
 import org.geysermc.geyser.entity.EntityDefinition;
@@ -36,17 +38,19 @@ import org.geysermc.mcprotocollib.protocol.data.game.entity.metadata.EntityMetad
 import java.util.UUID;
 
 // Note: 1.19.4 requires that the billboard is set to something in order to show, on Java Edition
+@Getter
 public class TextDisplayEntity extends DisplayBaseEntity {
 
     private Component text;
+    private int lines;
 
     public TextDisplayEntity(GeyserSession session, int entityId, long geyserId, UUID uuid, EntityDefinition<?> definition, Vector3f position, Vector3f motion, float yaw, float pitch, float headYaw) {
-        super(session, entityId, geyserId, uuid, definition, position.add(0, definition.offset() + 20, 0), motion, yaw, pitch, headYaw);
+        super(session, entityId, geyserId, uuid, definition, position.add(0, definition.offset(), 0), motion, yaw, pitch, headYaw);
     }
 
     @Override
     public void moveRelative(double relX, double relY, double relZ, float yaw, float pitch, boolean isOnGround) {
-        super.moveRelative(relX, relY + definition.offset() + 20, relZ, yaw, pitch, isOnGround);
+        super.moveRelative(relX, relY + definition.offset(), relZ, yaw, pitch, isOnGround);
     }
 
     @Override
@@ -65,9 +69,13 @@ public class TextDisplayEntity extends DisplayBaseEntity {
     public void setText(EntityMetadata<Component, ?> entityMetadata) {
         this.text = entityMetadata.getValue();
         this.dirtyMetadata.put(EntityDataTypes.NAME, MessageTranslator.convertMessage(entityMetadata.getValue()));
+        calculateLines();
     }
 
-    public Component getText() {
-        return text;
+    private void calculateLines() {
+        if (text == null) {
+            return;
+        }
+        lines = PlainTextComponentSerializer.plainText().serialize(text).split("\n").length;
     }
 }

--- a/core/src/main/java/org/geysermc/geyser/entity/type/TextDisplayEntity.java
+++ b/core/src/main/java/org/geysermc/geyser/entity/type/TextDisplayEntity.java
@@ -37,13 +37,16 @@ import java.util.UUID;
 
 // Note: 1.19.4 requires that the billboard is set to something in order to show, on Java Edition
 public class TextDisplayEntity extends DisplayBaseEntity {
+
+    private Component text;
+
     public TextDisplayEntity(GeyserSession session, int entityId, long geyserId, UUID uuid, EntityDefinition<?> definition, Vector3f position, Vector3f motion, float yaw, float pitch, float headYaw) {
-        super(session, entityId, geyserId, uuid, definition, position.add(0, definition.offset(), 0), motion, yaw, pitch, headYaw);
+        super(session, entityId, geyserId, uuid, definition, position.add(0, definition.offset() + 20, 0), motion, yaw, pitch, headYaw);
     }
 
     @Override
     public void moveRelative(double relX, double relY, double relZ, float yaw, float pitch, boolean isOnGround) {
-        super.moveRelative(relX, relY + definition.offset(), relZ, yaw, pitch, isOnGround);
+        super.moveRelative(relX, relY + definition.offset() + 20, relZ, yaw, pitch, isOnGround);
     }
 
     @Override
@@ -60,6 +63,11 @@ public class TextDisplayEntity extends DisplayBaseEntity {
     }
 
     public void setText(EntityMetadata<Component, ?> entityMetadata) {
+        this.text = entityMetadata.getValue();
         this.dirtyMetadata.put(EntityDataTypes.NAME, MessageTranslator.convertMessage(entityMetadata.getValue()));
+    }
+
+    public Component getText() {
+        return text;
     }
 }

--- a/core/src/main/java/org/geysermc/geyser/entity/type/TextDisplayEntity.java
+++ b/core/src/main/java/org/geysermc/geyser/entity/type/TextDisplayEntity.java
@@ -74,6 +74,7 @@ public class TextDisplayEntity extends DisplayBaseEntity {
 
     private void calculateLines() {
         if (text == null) {
+            lines = 0;
             return;
         }
         lines = PlainTextComponentSerializer.plainText().serialize(text).split("\n").length;

--- a/core/src/main/java/org/geysermc/geyser/entity/type/TextDisplayEntity.java
+++ b/core/src/main/java/org/geysermc/geyser/entity/type/TextDisplayEntity.java
@@ -34,7 +34,6 @@ import org.geysermc.geyser.entity.EntityDefinition;
 import org.geysermc.geyser.session.GeyserSession;
 import org.geysermc.geyser.translator.text.MessageTranslator;
 import org.geysermc.mcprotocollib.protocol.data.game.entity.metadata.EntityMetadata;
-import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
 import java.util.UUID;
@@ -43,7 +42,7 @@ import java.util.UUID;
 @Getter
 public class TextDisplayEntity extends DisplayBaseEntity {
 
-    private int lines;
+    private int lineCount;
 
     public TextDisplayEntity(GeyserSession session, int entityId, long geyserId, UUID uuid, EntityDefinition<?> definition, Vector3f position, Vector3f motion, float yaw, float pitch, float headYaw) {
         super(session, entityId, geyserId, uuid, definition, position.add(0, definition.offset(), 0), motion, yaw, pitch, headYaw);
@@ -69,14 +68,14 @@ public class TextDisplayEntity extends DisplayBaseEntity {
 
     public void setText(EntityMetadata<Component, ?> entityMetadata) {
         this.dirtyMetadata.put(EntityDataTypes.NAME, MessageTranslator.convertMessage(entityMetadata.getValue()));
-        calculateLines(entityMetadata.getValue());
+        calculateLineCount(entityMetadata.getValue());
     }
 
-    private void calculateLines(@Nullable Component text) {
+    private void calculateLineCount(@Nullable Component text) {
         if (text == null) {
-            lines = 0;
+            lineCount = 0;
             return;
         }
-        lines = PlainTextComponentSerializer.plainText().serialize(text).split("\n").length;
+        lineCount = PlainTextComponentSerializer.plainText().serialize(text).split("\n").length;
     }
 }

--- a/core/src/main/java/org/geysermc/geyser/util/EntityUtils.java
+++ b/core/src/main/java/org/geysermc/geyser/util/EntityUtils.java
@@ -26,7 +26,6 @@
 package org.geysermc.geyser.util;
 
 import net.kyori.adventure.key.Key;
-import net.kyori.adventure.text.serializer.plain.PlainTextComponentSerializer;
 import org.checkerframework.checker.nullness.qual.NonNull;
 import org.checkerframework.checker.nullness.qual.Nullable;
 import org.cloudburstmc.math.vector.Vector3f;
@@ -214,7 +213,7 @@ public final class EntityUtils {
                     if (passenger instanceof  TextDisplayEntity textDisplay) {
                         Vector3f displayTranslation = textDisplay.getTranslation();
                         if (displayTranslation != null && textDisplay.getText() != null) {
-                            int lines = PlainTextComponentSerializer.plainText().serialize(textDisplay.getText()).split("\n").length;
+                            int lines = textDisplay.getLines();
                             float multiplier = (float) Math.max(0.22f, 0.45f - (0.06f * Math.floor((lines - 4) / 2f)));
                             xOffset = displayTranslation.getX();
                             yOffset = displayTranslation.getY() + multiplier * lines;

--- a/core/src/main/java/org/geysermc/geyser/util/EntityUtils.java
+++ b/core/src/main/java/org/geysermc/geyser/util/EntityUtils.java
@@ -213,7 +213,7 @@ public final class EntityUtils {
                 case PLAYER -> {
                     if (passenger instanceof  TextDisplayEntity textDisplay) {
                         Vector3f displayTranslation = textDisplay.getTranslation();
-                        if (displayTranslation != null) {
+                        if (displayTranslation != null && textDisplay.getText() != null) {
                             int lines = PlainTextComponentSerializer.plainText().serialize(textDisplay.getText()).split("\n").length;
                             float multiplier = (float) Math.max(0.22f, 0.45f - (0.06f * Math.floor((lines - 4) / 2f)));
                             xOffset = displayTranslation.getX();

--- a/core/src/main/java/org/geysermc/geyser/util/EntityUtils.java
+++ b/core/src/main/java/org/geysermc/geyser/util/EntityUtils.java
@@ -212,11 +212,11 @@ public final class EntityUtils {
                 case PLAYER -> {
                     if (passenger instanceof TextDisplayEntity textDisplay) {
                         Vector3f displayTranslation = textDisplay.getTranslation();
-                        int lines = textDisplay.getLines();
+                        int lines = textDisplay.getLineCount();
                         if (displayTranslation != null && lines != 0) {
-                            float multiplier = .16f;
+                            float multiplier = .1414f;
                             xOffset = displayTranslation.getX();
-                            yOffset = displayTranslation.getY() + 1.2f + multiplier * lines;
+                            yOffset += displayTranslation.getY() + multiplier * lines;
                             zOffset = displayTranslation.getZ();
                         }
                     }

--- a/core/src/main/java/org/geysermc/geyser/util/EntityUtils.java
+++ b/core/src/main/java/org/geysermc/geyser/util/EntityUtils.java
@@ -210,13 +210,13 @@ public final class EntityUtils {
                     }
                 }
                 case PLAYER -> {
-                    if (passenger instanceof  TextDisplayEntity textDisplay) {
+                    if (passenger instanceof TextDisplayEntity textDisplay) {
                         Vector3f displayTranslation = textDisplay.getTranslation();
                         int lines = textDisplay.getLines();
                         if (displayTranslation != null && lines != 0) {
-                            float multiplier = (float) Math.max(0.22f, 0.45f - (0.06f * Math.floor((lines - 4) / 2f)));
+                            float multiplier = .16f;
                             xOffset = displayTranslation.getX();
-                            yOffset = displayTranslation.getY() + multiplier * lines;
+                            yOffset = displayTranslation.getY() + 1.2f + multiplier * lines;
                             zOffset = displayTranslation.getZ();
                         }
                     }

--- a/core/src/main/java/org/geysermc/geyser/util/EntityUtils.java
+++ b/core/src/main/java/org/geysermc/geyser/util/EntityUtils.java
@@ -212,8 +212,8 @@ public final class EntityUtils {
                 case PLAYER -> {
                     if (passenger instanceof  TextDisplayEntity textDisplay) {
                         Vector3f displayTranslation = textDisplay.getTranslation();
-                        if (displayTranslation != null && textDisplay.getText() != null) {
-                            int lines = textDisplay.getLines();
+                        int lines = textDisplay.getLines();
+                        if (displayTranslation != null && lines != 0) {
                             float multiplier = (float) Math.max(0.22f, 0.45f - (0.06f * Math.floor((lines - 4) / 2f)));
                             xOffset = displayTranslation.getX();
                             yOffset = displayTranslation.getY() + multiplier * lines;

--- a/core/src/main/java/org/geysermc/geyser/util/EntityUtils.java
+++ b/core/src/main/java/org/geysermc/geyser/util/EntityUtils.java
@@ -26,6 +26,7 @@
 package org.geysermc.geyser.util;
 
 import net.kyori.adventure.key.Key;
+import net.kyori.adventure.text.serializer.plain.PlainTextComponentSerializer;
 import org.checkerframework.checker.nullness.qual.NonNull;
 import org.checkerframework.checker.nullness.qual.Nullable;
 import org.cloudburstmc.math.vector.Vector3f;
@@ -207,6 +208,18 @@ public final class EntityUtils {
                         xOffset = displayTranslation.getX();
                         yOffset = displayTranslation.getY() + 0.2f;
                         zOffset = displayTranslation.getZ();
+                    }
+                }
+                case PLAYER -> {
+                    if (passenger instanceof  TextDisplayEntity textDisplay) {
+                        Vector3f displayTranslation = textDisplay.getTranslation();
+                        if (displayTranslation != null) {
+                            int lines = PlainTextComponentSerializer.plainText().serialize(textDisplay.getText()).split("\n").length;
+                            float multiplier = (float) Math.max(0.22f, 0.45f - (0.06f * Math.floor((lines - 4) / 2f)));
+                            xOffset = displayTranslation.getX();
+                            yOffset = displayTranslation.getY() + multiplier * lines;
+                            zOffset = displayTranslation.getZ();
+                        }
                     }
                 }
             }


### PR DESCRIPTION
Implemented a simple formula that calculates y offset based on the lines the display entity has. It's not perfect for higher values but for values up to 4/5 is close to vanilla.

![image](https://github.com/user-attachments/assets/6181da8d-f826-46a3-a1b6-98a1ec1f4500)
![image](https://github.com/user-attachments/assets/d0c9c5f2-8d80-4678-89d1-ce7ae047315a)
