### PR TITLE
Switch all ping passthroughs to json to avoid parsing warning

### DIFF
--- a/bootstrap/bungeecord/src/main/java/org/geysermc/geyser/platform/bungeecord/GeyserBungeePingPassthrough.java
+++ b/bootstrap/bungeecord/src/main/java/org/geysermc/geyser/platform/bungeecord/GeyserBungeePingPassthrough.java
@@ -26,6 +26,8 @@
 package org.geysermc.geyser.platform.bungeecord;
 
 import lombok.AllArgsConstructor;
+import net.kyori.adventure.text.serializer.bungeecord.BungeeComponentSerializer;
+import net.kyori.adventure.text.serializer.gson.GsonComponentSerializer;
 import net.md_5.bungee.api.ProxyServer;
 import net.md_5.bungee.api.ServerPing;
 import net.md_5.bungee.api.chat.BaseComponent;
@@ -74,7 +76,7 @@ public class GeyserBungeePingPassthrough implements IGeyserPingPassthrough, List
 
         ServerPing response = event.getResponse();
         return new GeyserPingInfo(
-                response.getDescriptionComponent().toLegacyText(),
+                GsonComponentSerializer.gson().serialize(BungeeComponentSerializer.get().deserialize(new BaseComponent[]{ response.getDescriptionComponent() })),
                 response.getPlayers().getMax(),
                 response.getPlayers().getOnline()
         );

--- a/bootstrap/mod/src/main/java/org/geysermc/geyser/platform/mod/ModPingPassthrough.java
+++ b/bootstrap/mod/src/main/java/org/geysermc/geyser/platform/mod/ModPingPassthrough.java
@@ -80,11 +80,8 @@ public class ModPingPassthrough implements IGeyserPingPassthrough {
             }
         }
 
-        String jsonDescription = net.minecraft.network.chat.Component.Serializer.toJson(status.description(), RegistryAccess.EMPTY);
-        String legacyDescription = LEGACY_SERIALIZER.serialize(GSON_SERIALIZER.deserializeOr(jsonDescription, Component.empty()));
-
         return new GeyserPingInfo(
-            legacyDescription,
+            net.minecraft.network.chat.Component.Serializer.toJson(status.description(), RegistryAccess.EMPTY),
             status.players().map(ServerStatus.Players::max).orElse(1),
             status.players().map(ServerStatus.Players::online).orElse(0)
         );

--- a/bootstrap/spigot/src/main/java/org/geysermc/geyser/platform/spigot/GeyserPaperPingPassthrough.java
+++ b/bootstrap/spigot/src/main/java/org/geysermc/geyser/platform/spigot/GeyserPaperPingPassthrough.java
@@ -27,6 +27,8 @@ package org.geysermc.geyser.platform.spigot;
 
 import com.destroystokyo.paper.event.server.PaperServerListPingEvent;
 import com.destroystokyo.paper.network.StatusClient;
+import net.kyori.adventure.text.serializer.gson.GsonComponentSerializer;
+import net.kyori.adventure.text.serializer.legacy.LegacyComponentSerializer;
 import org.bukkit.Bukkit;
 import org.checkerframework.checker.nullness.qual.NonNull;
 import org.checkerframework.checker.nullness.qual.Nullable;
@@ -81,7 +83,10 @@ public final class GeyserPaperPingPassthrough implements IGeyserPingPassthrough 
                 players = new GeyserPingInfo.Players(event.getMaxPlayers(), event.getNumPlayers());
             }
 
