### PR TITLE
Change advancement form mechanics to match Java behaviour, fix NPE

### DIFF
--- a/core/src/main/java/org/geysermc/geyser/command/defaults/AdvancementsCommand.java
+++ b/core/src/main/java/org/geysermc/geyser/command/defaults/AdvancementsCommand.java
@@ -42,6 +42,6 @@ public class AdvancementsCommand extends GeyserCommand {
     @Override
     public void execute(CommandContext<GeyserCommandSource> context) {
         GeyserSession session = Objects.requireNonNull(context.sender().connection());
-        session.getAdvancementsCache().buildAndShowMenuForm();
+        session.getAdvancementsCache().buildAndShowForm();
     }
 }

--- a/core/src/main/java/org/geysermc/geyser/session/cache/AdvancementsCache.java
+++ b/core/src/main/java/org/geysermc/geyser/session/cache/AdvancementsCache.java
@@ -28,7 +28,6 @@ package org.geysermc.geyser.session.cache;
 import org.geysermc.mcprotocollib.protocol.data.game.advancement.Advancement;
 import org.geysermc.mcprotocollib.protocol.packet.ingame.serverbound.inventory.ServerboundSeenAdvancementsPacket;
 import lombok.Getter;
-import lombok.Setter;
 import org.geysermc.cumulus.form.SimpleForm;
 import org.geysermc.geyser.level.GeyserAdvancement;
 import org.geysermc.geyser.session.GeyserSession;
