### PR TITLE
Fix: Virtual lecterns not displaying book contents

### DIFF
--- a/core/src/main/java/org/geysermc/geyser/inventory/LecternContainer.java
+++ b/core/src/main/java/org/geysermc/geyser/inventory/LecternContainer.java
@@ -34,17 +34,15 @@ import org.geysermc.geyser.session.GeyserSession;
 import org.geysermc.geyser.translator.protocol.java.inventory.JavaOpenBookTranslator;
 import org.geysermc.mcprotocollib.protocol.data.game.inventory.ContainerType;
 
+@Getter
 public class LecternContainer extends Container {
-    @Getter @Setter
+    @Setter
     private int currentBedrockPage = 0;
-    @Getter @Setter
+    @Setter
     private NbtMap blockEntityTag;
-    @Getter @Setter
+    @Setter
     private Vector3i position;
 
-    // Sigh. When the lectern container is created, we don't know (yet) if it's fake or not.
-    // So... time for a manual check :/
-    @Getter
     private boolean isFakeLectern = false;
 
     public LecternContainer(String title, int id, int size, ContainerType containerType, PlayerInventory playerInventory) {
@@ -52,8 +50,8 @@ public class LecternContainer extends Container {
     }
 
     /**
-     * When we are using a fake lectern, the Java server expects us to still be in a player inventory.
-     * We can't use {@link #isUsingRealBlock()} as that may not be determined yet.
+     * When the Java server asks the client to open a book in their hotbar, we create a fake lectern to show it to the client.
+     * We can't use the {@link #isUsingRealBlock()} check as we may also be dealing with a real virtual lectern (with its own inventory).
      */
     @Override
     public void setItem(int slot, @NonNull GeyserItemStack newItem, GeyserSession session) {

--- a/core/src/main/java/org/geysermc/geyser/inventory/holder/BlockInventoryHolder.java
+++ b/core/src/main/java/org/geysermc/geyser/inventory/holder/BlockInventoryHolder.java
@@ -157,7 +157,7 @@ public class BlockInventoryHolder extends InventoryHolder {
     @Override
     public void closeInventory(InventoryTranslator translator, GeyserSession session, Inventory inventory) {
         if (inventory instanceof Container container) {
-            if (container.isUsingRealBlock() && !(inventory instanceof LecternContainer)) {
+            if (container.isUsingRealBlock() && !(container instanceof LecternContainer)) {
                 // No need to reset a block since we didn't change any blocks
                 // But send a container close packet because we aren't destroying the original.
                 ContainerClosePacket packet = new ContainerClosePacket();


### PR DESCRIPTION
Fixes https://github.com/GeyserMC/Geyser/issues/5139

When i added the code initially i didn't account for *actual* lecterns (as opposed to the open book inventory) sent by the Java server. This properly adjusts the check - and adjusts some javadocs.