### PR TITLE
Fix: Server-side requested container closing

### DIFF
--- a/core/src/main/java/org/geysermc/geyser/inventory/Container.java
+++ b/core/src/main/java/org/geysermc/geyser/inventory/Container.java
@@ -25,12 +25,12 @@
 
 package org.geysermc.geyser.inventory;
 
-import org.geysermc.geyser.level.block.type.Block;
-import org.geysermc.mcprotocollib.protocol.data.game.inventory.ContainerType;
 import lombok.Getter;
 import org.checkerframework.checker.nullness.qual.NonNull;
+import org.geysermc.geyser.level.block.type.Block;
 import org.geysermc.geyser.session.GeyserSession;
 import org.geysermc.geyser.translator.inventory.InventoryTranslator;
+import org.geysermc.mcprotocollib.protocol.data.game.inventory.ContainerType;
 import org.jetbrains.annotations.Range;
 
 /**

--- a/core/src/main/java/org/geysermc/geyser/inventory/Inventory.java
+++ b/core/src/main/java/org/geysermc/geyser/inventory/Inventory.java
@@ -171,4 +171,12 @@ public abstract class Inventory {
     public void resetNextStateId() {
         nextStateId = -1;
     }
+
+    /**
+     * Whether we should be sending a {@link org.geysermc.mcprotocollib.protocol.packet.ingame.serverbound.inventory.ServerboundContainerClosePacket}
+     * when closing the inventory.
+     */
+    public boolean shouldConfirmContainerClose() {
+        return true;
+    }
 }

--- a/core/src/main/java/org/geysermc/geyser/inventory/LecternContainer.java
+++ b/core/src/main/java/org/geysermc/geyser/inventory/LecternContainer.java
@@ -70,4 +70,9 @@ public class LecternContainer extends Container {
         this.isBookInPlayerInventory = true;
         super.setItem(0, book, session);
     }
+
+    @Override
+    public boolean shouldConfirmContainerClose() {
+        return !isBookInPlayerInventory;
+    }
 }