@@ -41,6 +40,7 @@ import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 
 public class AdvancementsCache {
     /**
@@ -58,13 +58,35 @@ public class AdvancementsCache {
     /**
      * Stores player's chosen advancement's ID and title for use in form creators.
      */
-    @Setter
     private String currentAdvancementCategoryId = null;
+
+    /**
+     * Stores if the player is currently viewing advancements.
+     */
+    private boolean formOpen = false;
 
     private final GeyserSession session;
 
     public AdvancementsCache(GeyserSession session) {
         this.session = session;
+    }
+
+    public void setCurrentAdvancementCategoryId(String categoryId) {
+        if (!Objects.equals(currentAdvancementCategoryId, categoryId)) {
+            // Only open and show list form if we're going to a different category
+            currentAdvancementCategoryId = categoryId;
+            if (formOpen) {
+                buildAndShowListForm();
+            }
+        }
+    }
+
+    public void buildAndShowForm() {
+        if (currentAdvancementCategoryId == null) {
+            buildAndShowMenuForm();
+        } else {
+            buildAndShowListForm();
+        }
     }
 
     /**
@@ -88,9 +110,11 @@ public class AdvancementsCache {
             builder.content("advancements.empty");
         }
 
-        builder.validResultHandler((response) -> {
+        builder.closedResultHandler(() -> {
+            formOpen = false;
+        }).validResultHandler((response) -> {
             String id = rootAdvancementIds.get(response.clickedButtonId());
-            if (!id.equals("")) {
+            if (!id.isEmpty()) {
                 // Send a packet indicating that we are opening this particular advancement window
                 ServerboundSeenAdvancementsPacket packet = new ServerboundSeenAdvancementsPacket(id);
                 session.sendDownstreamGamePacket(packet);
@@ -99,6 +123,7 @@ public class AdvancementsCache {
             }
         });
 
+        formOpen = true;
         session.sendForm(builder);
     }
 
@@ -106,6 +131,7 @@ public class AdvancementsCache {
      * Build and send the list of advancements
      */
     public void buildAndShowListForm() {
+        System.out.println("showing list form called");
         GeyserAdvancement categoryAdvancement = storedAdvancements.get(currentAdvancementCategoryId);
         String language = session.locale();
 
@@ -133,6 +159,9 @@ public class AdvancementsCache {
 
         builder.closedResultHandler(() -> {
             // Indicate that we have closed the current advancement tab
+            // Don't set currentAdvancementCategoryId to null here, so that when the advancements form is shown again (buildAndShowForm),
+            // the tab that was last open is opened again, which matches Java behaviour
+            formOpen = false;
             session.sendDownstreamGamePacket(new ServerboundSeenAdvancementsPacket());
 
         }).validResultHandler((response) -> {
@@ -142,6 +171,7 @@ public class AdvancementsCache {
             } else {
                 buildAndShowMenuForm();
                 // Indicate that we have closed the current advancement tab
+                currentAdvancementCategoryId = null;
                 session.sendDownstreamGamePacket(new ServerboundSeenAdvancementsPacket());
             }
         });
@@ -206,6 +236,7 @@ public class AdvancementsCache {
                         .validResultHandler((response) -> buildAndShowListForm())
                         .closedResultHandler(() -> {
                             // Indicate that we have closed the current advancement tab
+                            formOpen = false;
                             session.sendDownstreamGamePacket(new ServerboundSeenAdvancementsPacket());
                         })
         );

--- a/core/src/main/java/org/geysermc/geyser/session/cache/AdvancementsCache.java
+++ b/core/src/main/java/org/geysermc/geyser/session/cache/AdvancementsCache.java
@@ -131,7 +131,6 @@ public class AdvancementsCache {
      * Build and send the list of advancements
      */
     public void buildAndShowListForm() {
-        System.out.println("showing list form called");
         GeyserAdvancement categoryAdvancement = storedAdvancements.get(currentAdvancementCategoryId);
         String language = session.locale();
 

--- a/core/src/main/java/org/geysermc/geyser/session/cache/AdvancementsCache.java
+++ b/core/src/main/java/org/geysermc/geyser/session/cache/AdvancementsCache.java
@@ -76,7 +76,9 @@ public class AdvancementsCache {
             // Only open and show list form if we're going to a different category
             currentAdvancementCategoryId = categoryId;
             if (formOpen) {
+                session.closeForm();
                 buildAndShowForm();
+                formOpen = true;
             }
         }
     }

--- a/core/src/main/java/org/geysermc/geyser/session/cache/AdvancementsCache.java
+++ b/core/src/main/java/org/geysermc/geyser/session/cache/AdvancementsCache.java
@@ -76,7 +76,7 @@ public class AdvancementsCache {
             // Only open and show list form if we're going to a different category
             currentAdvancementCategoryId = categoryId;
             if (formOpen) {
-                buildAndShowListForm();
+                buildAndShowForm();
             }
         }
     }

--- a/core/src/main/java/org/geysermc/geyser/translator/protocol/java/JavaSelectAdvancementsTabTranslator.java
+++ b/core/src/main/java/org/geysermc/geyser/translator/protocol/java/JavaSelectAdvancementsTabTranslator.java
@@ -27,7 +27,6 @@ package org.geysermc.geyser.translator.protocol.java;
 
 import org.geysermc.mcprotocollib.protocol.packet.ingame.clientbound.ClientboundSelectAdvancementsTabPacket;
 import org.geysermc.geyser.session.GeyserSession;
-import org.geysermc.geyser.session.cache.AdvancementsCache;
 import org.geysermc.geyser.translator.protocol.PacketTranslator;
 import org.geysermc.geyser.translator.protocol.Translator;
 

--- a/core/src/main/java/org/geysermc/geyser/translator/protocol/java/JavaSelectAdvancementsTabTranslator.java
+++ b/core/src/main/java/org/geysermc/geyser/translator/protocol/java/JavaSelectAdvancementsTabTranslator.java
@@ -39,8 +39,6 @@ public class JavaSelectAdvancementsTabTranslator extends PacketTranslator<Client
 
     @Override
     public void translate(GeyserSession session, ClientboundSelectAdvancementsTabPacket packet) {
-        AdvancementsCache advancementsCache = session.getAdvancementsCache();
-        advancementsCache.setCurrentAdvancementCategoryId(packet.getTabId());
-        advancementsCache.buildAndShowListForm();
+        session.getAdvancementsCache().setCurrentAdvancementCategoryId(packet.getTabId());
     }
 }


### PR DESCRIPTION
This PR changes the behaviour of the Geyser advancements form a bit. Now, when a `ClientboundSelectAdvancementsTabPacket` is received, Geyser stores the specified `tabId`, but only shows the category form when the user is already viewing advancements. If the user is not viewing advancements, then the `tabId` is stored, and the user is automatically redirected to the stored category when the user uses `/geyser advancements`.

The same goes for when a user closes and reopens the advancements form - the form will be at the same category as it was when the user closed it, or the root menu form if the user wasn't at any category.

These changes match Java behaviour, and should also resolve a NPE described in #5394 (when `tabId` is null), which this PR should fully resolve.
