### PR TITLE
Feature：Make custom effect information visible & Support for customizing item name via 'custom_name' tag in 'potion_contents' component (new feature since 1.21.2)

### DIFF
--- a/core/src/main/java/org/geysermc/geyser/item/type/PotionItem.java
+++ b/core/src/main/java/org/geysermc/geyser/item/type/PotionItem.java
@@ -72,13 +72,13 @@ public class PotionItem extends Item {
 
     @Override
     public void translateComponentsToBedrock(@NonNull GeyserSession session, @NonNull DataComponents components, @NonNull BedrockItemBuilder builder) {
-        super.translateComponentsToBedrock(session, components, builder);
-
         // Make custom effect information visible
         PotionContents potionContents = components.get(DataComponentType.POTION_CONTENTS);
         if (potionContents != null) {
             ItemTranslator.addPotionEffectLore(potionContents, builder, session.locale());
         }
+
+        super.translateComponentsToBedrock(session, components, builder);
     }
 
     @Override

--- a/core/src/main/java/org/geysermc/geyser/item/type/PotionItem.java
+++ b/core/src/main/java/org/geysermc/geyser/item/type/PotionItem.java
@@ -34,7 +34,9 @@ import org.geysermc.geyser.inventory.item.Potion;
 import org.geysermc.geyser.registry.type.ItemMapping;
 import org.geysermc.geyser.registry.type.ItemMappings;
 import org.geysermc.geyser.session.GeyserSession;
+import org.geysermc.geyser.translator.item.BedrockItemBuilder;
 import org.geysermc.geyser.translator.item.CustomItemTranslator;
+import org.geysermc.geyser.translator.item.ItemTranslator;
 import org.geysermc.mcprotocollib.protocol.data.game.item.component.DataComponentType;
 import org.geysermc.mcprotocollib.protocol.data.game.item.component.DataComponents;
 import org.geysermc.mcprotocollib.protocol.data.game.item.component.PotionContents;
@@ -66,6 +68,17 @@ public class PotionItem extends Item {
             }
         }
         return super.translateToBedrock(session, count, components, mapping, mappings);
+    }
+
+    @Override
+    public void translateComponentsToBedrock(@NonNull GeyserSession session, @NonNull DataComponents components, @NonNull BedrockItemBuilder builder) {
+        super.translateComponentsToBedrock(session, components, builder);
+
+        // Make custom effect information visible
+        PotionContents potionContents = components.get(DataComponentType.POTION_CONTENTS);
+        if (potionContents != null) {
+            ItemTranslator.addPotionEffectLore(potionContents, builder, session.locale());
+        }
     }
 
     @Override

--- a/core/src/main/java/org/geysermc/geyser/item/type/TippedArrowItem.java
+++ b/core/src/main/java/org/geysermc/geyser/item/type/TippedArrowItem.java
@@ -63,12 +63,12 @@ public class TippedArrowItem extends ArrowItem {
 
     @Override
     public void translateComponentsToBedrock(@NonNull GeyserSession session, @NonNull DataComponents components, @NonNull BedrockItemBuilder builder) {
-        super.translateComponentsToBedrock(session, components, builder);
-
         // Make custom effect information visible
         PotionContents potionContents = components.get(DataComponentType.POTION_CONTENTS);
         if (potionContents != null) {
             ItemTranslator.addPotionEffectLore(potionContents, builder, session.locale());
         }
+
+        super.translateComponentsToBedrock(session, components, builder);
     }
 }

--- a/core/src/main/java/org/geysermc/geyser/item/type/TippedArrowItem.java
+++ b/core/src/main/java/org/geysermc/geyser/item/type/TippedArrowItem.java
@@ -25,12 +25,15 @@
 
 package org.geysermc.geyser.item.type;
 
+import org.checkerframework.checker.nullness.qual.NonNull;
 import org.cloudburstmc.protocol.bedrock.data.inventory.ItemData;
 import org.geysermc.geyser.GeyserImpl;
 import org.geysermc.geyser.inventory.item.Potion;
 import org.geysermc.geyser.registry.type.ItemMapping;
 import org.geysermc.geyser.registry.type.ItemMappings;
 import org.geysermc.geyser.session.GeyserSession;