--- a/core/src/main/java/org/geysermc/geyser/inventory/LecternContainer.java
+++ b/core/src/main/java/org/geysermc/geyser/inventory/LecternContainer.java
@@ -43,7 +43,7 @@ public class LecternContainer extends Container {
     @Setter
     private Vector3i position;
 
-    private boolean isFakeLectern = false;
+    private boolean isBookInPlayerInventory = false;
 
     public LecternContainer(String title, int id, int size, ContainerType containerType, PlayerInventory playerInventory) {
         super(title, id, size, containerType, playerInventory);
@@ -55,7 +55,7 @@ public class LecternContainer extends Container {
      */
     @Override
     public void setItem(int slot, @NonNull GeyserItemStack newItem, GeyserSession session) {
-        if (isFakeLectern) {
+        if (isBookInPlayerInventory) {
             session.getPlayerInventory().setItem(slot, newItem, session);
         } else {
             super.setItem(slot, newItem, session);
@@ -67,7 +67,7 @@ public class LecternContainer extends Container {
      * See {@link LecternContainer#setItem(int, GeyserItemStack, GeyserSession)} as for why this is separate.
      */
     public void setFakeLecternBook(GeyserItemStack book, GeyserSession session) {
-        this.isFakeLectern = true;
+        this.isBookInPlayerInventory = true;
         super.setItem(0, book, session);
     }
 }

--- a/core/src/main/java/org/geysermc/geyser/inventory/holder/BlockInventoryHolder.java
+++ b/core/src/main/java/org/geysermc/geyser/inventory/holder/BlockInventoryHolder.java
@@ -155,19 +155,8 @@ public class BlockInventoryHolder extends InventoryHolder {
     }
 
     @Override
-    public void closeInventory(InventoryTranslator translator, GeyserSession session, Inventory inventory) {
-        if (inventory instanceof Container container) {
-            if (container.isUsingRealBlock() && !(container instanceof LecternContainer)) {
-                // No need to reset a block since we didn't change any blocks
-                // But send a container close packet because we aren't destroying the original.
-                ContainerClosePacket packet = new ContainerClosePacket();
-                packet.setId((byte) inventory.getBedrockId());
-                packet.setServerInitiated(true);
-                packet.setType(ContainerType.CONTAINER);
-                session.sendUpstreamPacket(packet);
-                return;
-            }
-        } else {
+    public void closeInventory(InventoryTranslator translator, GeyserSession session, Inventory inventory, ContainerType type) {
+        if (!(inventory instanceof Container container)) {
             GeyserImpl.getInstance().getLogger().warning("Tried to close a non-container inventory in a block inventory holder! ");
             if (GeyserImpl.getInstance().getLogger().isDebug()) {
                 GeyserImpl.getInstance().getLogger().debug("Current inventory: " + inventory);
@@ -175,12 +164,41 @@ public class BlockInventoryHolder extends InventoryHolder {
             }
             // Try to save ourselves? maybe?
             // https://github.com/GeyserMC/Geyser/issues/4141
-            // TODO: improve once this issue is pinned down properly
+            // TODO: improve once this issue is pinned down
             session.setOpenInventory(null);
             session.setInventoryTranslator(InventoryTranslator.PLAYER_INVENTORY_TRANSLATOR);
             return;
         }
 
+        // Bedrock broke inventory closing. I wish i was kidding.
+        // "type" is explicitly passed to keep track of which inventory types can be closed without
+        // ""workarounds"". yippie.
+        // Further, Lecterns cannot be closed with any of the two methods below.
+        if (container.isUsingRealBlock() && !(container instanceof LecternContainer)) {
+            if (type != null) {
+                // No need to reset a block since we didn't change any blocks
+                // But send a container close packet because we aren't destroying the original.
+                ContainerClosePacket packet = new ContainerClosePacket();
+                packet.setId((byte) inventory.getBedrockId());
+                packet.setServerInitiated(true);
+                packet.setType(type);
+                session.sendUpstreamPacket(packet);
+
+                GeyserImpl.getInstance().getLogger().warning(packet.toString());
+                return;
+            }
+
+            // Destroy the block. There's no inventory to view => it gets closed!
+            Vector3i holderPos = inventory.getHolderPosition();
+            UpdateBlockPacket blockPacket = new UpdateBlockPacket();
+            blockPacket.setDataLayer(0);
+            blockPacket.setBlockPosition(holderPos);
+            blockPacket.setDefinition(session.getBlockMappings().getBedrockAir());
+            blockPacket.getFlags().addAll(UpdateBlockPacket.FLAG_ALL_PRIORITY);
+            session.sendUpstreamPacket(blockPacket);
+        }
+
+        // Reset to correct block
         Vector3i holderPos = inventory.getHolderPosition();
         int realBlock = session.getGeyser().getWorldManager().getBlockAt(session, holderPos.getX(), holderPos.getY(), holderPos.getZ());
         UpdateBlockPacket blockPacket = new UpdateBlockPacket();

--- a/core/src/main/java/org/geysermc/geyser/inventory/holder/BlockInventoryHolder.java
+++ b/core/src/main/java/org/geysermc/geyser/inventory/holder/BlockInventoryHolder.java
@@ -181,8 +181,6 @@ public class BlockInventoryHolder extends InventoryHolder {
                 packet.setServerInitiated(true);
                 packet.setType(type);
                 session.sendUpstreamPacket(packet);
-
-                GeyserImpl.getInstance().getLogger().warning(packet.toString());
                 return;
             }
 

--- a/core/src/main/java/org/geysermc/geyser/inventory/holder/BlockInventoryHolder.java
+++ b/core/src/main/java/org/geysermc/geyser/inventory/holder/BlockInventoryHolder.java
@@ -157,11 +157,9 @@ public class BlockInventoryHolder extends InventoryHolder {
     @Override
     public void closeInventory(InventoryTranslator translator, GeyserSession session, Inventory inventory, ContainerType type) {
         if (!(inventory instanceof Container container)) {
-            GeyserImpl.getInstance().getLogger().warning("Tried to close a non-container inventory in a block inventory holder! ");
-            if (GeyserImpl.getInstance().getLogger().isDebug()) {
-                GeyserImpl.getInstance().getLogger().debug("Current inventory: " + inventory);
-                GeyserImpl.getInstance().getLogger().debug("Open inventory: " + session.getOpenInventory());
-            }
+            GeyserImpl.getInstance().getLogger().warning("Tried to close a non-container inventory in a block inventory holder! Please report this error on discord.");
+            GeyserImpl.getInstance().getLogger().warning("Current inventory translator: " + translator.getClass().getSimpleName());
+            GeyserImpl.getInstance().getLogger().warning("Current inventory: " + inventory.getClass().getSimpleName());
             // Try to save ourselves? maybe?
             // https://github.com/GeyserMC/Geyser/issues/4141
             // TODO: improve once this issue is pinned down

--- a/core/src/main/java/org/geysermc/geyser/inventory/holder/InventoryHolder.java
+++ b/core/src/main/java/org/geysermc/geyser/inventory/holder/InventoryHolder.java
@@ -25,6 +25,7 @@
 
 package org.geysermc.geyser.inventory.holder;
 
+import org.cloudburstmc.protocol.bedrock.data.inventory.ContainerType;
 import org.geysermc.geyser.inventory.Inventory;
 import org.geysermc.geyser.session.GeyserSession;
 import org.geysermc.geyser.translator.inventory.InventoryTranslator;
@@ -32,5 +33,5 @@ import org.geysermc.geyser.translator.inventory.InventoryTranslator;
 public abstract class InventoryHolder {
     public abstract boolean prepareInventory(InventoryTranslator translator, GeyserSession session, Inventory inventory);
     public abstract void openInventory(InventoryTranslator translator, GeyserSession session, Inventory inventory);
-    public abstract void closeInventory(InventoryTranslator translator, GeyserSession session, Inventory inventory);
+    public abstract void closeInventory(InventoryTranslator translator, GeyserSession session, Inventory inventory, ContainerType containerType);
 }

--- a/core/src/main/java/org/geysermc/geyser/registry/populator/BlockRegistryPopulator.java
+++ b/core/src/main/java/org/geysermc/geyser/registry/populator/BlockRegistryPopulator.java
@@ -245,6 +245,7 @@ public final class BlockRegistryPopulator {
             GeyserBedrockBlock airDefinition = null;
             BlockDefinition commandBlockDefinition = null;
             BlockDefinition mobSpawnerBlockDefinition = null;
+            BlockDefinition netherPortalBlockDefinition = null;
             BlockDefinition waterDefinition = null;
             BlockDefinition movingBlockDefinition = null;
             Iterator<NbtMap> blocksIterator = BLOCKS_NBT.iterator();
@@ -330,6 +331,10 @@ public final class BlockRegistryPopulator {
                     structureBlockDefinitions.put(mode.toUpperCase(Locale.ROOT), bedrockDefinition);
                 }
 
+                if (block == Blocks.NETHER_PORTAL) {
+                    netherPortalBlockDefinition = bedrockDefinition;
+                }
+
                 boolean waterlogged = blockState.getValue(Properties.WATERLOGGED, false)
                         || block == Blocks.BUBBLE_COLUMN || block == Blocks.KELP || block == Blocks.KELP_PLANT
                         || block == Blocks.SEAGRASS || block == Blocks.TALL_SEAGRASS;
@@ -357,6 +362,11 @@ public final class BlockRegistryPopulator {
                 throw new AssertionError("Unable to find mob spawner block in palette");
             }
             builder.mobSpawnerBlock(mobSpawnerBlockDefinition);
+
+            if (netherPortalBlockDefinition == null) {
+                throw new AssertionError("Unable to find nether portal block in palette");
+            }
+            builder.netherPortalBlock(netherPortalBlockDefinition);
 
             if (waterDefinition  == null) {
                 throw new AssertionError("Unable to find water in palette");

--- a/core/src/main/java/org/geysermc/geyser/registry/type/BlockMappings.java
+++ b/core/src/main/java/org/geysermc/geyser/registry/type/BlockMappings.java
@@ -64,6 +64,7 @@ public class BlockMappings implements DefinitionRegistry<BlockDefinition> {
 
     BlockDefinition commandBlock;
     BlockDefinition mobSpawnerBlock;
+    BlockDefinition netherPortalBlock;
 
     Map<NbtMap, BlockDefinition> itemFrames;
     Map<Block, NbtMap> flowerPotBlocks;

--- a/core/src/main/java/org/geysermc/geyser/session/GeyserSession.java
+++ b/core/src/main/java/org/geysermc/geyser/session/GeyserSession.java
@@ -527,6 +527,14 @@ public class GeyserSession implements GeyserConnection, GeyserCommandSource {
     private boolean placedBucket;
 
     /**
+     * Stores whether the Java server requested the player inventory to be closed.
+     * Used to prevent our hacky player inventory closing workaround in {@link org.geysermc.geyser.translator.inventory.PlayerInventoryTranslator#closeInventory(GeyserSession, Inventory)}
+     * to run when the closing is initated by the Bedrock client.
+     */
+    @Setter
+    private boolean serverRequestedClosePlayerInventory;
+
+    /**
      * Counts how many ticks have occurred since an arm animation started.
      * -1 means there is no active arm swing; -2 means an arm swing will start in a tick.
      */

--- a/core/src/main/java/org/geysermc/geyser/translator/inventory/AbstractBlockInventoryTranslator.java
+++ b/core/src/main/java/org/geysermc/geyser/translator/inventory/AbstractBlockInventoryTranslator.java
@@ -25,8 +25,6 @@
 
 package org.geysermc.geyser.translator.inventory;
 
-import lombok.Getter;
-import org.checkerframework.checker.nullness.qual.NonNull;
 import org.checkerframework.checker.nullness.qual.Nullable;
 import org.cloudburstmc.protocol.bedrock.data.inventory.ContainerType;
 import org.geysermc.geyser.inventory.Inventory;
@@ -43,8 +41,6 @@ import org.geysermc.geyser.session.GeyserSession;
 public abstract class AbstractBlockInventoryTranslator extends BaseInventoryTranslator {
     private final InventoryHolder holder;
     private final InventoryUpdater updater;
-    @Getter
-    private final @NonNull ContainerType type;
 
     /**
      * @param javaBlock a Java block that is used as a temporary block
@@ -66,7 +62,6 @@ public abstract class AbstractBlockInventoryTranslator extends BaseInventoryTran
         super(size);
         this.holder = new BlockInventoryHolder(javaBlockState, containerType, additionalValidBlocks);
         this.updater = updater;
-        this.type = containerType;
     }
 
     /**
@@ -74,11 +69,10 @@ public abstract class AbstractBlockInventoryTranslator extends BaseInventoryTran
      * @param holder the custom block holder
      * @param updater updater
      */
-    public AbstractBlockInventoryTranslator(int size, InventoryHolder holder, InventoryUpdater updater, ContainerType containerType) {
+    public AbstractBlockInventoryTranslator(int size, InventoryHolder holder, InventoryUpdater updater) {
         super(size);
         this.holder = holder;
         this.updater = updater;
-        this.type = containerType;
     }
 
     @Override
@@ -110,8 +104,7 @@ public abstract class AbstractBlockInventoryTranslator extends BaseInventoryTran
     So. Sometime in 1.21, Bedrock just broke the ContainerClosePacket. As in: Geyser sends it, the player ignores it.
     But only for some blocks! And some blocks only respond to specific container types (dispensers/droppers now require the specific type...)
     And closing the player inventory type is seemingly impossible :( hurray.
+    When this returns null, we just... break the block, and replace it. Primitive. But if that works... fine.
      */
-    public @Nullable ContainerType closeContainerType(Inventory inventory) {
-        return this.type;
-    }
+    public abstract @Nullable ContainerType closeContainerType(Inventory inventory);
 }

--- a/core/src/main/java/org/geysermc/geyser/translator/inventory/AbstractBlockInventoryTranslator.java
+++ b/core/src/main/java/org/geysermc/geyser/translator/inventory/AbstractBlockInventoryTranslator.java
@@ -103,7 +103,6 @@ public abstract class AbstractBlockInventoryTranslator extends BaseInventoryTran
     /*
     So. Sometime in 1.21, Bedrock just broke the ContainerClosePacket. As in: Geyser sends it, the player ignores it.
     But only for some blocks! And some blocks only respond to specific container types (dispensers/droppers now require the specific type...)
-    And closing the player inventory type is seemingly impossible :( hurray.
     When this returns null, we just... break the block, and replace it. Primitive. But if that works... fine.
      */
     public abstract @Nullable ContainerType closeContainerType(Inventory inventory);

--- a/core/src/main/java/org/geysermc/geyser/translator/inventory/AnvilInventoryTranslator.java
+++ b/core/src/main/java/org/geysermc/geyser/translator/inventory/AnvilInventoryTranslator.java
@@ -25,6 +25,7 @@
 
 package org.geysermc.geyser.translator.inventory;
 
+import org.checkerframework.checker.nullness.qual.Nullable;
 import org.cloudburstmc.protocol.bedrock.data.inventory.ContainerSlotType;
 import org.cloudburstmc.protocol.bedrock.data.inventory.itemstack.request.ItemStackRequest;
 import org.cloudburstmc.protocol.bedrock.data.inventory.itemstack.request.ItemStackRequestSlotData;
@@ -114,5 +115,10 @@ public class AnvilInventoryTranslator extends AbstractBlockInventoryTranslator {
         anvilContainer.setJavaLevelCost(value);
         anvilContainer.setUseJavaLevelCost(true);
         updateSlot(session, anvilContainer, 1);
+    }
+
+    @Override
+    public org.cloudburstmc.protocol.bedrock.data.inventory.@Nullable ContainerType closeContainerType(Inventory inventory) {
+        return null;
     }
 }

--- a/core/src/main/java/org/geysermc/geyser/translator/inventory/BeaconInventoryTranslator.java
+++ b/core/src/main/java/org/geysermc/geyser/translator/inventory/BeaconInventoryTranslator.java
@@ -147,4 +147,9 @@ public class BeaconInventoryTranslator extends AbstractBlockInventoryTranslator 
     public Inventory createInventory(String name, int windowId, ContainerType containerType, PlayerInventory playerInventory) {
         return new BeaconContainer(name, windowId, this.size, containerType, playerInventory);
     }
+
+    @Override
+    public org.cloudburstmc.protocol.bedrock.data.inventory.ContainerType closeContainerType(Inventory inventory) {
+        return null;
+    }
 }

--- a/core/src/main/java/org/geysermc/geyser/translator/inventory/BrewingInventoryTranslator.java
+++ b/core/src/main/java/org/geysermc/geyser/translator/inventory/BrewingInventoryTranslator.java
@@ -25,6 +25,7 @@
 
 package org.geysermc.geyser.translator.inventory;
 
+import org.checkerframework.checker.nullness.qual.Nullable;
 import org.cloudburstmc.protocol.bedrock.data.inventory.ContainerSlotType;
 import org.cloudburstmc.protocol.bedrock.data.inventory.ContainerType;
 import org.cloudburstmc.protocol.bedrock.data.inventory.itemstack.request.ItemStackRequestSlotData;
@@ -105,5 +106,10 @@ public class BrewingInventoryTranslator extends AbstractBlockInventoryTranslator
             case 4 -> new BedrockContainerSlot(ContainerSlotType.BREWING_FUEL, 4);
             default -> super.javaSlotToBedrockContainer(slot);
         };
+    }
+
+    @Override
+    public @Nullable ContainerType closeContainerType(Inventory inventory) {
+        return ContainerType.BREWING_STAND;
     }
 }

--- a/core/src/main/java/org/geysermc/geyser/translator/inventory/CartographyInventoryTranslator.java
+++ b/core/src/main/java/org/geysermc/geyser/translator/inventory/CartographyInventoryTranslator.java
@@ -25,6 +25,7 @@
 
 package org.geysermc.geyser.translator.inventory;
 
+import org.checkerframework.checker.nullness.qual.Nullable;
 import org.cloudburstmc.protocol.bedrock.data.inventory.ContainerSlotType;
 import org.cloudburstmc.protocol.bedrock.data.inventory.itemstack.request.ItemStackRequestSlotData;
 import org.geysermc.geyser.inventory.*;
@@ -87,5 +88,10 @@ public class CartographyInventoryTranslator extends AbstractBlockInventoryTransl
     @Override
     public Inventory createInventory(String name, int windowId, ContainerType containerType, PlayerInventory playerInventory) {
         return new CartographyContainer(name, windowId, this.size, containerType, playerInventory);
+    }
+
+    @Override
+    public org.cloudburstmc.protocol.bedrock.data.inventory.@Nullable ContainerType closeContainerType(Inventory inventory) {
+        return null;
     }
 }

--- a/core/src/main/java/org/geysermc/geyser/translator/inventory/CrafterInventoryTranslator.java
+++ b/core/src/main/java/org/geysermc/geyser/translator/inventory/CrafterInventoryTranslator.java
@@ -162,4 +162,9 @@ public class CrafterInventoryTranslator extends AbstractBlockInventoryTranslator
 
         BlockEntityUtils.updateBlockEntity(session, tag.build(), container.getHolderPosition());
     }
+
+    @Override
+    public org.cloudburstmc.protocol.bedrock.data.inventory.ContainerType closeContainerType(Inventory inventory) {
+        return null;
+    }
 }

--- a/core/src/main/java/org/geysermc/geyser/translator/inventory/CraftingInventoryTranslator.java
+++ b/core/src/main/java/org/geysermc/geyser/translator/inventory/CraftingInventoryTranslator.java
@@ -29,6 +29,7 @@ import org.cloudburstmc.protocol.bedrock.data.inventory.ContainerSlotType;
 import org.cloudburstmc.protocol.bedrock.data.inventory.ContainerType;
 import org.cloudburstmc.protocol.bedrock.data.inventory.itemstack.request.ItemStackRequestSlotData;
 import org.geysermc.geyser.inventory.BedrockContainerSlot;
+import org.geysermc.geyser.inventory.Inventory;
 import org.geysermc.geyser.inventory.SlotType;
 import org.geysermc.geyser.inventory.updater.UIInventoryUpdater;
 import org.geysermc.geyser.level.block.Blocks;
@@ -85,5 +86,10 @@ public class CraftingInventoryTranslator extends AbstractBlockInventoryTranslato
 
     public static boolean isCraftingGrid(int slot) {
         return slot >= 1 && slot <= 9;
+    }
+
+    @Override
+    public ContainerType closeContainerType(Inventory inventory) {
+        return null; // nothing else works :(
     }
 }

--- a/core/src/main/java/org/geysermc/geyser/translator/inventory/CraftingInventoryTranslator.java
+++ b/core/src/main/java/org/geysermc/geyser/translator/inventory/CraftingInventoryTranslator.java
@@ -90,6 +90,6 @@ public class CraftingInventoryTranslator extends AbstractBlockInventoryTranslato
 
     @Override
     public ContainerType closeContainerType(Inventory inventory) {
-        return null; // nothing else works :(
+        return null;
     }
 }

--- a/core/src/main/java/org/geysermc/geyser/translator/inventory/EnchantingInventoryTranslator.java
+++ b/core/src/main/java/org/geysermc/geyser/translator/inventory/EnchantingInventoryTranslator.java
@@ -26,6 +26,7 @@
 package org.geysermc.geyser.translator.inventory;
 
 import it.unimi.dsi.fastutil.ints.IntSets;
+import org.checkerframework.checker.nullness.qual.Nullable;
 import org.cloudburstmc.protocol.bedrock.data.inventory.ContainerSlotType;
 import org.cloudburstmc.protocol.bedrock.data.inventory.EnchantOptionData;
 import org.cloudburstmc.protocol.bedrock.data.inventory.itemstack.request.ItemStackRequest;
@@ -169,5 +170,10 @@ public class EnchantingInventoryTranslator extends AbstractBlockInventoryTransla
     @Override
     public Inventory createInventory(String name, int windowId, ContainerType containerType, PlayerInventory playerInventory) {
         return new EnchantingContainer(name, windowId, this.size, containerType, playerInventory);
+    }
+
+    @Override
+    public org.cloudburstmc.protocol.bedrock.data.inventory.@Nullable ContainerType closeContainerType(Inventory inventory) {
+        return null;
     }
 }

--- a/core/src/main/java/org/geysermc/geyser/translator/inventory/Generic3X3InventoryTranslator.java
+++ b/core/src/main/java/org/geysermc/geyser/translator/inventory/Generic3X3InventoryTranslator.java
@@ -68,4 +68,10 @@ public class Generic3X3InventoryTranslator extends AbstractBlockInventoryTransla
         }
         return super.javaSlotToBedrockContainer(javaSlot);
     }
+
+    @Override
+    public org.cloudburstmc.protocol.bedrock.data.inventory.ContainerType closeContainerType(Inventory inventory) {
+        return ((Generic3X3Container) inventory).isDropper() ? org.cloudburstmc.protocol.bedrock.data.inventory.ContainerType.DROPPER :
+            org.cloudburstmc.protocol.bedrock.data.inventory.ContainerType.DISPENSER;
+    }
 }

--- a/core/src/main/java/org/geysermc/geyser/translator/inventory/GrindstoneInventoryTranslator.java
+++ b/core/src/main/java/org/geysermc/geyser/translator/inventory/GrindstoneInventoryTranslator.java
@@ -29,6 +29,7 @@ import org.cloudburstmc.protocol.bedrock.data.inventory.ContainerSlotType;
 import org.cloudburstmc.protocol.bedrock.data.inventory.ContainerType;
 import org.cloudburstmc.protocol.bedrock.data.inventory.itemstack.request.ItemStackRequestSlotData;
 import org.geysermc.geyser.inventory.BedrockContainerSlot;
+import org.geysermc.geyser.inventory.Inventory;
 import org.geysermc.geyser.inventory.updater.UIInventoryUpdater;
 import org.geysermc.geyser.level.block.Blocks;
 
@@ -65,5 +66,10 @@ public class GrindstoneInventoryTranslator extends AbstractBlockInventoryTransla
             case 2 -> 50;
             default -> super.javaSlotToBedrock(slot);
         };
+    }
+
+    @Override
+    public ContainerType closeContainerType(Inventory inventory) {
+        return null;
     }
 }

--- a/core/src/main/java/org/geysermc/geyser/translator/inventory/HopperInventoryTranslator.java
+++ b/core/src/main/java/org/geysermc/geyser/translator/inventory/HopperInventoryTranslator.java
@@ -25,9 +25,11 @@
 
 package org.geysermc.geyser.translator.inventory;
 
+import org.checkerframework.checker.nullness.qual.Nullable;
 import org.cloudburstmc.protocol.bedrock.data.inventory.ContainerSlotType;
 import org.cloudburstmc.protocol.bedrock.data.inventory.ContainerType;
 import org.geysermc.geyser.inventory.BedrockContainerSlot;
+import org.geysermc.geyser.inventory.Inventory;
 import org.geysermc.geyser.inventory.updater.ContainerInventoryUpdater;
 import org.geysermc.geyser.level.block.Blocks;
 
@@ -45,5 +47,10 @@ public class HopperInventoryTranslator extends AbstractBlockInventoryTranslator 
             return new BedrockContainerSlot(ContainerSlotType.LEVEL_ENTITY, javaSlot);
         }
         return super.javaSlotToBedrockContainer(javaSlot);
+    }
+
+    @Override
+    public @Nullable ContainerType closeContainerType(Inventory inventory) {
+        return ContainerType.HOPPER;
     }
 }

