### PR TITLE
Fix: Fabric permissions api conflict

### DIFF
--- a/bootstrap/mod/fabric/build.gradle.kts
+++ b/bootstrap/mod/fabric/build.gradle.kts
@@ -38,6 +38,7 @@ dependencies {
 
     modImplementation(libs.cloud.fabric)
     include(libs.cloud.fabric)
+    include(libs.fabric.permissions.api)
 }
 
 tasks.withType<Jar> {

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -28,13 +28,14 @@ viaversion = "4.9.2"
 adapters = "1.15-SNAPSHOT"
 cloud = "2.0.0-rc.2"
 cloud-minecraft = "2.0.0-beta.9"
-cloud-minecraft-modded = "2.0.0-beta.7"
+cloud-minecraft-modded = "2.0.0-beta.9"
 commodore = "2.2"
 bungeecord = "a7c6ede"
 velocity = "3.3.0-SNAPSHOT"
 viaproxy = "3.3.2-SNAPSHOT"
 fabric-loader = "0.16.7"
 fabric-api = "0.106.1+1.21.3"
+fabric-permissions-api = "0.3.3"
 neoforge-minecraft = "21.3.0-beta"
 mixin = "0.8.5"
 mixinextras = "0.3.5"
@@ -109,6 +110,7 @@ minecraft = { group = "com.mojang", name = "minecraft", version.ref = "minecraft
 # Check these on https://fabricmc.net/develop/
 fabric-loader = { group = "net.fabricmc", name = "fabric-loader", version.ref = "fabric-loader" }
 fabric-api = { group = "net.fabricmc.fabric-api", name = "fabric-api", version.ref = "fabric-api" }
+fabric-permissions-api = { group = "me.lucko", name = "fabric-permissions-api", version.ref = "fabric-permissions-api" }
 
 neoforge-minecraft = { group = "net.neoforged", name = "neoforge", version.ref = "neoforge-minecraft" }
 


### PR DESCRIPTION
Cloud fixed a similar issue by making the fabric permission api mod optional in https://github.com/Incendo/cloud-minecraft-modded/commit/6143fd36068c9ba1dccc298e3fcb92a40cae101c. Hence, this commit updates cloud-minecraft-modded, and includes the fabric permissions api to ensure permissions checking works properly.

Fixes https://github.com/GeyserMC/Geyser/issues/5164 