### PR TITLE
Add run tasks and remove useless variables

### DIFF
--- a/bootstrap/bungeecord/build.gradle.kts
+++ b/bootstrap/bungeecord/build.gradle.kts
@@ -1,6 +1,7 @@
 plugins {
     id("geyser.platform-conventions")
     id("geyser.modrinth-uploading-conventions")
+    alias(libs.plugins.runwaterfall)
 }
 
 dependencies {
@@ -47,4 +48,10 @@ tasks.withType<com.github.jengelman.gradle.plugins.shadow.tasks.ShadowJar> {
 modrinth {
     uploadFile.set(tasks.getByPath("shadowJar"))
     loaders.add("bungeecord")
+}
+
+tasks {
+    runWaterfall {
+        version(libs.versions.runwaterfallversion.get())
+    }
 }

--- a/bootstrap/bungeecord/build.gradle.kts
+++ b/bootstrap/bungeecord/build.gradle.kts
@@ -1,7 +1,6 @@
 plugins {
     id("geyser.platform-conventions")
     id("geyser.modrinth-uploading-conventions")
-    alias(libs.plugins.runwaterfall)
 }
 
 dependencies {
@@ -48,10 +47,4 @@ tasks.withType<com.github.jengelman.gradle.plugins.shadow.tasks.ShadowJar> {
 modrinth {
     uploadFile.set(tasks.getByPath("shadowJar"))
     loaders.add("bungeecord")
-}
-
-tasks {
-    runWaterfall {
-        version(libs.versions.runwaterfallversion.get())
-    }
 }

--- a/bootstrap/spigot/build.gradle.kts
+++ b/bootstrap/spigot/build.gradle.kts
@@ -1,6 +1,7 @@
 plugins {
     id("geyser.platform-conventions")
     id("geyser.modrinth-uploading-conventions")
+    alias(libs.plugins.runpaper)
 }
 
 dependencies {
@@ -89,4 +90,10 @@ modrinth {
     gameVersions.addAll("1.16.5", "1.17", "1.17.1", "1.18", "1.18.1", "1.18.2", "1.19",
         "1.19.1", "1.19.2", "1.19.3", "1.19.4", "1.20", "1.20.1", "1.20.2", "1.20.3", "1.20.4", "1.20.5", "1.20.6")
     loaders.addAll("spigot", "paper")
+}
+
+tasks {
+    runServer {
+        minecraftVersion(libs.versions.runpaperversion.get())
+    }
 }

--- a/bootstrap/standalone/build.gradle.kts
+++ b/bootstrap/standalone/build.gradle.kts
@@ -5,9 +5,6 @@ plugins {
     id("geyser.platform-conventions")
 }
 
-val terminalConsoleVersion = "1.2.0"
-val jlineVersion = "3.21.0"
-
 dependencies {
     api(projects.core)
 

--- a/bootstrap/velocity/build.gradle.kts
+++ b/bootstrap/velocity/build.gradle.kts
@@ -1,6 +1,7 @@
 plugins {
     id("geyser.platform-conventions")
     id("geyser.modrinth-uploading-conventions")
+    alias(libs.plugins.runvelocity)
 }
 
 dependencies {
@@ -82,4 +83,10 @@ tasks.withType<com.github.jengelman.gradle.plugins.shadow.tasks.ShadowJar> {
 modrinth {
     uploadFile.set(tasks.getByPath("shadowJar"))
     loaders.addAll("velocity")
+}
+
+tasks {
+    runVelocity {
+        version(libs.versions.runvelocityversion.get())
+    }
 }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -41,6 +41,10 @@ mixin = "0.8.5"
 mixinextras = "0.3.5"
 minecraft = "1.21.4"
 mockito = "5.+"
+runtask = "2.3.1"
+runpaperversion = "1.21.4"
+runwaterfallversion = "1.19"
+runvelocityversion = "3.4.0-SNAPSHOT"
 
 # plugin versions
 indra = "3.1.3"
@@ -150,6 +154,9 @@ minotaur = { group = "com.modrinth.minotaur", name = "Minotaur", version.ref = "
 [plugins]
 indra = { id = "net.kyori.indra", version.ref = "indra" }
 blossom = { id = "net.kyori.blossom", version.ref = "blossom" }
+runvelocity = { id = "xyz.jpenilla.run-velocity", version.ref = "runtask" }
+runpaper = { id = "xyz.jpenilla.run-paper", version.ref = "runtask" }
+runwaterfall = { id = "xyz.jpenilla.run-waterfall", version.ref = "runtask" }
 
 [bundles]
 jackson = [ "jackson-annotations", "jackson-databind", "jackson-dataformat-yaml" ]

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -43,7 +43,6 @@ minecraft = "1.21.4"
 mockito = "5.+"
 runtask = "2.3.1"
 runpaperversion = "1.21.4"
-runwaterfallversion = "1.19"
 runvelocityversion = "3.4.0-SNAPSHOT"
 
 # plugin versions
@@ -156,7 +155,6 @@ indra = { id = "net.kyori.indra", version.ref = "indra" }
 blossom = { id = "net.kyori.blossom", version.ref = "blossom" }
 runvelocity = { id = "xyz.jpenilla.run-velocity", version.ref = "runtask" }
 runpaper = { id = "xyz.jpenilla.run-paper", version.ref = "runtask" }
-runwaterfall = { id = "xyz.jpenilla.run-waterfall", version.ref = "runtask" }
 
 [bundles]
 jackson = [ "jackson-annotations", "jackson-databind", "jackson-dataformat-yaml" ]


### PR DESCRIPTION
The benefit of run tasks is that proxies like velocity can be prototyped on without using standalone or a GUI. Thus simplifying the prototyping/fixing process.