### PR TITLE
Set UUID and Username earlier

### DIFF
--- a/core/src/main/java/org/geysermc/geyser/session/GeyserSessionAdapter.java
+++ b/core/src/main/java/org/geysermc/geyser/session/GeyserSessionAdapter.java
@@ -137,18 +137,6 @@ public class GeyserSessionAdapter extends SessionAdapter {
                 geyserSession.bedrockUsername(), geyserSession.getProtocol().getProfile().getName(), geyserSession.remoteServer().address()));
         }
 
-        UUID uuid = geyserSession.getProtocol().getProfile().getId();
-        if (uuid == null) {
-            // Set what our UUID *probably* is going to be
-            if (geyserSession.remoteServer().authType() == AuthType.FLOODGATE) {
-                uuid = new UUID(0, Long.parseLong(geyserSession.xuid()));
-            } else {
-                uuid = UUID.nameUUIDFromBytes(("OfflinePlayer:" + geyserSession.getProtocol().getProfile().getName()).getBytes(StandardCharsets.UTF_8));
-            }
-        }
-        geyserSession.getPlayerEntity().setUuid(uuid);
-        geyserSession.getPlayerEntity().setUsername(geyserSession.getProtocol().getProfile().getName());
-
         String locale = geyserSession.getClientData().getLanguageCode();
 
         // Let the user know there locale may take some time to download


### PR DESCRIPTION
Currently, the Java UUID and Username are null during login events, causing remotes to receive a random UUID.

This PR initializes them after the Bedrock player is authenticated, before SessionInitializeEvent

I'm not the most familiar with Geyser code, so I am unaware of any problems that might occur from this. It is working as expected with Velocity online floodgate