--- a/core/src/main/java/org/geysermc/geyser/translator/inventory/LecternInventoryTranslator.java
+++ b/core/src/main/java/org/geysermc/geyser/translator/inventory/LecternInventoryTranslator.java
@@ -25,6 +25,7 @@
 
 package org.geysermc.geyser.translator.inventory;
 
+import org.checkerframework.checker.nullness.qual.Nullable;
 import org.cloudburstmc.math.vector.Vector3i;
 import org.cloudburstmc.nbt.NbtMap;
 import org.cloudburstmc.nbt.NbtMapBuilder;
@@ -147,6 +148,11 @@ public class LecternInventoryTranslator extends AbstractBlockInventoryTranslator
         if (slot == 0) {
             updateBook(session, inventory, inventory.getItem(0));
         }
+    }
+
+    @Override
+    public org.cloudburstmc.protocol.bedrock.data.inventory.@Nullable ContainerType closeContainerType(Inventory inventory) {
+        return null;
     }
 
     /**

--- a/core/src/main/java/org/geysermc/geyser/translator/inventory/LoomInventoryTranslator.java
+++ b/core/src/main/java/org/geysermc/geyser/translator/inventory/LoomInventoryTranslator.java
@@ -27,6 +27,7 @@ package org.geysermc.geyser.translator.inventory;
 
 import it.unimi.dsi.fastutil.objects.Object2IntMap;
 import it.unimi.dsi.fastutil.objects.Object2IntOpenHashMap;
+import org.checkerframework.checker.nullness.qual.Nullable;
 import org.cloudburstmc.nbt.NbtMap;
 import org.cloudburstmc.nbt.NbtType;
 import org.cloudburstmc.protocol.bedrock.data.inventory.ContainerSlotType;
@@ -206,5 +207,10 @@ public class LoomInventoryTranslator extends AbstractBlockInventoryTranslator {
             return SlotType.OUTPUT;
         }
         return super.getSlotType(javaSlot);
+    }
+
+    @Override
+    public @Nullable ContainerType closeContainerType(Inventory inventory) {
+        return null;
     }
 }

--- a/core/src/main/java/org/geysermc/geyser/translator/inventory/OldSmithingTableTranslator.java
+++ b/core/src/main/java/org/geysermc/geyser/translator/inventory/OldSmithingTableTranslator.java
@@ -25,6 +25,7 @@
 
 package org.geysermc.geyser.translator.inventory;
 
+import org.checkerframework.checker.nullness.qual.Nullable;
 import org.cloudburstmc.protocol.bedrock.data.inventory.ContainerId;
 import org.cloudburstmc.protocol.bedrock.data.inventory.ContainerSlotType;
 import org.cloudburstmc.protocol.bedrock.data.inventory.ContainerType;
@@ -144,5 +145,10 @@ public class OldSmithingTableTranslator extends AbstractBlockInventoryTranslator
         slotPacket.setSlot(53);
         slotPacket.setItem(UPGRADE_TEMPLATE.apply(session.getUpstream().getProtocolVersion()));
         session.sendUpstreamPacket(slotPacket);
+    }
+
+    @Override
+    public @Nullable ContainerType closeContainerType(Inventory inventory) {
+        return null;
     }
 }

--- a/core/src/main/java/org/geysermc/geyser/translator/inventory/PlayerInventoryTranslator.java
+++ b/core/src/main/java/org/geysermc/geyser/translator/inventory/PlayerInventoryTranslator.java
@@ -28,6 +28,8 @@ package org.geysermc.geyser.translator.inventory;
 import it.unimi.dsi.fastutil.ints.IntIterator;
 import it.unimi.dsi.fastutil.ints.IntOpenHashSet;
 import it.unimi.dsi.fastutil.ints.IntSet;
+import org.cloudburstmc.math.vector.Vector3i;
+import org.cloudburstmc.protocol.bedrock.data.definitions.BlockDefinition;
 import org.cloudburstmc.protocol.bedrock.data.inventory.ContainerId;
 import org.cloudburstmc.protocol.bedrock.data.inventory.ContainerSlotType;
 import org.cloudburstmc.protocol.bedrock.data.inventory.CreativeItemData;
@@ -41,10 +43,11 @@ import org.cloudburstmc.protocol.bedrock.data.inventory.itemstack.request.action
 import org.cloudburstmc.protocol.bedrock.data.inventory.itemstack.request.action.SwapAction;
 import org.cloudburstmc.protocol.bedrock.data.inventory.itemstack.request.action.TransferItemStackRequestAction;
 import org.cloudburstmc.protocol.bedrock.data.inventory.itemstack.response.ItemStackResponse;
-import org.cloudburstmc.protocol.bedrock.packet.ContainerClosePacket;
 import org.cloudburstmc.protocol.bedrock.packet.ContainerOpenPacket;
 import org.cloudburstmc.protocol.bedrock.packet.InventoryContentPacket;
 import org.cloudburstmc.protocol.bedrock.packet.InventorySlotPacket;
+import org.cloudburstmc.protocol.bedrock.packet.UpdateBlockPacket;
+import org.geysermc.geyser.GeyserImpl;
 import org.geysermc.geyser.inventory.BedrockContainerSlot;
 import org.geysermc.geyser.inventory.GeyserItemStack;
 import org.geysermc.geyser.inventory.Inventory;
@@ -65,6 +68,7 @@ import org.geysermc.mcprotocollib.protocol.packet.ingame.serverbound.inventory.S
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
+import java.util.concurrent.TimeUnit;
 import java.util.function.IntFunction;
 
 public class PlayerInventoryTranslator extends InventoryTranslator {
@@ -577,11 +581,26 @@ public class PlayerInventoryTranslator extends InventoryTranslator {
 
     @Override
     public void closeInventory(GeyserSession session, Inventory inventory) {
-        ContainerClosePacket packet = new ContainerClosePacket();
-        packet.setServerInitiated(true);
-        packet.setId((byte) ContainerId.INVENTORY);
-        packet.setType(org.cloudburstmc.protocol.bedrock.data.inventory.ContainerType.INVENTORY);
+        // TODO only run if close is server-initiated
+        GeyserImpl.getInstance().getLogger().info("Closing player inventory!");
+        Vector3i pos = session.getPlayerEntity().getPosition().toInt();
+
+        UpdateBlockPacket packet = new UpdateBlockPacket();
+        packet.setBlockPosition(pos);
+        packet.setDefinition(session.getBlockMappings().getNetherPortalBlock());
+        packet.setDataLayer(0);
+        packet.getFlags().add(UpdateBlockPacket.Flag.PRIORITY);
         session.sendUpstreamPacket(packet);
+
+        session.scheduleInEventLoop(() -> {
+            BlockDefinition definition = session.getBlockMappings().getBedrockBlock(session.getGeyser().getWorldManager().blockAt(session, pos));
+
+            packet.setBlockPosition(pos);
+            packet.setDefinition(definition);
+            packet.getFlags().add(UpdateBlockPacket.Flag.PRIORITY);
+            packet.setDataLayer(0);
+            session.sendUpstreamPacket(packet);
+        }, 50, TimeUnit.MILLISECONDS);
     }
 
     @Override

--- a/core/src/main/java/org/geysermc/geyser/translator/inventory/ShulkerInventoryTranslator.java
+++ b/core/src/main/java/org/geysermc/geyser/translator/inventory/ShulkerInventoryTranslator.java
@@ -70,7 +70,7 @@ public class ShulkerInventoryTranslator extends AbstractBlockInventoryTranslator
                 dataPacket.setBlockPosition(position);
                 session.sendUpstreamPacket(dataPacket);
             }
-        }, ContainerInventoryUpdater.INSTANCE);
+        }, ContainerInventoryUpdater.INSTANCE, ContainerType.CONTAINER);
     }
 
     @Override

--- a/core/src/main/java/org/geysermc/geyser/translator/inventory/ShulkerInventoryTranslator.java
+++ b/core/src/main/java/org/geysermc/geyser/translator/inventory/ShulkerInventoryTranslator.java
@@ -25,6 +25,7 @@
 
 package org.geysermc.geyser.translator.inventory;
 
+import org.checkerframework.checker.nullness.qual.Nullable;
 import org.cloudburstmc.math.vector.Vector3i;
 import org.cloudburstmc.nbt.NbtMap;
 import org.cloudburstmc.nbt.NbtMapBuilder;
@@ -70,7 +71,7 @@ public class ShulkerInventoryTranslator extends AbstractBlockInventoryTranslator
                 dataPacket.setBlockPosition(position);
                 session.sendUpstreamPacket(dataPacket);
             }
-        }, ContainerInventoryUpdater.INSTANCE, ContainerType.CONTAINER);
+        }, ContainerInventoryUpdater.INSTANCE);
     }
 
     @Override
@@ -79,5 +80,10 @@ public class ShulkerInventoryTranslator extends AbstractBlockInventoryTranslator
             return new BedrockContainerSlot(ContainerSlotType.SHULKER_BOX, javaSlot);
         }
         return super.javaSlotToBedrockContainer(javaSlot);
+    }
+
+    @Override
+    public @Nullable ContainerType closeContainerType(Inventory inventory) {
+        return ContainerType.CONTAINER;
     }
 }

--- a/core/src/main/java/org/geysermc/geyser/translator/inventory/SmithingInventoryTranslator.java
+++ b/core/src/main/java/org/geysermc/geyser/translator/inventory/SmithingInventoryTranslator.java
@@ -29,6 +29,7 @@ import org.cloudburstmc.protocol.bedrock.data.inventory.ContainerSlotType;
 import org.cloudburstmc.protocol.bedrock.data.inventory.ContainerType;
 import org.cloudburstmc.protocol.bedrock.data.inventory.itemstack.request.ItemStackRequestSlotData;
 import org.geysermc.geyser.inventory.BedrockContainerSlot;
+import org.geysermc.geyser.inventory.Inventory;
 import org.geysermc.geyser.inventory.updater.UIInventoryUpdater;
 import org.geysermc.geyser.level.block.Blocks;
 
@@ -73,5 +74,10 @@ public class SmithingInventoryTranslator extends AbstractBlockInventoryTranslato
             case OUTPUT -> 50;
             default -> super.javaSlotToBedrock(slot);
         };
+    }
+
+    @Override
+    public ContainerType closeContainerType(Inventory inventory) {
+        return null;
     }
 }

--- a/core/src/main/java/org/geysermc/geyser/translator/inventory/StonecutterInventoryTranslator.java
+++ b/core/src/main/java/org/geysermc/geyser/translator/inventory/StonecutterInventoryTranslator.java
@@ -25,6 +25,7 @@
 
 package org.geysermc.geyser.translator.inventory;
 
+import org.checkerframework.checker.nullness.qual.Nullable;
 import org.cloudburstmc.protocol.bedrock.data.inventory.ContainerSlotType;
 import org.cloudburstmc.protocol.bedrock.data.inventory.itemstack.request.ItemStackRequest;
 import org.cloudburstmc.protocol.bedrock.data.inventory.itemstack.request.ItemStackRequestSlotData;
@@ -124,5 +125,10 @@ public class StonecutterInventoryTranslator extends AbstractBlockInventoryTransl
     @Override
     public Inventory createInventory(String name, int windowId, ContainerType containerType, PlayerInventory playerInventory) {
         return new StonecutterContainer(name, windowId, this.size, containerType, playerInventory);
+    }
+
+    @Override
+    public org.cloudburstmc.protocol.bedrock.data.inventory.@Nullable ContainerType closeContainerType(Inventory inventory) {
+        return org.cloudburstmc.protocol.bedrock.data.inventory.ContainerType.STONECUTTER;
     }
 }

--- a/core/src/main/java/org/geysermc/geyser/translator/inventory/chest/DoubleChestInventoryTranslator.java
+++ b/core/src/main/java/org/geysermc/geyser/translator/inventory/chest/DoubleChestInventoryTranslator.java
@@ -34,6 +34,7 @@ import org.cloudburstmc.protocol.bedrock.packet.BlockEntityDataPacket;
 import org.cloudburstmc.protocol.bedrock.packet.ContainerClosePacket;
 import org.cloudburstmc.protocol.bedrock.packet.ContainerOpenPacket;
 import org.cloudburstmc.protocol.bedrock.packet.UpdateBlockPacket;
+import org.geysermc.geyser.GeyserImpl;
 import org.geysermc.geyser.inventory.Container;
 import org.geysermc.geyser.inventory.Inventory;
 import org.geysermc.geyser.level.block.Blocks;
@@ -43,6 +44,7 @@ import org.geysermc.geyser.level.block.type.BlockState;
 import org.geysermc.geyser.level.physics.Direction;
 import org.geysermc.geyser.registry.BlockRegistries;
 import org.geysermc.geyser.session.GeyserSession;
+import org.geysermc.geyser.translator.inventory.InventoryTranslator;
 import org.geysermc.geyser.translator.level.block.entity.BlockEntityTranslator;
 import org.geysermc.geyser.translator.level.block.entity.DoubleChestBlockEntityTranslator;
 import org.geysermc.geyser.util.InventoryUtils;
@@ -146,7 +148,19 @@ public class DoubleChestInventoryTranslator extends ChestInventoryTranslator {
 
     @Override
     public void closeInventory(GeyserSession session, Inventory inventory) {
-        if (((Container) inventory).isUsingRealBlock()) {
+        if (!(inventory instanceof Container container)) {
+            GeyserImpl.getInstance().getLogger().warning("Tried to close a non-container inventory in a block inventory holder! Please report this error on discord.");
+            GeyserImpl.getInstance().getLogger().warning("Current inventory translator: " + session.getInventoryTranslator().getClass().getSimpleName());
+            GeyserImpl.getInstance().getLogger().warning("Current inventory: " + inventory.getClass().getSimpleName());
+            // Try to save ourselves? maybe?
+            // https://github.com/GeyserMC/Geyser/issues/4141
+            // TODO: improve once this issue is pinned down
+            session.setOpenInventory(null);
+            session.setInventoryTranslator(InventoryTranslator.PLAYER_INVENTORY_TRANSLATOR);
+            return;
+        }
+
+        if (container.isUsingRealBlock()) {
             // No need to reset a block since we didn't change any blocks
             // But send a container close packet because we aren't destroying the original.
             ContainerClosePacket packet = new ContainerClosePacket();

--- a/core/src/main/java/org/geysermc/geyser/translator/inventory/chest/DoubleChestInventoryTranslator.java
+++ b/core/src/main/java/org/geysermc/geyser/translator/inventory/chest/DoubleChestInventoryTranslator.java
@@ -152,7 +152,7 @@ public class DoubleChestInventoryTranslator extends ChestInventoryTranslator {
             ContainerClosePacket packet = new ContainerClosePacket();
             packet.setId((byte) inventory.getBedrockId());
             packet.setServerInitiated(true);
-            packet.setType(ContainerType.MINECART_CHEST);
+            packet.setType(ContainerType.CONTAINER);
             session.sendUpstreamPacket(packet);
             return;
         }

--- a/core/src/main/java/org/geysermc/geyser/translator/inventory/chest/SingleChestInventoryTranslator.java
+++ b/core/src/main/java/org/geysermc/geyser/translator/inventory/chest/SingleChestInventoryTranslator.java
@@ -67,6 +67,6 @@ public class SingleChestInventoryTranslator extends ChestInventoryTranslator {
 
     @Override
     public void closeInventory(GeyserSession session, Inventory inventory) {
-        holder.closeInventory(this, session, inventory);
+        holder.closeInventory(this, session, inventory, ContainerType.CONTAINER);
     }
 }

--- a/core/src/main/java/org/geysermc/geyser/translator/inventory/furnace/BlastFurnaceInventoryTranslator.java
+++ b/core/src/main/java/org/geysermc/geyser/translator/inventory/furnace/BlastFurnaceInventoryTranslator.java
@@ -25,9 +25,11 @@
 
 package org.geysermc.geyser.translator.inventory.furnace;
 
+import org.checkerframework.checker.nullness.qual.Nullable;
 import org.cloudburstmc.protocol.bedrock.data.inventory.ContainerSlotType;
 import org.cloudburstmc.protocol.bedrock.data.inventory.ContainerType;
 import org.geysermc.geyser.inventory.BedrockContainerSlot;
+import org.geysermc.geyser.inventory.Inventory;
 import org.geysermc.geyser.level.block.Blocks;
 
 public class BlastFurnaceInventoryTranslator extends AbstractFurnaceInventoryTranslator {
@@ -41,5 +43,10 @@ public class BlastFurnaceInventoryTranslator extends AbstractFurnaceInventoryTra
             return new BedrockContainerSlot(ContainerSlotType.BLAST_FURNACE_INGREDIENT, javaSlotToBedrock(slot));
         }
         return super.javaSlotToBedrockContainer(slot);
+    }
+
+    @Override
+    public @Nullable ContainerType closeContainerType(Inventory inventory) {
+        return ContainerType.BLAST_FURNACE;
     }
 }

--- a/core/src/main/java/org/geysermc/geyser/translator/inventory/furnace/FurnaceInventoryTranslator.java
+++ b/core/src/main/java/org/geysermc/geyser/translator/inventory/furnace/FurnaceInventoryTranslator.java
@@ -25,9 +25,11 @@
 
 package org.geysermc.geyser.translator.inventory.furnace;
 
+import org.checkerframework.checker.nullness.qual.Nullable;
 import org.cloudburstmc.protocol.bedrock.data.inventory.ContainerSlotType;
 import org.cloudburstmc.protocol.bedrock.data.inventory.ContainerType;
 import org.geysermc.geyser.inventory.BedrockContainerSlot;
+import org.geysermc.geyser.inventory.Inventory;
 import org.geysermc.geyser.level.block.Blocks;
 
 public class FurnaceInventoryTranslator extends AbstractFurnaceInventoryTranslator {
@@ -41,5 +43,10 @@ public class FurnaceInventoryTranslator extends AbstractFurnaceInventoryTranslat
             return new BedrockContainerSlot(ContainerSlotType.FURNACE_INGREDIENT, javaSlotToBedrock(slot));
         }
         return super.javaSlotToBedrockContainer(slot);
+    }
+
+    @Override
+    public @Nullable ContainerType closeContainerType(Inventory inventory) {
+        return ContainerType.FURNACE;
     }
 }

--- a/core/src/main/java/org/geysermc/geyser/translator/inventory/furnace/SmokerInventoryTranslator.java
+++ b/core/src/main/java/org/geysermc/geyser/translator/inventory/furnace/SmokerInventoryTranslator.java
@@ -25,9 +25,11 @@
 
 package org.geysermc.geyser.translator.inventory.furnace;
 
+import org.checkerframework.checker.nullness.qual.Nullable;
 import org.cloudburstmc.protocol.bedrock.data.inventory.ContainerSlotType;
 import org.cloudburstmc.protocol.bedrock.data.inventory.ContainerType;
 import org.geysermc.geyser.inventory.BedrockContainerSlot;
+import org.geysermc.geyser.inventory.Inventory;
 import org.geysermc.geyser.level.block.Blocks;
 
 public class SmokerInventoryTranslator extends AbstractFurnaceInventoryTranslator {
@@ -41,5 +43,10 @@ public class SmokerInventoryTranslator extends AbstractFurnaceInventoryTranslato
             return new BedrockContainerSlot(ContainerSlotType.SMOKER_INGREDIENT, javaSlotToBedrock(slot));
         }
         return super.javaSlotToBedrockContainer(slot);
+    }
+
+    @Override
+    public @Nullable ContainerType closeContainerType(Inventory inventory) {
+        return ContainerType.SMOKER;
     }
 }

--- a/core/src/main/java/org/geysermc/geyser/translator/inventory/horse/AbstractHorseInventoryTranslator.java
+++ b/core/src/main/java/org/geysermc/geyser/translator/inventory/horse/AbstractHorseInventoryTranslator.java
@@ -50,6 +50,8 @@ public abstract class AbstractHorseInventoryTranslator extends BaseInventoryTran
 
     @Override
     public void closeInventory(GeyserSession session, Inventory inventory) {
+        // TODO find a way to implement
+        // Can cause inventory de-sync if the Java server requests an inventory close
     }
 
     @Override

--- a/core/src/main/java/org/geysermc/geyser/translator/protocol/bedrock/BedrockContainerCloseTranslator.java
+++ b/core/src/main/java/org/geysermc/geyser/translator/protocol/bedrock/BedrockContainerCloseTranslator.java
@@ -33,7 +33,6 @@ import org.geysermc.geyser.translator.protocol.PacketTranslator;
 import org.geysermc.geyser.translator.protocol.Translator;
 import org.geysermc.geyser.translator.protocol.java.inventory.JavaMerchantOffersTranslator;
 import org.geysermc.geyser.util.InventoryUtils;
-import org.geysermc.mcprotocollib.protocol.packet.ingame.serverbound.inventory.ServerboundContainerClosePacket;
 
 @Translator(packet = ContainerClosePacket.class)
 public class BedrockContainerCloseTranslator extends PacketTranslator<ContainerClosePacket> {
@@ -54,10 +53,7 @@ public class BedrockContainerCloseTranslator extends PacketTranslator<ContainerC
         Inventory openInventory = session.getOpenInventory();
         if (openInventory != null) {
             if (bedrockId == openInventory.getBedrockId()) {
-                if (openInventory.shouldConfirmContainerClose()) {
-                    ServerboundContainerClosePacket closeWindowPacket = new ServerboundContainerClosePacket(openInventory.getJavaId());
-                    session.sendDownstreamGamePacket(closeWindowPacket);
-                }
+                InventoryUtils.sendJavaContainerClose(session, openInventory);
                 InventoryUtils.closeInventory(session, openInventory.getJavaId(), false);
             } else if (openInventory.isPending()) {
                 InventoryUtils.displayInventory(session, openInventory);

--- a/core/src/main/java/org/geysermc/geyser/translator/protocol/bedrock/BedrockContainerCloseTranslator.java
+++ b/core/src/main/java/org/geysermc/geyser/translator/protocol/bedrock/BedrockContainerCloseTranslator.java
@@ -25,7 +25,6 @@
 
 package org.geysermc.geyser.translator.protocol.bedrock;
 
-import org.geysermc.mcprotocollib.protocol.packet.ingame.serverbound.inventory.ServerboundContainerClosePacket;
 import org.cloudburstmc.protocol.bedrock.packet.ContainerClosePacket;
 import org.geysermc.geyser.inventory.Inventory;
 import org.geysermc.geyser.inventory.MerchantContainer;
@@ -34,6 +33,7 @@ import org.geysermc.geyser.translator.protocol.PacketTranslator;
 import org.geysermc.geyser.translator.protocol.Translator;
 import org.geysermc.geyser.translator.protocol.java.inventory.JavaMerchantOffersTranslator;
 import org.geysermc.geyser.util.InventoryUtils;
+import org.geysermc.mcprotocollib.protocol.packet.ingame.serverbound.inventory.ServerboundContainerClosePacket;
 
 @Translator(packet = ContainerClosePacket.class)
 public class BedrockContainerCloseTranslator extends PacketTranslator<ContainerClosePacket> {
@@ -54,8 +54,10 @@ public class BedrockContainerCloseTranslator extends PacketTranslator<ContainerC
         Inventory openInventory = session.getOpenInventory();
         if (openInventory != null) {
             if (bedrockId == openInventory.getBedrockId()) {
-                ServerboundContainerClosePacket closeWindowPacket = new ServerboundContainerClosePacket(openInventory.getJavaId());
-                session.sendDownstreamGamePacket(closeWindowPacket);
+                if (openInventory.shouldConfirmContainerClose()) {
+                    ServerboundContainerClosePacket closeWindowPacket = new ServerboundContainerClosePacket(openInventory.getJavaId());
+                    session.sendDownstreamGamePacket(closeWindowPacket);
+                }
                 InventoryUtils.closeInventory(session, openInventory.getJavaId(), false);
             } else if (openInventory.isPending()) {
                 InventoryUtils.displayInventory(session, openInventory);

--- a/core/src/main/java/org/geysermc/geyser/translator/protocol/bedrock/BedrockLecternUpdateTranslator.java
+++ b/core/src/main/java/org/geysermc/geyser/translator/protocol/bedrock/BedrockLecternUpdateTranslator.java
@@ -34,7 +34,6 @@ import org.geysermc.geyser.translator.protocol.PacketTranslator;
 import org.geysermc.geyser.translator.protocol.Translator;
 import org.geysermc.geyser.util.InventoryUtils;
 import org.geysermc.mcprotocollib.protocol.packet.ingame.serverbound.inventory.ServerboundContainerButtonClickPacket;
-import org.geysermc.mcprotocollib.protocol.packet.ingame.serverbound.inventory.ServerboundContainerClosePacket;
 
 /**
  * Used to translate moving pages, or closing the inventory
@@ -52,8 +51,7 @@ public class BedrockLecternUpdateTranslator extends PacketTranslator<LecternUpda
 
         if (lecternContainer.getCurrentBedrockPage() == packet.getPage()) {
             // The same page means Bedrock is closing the window
-            ServerboundContainerClosePacket closeWindowPacket = new ServerboundContainerClosePacket(lecternContainer.getJavaId());
-            session.sendDownstreamGamePacket(closeWindowPacket);
+            InventoryUtils.sendJavaContainerClose(session, lecternContainer);
             InventoryUtils.closeInventory(session, lecternContainer.getJavaId(), false);
         } else {
             // Each "page" Bedrock gives to us actually represents two pages (think opening a book and seeing two pages)

--- a/core/src/main/java/org/geysermc/geyser/translator/protocol/java/inventory/JavaContainerCloseTranslator.java
+++ b/core/src/main/java/org/geysermc/geyser/translator/protocol/java/inventory/JavaContainerCloseTranslator.java
@@ -38,6 +38,7 @@ public class JavaContainerCloseTranslator extends PacketTranslator<ClientboundCo
     public void translate(GeyserSession session, ClientboundContainerClosePacket packet) {
         // Sometimes the server can request a window close of ID 0... when the window isn't even open
         // Don't confirm in this instance
+        session.setServerRequestedClosePlayerInventory(packet.getContainerId() == 0);
         InventoryUtils.closeInventory(session, packet.getContainerId(), (session.getOpenInventory() != null && session.getOpenInventory().getJavaId() == packet.getContainerId()));
     }
 }

--- a/core/src/main/java/org/geysermc/geyser/translator/protocol/java/inventory/JavaOpenBookTranslator.java
+++ b/core/src/main/java/org/geysermc/geyser/translator/protocol/java/inventory/JavaOpenBookTranslator.java
@@ -36,7 +36,6 @@ import org.geysermc.geyser.translator.protocol.Translator;
 import org.geysermc.geyser.util.InventoryUtils;
 import org.geysermc.mcprotocollib.protocol.data.game.inventory.ContainerType;
 import org.geysermc.mcprotocollib.protocol.packet.ingame.clientbound.inventory.ClientboundOpenBookPacket;
-import org.geysermc.mcprotocollib.protocol.packet.ingame.serverbound.inventory.ServerboundContainerClosePacket;
 
 import java.util.Objects;
 
@@ -65,8 +64,7 @@ public class JavaOpenBookTranslator extends PacketTranslator<ClientboundOpenBook
             if (openInventory != null) {
                 InventoryUtils.closeInventory(session, openInventory.getJavaId(), true);
 
-                ServerboundContainerClosePacket closeWindowPacket = new ServerboundContainerClosePacket(openInventory.getJavaId());
-                session.sendDownstreamGamePacket(closeWindowPacket);
+                InventoryUtils.sendJavaContainerClose(session, openInventory);
             }
 
             InventoryTranslator translator = InventoryTranslator.inventoryTranslator(ContainerType.LECTERN);

--- a/core/src/main/java/org/geysermc/geyser/util/InventoryUtils.java
+++ b/core/src/main/java/org/geysermc/geyser/util/InventoryUtils.java
@@ -119,8 +119,7 @@ public class InventoryUtils {
             }
         } else {
             // Can occur if we e.g. did not find a spot to put a fake container in
-            ServerboundContainerClosePacket closePacket = new ServerboundContainerClosePacket(inventory.getJavaId());
-            session.sendDownstreamGamePacket(closePacket);
+            sendJavaContainerClose(session, inventory);
             session.setOpenInventory(null);
             session.setInventoryTranslator(InventoryTranslator.PLAYER_INVENTORY_TRANSLATOR);
         }
@@ -158,6 +157,13 @@ public class InventoryUtils {
                 return openInventory;
             }
             return null;
+        }
+    }
+
+    public static void sendJavaContainerClose(GeyserSession session, Inventory inventory) {
+        if (inventory.shouldConfirmContainerClose()) {
+            ServerboundContainerClosePacket closeWindowPacket = new ServerboundContainerClosePacket(inventory.getJavaId());
+            session.sendDownstreamGamePacket(closeWindowPacket);
         }
     }
 


### PR DESCRIPTION
Bedrock broke the ContainerClosePacket. Hurray.

This works around that by either breaking (and replacing) the original container block, or, in the player inventory case, by placing a nether portal into the player. This, in my testing, was the only way to get the player to close its player inventory.