### PR TITLE
Implemented a way to close forms from floodgate

### DIFF
--- a/core/src/main/java/org/geysermc/geyser/translator/protocol/java/JavaCustomPayloadTranslator.java
+++ b/core/src/main/java/org/geysermc/geyser/translator/protocol/java/JavaCustomPayloadTranslator.java
@@ -28,6 +28,8 @@ package org.geysermc.geyser.translator.protocol.java;
 import com.google.common.base.Charsets;
 import io.netty.buffer.ByteBuf;
 import io.netty.buffer.Unpooled;
+
+import org.cloudburstmc.protocol.bedrock.packet.ClientboundCloseFormPacket;
 import org.cloudburstmc.protocol.bedrock.packet.TransferPacket;
 import org.cloudburstmc.protocol.bedrock.packet.UnknownPacket;
 import org.geysermc.cumulus.Forms;
@@ -67,6 +69,12 @@ public class JavaCustomPayloadTranslator extends PacketTranslator<ClientboundCus
             session.ensureInEventLoop(() -> {
                 byte[] data = packet.getData();
 
+                // If the data is empty, we just need to close the form
+                if (data.length == 0) {
+                    session.sendUpstreamPacketImmediately(new ClientboundCloseFormPacket());
+                    return;
+                }
+
                 // receive: first byte is form type, second and third are the id, remaining is the form data
                 // respond: first and second byte id, remaining is form response data
 
@@ -96,7 +104,6 @@ public class JavaCustomPayloadTranslator extends PacketTranslator<ClientboundCus
                 });
                 session.sendForm(form);
             });
-
         } else if (channel.equals(PluginMessageChannels.TRANSFER)) {
             session.ensureInEventLoop(() -> {
                 byte[] data = packet.getData();

--- a/core/src/main/java/org/geysermc/geyser/translator/protocol/java/JavaCustomPayloadTranslator.java
+++ b/core/src/main/java/org/geysermc/geyser/translator/protocol/java/JavaCustomPayloadTranslator.java
@@ -28,8 +28,6 @@ package org.geysermc.geyser.translator.protocol.java;
 import com.google.common.base.Charsets;
 import io.netty.buffer.ByteBuf;
 import io.netty.buffer.Unpooled;
-
-import org.cloudburstmc.protocol.bedrock.packet.ClientboundCloseFormPacket;
 import org.cloudburstmc.protocol.bedrock.packet.TransferPacket;
 import org.cloudburstmc.protocol.bedrock.packet.UnknownPacket;
 import org.geysermc.cumulus.Forms;
@@ -71,7 +69,7 @@ public class JavaCustomPayloadTranslator extends PacketTranslator<ClientboundCus
 
                 // If the data is empty, we just need to close the form
                 if (data.length == 0) {
-                    session.sendUpstreamPacketImmediately(new ClientboundCloseFormPacket());
+                    session.closeForm();
                     return;
                 }
 


### PR DESCRIPTION
Hey guys!
My PRs are quite small and just aims to add the ability to close forms from the floodgate api.

I made it the simplest possible, it's just sending empty form data to geyser through the form plugin channel and then when geyser receive that empty data it send a form close packet down the connection pipeline.

This PR goes along with [this one](https://github.com/GeyserMC/Floodgate/pull/566) I made on the floodgate repo.