+import org.geysermc.geyser.translator.item.BedrockItemBuilder;
+import org.geysermc.geyser.translator.item.ItemTranslator;
 import org.geysermc.mcprotocollib.protocol.data.game.item.component.DataComponentType;
 import org.geysermc.mcprotocollib.protocol.data.game.item.component.DataComponents;
 import org.geysermc.mcprotocollib.protocol.data.game.item.component.PotionContents;
@@ -56,5 +59,16 @@ public class TippedArrowItem extends ArrowItem {
             }
         }
         return super.translateToBedrock(session, count, components, mapping, mappings);
+    }
+
+    @Override
+    public void translateComponentsToBedrock(@NonNull GeyserSession session, @NonNull DataComponents components, @NonNull BedrockItemBuilder builder) {
+        super.translateComponentsToBedrock(session, components, builder);
+
+        // Make custom effect information visible
+        PotionContents potionContents = components.get(DataComponentType.POTION_CONTENTS);
+        if (potionContents != null) {
+            ItemTranslator.addPotionEffectLore(potionContents, builder, session.locale());
+        }
     }
 }

--- a/core/src/main/java/org/geysermc/geyser/translator/item/ItemTranslator.java
+++ b/core/src/main/java/org/geysermc/geyser/translator/item/ItemTranslator.java
@@ -71,10 +71,10 @@ import org.geysermc.mcprotocollib.protocol.data.game.item.component.PotionConten
 
 import java.text.DecimalFormat;
 import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.EnumMap;
 import java.util.HashMap;
 import java.util.List;
