### PR TITLE
Fix skull mix-up by not reusing skulls

### DIFF
--- a/core/src/main/java/org/geysermc/geyser/entity/type/player/SkullPlayerEntity.java
+++ b/core/src/main/java/org/geysermc/geyser/entity/type/player/SkullPlayerEntity.java
@@ -102,17 +102,6 @@ public class SkullPlayerEntity extends PlayerEntity {
         session.sendUpstreamPacket(addPlayerPacket);
     }
 
-    /**
-     * Hide the player entity so that it can be reused for a different skull.
-     */
-    public void free() {
-        setFlag(EntityFlag.INVISIBLE, true);
-        updateBedrockMetadata();
-
-        // Move skull entity out of the way
-        moveAbsolute(session.getPlayerEntity().getPosition().up(128), 0, 0, 0, false, true);
-    }
-
     public void updateSkull(SkullCache.Skull skull) {
         skullPosition = skull.getPosition();
 


### PR DESCRIPTION
Skulls seems to have the wrong texture if they are re-used (the client doesn't update the texture for some reason).

This fixes it by removing the re-use logic. It doesn't reduce lag or memory usage for the client anyway, therefore its just additional complexity, and doesn't work with the latest version and isn't worth fixing.