### PR TITLE
Fix `item_name` component not work; Improve display of custom effects and shulker box tooltips for item names

### DIFF
--- a/core/src/main/java/org/geysermc/geyser/entity/type/ItemFrameEntity.java
+++ b/core/src/main/java/org/geysermc/geyser/entity/type/ItemFrameEntity.java
@@ -118,7 +118,17 @@ public class ItemFrameEntity extends Entity {
             NbtMapBuilder builder = NbtMap.builder();
             builder.putByte("Count", (byte) itemData.getCount());
             NbtMap itemDataTag = itemData.getTag();
-            if (itemData.getTag() != null) {
+            if (itemDataTag != null) {
+                // Remove custom name that Geyser sets for items due to translating non-"custom_name" components
+                String customName = ItemTranslator.getCustomName(session, heldItem.getDataComponents(),
+                    session.getItemMappings().getMapping(heldItem), 'f', false);
+                if (customName == null) {
+                    // No custom name found, must modify tag if custom name exists
+                    NbtMapBuilder copy = itemDataTag.toBuilder();
+                    copy.remove("display"); // Also removes lore, but, should not matter
+                    itemDataTag = copy.build();
+                }
+
                 builder.put("tag", itemDataTag);
             }
             builder.putShort("Damage", (short) itemData.getDamage());

--- a/core/src/main/java/org/geysermc/geyser/entity/type/ItemFrameEntity.java
+++ b/core/src/main/java/org/geysermc/geyser/entity/type/ItemFrameEntity.java
@@ -121,7 +121,7 @@ public class ItemFrameEntity extends Entity {
             if (itemDataTag != null) {
                 // Remove custom name that Geyser sets for items due to translating non-"custom_name" components
                 String customName = ItemTranslator.getCustomName(session, heldItem.getDataComponents(),
-                    session.getItemMappings().getMapping(heldItem), 'f', false);
+                    session.getItemMappings().getMapping(heldItem), 'f', true, false);
                 if (customName == null) {
                     // No custom name found, must modify tag if custom name exists
                     NbtMapBuilder copy = itemDataTag.toBuilder();

--- a/core/src/main/java/org/geysermc/geyser/item/type/PotionItem.java
+++ b/core/src/main/java/org/geysermc/geyser/item/type/PotionItem.java
@@ -34,9 +34,7 @@ import org.geysermc.geyser.inventory.item.Potion;
 import org.geysermc.geyser.registry.type.ItemMapping;
 import org.geysermc.geyser.registry.type.ItemMappings;
 import org.geysermc.geyser.session.GeyserSession;
-import org.geysermc.geyser.translator.item.BedrockItemBuilder;
 import org.geysermc.geyser.translator.item.CustomItemTranslator;
-import org.geysermc.geyser.translator.item.ItemTranslator;
 import org.geysermc.mcprotocollib.protocol.data.game.item.component.DataComponentType;
 import org.geysermc.mcprotocollib.protocol.data.game.item.component.DataComponents;
 import org.geysermc.mcprotocollib.protocol.data.game.item.component.PotionContents;
@@ -68,17 +66,6 @@ public class PotionItem extends Item {
             }
         }
         return super.translateToBedrock(session, count, components, mapping, mappings);
-    }
-
-    @Override
-    public void translateComponentsToBedrock(@NonNull GeyserSession session, @NonNull DataComponents components, @NonNull BedrockItemBuilder builder) {
-        // Make custom effect information visible
-        PotionContents potionContents = components.get(DataComponentType.POTION_CONTENTS);
-        if (potionContents != null) {
-            ItemTranslator.addPotionEffectLore(potionContents, builder, session.locale());
-        }
-
-        super.translateComponentsToBedrock(session, components, builder);
     }
 
     @Override

--- a/core/src/main/java/org/geysermc/geyser/item/type/ShulkerBoxItem.java
+++ b/core/src/main/java/org/geysermc/geyser/item/type/ShulkerBoxItem.java
@@ -101,6 +101,7 @@ public class ShulkerBoxItem extends BlockItem {
             if (boxComponents != null) {
                 String customName = ItemTranslator.getCustomName(session, boxComponents, boxMapping, '7', false, true);
                 if (customName != null) {
+                    // Fix count display (e.g., x16) with incorrect color due to some items with colored names
                     if (customName.contains("" + ChatColor.ESCAPE)) customName += ChatColor.RESET + ChatColor.GRAY;
                     boxItemNbt.putCompound("tag", NbtMap.builder()
                             .putCompound("display", NbtMap.builder()

--- a/core/src/main/java/org/geysermc/geyser/item/type/ShulkerBoxItem.java
+++ b/core/src/main/java/org/geysermc/geyser/item/type/ShulkerBoxItem.java
@@ -102,7 +102,9 @@ public class ShulkerBoxItem extends BlockItem {
                 String customName = ItemTranslator.getCustomName(session, boxComponents, boxMapping, '7', false, true);
                 if (customName != null) {
                     // Fix count display (e.g., x16) with incorrect color due to some items with colored names
-                    if (customName.contains("" + ChatColor.ESCAPE)) customName += ChatColor.RESET + ChatColor.GRAY;
+                    if (customName.contains("" + ChatColor.ESCAPE)) {
+                        customName += ChatColor.RESET + ChatColor.GRAY;
+                    }
                     boxItemNbt.putCompound("tag", NbtMap.builder()
                             .putCompound("display", NbtMap.builder()
                                     .putString("Name", customName)

--- a/core/src/main/java/org/geysermc/geyser/item/type/ShulkerBoxItem.java
+++ b/core/src/main/java/org/geysermc/geyser/item/type/ShulkerBoxItem.java
@@ -35,6 +35,7 @@ import org.geysermc.geyser.item.Items;
 import org.geysermc.geyser.level.block.type.Block;
 import org.geysermc.geyser.registry.type.ItemMapping;
 import org.geysermc.geyser.session.GeyserSession;
+import org.geysermc.geyser.text.ChatColor;
 import org.geysermc.geyser.translator.item.BedrockItemBuilder;
 import org.geysermc.geyser.translator.item.CustomItemTranslator;
 import org.geysermc.geyser.translator.item.ItemTranslator;
@@ -100,6 +101,7 @@ public class ShulkerBoxItem extends BlockItem {
             if (boxComponents != null) {
                 String customName = ItemTranslator.getCustomName(session, boxComponents, boxMapping, '7', false, true);
                 if (customName != null) {
+                    if (customName.contains("" + ChatColor.ESCAPE)) customName += ChatColor.RESET + ChatColor.GRAY;
                     boxItemNbt.putCompound("tag", NbtMap.builder()
                             .putCompound("display", NbtMap.builder()
                                     .putString("Name", customName)

--- a/core/src/main/java/org/geysermc/geyser/item/type/ShulkerBoxItem.java
+++ b/core/src/main/java/org/geysermc/geyser/item/type/ShulkerBoxItem.java
@@ -98,7 +98,7 @@ public class ShulkerBoxItem extends BlockItem {
 
             // Only the display name is what we have interest in, so just translate that if relevant
             if (boxComponents != null) {
-                String customName = ItemTranslator.getCustomName(session, boxComponents, boxMapping, '7', true);
+                String customName = ItemTranslator.getCustomName(session, boxComponents, boxMapping, '7', false, true);
                 if (customName != null) {
                     boxItemNbt.putCompound("tag", NbtMap.builder()
                             .putCompound("display", NbtMap.builder()

--- a/core/src/main/java/org/geysermc/geyser/item/type/TippedArrowItem.java
+++ b/core/src/main/java/org/geysermc/geyser/item/type/TippedArrowItem.java
@@ -25,15 +25,12 @@
 
 package org.geysermc.geyser.item.type;
 
-import org.checkerframework.checker.nullness.qual.NonNull;
 import org.cloudburstmc.protocol.bedrock.data.inventory.ItemData;
 import org.geysermc.geyser.GeyserImpl;
 import org.geysermc.geyser.inventory.item.Potion;
 import org.geysermc.geyser.registry.type.ItemMapping;
 import org.geysermc.geyser.registry.type.ItemMappings;
 import org.geysermc.geyser.session.GeyserSession;
-import org.geysermc.geyser.translator.item.BedrockItemBuilder;
-import org.geysermc.geyser.translator.item.ItemTranslator;
 import org.geysermc.mcprotocollib.protocol.data.game.item.component.DataComponentType;
 import org.geysermc.mcprotocollib.protocol.data.game.item.component.DataComponents;
 import org.geysermc.mcprotocollib.protocol.data.game.item.component.PotionContents;
@@ -59,16 +56,5 @@ public class TippedArrowItem extends ArrowItem {
             }
         }
         return super.translateToBedrock(session, count, components, mapping, mappings);
-    }
-
-    @Override
-    public void translateComponentsToBedrock(@NonNull GeyserSession session, @NonNull DataComponents components, @NonNull BedrockItemBuilder builder) {
-        // Make custom effect information visible
-        PotionContents potionContents = components.get(DataComponentType.POTION_CONTENTS);
-        if (potionContents != null) {
-            ItemTranslator.addPotionEffectLore(potionContents, builder, session.locale());
-        }
-
-        super.translateComponentsToBedrock(session, components, builder);
     }
 }

--- a/core/src/main/java/org/geysermc/geyser/translator/item/ItemTranslator.java
+++ b/core/src/main/java/org/geysermc/geyser/translator/item/ItemTranslator.java
@@ -388,7 +388,7 @@ public final class ItemTranslator {
         return finalText.toString();
     }
 
-    public static String getPotionName(PotionContents contents, ItemMapping mapping, String language) {
+    public static String getPotionName(PotionContents contents, ItemMapping mapping, boolean hideAdditionalTooltip, String language) {
         String customPotionName = contents.getCustomName();
         Potion potion = Potion.getByJavaId(contents.getPotionId());
 
@@ -398,7 +398,7 @@ public final class ItemTranslator {
                 Component.translatable(mapping.getJavaItem().translationKey() + ".effect." + customPotionName),
                 language);
         }
-        if (!contents.getCustomEffects().isEmpty()) {
+        if (!hideAdditionalTooltip && !contents.getCustomEffects().isEmpty()) {
             // Make a name when has custom effects
             String potionName;
             if (potion != null) {
@@ -541,7 +541,7 @@ public final class ItemTranslator {
             if (!customNameOnly) {
                 PotionContents potionContents = components.get(DataComponentType.POTION_CONTENTS);
                 if (potionContents != null) {
-                    String potionName = getPotionName(potionContents, mapping, session.locale());
+                    String potionName = getPotionName(potionContents, mapping, components.get(DataComponentType.HIDE_ADDITIONAL_TOOLTIP) != null, session.locale());
                     if (potionName != null) return ChatColor.RESET + ChatColor.ESCAPE + translationColor + potionName;
                 }
                 if (includeAll) {

--- a/core/src/main/java/org/geysermc/geyser/translator/item/ItemTranslator.java
+++ b/core/src/main/java/org/geysermc/geyser/translator/item/ItemTranslator.java
@@ -175,7 +175,7 @@ public final class ItemTranslator {
         javaItem.translateComponentsToBedrock(session, components, nbtBuilder);
 
         Rarity rarity = Rarity.fromId(components.getOrDefault(DataComponentType.RARITY, 0));
-        String customName = getCustomName(session, customComponents, bedrockItem, rarity.getColor(), true);
+        String customName = getCustomName(session, customComponents, bedrockItem, rarity.getColor(), false, false);
         if (customName != null) {
             PotionContents potionContents = components.get(DataComponentType.POTION_CONTENTS);
             // Make custom effect information visible
@@ -530,18 +530,24 @@ public final class ItemTranslator {
      * @param translationColor if this item is not available on Java, the color that the new name should be.
      *                         Normally, this should just be white, but for shulker boxes this should be gray.
      */
-    public static String getCustomName(GeyserSession session, DataComponents components, ItemMapping mapping, char translationColor, boolean includeNonCustomName) {
+    public static String getCustomName(GeyserSession session, DataComponents components, ItemMapping mapping, char translationColor, boolean customNameOnly, boolean includeAll) {
         if (components != null) {
             // ItemStack#getHoverName as of 1.20.5
             Component customName = components.get(DataComponentType.CUSTOM_NAME);
             if (customName != null) {
                 return MessageTranslator.convertMessage(customName, session.locale());
             }
-            if (includeNonCustomName) {
+            if (!customNameOnly) {
                 PotionContents potionContents = components.get(DataComponentType.POTION_CONTENTS);
                 if (potionContents != null) {
                     String potionName = getPotionName(potionContents, mapping, session.locale());
                     if (potionName != null) return ChatColor.RESET + ChatColor.ESCAPE + translationColor + potionName;
+                }
+                if (includeAll) {
+                    WrittenBookContent bookContent = components.get(DataComponentType.WRITTEN_BOOK_CONTENT);
+                    if (bookContent != null) {
+                        return ChatColor.RESET + ChatColor.ESCAPE + translationColor + bookContent.getTitle().getRaw();
+                    }
                 }
                 customName = components.get(DataComponentType.ITEM_NAME);
                 if (customName != null) {

--- a/core/src/main/java/org/geysermc/geyser/translator/item/ItemTranslator.java
+++ b/core/src/main/java/org/geysermc/geyser/translator/item/ItemTranslator.java
@@ -41,6 +41,7 @@ import org.geysermc.geyser.GeyserImpl;
 import org.geysermc.geyser.api.block.custom.CustomBlockData;
 import org.geysermc.geyser.entity.attribute.GeyserAttributeType;
 import org.geysermc.geyser.inventory.GeyserItemStack;
+import org.geysermc.geyser.inventory.item.Potion;
 import org.geysermc.geyser.item.Items;
 import org.geysermc.geyser.item.components.Rarity;
 import org.geysermc.geyser.item.type.Item;
@@ -175,6 +176,13 @@ public final class ItemTranslator {
         Rarity rarity = Rarity.fromId(components.getOrDefault(DataComponentType.RARITY, 0));
         String customName = getCustomName(session, components, bedrockItem, rarity.getColor(), false);
         if (customName != null) {
+            PotionContents potionContents = components.get(DataComponentType.POTION_CONTENTS);
+            // Make custom effect information visible
+            // Ignore when item have "hide_additional_tooltip" component
+            if (potionContents != null && components.get(DataComponentType.HIDE_ADDITIONAL_TOOLTIP) == null) {
+                customName += getPotionEffectInfo(potionContents, session.locale());
+            }
+
             nbtBuilder.setCustomName(customName);
         }
 
@@ -336,7 +344,8 @@ public final class ItemTranslator {
         Effect.INFESTED
     );
 
-    public static void addPotionEffectLore(PotionContents contents, BedrockItemBuilder builder, String language) {
+    public static String getPotionEffectInfo(PotionContents contents, String language) {
+        StringBuilder finalText = new StringBuilder();
         List<MobEffectInstance> effectInstanceList = contents.getCustomEffects();
         for (MobEffectInstance effectInstance : effectInstanceList) {
             Effect effect = effectInstance.getEffect();
@@ -372,8 +381,35 @@ public final class ItemTranslator {
                 .color((negativeEffectList.contains(effect)) ? NamedTextColor.RED : NamedTextColor.BLUE)
                 .append(appendTranslatable)
                 .build();
-            builder.getOrCreateLore().add(MessageTranslator.convertMessage(component, language));
+            finalText.append('\n').append(MessageTranslator.convertMessage(component, language));
         }
+        return finalText.toString();
+    }
+
+    public static String getPotionName(PotionContents contents, ItemMapping mapping, String language) {
+        String customPotionName = contents.getCustomName();
+        Potion potion = Potion.getByJavaId(contents.getPotionId());
+
+        if (customPotionName != null) {
+            // "custom_name" tag in "potion_contents" component
+            return MessageTranslator.convertMessage(
+                Component.translatable(mapping.getJavaItem().translationKey() + ".effect." + customPotionName),
+                language);
+        }
+        if (!contents.getCustomEffects().isEmpty()) {
+            // Make a name when has custom effects
+            String potionName;
+            if (potion != null) {
+                potionName = potion.toString().toLowerCase(Locale.ROOT);
+                if (potionName.startsWith("strong_")) potionName = potionName.substring(6);
+                else if (potionName.startsWith("long_")) potionName = potionName.substring(4);
+            }
+            else potionName = "empty";
+            return MessageTranslator.convertMessage(
+                Component.translatable(mapping.getJavaItem().translationKey() + ".effect." + potionName),
+                language);
+        }
+        return null;
     }
 
     private static void addAdvancedTooltips(@Nullable DataComponents components, BedrockItemBuilder builder, Item item, String language) {
@@ -502,16 +538,8 @@ public final class ItemTranslator {
             }
             PotionContents potionContents = components.get(DataComponentType.POTION_CONTENTS);
             if (potionContents != null) {
-                // "custom_name" tag in "potion_contents" component
-                String customPotionName = potionContents.getCustomName();
-                if (customPotionName != null) {
-                    Component component = Component.text()
-                        .resetStyle()
-                        .color(NamedTextColor.WHITE)
-                        .append(Component.translatable(mapping.getJavaItem().translationKey() + ".effect." + customPotionName))
-                        .build();
-                    return MessageTranslator.convertMessage(component, session.locale());
-                }
+                String potionName = getPotionName(potionContents, mapping, session.locale());
+                if (potionName != null) return ChatColor.RESET + ChatColor.ESCAPE + translationColor + potionName;
             }
             customName = components.get(DataComponentType.ITEM_NAME);
             if (customName != null && includeDefault) {

--- a/core/src/main/java/org/geysermc/geyser/translator/item/ItemTranslator.java
+++ b/core/src/main/java/org/geysermc/geyser/translator/item/ItemTranslator.java
@@ -403,10 +403,14 @@ public final class ItemTranslator {
             String potionName;
             if (potion != null) {
                 potionName = potion.toString().toLowerCase(Locale.ROOT);
-                if (potionName.startsWith("strong_")) potionName = potionName.substring(6);
-                else if (potionName.startsWith("long_")) potionName = potionName.substring(4);
+                if (potionName.startsWith("strong_")) {
+                    potionName = potionName.substring(6);
+                } else if (potionName.startsWith("long_")) {
+                    potionName = potionName.substring(4);
+                }
+            } else {
+                potionName = "empty";
             }
-            else potionName = "empty";
             return MessageTranslator.convertMessage(
                 Component.translatable(mapping.getJavaItem().translationKey() + ".effect." + potionName),
                 language);
@@ -542,7 +546,9 @@ public final class ItemTranslator {
                 PotionContents potionContents = components.get(DataComponentType.POTION_CONTENTS);
                 if (potionContents != null) {
                     String potionName = getPotionName(potionContents, mapping, components.get(DataComponentType.HIDE_ADDITIONAL_TOOLTIP) != null, session.locale());
-                    if (potionName != null) return ChatColor.RESET + ChatColor.ESCAPE + translationColor + potionName;
+                    if (potionName != null) {
+                        return ChatColor.RESET + ChatColor.ESCAPE + translationColor + potionName;
+                    }
                 }
                 if (includeAll) {
                     // Fix book title display in tooltips of shulker box

--- a/core/src/main/java/org/geysermc/geyser/translator/item/ItemTranslator.java
+++ b/core/src/main/java/org/geysermc/geyser/translator/item/ItemTranslator.java
@@ -382,6 +382,7 @@ public final class ItemTranslator {
                 .color((negativeEffectList.contains(effect)) ? NamedTextColor.RED : NamedTextColor.BLUE)
                 .append(appendTranslatable)
                 .build();
+            // Bedrock supports wrap lines with '\n' in a single string in custom name
             finalText.append('\n').append(MessageTranslator.convertMessage(component, language));
         }
         return finalText.toString();
@@ -544,6 +545,7 @@ public final class ItemTranslator {
                     if (potionName != null) return ChatColor.RESET + ChatColor.ESCAPE + translationColor + potionName;
                 }
                 if (includeAll) {
+                    // Fix book title display in tooltips of shulker box
                     WrittenBookContent bookContent = components.get(DataComponentType.WRITTEN_BOOK_CONTENT);
                     if (bookContent != null) {
                         return ChatColor.RESET + ChatColor.ESCAPE + translationColor + bookContent.getTitle().getRaw();


### PR DESCRIPTION
(Test in 1.21.4)
## `item_name` Compoment (Issues since 6bd60d4)

`/give @s grass_block[item_name="TestName"]`

Version 2.6.0-b739 (git-master-623ec2b):
![image](https://github.com/user-attachments/assets/7f180873-6d01-4395-b933-9a8460d14b86)

**After this fixes**:
![image](https://github.com/user-attachments/assets/f04b6711-c41f-4d71-ba38-6a47a1140cf1)

## Custom effects display

`/give @s potion[potion_contents={custom_effects:[{id:"hero_of_the_village",duration:-1},{id:"unluck",amplifier:1,duration:140},{id:"jump_boost",amplifier:5,duration:658980}]}]`

Version 2.6.0-b739 (git-master-623ec2b):
![image](https://github.com/user-attachments/assets/cbf88b8c-5f1c-414f-a670-bff31f47474e)

**After this fixes**:
![image](https://github.com/user-attachments/assets/9f4ed2e0-fd84-4c66-9fe4-44dcac353eff)

To resolve "No Effects" under the effects information, make it a custom item, or use the `potion` tag to base it on the vanilla potion.

### Use hide_additional_tooltip component to hide custom effects information:

`/give @s potion[potion_contents={custom_effects:[{id:"hero_of_the_village",duration:-1},{id:"unluck",amplifier:1,duration:140},{id:"jump_boost",amplifier:5,duration:658980}]},hide_additional_tooltip={}]`
![image](https://github.com/user-attachments/assets/cf64ab17-2681-45f6-9a75-5b447bb43a9f)

### Custom name in `potion_contents`

Put on an item frame: `potion[potion_contents={custom_name:"healing"}]`

Version 2.6.0-b739 (git-master-623ec2b):
![image](https://github.com/user-attachments/assets/f2ce0265-a1ae-426d-ac69-c0202f19a353)

**After this fixes**:
![image](https://github.com/user-attachments/assets/cf830512-7f0b-4857-a60f-de8a0fac0577)

## Shulker box tooltips

Putting these in a shulker box:

Any written book:
![image](https://github.com/user-attachments/assets/556df4a9-c999-47ab-a88c-3df4d2df897b)

Any item with colored name (`[custom_name='{"text":"GreenName","color":"green"}']`):
![image](https://github.com/user-attachments/assets/71baed45-420b-4d71-95b3-cf1ea97b9a4b)

Any item with `custom_name` inside `potion_contents` (`[potion_contents={custom_name:"healing"}]`)
![image](https://github.com/user-attachments/assets/99a69d97-8fc0-4033-ada7-3757db61d995)

Version 2.6.0-b739 (git-master-623ec2b):
![image](https://github.com/user-attachments/assets/55be4a06-8046-483b-9e66-1d61d4856285)
- Title of Written book not display
- Count display (e.g., x16) with incorrect color due to some items with colored names
- `custom_name` inside `potion_contents` always show incorrect white color

**After this fixes**:
![image](https://github.com/user-attachments/assets/330e0eb4-72f2-474b-ba71-dab4db0f6653)