+import java.util.Locale;
 import java.util.Map;
 
 public final class ItemTranslator {
@@ -155,14 +155,6 @@ public final class ItemTranslator {
 
     public static ItemData.@NonNull Builder translateToBedrock(GeyserSession session, Item javaItem, ItemMapping bedrockItem, int count, @Nullable DataComponents components) {
         BedrockItemBuilder nbtBuilder = new BedrockItemBuilder();
-
-        if (components != null) {
-            // Make custom effect information visible
-            PotionContents potionContents = components.get(DataComponentType.POTION_CONTENTS);
-            if (potionContents != null) {
-                addPotionEffectLore(potionContents, nbtBuilder, session.locale());
-            }
-        }
 
         boolean hideTooltips = false;
         if (components != null) {
@@ -338,7 +330,7 @@ public final class ItemTranslator {
         return MessageTranslator.convertMessage(attributeComponent, language);
     }
 
-    private static final List<Effect> negativeEffectList = Arrays.asList(
+    private static final List<Effect> negativeEffectList = List.of(
         Effect.SLOWNESS,
         Effect.MINING_FATIGUE,
         Effect.INSTANT_DAMAGE,
@@ -357,14 +349,14 @@ public final class ItemTranslator {
         Effect.INFESTED
     );
 
-    private static void addPotionEffectLore(PotionContents contents, BedrockItemBuilder builder, String language) {
+    public static void addPotionEffectLore(PotionContents contents, BedrockItemBuilder builder, String language) {
         List<MobEffectInstance> effectInstanceList = contents.getCustomEffects();
         for (MobEffectInstance effectInstance : effectInstanceList) {
             Effect effect = effectInstance.getEffect();
             MobEffectDetails details = effectInstance.getDetails();
             int amplifier = details.getAmplifier();
             int durations = details.getDuration();
-            TranslatableComponent appendTranslatable = Component.translatable("effect.minecraft." + effect.toString().toLowerCase());
+            TranslatableComponent appendTranslatable = Component.translatable("effect.minecraft." + effect.toString().toLowerCase(Locale.ROOT));
             if (amplifier != 0) {
                 appendTranslatable = Component.translatable("potion.withAmplifier",
                     appendTranslatable,

--- a/core/src/main/java/org/geysermc/geyser/translator/item/ItemTranslator.java
+++ b/core/src/main/java/org/geysermc/geyser/translator/item/ItemTranslator.java
@@ -26,6 +26,7 @@
 package org.geysermc.geyser.translator.item;
 
 import net.kyori.adventure.text.Component;
+import net.kyori.adventure.text.TranslatableComponent;
 import net.kyori.adventure.text.format.NamedTextColor;
 import org.checkerframework.checker.nullness.qual.NonNull;
 import org.checkerframework.checker.nullness.qual.Nullable;
@@ -55,6 +56,7 @@ import org.geysermc.geyser.util.InventoryUtils;
 import org.geysermc.mcprotocollib.auth.GameProfile;
 import org.geysermc.mcprotocollib.auth.GameProfile.Texture;
 import org.geysermc.mcprotocollib.auth.GameProfile.TextureType;
+import org.geysermc.mcprotocollib.protocol.data.game.entity.Effect;
 import org.geysermc.mcprotocollib.protocol.data.game.entity.attribute.AttributeType;
 import org.geysermc.mcprotocollib.protocol.data.game.entity.attribute.ModifierOperation;
 import org.geysermc.mcprotocollib.protocol.data.game.item.ItemStack;
@@ -63,9 +65,13 @@ import org.geysermc.mcprotocollib.protocol.data.game.item.component.DataComponen
 import org.geysermc.mcprotocollib.protocol.data.game.item.component.DataComponents;
 import org.geysermc.mcprotocollib.protocol.data.game.item.component.HolderSet;
 import org.geysermc.mcprotocollib.protocol.data.game.item.component.ItemAttributeModifiers;
+import org.geysermc.mcprotocollib.protocol.data.game.item.component.MobEffectDetails;
+import org.geysermc.mcprotocollib.protocol.data.game.item.component.MobEffectInstance;
+import org.geysermc.mcprotocollib.protocol.data.game.item.component.PotionContents;
 
 import java.text.DecimalFormat;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.EnumMap;
 import java.util.HashMap;
 import java.util.List;
@@ -149,6 +155,14 @@ public final class ItemTranslator {
 
     public static ItemData.@NonNull Builder translateToBedrock(GeyserSession session, Item javaItem, ItemMapping bedrockItem, int count, @Nullable DataComponents components) {
         BedrockItemBuilder nbtBuilder = new BedrockItemBuilder();
+
+        if (components != null) {
+            // Make custom effect information visible
+            PotionContents potionContents = components.get(DataComponentType.POTION_CONTENTS);
+            if (potionContents != null) {
+                addPotionEffectLore(potionContents, nbtBuilder, session.locale());
+            }
+        }
 
         boolean hideTooltips = false;
         if (components != null) {
@@ -322,6 +336,65 @@ public final class ItemTranslator {
                 .build();
 
         return MessageTranslator.convertMessage(attributeComponent, language);
+    }
+
+    private static final List<Effect> negativeEffectList = Arrays.asList(
+        Effect.SLOWNESS,
+        Effect.MINING_FATIGUE,
+        Effect.INSTANT_DAMAGE,
+        Effect.NAUSEA,
+        Effect.BLINDNESS,
+        Effect.HUNGER,
+        Effect.WEAKNESS,
+        Effect.POISON,
+        Effect.WITHER,
+        Effect.LEVITATION,
+        Effect.UNLUCK,
+        Effect.DARKNESS,
+        Effect.WIND_CHARGED,
+        Effect.WEAVING,
+        Effect.OOZING,
+        Effect.INFESTED
+    );
+
+    private static void addPotionEffectLore(PotionContents contents, BedrockItemBuilder builder, String language) {
+        List<MobEffectInstance> effectInstanceList = contents.getCustomEffects();
+        for (MobEffectInstance effectInstance : effectInstanceList) {
+            Effect effect = effectInstance.getEffect();
+            MobEffectDetails details = effectInstance.getDetails();
+            int amplifier = details.getAmplifier();
+            int durations = details.getDuration();
+            TranslatableComponent appendTranslatable = Component.translatable("effect.minecraft." + effect.toString().toLowerCase());
+            if (amplifier != 0) {
+                appendTranslatable = Component.translatable("potion.withAmplifier",
+                    appendTranslatable,
+                    Component.translatable("potion.potency." + amplifier));
+            }
+            if (durations > 20) {
+                int seconds = durations / 20;
+                int secondsFormat = seconds % 60;
+                int minutes = seconds / 60;
+                int minutesFormat = minutes % 60;
+                int hours = minutes / 60;
+                String text = ((minutesFormat > 9) ? "" : "0") + minutesFormat + ":" + ((secondsFormat > 9) ? "" : "0") + secondsFormat;
+                if (minutes >= 60) {
+                    text = ((hours > 9) ? "" : "0") + hours + ":" + text;
+                }
+                appendTranslatable = Component.translatable("potion.withDuration",
+                    appendTranslatable,
+                    Component.text(text));
+            } else if (durations == -1) {
+                appendTranslatable = Component.translatable("potion.withDuration",
+                    appendTranslatable,
+                    Component.translatable("effect.duration.infinite"));
+            }
+            Component component = Component.text()
+                .resetStyle()
+                .color((negativeEffectList.contains(effect)) ? NamedTextColor.RED : NamedTextColor.BLUE)
+                .append(appendTranslatable)
+                .build();
+            builder.getOrCreateLore().add(MessageTranslator.convertMessage(component, language));
+        }
     }
 
     private static void addAdvancedTooltips(@Nullable DataComponents components, BedrockItemBuilder builder, Item item, String language) {

--- a/core/src/main/java/org/geysermc/geyser/translator/item/ItemTranslator.java
+++ b/core/src/main/java/org/geysermc/geyser/translator/item/ItemTranslator.java
@@ -521,6 +521,19 @@ public final class ItemTranslator {
             if (customName != null) {
                 return MessageTranslator.convertMessage(customName, session.locale());
             }
+            PotionContents potionContents = components.get(DataComponentType.POTION_CONTENTS);
+            if (potionContents != null) {
+                // "custom_name" tag in "potion_contents" component
+                String customPotionName = potionContents.getCustomName();
+                if (customPotionName != null) {
+                    Component component = Component.text()
+                        .resetStyle()
+                        .color(NamedTextColor.WHITE)
+                        .append(Component.translatable(mapping.getJavaItem().translationKey() + ".effect." + customPotionName))
+                        .build();
+                    return MessageTranslator.convertMessage(component, session.locale());
+                }
+            }
             customName = components.get(DataComponentType.ITEM_NAME);
             if (customName != null) {
                 // Get the translated name and prefix it with a reset char to prevent italics - matches Java Edition


### PR DESCRIPTION
(Test in 1.21.3) These fixes applies to all items with `potion_contents` component.

Use this command to make a custom potion easily: `/give @s minecraft:potion[potion_contents={custom_effects:[{id:"minecraft:hero_of_the_village",duration:-1},{id:"minecraft:unluck",amplifier:1,duration:140},{id:"minecraft:jump_boost",amplifier:5,duration:658980}],custom_name:"healing"}]`

Information display in JE:
![image](https://github.com/user-attachments/assets/b594daf3-84b3-472f-88d4-b93162ddc4b3)

Information display in BE with Geyser 2.5.0-b720 (git-master-c240c1c):
![image](https://github.com/user-attachments/assets/d0665c5e-b6a3-4ba6-aca2-223ecf0263b7)

Information display in BE after this fixes:
![image](https://github.com/user-attachments/assets/5bd00c02-881f-41b4-9237-f77aaa1f594d)

### Known problem:
the effect list in HUD & "When Applied" list in item informations still controlling by `potion` tag in `potion_contents` component, these custom effect will not display.
 ![image](https://github.com/user-attachments/assets/5c742e3a-8603-4f87-b94e-84879abe4651)