-            return new GeyserPingInfo(event.getMotd(), players);
+            return new GeyserPingInfo(
+                GsonComponentSerializer.gson().serialize(LegacyComponentSerializer.legacySection().deserialize(event.getMotd())),
+                players
+            );
         } catch (Exception | LinkageError e) { // LinkageError in the event that method/constructor signatures change
             logger.debug("Error while getting Paper ping passthrough: " + e);
             return null;

--- a/bootstrap/spigot/src/main/java/org/geysermc/geyser/platform/spigot/GeyserSpigotPingPassthrough.java
+++ b/bootstrap/spigot/src/main/java/org/geysermc/geyser/platform/spigot/GeyserSpigotPingPassthrough.java
@@ -26,6 +26,8 @@
 package org.geysermc.geyser.platform.spigot;
 
 import lombok.AllArgsConstructor;
+import net.kyori.adventure.text.serializer.gson.GsonComponentSerializer;
+import net.kyori.adventure.text.serializer.legacy.LegacyComponentSerializer;
 import org.bukkit.Bukkit;
 import org.bukkit.entity.Player;
 import org.bukkit.event.server.ServerListPingEvent;
@@ -52,7 +54,11 @@ public class GeyserSpigotPingPassthrough implements IGeyserPingPassthrough {
         try {
             ServerListPingEvent event = new GeyserPingEvent(inetSocketAddress.getAddress(), Bukkit.getMotd(), Bukkit.getOnlinePlayers().size(), Bukkit.getMaxPlayers());
             Bukkit.getPluginManager().callEvent(event);
-            return new GeyserPingInfo(event.getMotd(), event.getMaxPlayers(), event.getNumPlayers());
+            return new GeyserPingInfo(
+                GsonComponentSerializer.gson().serialize(LegacyComponentSerializer.legacySection().deserialize(event.getMotd())),
+                event.getMaxPlayers(),
+                event.getNumPlayers()
+            );
         } catch (Exception | LinkageError e) { // LinkageError in the event that method/constructor signatures change
             logger.debug("Error while getting Bukkit ping passthrough: " + e);
             return null;

--- a/bootstrap/velocity/src/main/java/org/geysermc/geyser/platform/velocity/GeyserVelocityPingPassthrough.java
+++ b/bootstrap/velocity/src/main/java/org/geysermc/geyser/platform/velocity/GeyserVelocityPingPassthrough.java
@@ -33,7 +33,7 @@ import com.velocitypowered.api.proxy.ProxyServer;
 import com.velocitypowered.api.proxy.server.ServerPing;
 import com.velocitypowered.api.proxy.server.ServerPing.Version;
 import lombok.AllArgsConstructor;
-import net.kyori.adventure.text.serializer.legacy.LegacyComponentSerializer;
+import net.kyori.adventure.text.serializer.gson.GsonComponentSerializer;
 import org.geysermc.geyser.network.GameProtocol;
 import org.geysermc.geyser.ping.GeyserPingInfo;
 import org.geysermc.geyser.ping.IGeyserPingPassthrough;
@@ -60,7 +60,7 @@ public class GeyserVelocityPingPassthrough implements IGeyserPingPassthrough {
             throw new RuntimeException(e);
         }
         return new GeyserPingInfo(
-                LegacyComponentSerializer.legacy('§').serialize(event.getPing().getDescriptionComponent()),
+                GsonComponentSerializer.gson().serialize(event.getPing().getDescriptionComponent()),
                 event.getPing().getPlayers().map(ServerPing.Players::getMax).orElse(1),
                 event.getPing().getPlayers().map(ServerPing.Players::getOnline).orElse(0)
         );

--- a/bootstrap/velocity/src/main/java/org/geysermc/geyser/platform/velocity/command/VelocityCommandSource.java
+++ b/bootstrap/velocity/src/main/java/org/geysermc/geyser/platform/velocity/command/VelocityCommandSource.java
@@ -60,7 +60,7 @@ public class VelocityCommandSource implements GeyserCommandSource {
 
     @Override
     public void sendMessage(@NonNull String message) {
-        handle.sendMessage(LegacyComponentSerializer.legacy('§').deserialize(message));
+        handle.sendMessage(LegacyComponentSerializer.legacySection().deserialize(message));
     }
 
     @Override


### PR DESCRIPTION
This will permanently fix warnings of legacy section chars being used inside text components. And it should also improve color accuracy because gson does not downscale. (So bedrock-only colors can be mapped to better)