### PR TITLE
Fix: Allow players to hit air

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ The ultimate goal of this project is to allow Minecraft: Bedrock Edition users t
 Special thanks to the DragonProxy project for being a trailblazer in protocol translation and for all the team members who have joined us here!
 
 ## Supported Versions
-Geyser is currently supporting Minecraft Bedrock 1.21.40 - 1.21.60 and Minecraft Java 1.21.4. For more information, please see [here](https://geysermc.org/wiki/geyser/supported-versions/).
+Geyser is currently supporting Minecraft Bedrock 1.21.40 - 1.21.61 and Minecraft Java 1.21.4. For more information, please see [here](https://geysermc.org/wiki/geyser/supported-versions/).
 
 ## Setting Up
 Take a look [here](https://geysermc.org/wiki/geyser/setup/) for how to set up Geyser.

--- a/core/src/main/java/org/geysermc/geyser/dump/DumpInfo.java
+++ b/core/src/main/java/org/geysermc/geyser/dump/DumpInfo.java
@@ -87,7 +87,7 @@ public class DumpInfo {
         this.cpuCount = Runtime.getRuntime().availableProcessors();
         this.cpuName = CpuUtils.tryGetProcessorName();
         this.systemLocale = Locale.getDefault();
-        this.systemEncoding = System.getProperty("file.encoding");
+        this.systemEncoding = System. getProperty("file.encoding");
 
         this.gitInfo = new GitInfo(GeyserImpl.BUILD_NUMBER, GeyserImpl.COMMIT.substring(0, 7), GeyserImpl.COMMIT, GeyserImpl.BRANCH, GeyserImpl.REPOSITORY);
 
@@ -178,9 +178,8 @@ public class DumpInfo {
 
         NetworkInfo() {
             if (AsteriskSerializer.showSensitive) {
-                try {
+                try (Socket socket = new Socket()) {
                     // This is the most reliable for getting the main local IP
-                    Socket socket = new Socket();
                     socket.connect(new InetSocketAddress("geysermc.org", 80));
                     this.internalIP = socket.getLocalAddress().getHostAddress();
                 } catch (IOException e1) {

--- a/core/src/main/java/org/geysermc/geyser/dump/DumpInfo.java
+++ b/core/src/main/java/org/geysermc/geyser/dump/DumpInfo.java
@@ -87,7 +87,7 @@ public class DumpInfo {
         this.cpuCount = Runtime.getRuntime().availableProcessors();
         this.cpuName = CpuUtils.tryGetProcessorName();
         this.systemLocale = Locale.getDefault();
-        this.systemEncoding = System. getProperty("file.encoding");
+        this.systemEncoding = System.getProperty("file.encoding");
 
         this.gitInfo = new GitInfo(GeyserImpl.BUILD_NUMBER, GeyserImpl.COMMIT.substring(0, 7), GeyserImpl.COMMIT, GeyserImpl.BRANCH, GeyserImpl.REPOSITORY);
 

--- a/core/src/main/java/org/geysermc/geyser/session/GeyserSession.java
+++ b/core/src/main/java/org/geysermc/geyser/session/GeyserSession.java
@@ -208,7 +208,6 @@ import org.geysermc.mcprotocollib.protocol.packet.ingame.serverbound.Serverbound
 import org.geysermc.mcprotocollib.protocol.packet.ingame.serverbound.ServerboundClientTickEndPacket;
 import org.geysermc.mcprotocollib.protocol.packet.ingame.serverbound.player.ServerboundPlayerAbilitiesPacket;
 import org.geysermc.mcprotocollib.protocol.packet.ingame.serverbound.player.ServerboundPlayerActionPacket;
-import org.geysermc.mcprotocollib.protocol.packet.ingame.serverbound.player.ServerboundSwingPacket;
 import org.geysermc.mcprotocollib.protocol.packet.ingame.serverbound.player.ServerboundUseItemPacket;
 import org.geysermc.mcprotocollib.protocol.packet.login.serverbound.ServerboundCustomQueryAnswerPacket;
 
@@ -1643,9 +1642,6 @@ public class GeyserSession implements GeyserConnection, GeyserCommandSource {
      * @param packet the java edition packet from MCProtocolLib
      */
     public void sendDownstreamGamePacket(Packet packet) {
-        if (packet instanceof ServerboundSwingPacket) {
-            geyser.getLogger().error("sending: " + packet.toString());
-        }
         sendDownstreamPacket(packet, ProtocolState.GAME);
     }
 

--- a/core/src/main/java/org/geysermc/geyser/session/GeyserSession.java
+++ b/core/src/main/java/org/geysermc/geyser/session/GeyserSession.java
@@ -1184,7 +1184,6 @@ public class GeyserSession implements GeyserConnection, GeyserCommandSource {
             }
 
             if (armAnimationTicks >= 0) {
-                GeyserImpl.getInstance().getLogger().info("arm animation ticks: " + armAnimationTicks);
                 // As of 1.18.2 Java Edition, it appears that the swing time is dynamically updated depending on the
                 // player's effect status, but the animation can cut short if the duration suddenly decreases
                 // (from suddenly no longer having mining fatigue, for example)
@@ -1363,7 +1362,6 @@ public class GeyserSession implements GeyserConnection, GeyserCommandSource {
      * blocking.
      */
     public void activateArmAnimationTicking() {
-        GeyserImpl.getInstance().getLogger().info("activate arm animation ticking!");
         armAnimationTicks = 0;
         if (disableBlocking()) {
             playerEntity.updateBedrockMetadata();

--- a/core/src/main/java/org/geysermc/geyser/session/GeyserSession.java
+++ b/core/src/main/java/org/geysermc/geyser/session/GeyserSession.java
@@ -208,6 +208,7 @@ import org.geysermc.mcprotocollib.protocol.packet.ingame.serverbound.Serverbound
 import org.geysermc.mcprotocollib.protocol.packet.ingame.serverbound.ServerboundClientTickEndPacket;
 import org.geysermc.mcprotocollib.protocol.packet.ingame.serverbound.player.ServerboundPlayerAbilitiesPacket;
 import org.geysermc.mcprotocollib.protocol.packet.ingame.serverbound.player.ServerboundPlayerActionPacket;
+import org.geysermc.mcprotocollib.protocol.packet.ingame.serverbound.player.ServerboundSwingPacket;
 import org.geysermc.mcprotocollib.protocol.packet.ingame.serverbound.player.ServerboundUseItemPacket;
 import org.geysermc.mcprotocollib.protocol.packet.login.serverbound.ServerboundCustomQueryAnswerPacket;
 
@@ -536,9 +537,16 @@ public class GeyserSession implements GeyserConnection, GeyserCommandSource {
 
     /**
      * Counts how many ticks have occurred since an arm animation started.
-     * -1 means there is no active arm swing; -2 means an arm swing will start in a tick.
+     * -1 means there is no active arm swing
      */
     private int armAnimationTicks = -1;
+
+    /**
+     * The tick in which the player last hit air.
+     * Used to ensure we dont send two sing packets for one hit.
+     */
+    @Setter
+    private int lastAirHitTick;
 
     /**
      * Controls whether the daylight cycle gamerule has been sent to the client, so the sun/moon remain motionless.
@@ -1113,13 +1121,10 @@ public class GeyserSession implements GeyserConnection, GeyserCommandSource {
 
     public void updateTickingState(float tickRate, boolean frozen) {
         tickThread.cancel(false);
-
         this.tickingFrozen = frozen;
 
         tickRate = MathUtils.clamp(tickRate, 1.0f, 10000.0f);
-
         millisecondsPerTick = 1000.0f / tickRate;
-
         nanosecondsPerTick = MathUtils.ceil(1000000000.0f / tickRate);
         tickThread = tickEventLoop.scheduleAtFixedRate(this::tick, nanosecondsPerTick, nanosecondsPerTick, TimeUnit.NANOSECONDS);
     }
@@ -1132,7 +1137,6 @@ public class GeyserSession implements GeyserConnection, GeyserCommandSource {
         } catch (Throwable e) {
             geyser.getLogger().error("Error thrown in " + this.bedrockUsername() + "'s event loop!", e);
         }
-
     }
 
     /**
@@ -1180,6 +1184,7 @@ public class GeyserSession implements GeyserConnection, GeyserCommandSource {
             }
 
             if (armAnimationTicks >= 0) {
+                GeyserImpl.getInstance().getLogger().info("arm animation ticks: " + armAnimationTicks);
                 // As of 1.18.2 Java Edition, it appears that the swing time is dynamically updated depending on the
                 // player's effect status, but the animation can cut short if the duration suddenly decreases
                 // (from suddenly no longer having mining fatigue, for example)
@@ -1358,6 +1363,7 @@ public class GeyserSession implements GeyserConnection, GeyserCommandSource {
      * blocking.
      */
     public void activateArmAnimationTicking() {
+        GeyserImpl.getInstance().getLogger().info("activate arm animation ticking!");
         armAnimationTicks = 0;
         if (disableBlocking()) {
             playerEntity.updateBedrockMetadata();
@@ -1365,13 +1371,10 @@ public class GeyserSession implements GeyserConnection, GeyserCommandSource {
     }
 
     /**
-     * For <a href="https://github.com/GeyserMC/Geyser/issues/2113">issue 2113</a> and combating arm ticking activating being delayed in
-     * BedrockAnimateTranslator.
+     * You can't break blocks, attack entities, or use items while driving in a boat
      */
-    public void armSwingPending() {
-        if (armAnimationTicks == -1) {
-            armAnimationTicks = -2;
-        }
+    public boolean isHandsBusy() {
+        return steeringRight || steeringLeft;
     }
 
     /**
@@ -1642,6 +1645,9 @@ public class GeyserSession implements GeyserConnection, GeyserCommandSource {
      * @param packet the java edition packet from MCProtocolLib
      */
     public void sendDownstreamGamePacket(Packet packet) {
+        if (packet instanceof ServerboundSwingPacket) {
+            geyser.getLogger().error("sending: " + packet.toString());
+        }
         sendDownstreamPacket(packet, ProtocolState.GAME);
     }
 

--- a/core/src/main/java/org/geysermc/geyser/translator/level/block/entity/BrushableBlockEntityTranslator.java
+++ b/core/src/main/java/org/geysermc/geyser/translator/level/block/entity/BrushableBlockEntityTranslator.java
@@ -64,7 +64,7 @@ public class BrushableBlockEntityTranslator extends BlockEntityTranslator implem
         }
         NbtMapBuilder itemBuilder = NbtMap.builder()
             .putString("Name", mapping.getBedrockIdentifier())
-            .putByte("Count", (byte) itemTag.getByte("Count"));
+            .putByte("Count", itemTag.getByte("Count"));
 
         bedrockNbt.putCompound("item", itemBuilder.build());
         // controls which side the item protrudes from

--- a/core/src/main/java/org/geysermc/geyser/translator/protocol/bedrock/BedrockAnimateTranslator.java
+++ b/core/src/main/java/org/geysermc/geyser/translator/protocol/bedrock/BedrockAnimateTranslator.java
@@ -26,7 +26,6 @@
 package org.geysermc.geyser.translator.protocol.bedrock;
 
 import org.cloudburstmc.protocol.bedrock.packet.AnimatePacket;
-import org.geysermc.geyser.GeyserImpl;
 import org.geysermc.geyser.session.GeyserSession;
 import org.geysermc.geyser.translator.protocol.PacketTranslator;
 import org.geysermc.geyser.translator.protocol.Translator;
@@ -45,7 +44,6 @@ public class BedrockAnimateTranslator extends PacketTranslator<AnimatePacket> {
             return;
         }
 
-        GeyserImpl.getInstance().getLogger().info("(%s) animate packet: %s ".formatted(session.getTicks(), packet));
         if (packet.getAction() == AnimatePacket.Action.SWING_ARM) {
 
             // If this is the case, we just hit the air. Poor air.

--- a/core/src/main/java/org/geysermc/geyser/translator/protocol/bedrock/BedrockAnimateTranslator.java
+++ b/core/src/main/java/org/geysermc/geyser/translator/protocol/bedrock/BedrockAnimateTranslator.java
@@ -26,6 +26,7 @@
 package org.geysermc.geyser.translator.protocol.bedrock;
 
 import org.cloudburstmc.protocol.bedrock.packet.AnimatePacket;
+import org.geysermc.geyser.GeyserImpl;
 import org.geysermc.geyser.session.GeyserSession;
 import org.geysermc.geyser.translator.protocol.PacketTranslator;
 import org.geysermc.geyser.translator.protocol.Translator;
@@ -44,29 +45,41 @@ public class BedrockAnimateTranslator extends PacketTranslator<AnimatePacket> {
             return;
         }
 
+        GeyserImpl.getInstance().getLogger().info("(%s) animate packet: %s ".formatted(session.getTicks(), packet));
         if (packet.getAction() == AnimatePacket.Action.SWING_ARM) {
-            session.armSwingPending();
+
+            // If this is the case, we just hit the air. Poor air.
+            // Touch devices send PlayerAuthInputPackets with MISSED_SWING, and then the animate packet.
+            if (session.getTicks() - session.getLastAirHitTick() < 2) {
+                return;
+            }
+
+            // Windows unfortunately sends the animate packet first, then the auth input packet with the MISSED_SWING.
+            // So we also check that after the delay.
+
             // Delay so entity damage can be processed first
             session.scheduleInEventLoop(() -> {
-                    if (session.getArmAnimationTicks() != 0) {
-                        // So, generally, a Java player can only do one *thing* at a time.
-                        // If a player right-clicks, for example, then there's probably only one action associated with
-                        // that right-click that will send a swing.
-                        // The only exception I can think of to this, *maybe*, is a player dropping items
-                        // Bedrock is a little funkier than this - it can send several arm animation packets in the
-                        // same tick, notably with high levels of haste applied.
-                        // Packet limiters do not like this and can crash the player.
-                        // If arm animation ticks is 0, then we just sent an arm swing packet this tick.
-                        // See https://github.com/GeyserMC/Geyser/issues/2875
-                        // This behavior was last touched on with ViaVersion 4.5.1 (with its packet limiter), Java 1.16.5,
-                        // and Bedrock 1.19.51.
-                        // Note for the future: we should probably largely ignore this packet and instead replicate
-                        // all actions on our end, and send swings where needed.
-                        session.sendDownstreamGamePacket(new ServerboundSwingPacket(Hand.MAIN_HAND));
-                        session.activateArmAnimationTicking();
-                    }
-                },
-                25,
+                if (session.getArmAnimationTicks() != 0 && (session.getTicks() - session.getLastAirHitTick() > 2)) {
+                    GeyserImpl.getInstance().getLogger().info("(%s) We punching in animate! %s %s".formatted(session.getTicks(), session.getArmAnimationTicks() != 0, (session.getTicks() - session.getLastAirHitTick() > 2)));
+                    // So, generally, a Java player can only do one *thing* at a time.
+                    // If a player right-clicks, for example, then there's probably only one action associated with
+                    // that right-click that will send a swing.
+                    // The only exception I can think of to this, *maybe*, is a player dropping items
+                    // Bedrock is a little funkier than this - it can send several arm animation packets in the
+                    // same tick, notably with high levels of haste applied.
+                    // Packet limiters do not like this and can crash the player.
+                    // If arm animation ticks is 0, then we just sent an arm swing packet this tick.
+                    // See https://github.com/GeyserMC/Geyser/issues/2875
+                    // This behavior was last touched on with ViaVersion 4.5.1 (with its packet limiter), Java 1.16.5,
+                    // and Bedrock 1.19.51.
+                    // Note for the future: we should probably largely ignore this packet and instead replicate
+                    // all actions on our end, and send swings where needed.
+                    GeyserImpl.getInstance().getLogger().warning("send swing packet after half a tick (%s)".formatted(session.getTicks()));
+                    session.sendDownstreamGamePacket(new ServerboundSwingPacket(Hand.MAIN_HAND));
+                    session.activateArmAnimationTicking();
+                }
+            },
+                (long) (session.getMillisecondsPerTick() * 0.5),
                 TimeUnit.MILLISECONDS
             );
         }

--- a/core/src/main/java/org/geysermc/geyser/translator/protocol/bedrock/BedrockAnimateTranslator.java
+++ b/core/src/main/java/org/geysermc/geyser/translator/protocol/bedrock/BedrockAnimateTranslator.java
@@ -62,24 +62,24 @@ public class BedrockAnimateTranslator extends PacketTranslator<AnimatePacket> {
 
             // Also, delay the swing so entity damage can be processed first
             session.scheduleInEventLoop(() -> {
-                if (session.getArmAnimationTicks() != 0 && (session.getTicks() - session.getLastAirHitTick() > 2)) {
-                    // So, generally, a Java player can only do one *thing* at a time.
-                    // If a player right-clicks, for example, then there's probably only one action associated with
-                    // that right-click that will send a swing.
-                    // The only exception I can think of to this, *maybe*, is a player dropping items
-                    // Bedrock is a little funkier than this - it can send several arm animation packets in the
-                    // same tick, notably with high levels of haste applied.
-                    // Packet limiters do not like this and can crash the player.
-                    // If arm animation ticks is 0, then we just sent an arm swing packet this tick.
-                    // See https://github.com/GeyserMC/Geyser/issues/2875
-                    // This behavior was last touched on with ViaVersion 4.5.1 (with its packet limiter), Java 1.16.5,
-                    // and Bedrock 1.19.51.
-                    // Note for the future: we should probably largely ignore this packet and instead replicate
-                    // all actions on our end, and send swings where needed. Can be done once we replicate Block and Item interactions fully.
-                    session.sendDownstreamGamePacket(new ServerboundSwingPacket(Hand.MAIN_HAND));
-                    session.activateArmAnimationTicking();
-                }
-            },
+                    if (session.getArmAnimationTicks() != 0 && (session.getTicks() - session.getLastAirHitTick() > 2)) {
+                        // So, generally, a Java player can only do one *thing* at a time.
+                        // If a player right-clicks, for example, then there's probably only one action associated with
+                        // that right-click that will send a swing.
+                        // The only exception I can think of to this, *maybe*, is a player dropping items
+                        // Bedrock is a little funkier than this - it can send several arm animation packets in the
+                        // same tick, notably with high levels of haste applied.
+                        // Packet limiters do not like this and can crash the player.
+                        // If arm animation ticks is 0, then we just sent an arm swing packet this tick.
+                        // See https://github.com/GeyserMC/Geyser/issues/2875
+                        // This behavior was last touched on with ViaVersion 4.5.1 (with its packet limiter), Java 1.16.5,
+                        // and Bedrock 1.19.51.
+                        // Note for the future: we should probably largely ignore this packet and instead replicate
+                        // all actions on our end, and send swings where needed. Can be done once we replicate Block and Item interactions fully.
+                        session.sendDownstreamGamePacket(new ServerboundSwingPacket(Hand.MAIN_HAND));
+                        session.activateArmAnimationTicking();
+                    }
+                },
                 (long) (session.getMillisecondsPerTick() * 0.5),
                 TimeUnit.MILLISECONDS
             );

--- a/core/src/main/java/org/geysermc/geyser/translator/protocol/bedrock/BedrockAnimateTranslator.java
+++ b/core/src/main/java/org/geysermc/geyser/translator/protocol/bedrock/BedrockAnimateTranslator.java
@@ -50,17 +50,19 @@ public class BedrockAnimateTranslator extends PacketTranslator<AnimatePacket> {
 
             // If this is the case, we just hit the air. Poor air.
             // Touch devices send PlayerAuthInputPackets with MISSED_SWING, and then the animate packet.
-            if (session.getTicks() - session.getLastAirHitTick() < 2) {
+            // This tends to happen 1-2 ticks after the auth input packet.
+            if (session.getTicks() - session.getLastAirHitTick() < 3) {
                 return;
             }
 
             // Windows unfortunately sends the animate packet first, then the auth input packet with the MISSED_SWING.
-            // So we also check that after the delay.
+            // Often, these are sent in the same tick. In that case, the wait here ensures the auth input packet is processed first.
+            // Other times, there is a 1-tick-delay, which would result in the swing packet sent here. The BedrockAuthInputTranslator's
+            // MISSED_SWING case also accounts for that by checking if a swing was sent a tick ago here.
 
-            // Delay so entity damage can be processed first
+            // Also, delay the swing so entity damage can be processed first
             session.scheduleInEventLoop(() -> {
                 if (session.getArmAnimationTicks() != 0 && (session.getTicks() - session.getLastAirHitTick() > 2)) {
-                    GeyserImpl.getInstance().getLogger().info("(%s) We punching in animate! %s %s".formatted(session.getTicks(), session.getArmAnimationTicks() != 0, (session.getTicks() - session.getLastAirHitTick() > 2)));
                     // So, generally, a Java player can only do one *thing* at a time.
                     // If a player right-clicks, for example, then there's probably only one action associated with
                     // that right-click that will send a swing.
@@ -73,8 +75,7 @@ public class BedrockAnimateTranslator extends PacketTranslator<AnimatePacket> {
                     // This behavior was last touched on with ViaVersion 4.5.1 (with its packet limiter), Java 1.16.5,
                     // and Bedrock 1.19.51.
                     // Note for the future: we should probably largely ignore this packet and instead replicate
-                    // all actions on our end, and send swings where needed.
-                    GeyserImpl.getInstance().getLogger().warning("send swing packet after half a tick (%s)".formatted(session.getTicks()));
+                    // all actions on our end, and send swings where needed. Can be done once we replicate Block and Item interactions fully.
                     session.sendDownstreamGamePacket(new ServerboundSwingPacket(Hand.MAIN_HAND));
                     session.activateArmAnimationTicking();
                 }

--- a/core/src/main/java/org/geysermc/geyser/translator/protocol/bedrock/BedrockInventoryTransactionTranslator.java
+++ b/core/src/main/java/org/geysermc/geyser/translator/protocol/bedrock/BedrockInventoryTransactionTranslator.java
@@ -454,6 +454,11 @@ public class BedrockInventoryTransactionTranslator extends PacketTranslator<Inve
                 switch (packet.getActionType()) {
                     case 0 -> processEntityInteraction(session, packet, entity); // Interact
                     case 1 -> { // Attack
+                        if (session.isHandsBusy()) {
+                            // See Minecraft#startAttack and LocalPlayer#isHandsBusy
+                            return;
+                        }
+
                         int entityId;
                         if (entity.getDefinition() == EntityDefinitions.ENDER_DRAGON) {
                             // Redirects the attack to its body entity, this only happens when

--- a/core/src/main/java/org/geysermc/geyser/translator/protocol/bedrock/entity/player/input/BedrockBlockActions.java
+++ b/core/src/main/java/org/geysermc/geyser/translator/protocol/bedrock/entity/player/input/BedrockBlockActions.java
@@ -32,7 +32,6 @@ import org.cloudburstmc.protocol.bedrock.data.PlayerActionType;
 import org.cloudburstmc.protocol.bedrock.data.PlayerBlockActionData;
 import org.cloudburstmc.protocol.bedrock.data.definitions.ItemDefinition;
 import org.cloudburstmc.protocol.bedrock.packet.LevelEventPacket;
-import org.geysermc.geyser.GeyserImpl;
 import org.geysermc.geyser.api.block.custom.CustomBlockState;
 import org.geysermc.geyser.entity.type.Entity;
 import org.geysermc.geyser.entity.type.ItemFrameEntity;
@@ -84,6 +83,10 @@ final class BedrockBlockActions {
                     break;
                 }
 
+                if (!canMine(session, vector)) {
+                    return;
+                }
+
                 // Start the block breaking animation
                 int blockState = session.getGeyser().getWorldManager().getBlockAt(session, vector);
                 LevelEventPacket startBreak = new LevelEventPacket();
@@ -126,6 +129,11 @@ final class BedrockBlockActions {
                 if (session.getGameMode() == GameMode.CREATIVE) {
                     break;
                 }
+
+                if (!canMine(session, vector)) {
+                    return;
+                }
+
                 int breakingBlock = session.getBreakingBlock();
                 if (breakingBlock == -1) {
                     breakingBlock = Block.JAVA_AIR_ID;
@@ -187,12 +195,29 @@ final class BedrockBlockActions {
                 stopBreak.setPosition(vector.toFloat());
                 stopBreak.setData(0);
                 session.setBreakingBlock(-1);
+                session.setBlockBreakStartTime(0);
                 session.sendUpstreamPacket(stopBreak);
             }
             // Handled in BedrockInventoryTransactionTranslator
             case STOP_BREAK -> {
             }
         }
+    }
+
+    private static boolean canMine(GeyserSession session, Vector3i vector) {
+        if (session.isHandsBusy()) {
+            session.setBreakingBlock(-1);
+            session.setBlockBreakStartTime(0);
+
+            LevelEventPacket stopBreak = new LevelEventPacket();
+            stopBreak.setType(LevelEvent.BLOCK_STOP_BREAK);
+            stopBreak.setPosition(vector.toFloat());
+            stopBreak.setData(0);
+            session.setBreakingBlock(-1);
+            session.sendUpstreamPacket(stopBreak);
+            return true;
+        }
+        return false;
     }
 
     private static void spawnBlockBreakParticles(GeyserSession session, Direction direction, Vector3i position, BlockState blockState) {

--- a/core/src/main/java/org/geysermc/geyser/translator/protocol/bedrock/entity/player/input/BedrockBlockActions.java
+++ b/core/src/main/java/org/geysermc/geyser/translator/protocol/bedrock/entity/player/input/BedrockBlockActions.java
@@ -215,9 +215,9 @@ final class BedrockBlockActions {
             stopBreak.setData(0);
             session.setBreakingBlock(-1);
             session.sendUpstreamPacket(stopBreak);
-            return true;
+            return false;
         }
-        return false;
+        return true;
     }
 
     private static void spawnBlockBreakParticles(GeyserSession session, Direction direction, Vector3i position, BlockState blockState) {

--- a/core/src/main/java/org/geysermc/geyser/translator/protocol/bedrock/entity/player/input/BedrockPlayerAuthInputTranslator.java
+++ b/core/src/main/java/org/geysermc/geyser/translator/protocol/bedrock/entity/player/input/BedrockPlayerAuthInputTranslator.java
@@ -148,9 +148,6 @@ public final class BedrockPlayerAuthInputTranslator extends PacketTranslator<Pla
                 }
                 case STOP_GLIDING -> sendPlayerGlideToggle(session, entity);
                 case MISSED_SWING -> {
-                    // mobile: animate after swing
-                    // win: swing after animate
-                    GeyserImpl.getInstance().getLogger().info("auth packet, tick: " + session.getTicks() + " " + packet.toString());
                     session.setLastAirHitTick(session.getTicks());
 
                     if (session.getArmAnimationTicks() != 0 && session.getArmAnimationTicks() != 1) {

--- a/core/src/main/java/org/geysermc/geyser/translator/protocol/bedrock/entity/player/input/BedrockPlayerAuthInputTranslator.java
+++ b/core/src/main/java/org/geysermc/geyser/translator/protocol/bedrock/entity/player/input/BedrockPlayerAuthInputTranslator.java
@@ -29,14 +29,17 @@ import org.cloudburstmc.math.GenericMath;
 import org.cloudburstmc.math.vector.Vector2f;
 import org.cloudburstmc.math.vector.Vector3f;
 import org.cloudburstmc.math.vector.Vector3i;
+import org.cloudburstmc.protocol.bedrock.data.InputMode;
 import org.cloudburstmc.protocol.bedrock.data.LevelEvent;
 import org.cloudburstmc.protocol.bedrock.data.PlayerActionType;
 import org.cloudburstmc.protocol.bedrock.data.PlayerAuthInputData;
 import org.cloudburstmc.protocol.bedrock.data.entity.EntityFlag;
 import org.cloudburstmc.protocol.bedrock.data.inventory.transaction.ItemUseTransaction;
+import org.cloudburstmc.protocol.bedrock.packet.AnimatePacket;
 import org.cloudburstmc.protocol.bedrock.packet.LevelEventPacket;
 import org.cloudburstmc.protocol.bedrock.packet.PlayerActionPacket;
 import org.cloudburstmc.protocol.bedrock.packet.PlayerAuthInputPacket;
+import org.geysermc.geyser.GeyserImpl;
 import org.geysermc.geyser.entity.EntityDefinitions;
 import org.geysermc.geyser.entity.type.BoatEntity;
 import org.geysermc.geyser.entity.type.Entity;
@@ -53,6 +56,7 @@ import org.geysermc.geyser.translator.protocol.bedrock.BedrockInventoryTransacti
 import org.geysermc.geyser.util.CooldownUtils;
 import org.geysermc.mcprotocollib.protocol.data.game.entity.object.Direction;
 import org.geysermc.mcprotocollib.protocol.data.game.entity.player.GameMode;
+import org.geysermc.mcprotocollib.protocol.data.game.entity.player.Hand;
 import org.geysermc.mcprotocollib.protocol.data.game.entity.player.InteractAction;
 import org.geysermc.mcprotocollib.protocol.data.game.entity.player.PlayerAction;
 import org.geysermc.mcprotocollib.protocol.data.game.entity.player.PlayerState;
@@ -61,6 +65,7 @@ import org.geysermc.mcprotocollib.protocol.packet.ingame.serverbound.player.Serv
 import org.geysermc.mcprotocollib.protocol.packet.ingame.serverbound.player.ServerboundPlayerAbilitiesPacket;
 import org.geysermc.mcprotocollib.protocol.packet.ingame.serverbound.player.ServerboundPlayerActionPacket;
 import org.geysermc.mcprotocollib.protocol.packet.ingame.serverbound.player.ServerboundPlayerCommandPacket;
+import org.geysermc.mcprotocollib.protocol.packet.ingame.serverbound.player.ServerboundSwingPacket;
 
 import java.util.Set;
 
@@ -72,7 +77,7 @@ public final class BedrockPlayerAuthInputTranslator extends PacketTranslator<Pla
         SessionPlayerEntity entity = session.getPlayerEntity();
 
         boolean wasJumping = session.getInputCache().wasJumping();
-        session.getInputCache().processInputs(packet);
+        session.getInputCache().processInputs(entity, packet);
 
         BedrockMovePlayer.translate(session, packet);
 
@@ -83,18 +88,6 @@ public final class BedrockPlayerAuthInputTranslator extends PacketTranslator<Pla
             switch (input) {
                 case PERFORM_ITEM_INTERACTION -> processItemUseTransaction(session, packet.getItemUseTransaction());
                 case PERFORM_BLOCK_ACTIONS -> BedrockBlockActions.translate(session, packet.getPlayerActions());
-                case START_SNEAKING -> {
-                    ServerboundPlayerCommandPacket startSneakPacket = new ServerboundPlayerCommandPacket(entity.getEntityId(), PlayerState.START_SNEAKING);
-                    session.sendDownstreamGamePacket(startSneakPacket);
-
-                    session.startSneaking();
-                }
-                case STOP_SNEAKING -> {
-                    ServerboundPlayerCommandPacket stopSneakPacket = new ServerboundPlayerCommandPacket(entity.getEntityId(), PlayerState.STOP_SNEAKING);
-                    session.sendDownstreamGamePacket(stopSneakPacket);
-
-                    session.stopSneaking();
-                }
                 case START_SPRINTING -> {
                     if (!entity.getFlag(EntityFlag.SWIMMING)) {
                         ServerboundPlayerCommandPacket startSprintPacket = new ServerboundPlayerCommandPacket(entity.getEntityId(), PlayerState.START_SPRINTING);
@@ -154,7 +147,28 @@ public final class BedrockPlayerAuthInputTranslator extends PacketTranslator<Pla
                     sendPlayerGlideToggle(session, entity);
                 }
                 case STOP_GLIDING -> sendPlayerGlideToggle(session, entity);
-                case MISSED_SWING -> CooldownUtils.sendCooldown(session); // Java edition sends a cooldown when hitting air.
+                case MISSED_SWING -> {
+                    // mobile: animate after swing
+                    // win: swing after animate
+                    GeyserImpl.getInstance().getLogger().info("auth packet, tick: " + session.getTicks() + " " + packet.toString());
+                    session.setLastAirHitTick(session.getTicks());
+
+                    if (session.getArmAnimationTicks() != 0 && session.getArmAnimationTicks() != 1) {
+                        session.sendDownstreamGamePacket(new ServerboundSwingPacket(Hand.MAIN_HAND));
+                        session.activateArmAnimationTicking();
+                    }
+
+                    // Touch devices expect an animation packet sent back to them
+                    if (packet.getInputMode().equals(InputMode.TOUCH)) {
+                        AnimatePacket animatePacket = new AnimatePacket();
+                        animatePacket.setAction(AnimatePacket.Action.SWING_ARM);
+                        animatePacket.setRuntimeEntityId(session.getPlayerEntity().getGeyserId());
+                        session.sendUpstreamPacket(animatePacket);
+                    }
+
+                    // Java edition sends a cooldown when hitting air.
+                    CooldownUtils.sendCooldown(session);
+                }
             }
         }
         if (entity.getVehicle() instanceof BoatEntity) {

--- a/core/src/main/java/org/geysermc/geyser/translator/protocol/bedrock/world/BedrockLevelSoundEventTranslator.java
+++ b/core/src/main/java/org/geysermc/geyser/translator/protocol/bedrock/world/BedrockLevelSoundEventTranslator.java
@@ -28,8 +28,8 @@ package org.geysermc.geyser.translator.protocol.bedrock.world;
 import org.cloudburstmc.math.vector.Vector3f;
 import org.cloudburstmc.math.vector.Vector3i;
 import org.cloudburstmc.protocol.bedrock.data.SoundEvent;
-import org.cloudburstmc.protocol.bedrock.packet.AnimatePacket;
 import org.cloudburstmc.protocol.bedrock.packet.LevelSoundEventPacket;
+import org.geysermc.geyser.GeyserImpl;
 import org.geysermc.geyser.level.block.property.Properties;
 import org.geysermc.geyser.level.block.type.BlockState;
 import org.geysermc.geyser.session.GeyserSession;
@@ -38,7 +38,6 @@ import org.geysermc.geyser.translator.protocol.Translator;
 import org.geysermc.geyser.util.CooldownUtils;
 import org.geysermc.mcprotocollib.protocol.data.game.entity.object.Direction;
 import org.geysermc.mcprotocollib.protocol.data.game.entity.player.Hand;
-import org.geysermc.mcprotocollib.protocol.packet.ingame.serverbound.player.ServerboundSwingPacket;
 import org.geysermc.mcprotocollib.protocol.packet.ingame.serverbound.player.ServerboundUseItemOnPacket;
 
 @Translator(packet = LevelSoundEventPacket.class)
@@ -48,6 +47,7 @@ public class BedrockLevelSoundEventTranslator extends PacketTranslator<LevelSoun
     public void translate(GeyserSession session, LevelSoundEventPacket packet) {
         // lol what even :thinking:
         session.sendUpstreamPacket(packet);
+        GeyserImpl.getInstance().getLogger().info(packet.toString());
 
         // Yes, what even, but thankfully we can hijack this packet to send the cooldown
         if (packet.getSound() == SoundEvent.ATTACK_NODAMAGE || packet.getSound() == SoundEvent.ATTACK || packet.getSound() == SoundEvent.ATTACK_STRONG) {
@@ -57,20 +57,21 @@ public class BedrockLevelSoundEventTranslator extends PacketTranslator<LevelSoun
         }
 
         if (packet.getSound() == SoundEvent.ATTACK_NODAMAGE && session.getArmAnimationTicks() == -1) {
+            throw new IllegalStateException("o.o.");
             // https://github.com/GeyserMC/Geyser/issues/2113
             // Seems like consoles and Android with keyboard send the animation packet on 1.19.51, hence the animation
             // tick check - the animate packet is sent first.
             // ATTACK_NODAMAGE = player clicked air
             // This should only be revisited if Bedrock packets get full Java parity, or Bedrock starts sending arm
             // animation packets after ATTACK_NODAMAGE, OR ATTACK_NODAMAGE gets removed/isn't sent in the same spot
-            session.sendDownstreamGamePacket(new ServerboundSwingPacket(Hand.MAIN_HAND));
-            session.activateArmAnimationTicking();
-
-            // Send packet to Bedrock so it knows
-            AnimatePacket animatePacket = new AnimatePacket();
-            animatePacket.setRuntimeEntityId(session.getPlayerEntity().getGeyserId());
-            animatePacket.setAction(AnimatePacket.Action.SWING_ARM);
-            session.sendUpstreamPacket(animatePacket);
+//            session.sendDownstreamGamePacket(new ServerboundSwingPacket(Hand.MAIN_HAND));
+//            session.activateArmAnimationTicking();
+//
+//            // Send packet to Bedrock so it knows
+//            AnimatePacket animatePacket = new AnimatePacket();
+//            animatePacket.setRuntimeEntityId(session.getPlayerEntity().getGeyserId());
+//            animatePacket.setAction(AnimatePacket.Action.SWING_ARM);
+//            session.sendUpstreamPacket(animatePacket);
         }
 
         // Used by client to get book from lecterns in survial mode since 1.20.70

--- a/core/src/main/java/org/geysermc/geyser/translator/protocol/bedrock/world/BedrockLevelSoundEventTranslator.java
+++ b/core/src/main/java/org/geysermc/geyser/translator/protocol/bedrock/world/BedrockLevelSoundEventTranslator.java
@@ -29,7 +29,6 @@ import org.cloudburstmc.math.vector.Vector3f;
 import org.cloudburstmc.math.vector.Vector3i;
 import org.cloudburstmc.protocol.bedrock.data.SoundEvent;
 import org.cloudburstmc.protocol.bedrock.packet.LevelSoundEventPacket;
-import org.geysermc.geyser.GeyserImpl;
 import org.geysermc.geyser.level.block.property.Properties;
 import org.geysermc.geyser.level.block.type.BlockState;
 import org.geysermc.geyser.session.GeyserSession;
@@ -47,31 +46,12 @@ public class BedrockLevelSoundEventTranslator extends PacketTranslator<LevelSoun
     public void translate(GeyserSession session, LevelSoundEventPacket packet) {
         // lol what even :thinking:
         session.sendUpstreamPacket(packet);
-        GeyserImpl.getInstance().getLogger().info(packet.toString());
 
         // Yes, what even, but thankfully we can hijack this packet to send the cooldown
         if (packet.getSound() == SoundEvent.ATTACK_NODAMAGE || packet.getSound() == SoundEvent.ATTACK || packet.getSound() == SoundEvent.ATTACK_STRONG) {
             // Send a faux cooldown since Bedrock has no cooldown support
             // Sent here because Java still sends a cooldown if the player doesn't hit anything but Bedrock always sends a sound
             CooldownUtils.sendCooldown(session);
-        }
-
-        if (packet.getSound() == SoundEvent.ATTACK_NODAMAGE && session.getArmAnimationTicks() == -1) {
-            throw new IllegalStateException("o.o.");
-            // https://github.com/GeyserMC/Geyser/issues/2113
-            // Seems like consoles and Android with keyboard send the animation packet on 1.19.51, hence the animation
-            // tick check - the animate packet is sent first.
-            // ATTACK_NODAMAGE = player clicked air
-            // This should only be revisited if Bedrock packets get full Java parity, or Bedrock starts sending arm
-            // animation packets after ATTACK_NODAMAGE, OR ATTACK_NODAMAGE gets removed/isn't sent in the same spot
-//            session.sendDownstreamGamePacket(new ServerboundSwingPacket(Hand.MAIN_HAND));
-//            session.activateArmAnimationTicking();
-//
-//            // Send packet to Bedrock so it knows
-//            AnimatePacket animatePacket = new AnimatePacket();
-//            animatePacket.setRuntimeEntityId(session.getPlayerEntity().getGeyserId());
-//            animatePacket.setAction(AnimatePacket.Action.SWING_ARM);
-//            session.sendUpstreamPacket(animatePacket);
         }
 
         // Used by client to get book from lecterns in survial mode since 1.20.70

--- a/core/src/main/java/org/geysermc/geyser/translator/protocol/java/entity/JavaAnimateTranslator.java
+++ b/core/src/main/java/org/geysermc/geyser/translator/protocol/java/entity/JavaAnimateTranslator.java
@@ -31,6 +31,7 @@ import org.cloudburstmc.protocol.bedrock.packet.AnimateEntityPacket;
 import org.cloudburstmc.protocol.bedrock.packet.AnimatePacket;
 import org.cloudburstmc.protocol.bedrock.packet.EntityEventPacket;
 import org.cloudburstmc.protocol.bedrock.packet.SpawnParticleEffectPacket;
+import org.geysermc.geyser.GeyserImpl;
 import org.geysermc.geyser.entity.type.Entity;
 import org.geysermc.geyser.entity.type.LivingEntity;
 import org.geysermc.geyser.session.GeyserSession;
@@ -47,12 +48,13 @@ public class JavaAnimateTranslator extends PacketTranslator<ClientboundAnimatePa
 
     @Override
     public void translate(GeyserSession session, ClientboundAnimatePacket packet) {
-        Entity entity = session.getEntityCache().getEntityByJavaId(packet.getEntityId());
-        if (entity == null) {
-            return;
-        }
+        GeyserImpl.getInstance().getLogger().warning(packet.toString());
         Animation animation = packet.getAnimation();
         if (animation == null) {
+            return;
+        }
+        Entity entity = session.getEntityCache().getEntityByJavaId(packet.getEntityId());
+        if (entity == null) {
             return;
         }
 

--- a/core/src/main/java/org/geysermc/geyser/translator/protocol/java/entity/JavaAnimateTranslator.java
+++ b/core/src/main/java/org/geysermc/geyser/translator/protocol/java/entity/JavaAnimateTranslator.java
@@ -31,7 +31,6 @@ import org.cloudburstmc.protocol.bedrock.packet.AnimateEntityPacket;
 import org.cloudburstmc.protocol.bedrock.packet.AnimatePacket;
 import org.cloudburstmc.protocol.bedrock.packet.EntityEventPacket;
 import org.cloudburstmc.protocol.bedrock.packet.SpawnParticleEffectPacket;
-import org.geysermc.geyser.GeyserImpl;
 import org.geysermc.geyser.entity.type.Entity;
 import org.geysermc.geyser.entity.type.LivingEntity;
 import org.geysermc.geyser.session.GeyserSession;
@@ -48,7 +47,6 @@ public class JavaAnimateTranslator extends PacketTranslator<ClientboundAnimatePa
 
     @Override
     public void translate(GeyserSession session, ClientboundAnimatePacket packet) {
-        GeyserImpl.getInstance().getLogger().warning(packet.toString());
         Animation animation = packet.getAnimation();
         if (animation == null) {
             return;


### PR DESCRIPTION
Should fix https://github.com/GeyserMC/Geyser/issues/5190

Further, this implements blocking block breaking & entity attacking while steering boats to match the Java clients behaviour.

It now also updates shifting state before sending inputs to the Java client, also matching behaviour there.