### PR TITLE
Support new tooltip display component and other 1.21.5 things

### DIFF
--- a/build-logic/src/main/kotlin/geyser.base-conventions.gradle.kts
+++ b/build-logic/src/main/kotlin/geyser.base-conventions.gradle.kts
@@ -26,7 +26,7 @@ dependencies {
 }
 
 repositories {
-    // mavenLocal()
+    mavenLocal()
 
     mavenCentral()
 
@@ -69,6 +69,4 @@ repositories {
     maven("https://jitpack.io") {
         content { includeGroupByRegex("com\\.github\\..*") }
     }
-
-    mavenLocal()
 }

--- a/core/src/main/java/org/geysermc/geyser/entity/type/FireworkEntity.java
+++ b/core/src/main/java/org/geysermc/geyser/entity/type/FireworkEntity.java
@@ -59,7 +59,7 @@ public class FireworkEntity extends Entity {
         // TODO this looked the same, so I'm going to assume it is and (keep below comment if true)
         // Translate using item methods to get firework NBT for Bedrock
         BedrockItemBuilder builder = new BedrockItemBuilder();
-        Items.FIREWORK_ROCKET.translateComponentsToBedrock(session, components, builder);
+        Items.FIREWORK_ROCKET.translateComponentsToBedrock(session, components, , builder);
         
         dirtyMetadata.put(EntityDataTypes.DISPLAY_FIREWORK, builder.build());
     }

--- a/core/src/main/java/org/geysermc/geyser/entity/type/FireworkEntity.java
+++ b/core/src/main/java/org/geysermc/geyser/entity/type/FireworkEntity.java
@@ -31,6 +31,7 @@ import org.cloudburstmc.protocol.bedrock.packet.SetEntityMotionPacket;
 import org.geysermc.geyser.entity.EntityDefinition;
 import org.geysermc.geyser.entity.type.player.PlayerEntity;
 import org.geysermc.geyser.item.Items;
+import org.geysermc.geyser.item.TooltipOptions;
 import org.geysermc.geyser.session.GeyserSession;
 import org.geysermc.geyser.translator.item.BedrockItemBuilder;
 import org.geysermc.mcprotocollib.protocol.data.game.entity.metadata.EntityMetadata;
@@ -59,7 +60,8 @@ public class FireworkEntity extends Entity {
         // TODO this looked the same, so I'm going to assume it is and (keep below comment if true)
         // Translate using item methods to get firework NBT for Bedrock
         BedrockItemBuilder builder = new BedrockItemBuilder();
-        Items.FIREWORK_ROCKET.translateComponentsToBedrock(session, components, , builder);
+        TooltipOptions tooltip = TooltipOptions.fromComponents(components);
+        Items.FIREWORK_ROCKET.translateComponentsToBedrock(session, components, tooltip, builder);
         
         dirtyMetadata.put(EntityDataTypes.DISPLAY_FIREWORK, builder.build());
     }

--- a/core/src/main/java/org/geysermc/geyser/entity/type/LivingEntity.java
+++ b/core/src/main/java/org/geysermc/geyser/entity/type/LivingEntity.java
@@ -142,7 +142,7 @@ public class LivingEntity extends Entity {
         boolean saddled = false;
         Item item = Registries.JAVA_ITEMS.get(stack.getId());
         if (item != null) {
-            DataComponents components = item.gatherComponents(stack.getDataComponents());
+            DataComponents components = item.gatherComponents(stack.getDataComponentsPatch());
             Equippable equippable = components.get(DataComponentTypes.EQUIPPABLE);
             saddled = equippable != null && equippable.slot() == EquipmentSlot.SADDLE;
         }

--- a/core/src/main/java/org/geysermc/geyser/entity/type/LivingEntity.java
+++ b/core/src/main/java/org/geysermc/geyser/entity/type/LivingEntity.java
@@ -44,6 +44,8 @@ import org.geysermc.geyser.entity.attribute.GeyserAttributeType;
 import org.geysermc.geyser.entity.vehicle.ClientVehicle;
 import org.geysermc.geyser.inventory.GeyserItemStack;
 import org.geysermc.geyser.item.Items;
+import org.geysermc.geyser.item.type.Item;
+import org.geysermc.geyser.registry.Registries;
 import org.geysermc.geyser.registry.type.ItemMapping;
 import org.geysermc.geyser.scoreboard.Team;
 import org.geysermc.geyser.session.GeyserSession;
@@ -51,6 +53,7 @@ import org.geysermc.geyser.translator.item.ItemTranslator;
 import org.geysermc.geyser.util.AttributeUtils;
 import org.geysermc.geyser.util.InteractionResult;
 import org.geysermc.geyser.util.MathUtils;
+import org.geysermc.mcprotocollib.protocol.data.game.entity.EquipmentSlot;
 import org.geysermc.mcprotocollib.protocol.data.game.entity.attribute.Attribute;
 import org.geysermc.mcprotocollib.protocol.data.game.entity.attribute.AttributeType;
 import org.geysermc.mcprotocollib.protocol.data.game.entity.metadata.EntityMetadata;
@@ -62,6 +65,8 @@ import org.geysermc.mcprotocollib.protocol.data.game.entity.metadata.type.Object
 import org.geysermc.mcprotocollib.protocol.data.game.entity.player.Hand;
 import org.geysermc.mcprotocollib.protocol.data.game.item.ItemStack;
 import org.geysermc.mcprotocollib.protocol.data.game.item.component.DataComponentTypes;
+import org.geysermc.mcprotocollib.protocol.data.game.item.component.DataComponents;
+import org.geysermc.mcprotocollib.protocol.data.game.item.component.Equippable;
 import org.geysermc.mcprotocollib.protocol.data.game.level.particle.ColorParticleData;
 import org.geysermc.mcprotocollib.protocol.data.game.level.particle.Particle;
 import org.geysermc.mcprotocollib.protocol.data.game.level.particle.ParticleType;
@@ -133,7 +138,16 @@ public class LivingEntity extends Entity {
 
     public void setSaddle(ItemStack stack) {
         this.saddle = ItemTranslator.translateToBedrock(session, stack);
-        updateSaddled(stack.getId() == Items.SADDLE.javaId());
+
+        boolean saddled = false;
+        Item item = Registries.JAVA_ITEMS.get(stack.getId());
+        if (item != null) {
+            DataComponents components = item.gatherComponents(stack.getDataComponents());
+            Equippable equippable = components.get(DataComponentTypes.EQUIPPABLE);
+            saddled = equippable != null && equippable.slot() == EquipmentSlot.SADDLE;
+        }
+
+        updateSaddled(saddled);
     }
 
     public void setHand(ItemStack stack) {

--- a/core/src/main/java/org/geysermc/geyser/entity/type/living/animal/TropicalFishEntity.java
+++ b/core/src/main/java/org/geysermc/geyser/entity/type/living/animal/TropicalFishEntity.java
@@ -61,6 +61,10 @@ public class TropicalFishEntity extends AbstractFishEntity {
         dirtyMetadata.put(EntityDataTypes.COLOR_2, getPatternColor(varNumber)); // Pattern color 0-15
     }
 
+    public static int getPackedVariant(int pattern, int baseColor, int patternColor) {
+        return pattern & 65535 | (baseColor & 0xFF) << 16 | (patternColor & 0xFF) << 24;
+    }
+
     public static int getShape(int variant) {
         return Math.min(variant & 0xFF, 1);
     }

--- a/core/src/main/java/org/geysermc/geyser/inventory/item/GeyserInstrument.java
+++ b/core/src/main/java/org/geysermc/geyser/inventory/item/GeyserInstrument.java
@@ -89,13 +89,18 @@ public interface GeyserInstrument {
         return -1;
     }
 
-    // TODO 1.21.5
+    // TODO test in 1.21.5
     static GeyserInstrument fromComponent(GeyserSession session, InstrumentComponent component) {
-        if (component.instrumentHolder().isId()) {
-            return session.getRegistryCache().instruments().byId(component.instrumentHolder().id());
+        if (component.instrumentLocation() != null) {
+            return session.getRegistryCache().instruments().byKey(component.instrumentLocation());
+        } else if (component.instrumentHolder() != null) {
+            if (component.instrumentHolder().isId()) {
+                return session.getRegistryCache().instruments().byId(component.instrumentHolder().id());
+            }
+            InstrumentComponent.Instrument custom = component.instrumentHolder().custom();
+            return new Wrapper(custom, session.locale());
         }
-        InstrumentComponent.Instrument custom = component.instrumentHolder().custom();
-        return new Wrapper(custom, session.locale());
+        throw new IllegalStateException("InstrumentComponent must have either a location or a holder");
     }
 
     record Wrapper(InstrumentComponent.Instrument instrument, String locale) implements GeyserInstrument {

--- a/core/src/main/java/org/geysermc/geyser/item/TooltipOptions.java
+++ b/core/src/main/java/org/geysermc/geyser/item/TooltipOptions.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024 GeyserMC. http://geysermc.org
+ * Copyright (c) 2025 GeyserMC. http://geysermc.org
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -23,25 +23,31 @@
  * @link https://github.com/GeyserMC/Geyser
  */
 
-package org.geysermc.geyser.item.type;
+package org.geysermc.geyser.item;
 
-import org.checkerframework.checker.nullness.qual.NonNull;
-import org.geysermc.geyser.item.TooltipOptions;
-import org.geysermc.geyser.session.GeyserSession;
-import org.geysermc.geyser.translator.item.BedrockItemBuilder;
+import org.geysermc.mcprotocollib.protocol.data.game.item.component.DataComponentType;
 import org.geysermc.mcprotocollib.protocol.data.game.item.component.DataComponents;
-import org.jetbrains.annotations.NotNull;
+import org.geysermc.mcprotocollib.protocol.data.game.item.component.TooltipDisplay;
 
-public class WolfArmorItem extends Item {
-    public WolfArmorItem(String javaIdentifier, Builder builder) {
-        super(javaIdentifier, builder);
-    }
+@FunctionalInterface
+public interface TooltipOptions {
 
-    @Override
-    public void translateComponentsToBedrock(@NonNull GeyserSession session, @NonNull DataComponents components, @NotNull TooltipOptions tooltip, @NonNull BedrockItemBuilder builder) {
-        super.translateComponentsToBedrock(session, components, tooltip, builder);
+    TooltipOptions ALL_SHOWN = component -> true;
 
-        // Note that this is handled as of 1.21 in the ItemColors class.
-        translateDyedColor(components, builder);
+    TooltipOptions ALL_HIDDEN = component -> false;
+
+    boolean showInTooltip(DataComponentType<?> component);
+
+    static TooltipOptions fromComponents(DataComponents components) {
+        TooltipDisplay display = components.get(DataComponentTypes.TOOLTIP_DISPLAY);
+        if (display == null) {
+            return ALL_SHOWN;
+        } else if (display.hideTooltip()) {
+            return ALL_HIDDEN;
+        } else if (display.hiddenComponents().isEmpty()) {
+            return ALL_SHOWN;
+        }
+
+        return component -> !display.hiddenComponents().contains(component);
     }
 }

--- a/core/src/main/java/org/geysermc/geyser/item/TooltipOptions.java
+++ b/core/src/main/java/org/geysermc/geyser/item/TooltipOptions.java
@@ -26,6 +26,7 @@
 package org.geysermc.geyser.item;
 
 import org.geysermc.mcprotocollib.protocol.data.game.item.component.DataComponentType;
+import org.geysermc.mcprotocollib.protocol.data.game.item.component.DataComponentTypes;
 import org.geysermc.mcprotocollib.protocol.data.game.item.component.DataComponents;
 import org.geysermc.mcprotocollib.protocol.data.game.item.component.TooltipDisplay;
 
@@ -49,5 +50,10 @@ public interface TooltipOptions {
         }
 
         return component -> !display.hiddenComponents().contains(component);
+    }
+
+    static boolean hideTooltip(DataComponents components) {
+        TooltipDisplay display = components.get(DataComponentTypes.TOOLTIP_DISPLAY);
+        return display != null && display.hideTooltip();
     }
 }

--- a/core/src/main/java/org/geysermc/geyser/item/type/ArmorItem.java
+++ b/core/src/main/java/org/geysermc/geyser/item/type/ArmorItem.java
@@ -36,7 +36,6 @@ import org.geysermc.geyser.translator.item.BedrockItemBuilder;
 import org.geysermc.mcprotocollib.protocol.data.game.item.component.ArmorTrim;
 import org.geysermc.mcprotocollib.protocol.data.game.item.component.DataComponentTypes;
 import org.geysermc.mcprotocollib.protocol.data.game.item.component.DataComponents;
-import org.jetbrains.annotations.NotNull;
 
 public class ArmorItem extends Item {
 
@@ -45,7 +44,7 @@ public class ArmorItem extends Item {
     }
 
     @Override
-    public void translateComponentsToBedrock(@NonNull GeyserSession session, @NonNull DataComponents components, @NotNull TooltipOptions tooltip, @NonNull BedrockItemBuilder builder) {
+    public void translateComponentsToBedrock(@NonNull GeyserSession session, @NonNull DataComponents components, @NonNull TooltipOptions tooltip, @NonNull BedrockItemBuilder builder) {
         super.translateComponentsToBedrock(session, components, tooltip, builder);
 
         ArmorTrim trim = components.get(DataComponentTypes.TRIM);

--- a/core/src/main/java/org/geysermc/geyser/item/type/ArmorItem.java
+++ b/core/src/main/java/org/geysermc/geyser/item/type/ArmorItem.java
@@ -56,6 +56,7 @@ public class ArmorItem extends Item {
             // discard custom trim patterns/materials to prevent visual glitches on bedrock
             if (!getNamespace(material.getMaterialId()).equals("minecraft")
                     || !getNamespace(pattern.getPatternId()).equals("minecraft")) {
+                // TODO - how is this shown in tooltip? should we add a custom trim tooltip to the lore here
                 return;
             }
 

--- a/core/src/main/java/org/geysermc/geyser/item/type/ArmorItem.java
+++ b/core/src/main/java/org/geysermc/geyser/item/type/ArmorItem.java
@@ -30,11 +30,13 @@ import org.cloudburstmc.nbt.NbtMap;
 import org.cloudburstmc.nbt.NbtMapBuilder;
 import org.cloudburstmc.protocol.bedrock.data.TrimMaterial;
 import org.cloudburstmc.protocol.bedrock.data.TrimPattern;
+import org.geysermc.geyser.item.TooltipOptions;
 import org.geysermc.geyser.session.GeyserSession;
 import org.geysermc.geyser.translator.item.BedrockItemBuilder;
 import org.geysermc.mcprotocollib.protocol.data.game.item.component.ArmorTrim;
 import org.geysermc.mcprotocollib.protocol.data.game.item.component.DataComponentTypes;
 import org.geysermc.mcprotocollib.protocol.data.game.item.component.DataComponents;
+import org.jetbrains.annotations.NotNull;
 
 public class ArmorItem extends Item {
 
@@ -43,8 +45,8 @@ public class ArmorItem extends Item {
     }
 
     @Override
-    public void translateComponentsToBedrock(@NonNull GeyserSession session, @NonNull DataComponents components, @NonNull BedrockItemBuilder builder) {
-        super.translateComponentsToBedrock(session, components, builder);
+    public void translateComponentsToBedrock(@NonNull GeyserSession session, @NonNull DataComponents components, @NotNull TooltipOptions tooltip, @NonNull BedrockItemBuilder builder) {
+        super.translateComponentsToBedrock(session, components, tooltip, builder);
 
         ArmorTrim trim = components.get(DataComponentTypes.TRIM);
         if (trim != null) {

--- a/core/src/main/java/org/geysermc/geyser/item/type/AxolotlBucketItem.java
+++ b/core/src/main/java/org/geysermc/geyser/item/type/AxolotlBucketItem.java
@@ -26,10 +26,12 @@
 package org.geysermc.geyser.item.type;
 
 import org.checkerframework.checker.nullness.qual.NonNull;
+import org.geysermc.geyser.item.TooltipOptions;
 import org.geysermc.geyser.session.GeyserSession;
 import org.geysermc.geyser.text.MinecraftLocale;
 import org.geysermc.geyser.translator.item.BedrockItemBuilder;
 import org.geysermc.mcprotocollib.protocol.data.game.item.component.DataComponents;
+import org.jetbrains.annotations.NotNull;
 
 public class AxolotlBucketItem extends Item {
     public AxolotlBucketItem(String javaIdentifier, Builder builder) {
@@ -37,8 +39,8 @@ public class AxolotlBucketItem extends Item {
     }
 
     @Override
-    public void translateComponentsToBedrock(@NonNull GeyserSession session, @NonNull DataComponents components, @NonNull BedrockItemBuilder builder) {
-        super.translateComponentsToBedrock(session, components, builder);
+    public void translateComponentsToBedrock(@NonNull GeyserSession session, @NonNull DataComponents components, @NotNull TooltipOptions tooltip, @NonNull BedrockItemBuilder builder) {
+        super.translateComponentsToBedrock(session, components, tooltip, builder);
 
         // Bedrock Edition displays the properties of the axolotl. Java does not.
         // To work around this, set the custom name to the Axolotl translation and it's displayed correctly

--- a/core/src/main/java/org/geysermc/geyser/item/type/AxolotlBucketItem.java
+++ b/core/src/main/java/org/geysermc/geyser/item/type/AxolotlBucketItem.java
@@ -31,7 +31,6 @@ import org.geysermc.geyser.session.GeyserSession;
 import org.geysermc.geyser.text.MinecraftLocale;
 import org.geysermc.geyser.translator.item.BedrockItemBuilder;
 import org.geysermc.mcprotocollib.protocol.data.game.item.component.DataComponents;
-import org.jetbrains.annotations.NotNull;
 
 public class AxolotlBucketItem extends Item {
     public AxolotlBucketItem(String javaIdentifier, Builder builder) {
@@ -39,7 +38,7 @@ public class AxolotlBucketItem extends Item {
     }
 
     @Override
-    public void translateComponentsToBedrock(@NonNull GeyserSession session, @NonNull DataComponents components, @NotNull TooltipOptions tooltip, @NonNull BedrockItemBuilder builder) {
+    public void translateComponentsToBedrock(@NonNull GeyserSession session, @NonNull DataComponents components, @NonNull TooltipOptions tooltip, @NonNull BedrockItemBuilder builder) {
         super.translateComponentsToBedrock(session, components, tooltip, builder);
 
         // Bedrock Edition displays the properties of the axolotl. Java does not.

--- a/core/src/main/java/org/geysermc/geyser/item/type/BannerItem.java
+++ b/core/src/main/java/org/geysermc/geyser/item/type/BannerItem.java
@@ -36,6 +36,7 @@ import org.cloudburstmc.nbt.NbtMap;
 import org.cloudburstmc.nbt.NbtType;
 import org.geysermc.geyser.inventory.item.BannerPattern;
 import org.geysermc.geyser.inventory.item.DyeColor;
+import org.geysermc.geyser.item.TooltipOptions;
 import org.geysermc.geyser.level.block.type.Block;
 import org.geysermc.geyser.registry.type.ItemMapping;
 import org.geysermc.geyser.session.GeyserSession;
@@ -46,6 +47,7 @@ import org.geysermc.mcprotocollib.protocol.data.game.Holder;
 import org.geysermc.mcprotocollib.protocol.data.game.item.component.BannerPatternLayer;
 import org.geysermc.mcprotocollib.protocol.data.game.item.component.DataComponentTypes;
 import org.geysermc.mcprotocollib.protocol.data.game.item.component.DataComponents;
+import org.jetbrains.annotations.NotNull;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -202,8 +204,8 @@ public class BannerItem extends BlockItem {
     }
 
     @Override
-    public void translateComponentsToBedrock(@NonNull GeyserSession session, @NonNull DataComponents components, @NonNull BedrockItemBuilder builder) {
-        super.translateComponentsToBedrock(session, components, builder);
+    public void translateComponentsToBedrock(@NonNull GeyserSession session, @NonNull DataComponents components, @NotNull TooltipOptions tooltip, @NonNull BedrockItemBuilder builder) {
+        super.translateComponentsToBedrock(session, components, tooltip, builder);
 
         List<BannerPatternLayer> patterns = components.get(DataComponentTypes.BANNER_PATTERNS);
         if (patterns != null) {

--- a/core/src/main/java/org/geysermc/geyser/item/type/BannerItem.java
+++ b/core/src/main/java/org/geysermc/geyser/item/type/BannerItem.java
@@ -48,7 +48,6 @@ import org.geysermc.mcprotocollib.protocol.data.game.item.component.BannerPatter
 import org.geysermc.mcprotocollib.protocol.data.game.item.component.DataComponentTypes;
 import org.geysermc.mcprotocollib.protocol.data.game.item.component.DataComponents;
 import org.geysermc.mcprotocollib.protocol.data.game.item.component.TooltipDisplay;
-import org.jetbrains.annotations.NotNull;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -205,7 +204,7 @@ public class BannerItem extends BlockItem {
     }
 
     @Override
-    public void translateComponentsToBedrock(@NonNull GeyserSession session, @NonNull DataComponents components, @NotNull TooltipOptions tooltip, @NonNull BedrockItemBuilder builder) {
+    public void translateComponentsToBedrock(@NonNull GeyserSession session, @NonNull DataComponents components, @NonNull TooltipOptions tooltip, @NonNull BedrockItemBuilder builder) {
         super.translateComponentsToBedrock(session, components, tooltip, builder);
 
         List<BannerPatternLayer> patterns = components.get(DataComponentTypes.BANNER_PATTERNS);

--- a/core/src/main/java/org/geysermc/geyser/item/type/BannerItem.java
+++ b/core/src/main/java/org/geysermc/geyser/item/type/BannerItem.java
@@ -47,6 +47,7 @@ import org.geysermc.mcprotocollib.protocol.data.game.Holder;
 import org.geysermc.mcprotocollib.protocol.data.game.item.component.BannerPatternLayer;
 import org.geysermc.mcprotocollib.protocol.data.game.item.component.DataComponentTypes;
 import org.geysermc.mcprotocollib.protocol.data.game.item.component.DataComponents;
+import org.geysermc.mcprotocollib.protocol.data.game.item.component.TooltipDisplay;
 import org.jetbrains.annotations.NotNull;
 
 import java.util.ArrayList;
@@ -227,7 +228,8 @@ public class BannerItem extends BlockItem {
             }
 
             components.put(DataComponentTypes.BANNER_PATTERNS, patternLayers);
-            // TODO 1.21.5 hide components???
+            // The ominous banner item in the Java creative menu just has banner patterns hidden as of 1.21.5
+            components.put(DataComponentTypes.TOOLTIP_DISPLAY, new TooltipDisplay(false, List.of(DataComponentTypes.BANNER_PATTERNS)));
             components.put(DataComponentTypes.ITEM_NAME, Component
                     .translatable("block.minecraft.ominous_banner")
                     .style(Style.style(TextColor.color(16755200)))

--- a/core/src/main/java/org/geysermc/geyser/item/type/CompassItem.java
+++ b/core/src/main/java/org/geysermc/geyser/item/type/CompassItem.java
@@ -37,7 +37,6 @@ import org.geysermc.geyser.translator.item.BedrockItemBuilder;
 import org.geysermc.mcprotocollib.protocol.data.game.item.component.DataComponentTypes;
 import org.geysermc.mcprotocollib.protocol.data.game.item.component.DataComponents;
 import org.geysermc.mcprotocollib.protocol.data.game.item.component.LodestoneTracker;
-import org.jetbrains.annotations.NotNull;
 
 public class CompassItem extends Item {
     public CompassItem(String javaIdentifier, Builder builder) {
@@ -61,7 +60,7 @@ public class CompassItem extends Item {
     }
 
     @Override
-    public void translateComponentsToBedrock(@NonNull GeyserSession session, @NonNull DataComponents components, @NotNull TooltipOptions tooltip, @NonNull BedrockItemBuilder builder) {
+    public void translateComponentsToBedrock(@NonNull GeyserSession session, @NonNull DataComponents components, @NonNull TooltipOptions tooltip, @NonNull BedrockItemBuilder builder) {
         super.translateComponentsToBedrock(session, components, tooltip, builder);
 
         LodestoneTracker tracker = components.get(DataComponentTypes.LODESTONE_TRACKER);

--- a/core/src/main/java/org/geysermc/geyser/item/type/CompassItem.java
+++ b/core/src/main/java/org/geysermc/geyser/item/type/CompassItem.java
@@ -29,6 +29,7 @@ import org.checkerframework.checker.nullness.qual.NonNull;
 import org.checkerframework.checker.nullness.qual.Nullable;
 import org.cloudburstmc.protocol.bedrock.data.inventory.ItemData;
 import org.geysermc.geyser.inventory.GeyserItemStack;
+import org.geysermc.geyser.item.TooltipOptions;
 import org.geysermc.geyser.registry.type.ItemMapping;
 import org.geysermc.geyser.registry.type.ItemMappings;
 import org.geysermc.geyser.session.GeyserSession;
@@ -36,6 +37,7 @@ import org.geysermc.geyser.translator.item.BedrockItemBuilder;
 import org.geysermc.mcprotocollib.protocol.data.game.item.component.DataComponentTypes;
 import org.geysermc.mcprotocollib.protocol.data.game.item.component.DataComponents;
 import org.geysermc.mcprotocollib.protocol.data.game.item.component.LodestoneTracker;
+import org.jetbrains.annotations.NotNull;
 
 public class CompassItem extends Item {
     public CompassItem(String javaIdentifier, Builder builder) {
@@ -59,8 +61,8 @@ public class CompassItem extends Item {
     }
 
     @Override
-    public void translateComponentsToBedrock(@NonNull GeyserSession session, @NonNull DataComponents components, @NonNull BedrockItemBuilder builder) {
-        super.translateComponentsToBedrock(session, components, builder);
+    public void translateComponentsToBedrock(@NonNull GeyserSession session, @NonNull DataComponents components, @NotNull TooltipOptions tooltip, @NonNull BedrockItemBuilder builder) {
+        super.translateComponentsToBedrock(session, components, tooltip, builder);
 
         LodestoneTracker tracker = components.get(DataComponentTypes.LODESTONE_TRACKER);
         if (tracker != null) {

--- a/core/src/main/java/org/geysermc/geyser/item/type/CrossbowItem.java
+++ b/core/src/main/java/org/geysermc/geyser/item/type/CrossbowItem.java
@@ -36,7 +36,6 @@ import org.geysermc.geyser.translator.item.ItemTranslator;
 import org.geysermc.mcprotocollib.protocol.data.game.item.ItemStack;
 import org.geysermc.mcprotocollib.protocol.data.game.item.component.DataComponentTypes;
 import org.geysermc.mcprotocollib.protocol.data.game.item.component.DataComponents;
-import org.jetbrains.annotations.NotNull;
 
 import java.util.List;
 
@@ -46,7 +45,7 @@ public class CrossbowItem extends Item {
     }
 
     @Override
-    public void translateComponentsToBedrock(@NonNull GeyserSession session, @NonNull DataComponents components, @NotNull TooltipOptions tooltip, @NonNull BedrockItemBuilder builder) {
+    public void translateComponentsToBedrock(@NonNull GeyserSession session, @NonNull DataComponents components, @NonNull TooltipOptions tooltip, @NonNull BedrockItemBuilder builder) {
         super.translateComponentsToBedrock(session, components, tooltip, builder);
 
         List<ItemStack> chargedProjectiles = components.get(DataComponentTypes.CHARGED_PROJECTILES);

--- a/core/src/main/java/org/geysermc/geyser/item/type/CrossbowItem.java
+++ b/core/src/main/java/org/geysermc/geyser/item/type/CrossbowItem.java
@@ -28,6 +28,7 @@ package org.geysermc.geyser.item.type;
 import org.checkerframework.checker.nullness.qual.NonNull;
 import org.cloudburstmc.nbt.NbtMapBuilder;
 import org.cloudburstmc.protocol.bedrock.data.inventory.ItemData;
+import org.geysermc.geyser.item.TooltipOptions;
 import org.geysermc.geyser.registry.type.ItemMapping;
 import org.geysermc.geyser.session.GeyserSession;
 import org.geysermc.geyser.translator.item.BedrockItemBuilder;
@@ -35,6 +36,7 @@ import org.geysermc.geyser.translator.item.ItemTranslator;
 import org.geysermc.mcprotocollib.protocol.data.game.item.ItemStack;
 import org.geysermc.mcprotocollib.protocol.data.game.item.component.DataComponentTypes;
 import org.geysermc.mcprotocollib.protocol.data.game.item.component.DataComponents;
+import org.jetbrains.annotations.NotNull;
 
 import java.util.List;
 
@@ -44,8 +46,8 @@ public class CrossbowItem extends Item {
     }
 
     @Override
-    public void translateComponentsToBedrock(@NonNull GeyserSession session, @NonNull DataComponents components, @NonNull BedrockItemBuilder builder) {
-        super.translateComponentsToBedrock(session, components, builder);
+    public void translateComponentsToBedrock(@NonNull GeyserSession session, @NonNull DataComponents components, @NotNull TooltipOptions tooltip, @NonNull BedrockItemBuilder builder) {
+        super.translateComponentsToBedrock(session, components, tooltip, builder);
 
         List<ItemStack> chargedProjectiles = components.get(DataComponentTypes.CHARGED_PROJECTILES);
         if (chargedProjectiles != null && !chargedProjectiles.isEmpty()) {

--- a/core/src/main/java/org/geysermc/geyser/item/type/DecoratedPotItem.java
+++ b/core/src/main/java/org/geysermc/geyser/item/type/DecoratedPotItem.java
@@ -27,12 +27,14 @@ package org.geysermc.geyser.item.type;
 
 import org.checkerframework.checker.nullness.qual.NonNull;
 import org.cloudburstmc.nbt.NbtType;
+import org.geysermc.geyser.item.TooltipOptions;
 import org.geysermc.geyser.level.block.type.Block;
 import org.geysermc.geyser.registry.type.ItemMapping;
 import org.geysermc.geyser.session.GeyserSession;
 import org.geysermc.geyser.translator.item.BedrockItemBuilder;
 import org.geysermc.mcprotocollib.protocol.data.game.item.component.DataComponentTypes;
 import org.geysermc.mcprotocollib.protocol.data.game.item.component.DataComponents;
+import org.jetbrains.annotations.NotNull;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -44,8 +46,8 @@ public class DecoratedPotItem extends BlockItem {
     }
 
     @Override
-    public void translateComponentsToBedrock(@NonNull GeyserSession session, @NonNull DataComponents components, @NonNull BedrockItemBuilder builder) {
-        super.translateComponentsToBedrock(session, components, builder);
+    public void translateComponentsToBedrock(@NonNull GeyserSession session, @NonNull DataComponents components, @NotNull TooltipOptions tooltip, @NonNull BedrockItemBuilder builder) {
+        super.translateComponentsToBedrock(session, components, tooltip, builder);
 
         List<Integer> decorations = components.get(DataComponentTypes.POT_DECORATIONS); // TODO maybe unbox in MCProtocolLib
         if (decorations != null) {

--- a/core/src/main/java/org/geysermc/geyser/item/type/DecoratedPotItem.java
+++ b/core/src/main/java/org/geysermc/geyser/item/type/DecoratedPotItem.java
@@ -34,7 +34,6 @@ import org.geysermc.geyser.session.GeyserSession;
 import org.geysermc.geyser.translator.item.BedrockItemBuilder;
 import org.geysermc.mcprotocollib.protocol.data.game.item.component.DataComponentTypes;
 import org.geysermc.mcprotocollib.protocol.data.game.item.component.DataComponents;
-import org.jetbrains.annotations.NotNull;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -46,7 +45,7 @@ public class DecoratedPotItem extends BlockItem {
     }
 
     @Override
-    public void translateComponentsToBedrock(@NonNull GeyserSession session, @NonNull DataComponents components, @NotNull TooltipOptions tooltip, @NonNull BedrockItemBuilder builder) {
+    public void translateComponentsToBedrock(@NonNull GeyserSession session, @NonNull DataComponents components, @NonNull TooltipOptions tooltip, @NonNull BedrockItemBuilder builder) {
         super.translateComponentsToBedrock(session, components, tooltip, builder);
 
         List<Integer> decorations = components.get(DataComponentTypes.POT_DECORATIONS); // TODO maybe unbox in MCProtocolLib

--- a/core/src/main/java/org/geysermc/geyser/item/type/DyeableArmorItem.java
+++ b/core/src/main/java/org/geysermc/geyser/item/type/DyeableArmorItem.java
@@ -30,7 +30,6 @@ import org.geysermc.geyser.item.TooltipOptions;
 import org.geysermc.geyser.session.GeyserSession;
 import org.geysermc.geyser.translator.item.BedrockItemBuilder;
 import org.geysermc.mcprotocollib.protocol.data.game.item.component.DataComponents;
-import org.jetbrains.annotations.NotNull;
 
 public class DyeableArmorItem extends ArmorItem {
     public DyeableArmorItem(String javaIdentifier, Builder builder) {
@@ -38,7 +37,7 @@ public class DyeableArmorItem extends ArmorItem {
     }
 
     @Override
-    public void translateComponentsToBedrock(@NonNull GeyserSession session, @NonNull DataComponents components, @NotNull TooltipOptions tooltip, @NonNull BedrockItemBuilder builder) {
+    public void translateComponentsToBedrock(@NonNull GeyserSession session, @NonNull DataComponents components, @NonNull TooltipOptions tooltip, @NonNull BedrockItemBuilder builder) {
         super.translateComponentsToBedrock(session, components, tooltip, builder);
 
         // Note that this is handled as of 1.20.5 in the ItemColors class.

--- a/core/src/main/java/org/geysermc/geyser/item/type/DyeableArmorItem.java
+++ b/core/src/main/java/org/geysermc/geyser/item/type/DyeableArmorItem.java
@@ -26,9 +26,11 @@
 package org.geysermc.geyser.item.type;
 
 import org.checkerframework.checker.nullness.qual.NonNull;
+import org.geysermc.geyser.item.TooltipOptions;
 import org.geysermc.geyser.session.GeyserSession;
 import org.geysermc.geyser.translator.item.BedrockItemBuilder;
 import org.geysermc.mcprotocollib.protocol.data.game.item.component.DataComponents;
+import org.jetbrains.annotations.NotNull;
 
 public class DyeableArmorItem extends ArmorItem {
     public DyeableArmorItem(String javaIdentifier, Builder builder) {
@@ -36,8 +38,8 @@ public class DyeableArmorItem extends ArmorItem {
     }
 
     @Override
-    public void translateComponentsToBedrock(@NonNull GeyserSession session, @NonNull DataComponents components, @NonNull BedrockItemBuilder builder) {
-        super.translateComponentsToBedrock(session, components, builder);
+    public void translateComponentsToBedrock(@NonNull GeyserSession session, @NonNull DataComponents components, @NotNull TooltipOptions tooltip, @NonNull BedrockItemBuilder builder) {
+        super.translateComponentsToBedrock(session, components, tooltip, builder);
 
         // Note that this is handled as of 1.20.5 in the ItemColors class.
         // But horse leather armor and body leather armor are now both armor items. So it works!

--- a/core/src/main/java/org/geysermc/geyser/item/type/EnchantedBookItem.java
+++ b/core/src/main/java/org/geysermc/geyser/item/type/EnchantedBookItem.java
@@ -40,7 +40,6 @@ import org.geysermc.geyser.translator.item.BedrockItemBuilder;
 import org.geysermc.mcprotocollib.protocol.data.game.item.component.DataComponentTypes;
 import org.geysermc.mcprotocollib.protocol.data.game.item.component.DataComponents;
 import org.geysermc.mcprotocollib.protocol.data.game.item.component.ItemEnchantments;
-import org.jetbrains.annotations.NotNull;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -52,7 +51,7 @@ public class EnchantedBookItem extends Item {
     }
 
     @Override
-    public void translateComponentsToBedrock(@NonNull GeyserSession session, @NonNull DataComponents components, @NotNull TooltipOptions tooltip, @NonNull BedrockItemBuilder builder) {
+    public void translateComponentsToBedrock(@NonNull GeyserSession session, @NonNull DataComponents components, @NonNull TooltipOptions tooltip, @NonNull BedrockItemBuilder builder) {
         super.translateComponentsToBedrock(session, components, tooltip, builder);
 
         List<NbtMap> bedrockEnchants = new ArrayList<>();

--- a/core/src/main/java/org/geysermc/geyser/item/type/EnchantedBookItem.java
+++ b/core/src/main/java/org/geysermc/geyser/item/type/EnchantedBookItem.java
@@ -32,6 +32,7 @@ import org.cloudburstmc.nbt.NbtMap;
 import org.cloudburstmc.nbt.NbtType;
 import org.geysermc.geyser.GeyserImpl;
 import org.geysermc.geyser.inventory.item.BedrockEnchantment;
+import org.geysermc.geyser.item.TooltipOptions;
 import org.geysermc.geyser.item.enchantment.Enchantment;
 import org.geysermc.geyser.registry.type.ItemMapping;
 import org.geysermc.geyser.session.GeyserSession;
@@ -39,6 +40,7 @@ import org.geysermc.geyser.translator.item.BedrockItemBuilder;
 import org.geysermc.mcprotocollib.protocol.data.game.item.component.DataComponentTypes;
 import org.geysermc.mcprotocollib.protocol.data.game.item.component.DataComponents;
 import org.geysermc.mcprotocollib.protocol.data.game.item.component.ItemEnchantments;
+import org.jetbrains.annotations.NotNull;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -50,8 +52,8 @@ public class EnchantedBookItem extends Item {
     }
 
     @Override
-    public void translateComponentsToBedrock(@NonNull GeyserSession session, @NonNull DataComponents components, @NonNull BedrockItemBuilder builder) {
-        super.translateComponentsToBedrock(session, components, builder);
+    public void translateComponentsToBedrock(@NonNull GeyserSession session, @NonNull DataComponents components, @NotNull TooltipOptions tooltip, @NonNull BedrockItemBuilder builder) {
+        super.translateComponentsToBedrock(session, components, tooltip, builder);
 
         List<NbtMap> bedrockEnchants = new ArrayList<>();
         ItemEnchantments enchantments = components.get(DataComponentTypes.STORED_ENCHANTMENTS);

--- a/core/src/main/java/org/geysermc/geyser/item/type/FireworkRocketItem.java
+++ b/core/src/main/java/org/geysermc/geyser/item/type/FireworkRocketItem.java
@@ -31,6 +31,7 @@ import org.cloudburstmc.nbt.NbtList;
 import org.cloudburstmc.nbt.NbtMap;
 import org.cloudburstmc.nbt.NbtMapBuilder;
 import org.cloudburstmc.nbt.NbtType;
+import org.geysermc.geyser.item.TooltipOptions;
 import org.geysermc.geyser.level.FireworkColor;
 import org.geysermc.geyser.registry.type.ItemMapping;
 import org.geysermc.geyser.session.GeyserSession;
@@ -38,6 +39,7 @@ import org.geysermc.geyser.translator.item.BedrockItemBuilder;
 import org.geysermc.mcprotocollib.protocol.data.game.item.component.DataComponentTypes;
 import org.geysermc.mcprotocollib.protocol.data.game.item.component.DataComponents;
 import org.geysermc.mcprotocollib.protocol.data.game.item.component.Fireworks;
+import org.jetbrains.annotations.NotNull;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -48,8 +50,8 @@ public class FireworkRocketItem extends Item implements BedrockRequiresTagItem {
     }
 
     @Override
-    public void translateComponentsToBedrock(@NonNull GeyserSession session, @NonNull DataComponents components, @NonNull BedrockItemBuilder builder) {
-        super.translateComponentsToBedrock(session, components, builder);
+    public void translateComponentsToBedrock(@NonNull GeyserSession session, @NonNull DataComponents components, @NotNull TooltipOptions tooltip, @NonNull BedrockItemBuilder builder) {
+        super.translateComponentsToBedrock(session, components, tooltip, builder);
 
         Fireworks fireworks = components.get(DataComponentTypes.FIREWORKS);
         if (fireworks == null) {

--- a/core/src/main/java/org/geysermc/geyser/item/type/FireworkRocketItem.java
+++ b/core/src/main/java/org/geysermc/geyser/item/type/FireworkRocketItem.java
@@ -39,7 +39,6 @@ import org.geysermc.geyser.translator.item.BedrockItemBuilder;
 import org.geysermc.mcprotocollib.protocol.data.game.item.component.DataComponentTypes;
 import org.geysermc.mcprotocollib.protocol.data.game.item.component.DataComponents;
 import org.geysermc.mcprotocollib.protocol.data.game.item.component.Fireworks;
-import org.jetbrains.annotations.NotNull;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -50,7 +49,7 @@ public class FireworkRocketItem extends Item implements BedrockRequiresTagItem {
     }
 
     @Override
-    public void translateComponentsToBedrock(@NonNull GeyserSession session, @NonNull DataComponents components, @NotNull TooltipOptions tooltip, @NonNull BedrockItemBuilder builder) {
+    public void translateComponentsToBedrock(@NonNull GeyserSession session, @NonNull DataComponents components, @NonNull TooltipOptions tooltip, @NonNull BedrockItemBuilder builder) {
         super.translateComponentsToBedrock(session, components, tooltip, builder);
 
         Fireworks fireworks = components.get(DataComponentTypes.FIREWORKS);

--- a/core/src/main/java/org/geysermc/geyser/item/type/FireworkStarItem.java
+++ b/core/src/main/java/org/geysermc/geyser/item/type/FireworkStarItem.java
@@ -34,7 +34,6 @@ import org.geysermc.geyser.translator.item.BedrockItemBuilder;
 import org.geysermc.mcprotocollib.protocol.data.game.item.component.DataComponentTypes;
 import org.geysermc.mcprotocollib.protocol.data.game.item.component.DataComponents;
 import org.geysermc.mcprotocollib.protocol.data.game.item.component.Fireworks;
-import org.jetbrains.annotations.NotNull;
 
 public class FireworkStarItem extends Item {
     public FireworkStarItem(String javaIdentifier, Builder builder) {
@@ -42,7 +41,7 @@ public class FireworkStarItem extends Item {
     }
 
     @Override
-    public void translateComponentsToBedrock(@NonNull GeyserSession session, @NonNull DataComponents components, @NotNull TooltipOptions tooltip, @NonNull BedrockItemBuilder builder) {
+    public void translateComponentsToBedrock(@NonNull GeyserSession session, @NonNull DataComponents components, @NonNull TooltipOptions tooltip, @NonNull BedrockItemBuilder builder) {
         super.translateComponentsToBedrock(session, components, tooltip, builder);
 
         Fireworks.FireworkExplosion explosion = components.get(DataComponentTypes.FIREWORK_EXPLOSION);

--- a/core/src/main/java/org/geysermc/geyser/item/type/FireworkStarItem.java
+++ b/core/src/main/java/org/geysermc/geyser/item/type/FireworkStarItem.java
@@ -27,12 +27,14 @@ package org.geysermc.geyser.item.type;
 
 import org.checkerframework.checker.nullness.qual.NonNull;
 import org.cloudburstmc.nbt.NbtMap;
+import org.geysermc.geyser.item.TooltipOptions;
 import org.geysermc.geyser.registry.type.ItemMapping;
 import org.geysermc.geyser.session.GeyserSession;
 import org.geysermc.geyser.translator.item.BedrockItemBuilder;
 import org.geysermc.mcprotocollib.protocol.data.game.item.component.DataComponentTypes;
 import org.geysermc.mcprotocollib.protocol.data.game.item.component.DataComponents;
 import org.geysermc.mcprotocollib.protocol.data.game.item.component.Fireworks;
+import org.jetbrains.annotations.NotNull;
 
 public class FireworkStarItem extends Item {
     public FireworkStarItem(String javaIdentifier, Builder builder) {
@@ -40,8 +42,8 @@ public class FireworkStarItem extends Item {
     }
 
     @Override
-    public void translateComponentsToBedrock(@NonNull GeyserSession session, @NonNull DataComponents components, @NonNull BedrockItemBuilder builder) {
-        super.translateComponentsToBedrock(session, components, builder);
+    public void translateComponentsToBedrock(@NonNull GeyserSession session, @NonNull DataComponents components, @NotNull TooltipOptions tooltip, @NonNull BedrockItemBuilder builder) {
+        super.translateComponentsToBedrock(session, components, tooltip, builder);
 
         Fireworks.FireworkExplosion explosion = components.get(DataComponentTypes.FIREWORK_EXPLOSION);
         if (explosion != null) {

--- a/core/src/main/java/org/geysermc/geyser/item/type/FishingRodItem.java
+++ b/core/src/main/java/org/geysermc/geyser/item/type/FishingRodItem.java
@@ -30,7 +30,6 @@ import org.geysermc.geyser.item.TooltipOptions;
 import org.geysermc.geyser.session.GeyserSession;
 import org.geysermc.geyser.translator.item.BedrockItemBuilder;
 import org.geysermc.mcprotocollib.protocol.data.game.item.component.DataComponents;
-import org.jetbrains.annotations.NotNull;
 
 public class FishingRodItem extends Item {
     public FishingRodItem(String javaIdentifier, Builder builder) {
@@ -38,7 +37,7 @@ public class FishingRodItem extends Item {
     }
 
     @Override
-    public void translateComponentsToBedrock(@NonNull GeyserSession session, @NonNull DataComponents components, @NotNull TooltipOptions tooltip, @NonNull BedrockItemBuilder builder) {
+    public void translateComponentsToBedrock(@NonNull GeyserSession session, @NonNull DataComponents components, @NonNull TooltipOptions tooltip, @NonNull BedrockItemBuilder builder) {
         super.translateComponentsToBedrock(session, components, tooltip, builder);
 
         // Fix damage inconsistency

--- a/core/src/main/java/org/geysermc/geyser/item/type/FishingRodItem.java
+++ b/core/src/main/java/org/geysermc/geyser/item/type/FishingRodItem.java
@@ -26,9 +26,11 @@
 package org.geysermc.geyser.item.type;
 
 import org.checkerframework.checker.nullness.qual.NonNull;
+import org.geysermc.geyser.item.TooltipOptions;
 import org.geysermc.geyser.session.GeyserSession;
 import org.geysermc.geyser.translator.item.BedrockItemBuilder;
 import org.geysermc.mcprotocollib.protocol.data.game.item.component.DataComponents;
+import org.jetbrains.annotations.NotNull;
 
 public class FishingRodItem extends Item {
     public FishingRodItem(String javaIdentifier, Builder builder) {
@@ -36,8 +38,8 @@ public class FishingRodItem extends Item {
     }
 
     @Override
-    public void translateComponentsToBedrock(@NonNull GeyserSession session, @NonNull DataComponents components, @NonNull BedrockItemBuilder builder) {
-        super.translateComponentsToBedrock(session, components, builder);
+    public void translateComponentsToBedrock(@NonNull GeyserSession session, @NonNull DataComponents components, @NotNull TooltipOptions tooltip, @NonNull BedrockItemBuilder builder) {
+        super.translateComponentsToBedrock(session, components, tooltip, builder);
 
         // Fix damage inconsistency
         builder.getDamage().ifPresent(damage -> builder.setDamage(getBedrockDamage(damage)));

--- a/core/src/main/java/org/geysermc/geyser/item/type/GoatHornItem.java
+++ b/core/src/main/java/org/geysermc/geyser/item/type/GoatHornItem.java
@@ -29,6 +29,7 @@ import org.checkerframework.checker.nullness.qual.NonNull;
 import org.cloudburstmc.protocol.bedrock.data.inventory.ItemData;
 import org.geysermc.geyser.inventory.GeyserItemStack;
 import org.geysermc.geyser.inventory.item.GeyserInstrument;
+import org.geysermc.geyser.item.TooltipOptions;
 import org.geysermc.geyser.registry.type.ItemMapping;
 import org.geysermc.geyser.registry.type.ItemMappings;
 import org.geysermc.geyser.session.GeyserSession;
@@ -37,6 +38,7 @@ import org.geysermc.mcprotocollib.protocol.data.game.Holder;
 import org.geysermc.mcprotocollib.protocol.data.game.item.component.DataComponentTypes;
 import org.geysermc.mcprotocollib.protocol.data.game.item.component.DataComponents;
 import org.geysermc.mcprotocollib.protocol.data.game.item.component.InstrumentComponent;
+import org.jetbrains.annotations.NotNull;
 
 public class GoatHornItem extends Item {
     public GoatHornItem(String javaIdentifier, Builder builder) {
@@ -63,12 +65,11 @@ public class GoatHornItem extends Item {
     }
 
     @Override
-    public void translateComponentsToBedrock(@NonNull GeyserSession session, @NonNull DataComponents components, @NonNull BedrockItemBuilder builder) {
-        super.translateComponentsToBedrock(session, components, builder);
+    public void translateComponentsToBedrock(@NonNull GeyserSession session, @NonNull DataComponents components, @NotNull TooltipOptions tooltip, @NonNull BedrockItemBuilder builder) {
+        super.translateComponentsToBedrock(session, components, tooltip, builder);
 
         InstrumentComponent component = components.get(DataComponentTypes.INSTRUMENT);
-        // TODO 1.21.5 hiding????
-        if (component != null) {
+        if (component != null && tooltip.showInTooltip(DataComponentTypes.INSTRUMENT)) {
             GeyserInstrument instrument = GeyserInstrument.fromComponent(session, component);
             if (instrument.bedrockInstrument() == null) {
                 builder.getOrCreateLore().add(instrument.description());

--- a/core/src/main/java/org/geysermc/geyser/item/type/GoatHornItem.java
+++ b/core/src/main/java/org/geysermc/geyser/item/type/GoatHornItem.java
@@ -38,7 +38,6 @@ import org.geysermc.mcprotocollib.protocol.data.game.Holder;
 import org.geysermc.mcprotocollib.protocol.data.game.item.component.DataComponentTypes;
 import org.geysermc.mcprotocollib.protocol.data.game.item.component.DataComponents;
 import org.geysermc.mcprotocollib.protocol.data.game.item.component.InstrumentComponent;
-import org.jetbrains.annotations.NotNull;
 
 public class GoatHornItem extends Item {
     public GoatHornItem(String javaIdentifier, Builder builder) {
@@ -65,7 +64,7 @@ public class GoatHornItem extends Item {
     }
 
     @Override
-    public void translateComponentsToBedrock(@NonNull GeyserSession session, @NonNull DataComponents components, @NotNull TooltipOptions tooltip, @NonNull BedrockItemBuilder builder) {
+    public void translateComponentsToBedrock(@NonNull GeyserSession session, @NonNull DataComponents components, @NonNull TooltipOptions tooltip, @NonNull BedrockItemBuilder builder) {
         super.translateComponentsToBedrock(session, components, tooltip, builder);
 
         InstrumentComponent component = components.get(DataComponentTypes.INSTRUMENT);

--- a/core/src/main/java/org/geysermc/geyser/item/type/Item.java
+++ b/core/src/main/java/org/geysermc/geyser/item/type/Item.java
@@ -37,6 +37,7 @@ import org.geysermc.geyser.GeyserImpl;
 import org.geysermc.geyser.inventory.GeyserItemStack;
 import org.geysermc.geyser.inventory.item.BedrockEnchantment;
 import org.geysermc.geyser.item.Items;
+import org.geysermc.geyser.item.TooltipOptions;
 import org.geysermc.geyser.item.enchantment.Enchantment;
 import org.geysermc.geyser.level.block.type.Block;
 import org.geysermc.geyser.registry.Registries;
@@ -46,6 +47,7 @@ import org.geysermc.geyser.session.GeyserSession;
 import org.geysermc.geyser.text.ChatColor;
 import org.geysermc.geyser.text.MinecraftLocale;
 import org.geysermc.geyser.translator.item.BedrockItemBuilder;
+import org.geysermc.geyser.translator.text.MessageTranslator;
 import org.geysermc.geyser.util.MinecraftKey;
 import org.geysermc.mcprotocollib.protocol.data.game.item.component.DataComponentType;
 import org.geysermc.mcprotocollib.protocol.data.game.item.component.DataComponentTypes;
@@ -155,15 +157,14 @@ public class Item {
     /**
      * Takes components from Java Edition and map them into Bedrock.
      */
-    public void translateComponentsToBedrock(@NonNull GeyserSession session, @NonNull DataComponents components, @NonNull BedrockItemBuilder builder) {
+    public void translateComponentsToBedrock(@NonNull GeyserSession session, @NonNull DataComponents components, @NonNull TooltipOptions tooltip, @NonNull BedrockItemBuilder builder) {
         List<Component> loreComponents = components.get(DataComponentTypes.LORE);
-        // TODO 1.21.5
-//        if (loreComponents != null && components.get(DataComponentTypes.HIDE_TOOLTIP) == null) {
-//            List<String> lore = builder.getOrCreateLore();
-//            for (Component loreComponent : loreComponents) {
-//                lore.add(MessageTranslator.convertMessage(loreComponent, session.locale()));
-//            }
-//        }
+        if (loreComponents != null && tooltip.showInTooltip(DataComponentTypes.LORE)) {
+            List<String> lore = builder.getOrCreateLore();
+            for (Component loreComponent : loreComponents) {
+                lore.add(MessageTranslator.convertMessage(loreComponent, session.locale()));
+            }
+        }
 
         Integer damage = components.get(DataComponentTypes.DAMAGE);
         if (damage != null) {

--- a/core/src/main/java/org/geysermc/geyser/item/type/MapItem.java
+++ b/core/src/main/java/org/geysermc/geyser/item/type/MapItem.java
@@ -26,10 +26,12 @@
 package org.geysermc.geyser.item.type;
 
 import org.checkerframework.checker.nullness.qual.NonNull;
+import org.geysermc.geyser.item.TooltipOptions;
 import org.geysermc.geyser.session.GeyserSession;
 import org.geysermc.geyser.translator.item.BedrockItemBuilder;
 import org.geysermc.mcprotocollib.protocol.data.game.item.component.DataComponentTypes;
 import org.geysermc.mcprotocollib.protocol.data.game.item.component.DataComponents;
+import org.jetbrains.annotations.NotNull;
 
 public class MapItem extends Item {
     public MapItem(String javaIdentifier, Builder builder) {
@@ -37,8 +39,8 @@ public class MapItem extends Item {
     }
 
     @Override
-    public void translateComponentsToBedrock(@NonNull GeyserSession session, @NonNull DataComponents components, @NonNull BedrockItemBuilder builder) {
-        super.translateComponentsToBedrock(session, components, builder);
+    public void translateComponentsToBedrock(@NonNull GeyserSession session, @NonNull DataComponents components, @NotNull TooltipOptions tooltip, @NonNull BedrockItemBuilder builder) {
+        super.translateComponentsToBedrock(session, components, tooltip, builder);
 
         Integer mapValue = components.get(DataComponentTypes.MAP_ID);
         if (mapValue == null) {

--- a/core/src/main/java/org/geysermc/geyser/item/type/MapItem.java
+++ b/core/src/main/java/org/geysermc/geyser/item/type/MapItem.java
@@ -31,7 +31,6 @@ import org.geysermc.geyser.session.GeyserSession;
 import org.geysermc.geyser.translator.item.BedrockItemBuilder;
 import org.geysermc.mcprotocollib.protocol.data.game.item.component.DataComponentTypes;
 import org.geysermc.mcprotocollib.protocol.data.game.item.component.DataComponents;
-import org.jetbrains.annotations.NotNull;
 
 public class MapItem extends Item {
     public MapItem(String javaIdentifier, Builder builder) {
@@ -39,7 +38,7 @@ public class MapItem extends Item {
     }
 
     @Override
-    public void translateComponentsToBedrock(@NonNull GeyserSession session, @NonNull DataComponents components, @NotNull TooltipOptions tooltip, @NonNull BedrockItemBuilder builder) {
+    public void translateComponentsToBedrock(@NonNull GeyserSession session, @NonNull DataComponents components, @NonNull TooltipOptions tooltip, @NonNull BedrockItemBuilder builder) {
         super.translateComponentsToBedrock(session, components, tooltip, builder);
 
         Integer mapValue = components.get(DataComponentTypes.MAP_ID);

--- a/core/src/main/java/org/geysermc/geyser/item/type/PlayerHeadItem.java
+++ b/core/src/main/java/org/geysermc/geyser/item/type/PlayerHeadItem.java
@@ -36,7 +36,6 @@ import org.geysermc.geyser.translator.item.BedrockItemBuilder;
 import org.geysermc.mcprotocollib.auth.GameProfile;
 import org.geysermc.mcprotocollib.protocol.data.game.item.component.DataComponentTypes;
 import org.geysermc.mcprotocollib.protocol.data.game.item.component.DataComponents;
-import org.jetbrains.annotations.NotNull;
 
 public class PlayerHeadItem extends BlockItem {
     public PlayerHeadItem(Builder builder, Block block, Block... otherBlocks) {
@@ -44,7 +43,7 @@ public class PlayerHeadItem extends BlockItem {
     }
 
     @Override
-    public void translateComponentsToBedrock(@NonNull GeyserSession session, @NonNull DataComponents components, @NotNull TooltipOptions tooltip, @NonNull BedrockItemBuilder builder) {
+    public void translateComponentsToBedrock(@NonNull GeyserSession session, @NonNull DataComponents components, @NonNull TooltipOptions tooltip, @NonNull BedrockItemBuilder builder) {
         super.translateComponentsToBedrock(session, components, tooltip, builder);
 
         // Use the correct color, determined by the rarity of the item

--- a/core/src/main/java/org/geysermc/geyser/item/type/PlayerHeadItem.java
+++ b/core/src/main/java/org/geysermc/geyser/item/type/PlayerHeadItem.java
@@ -26,6 +26,7 @@
 package org.geysermc.geyser.item.type;
 
 import org.checkerframework.checker.nullness.qual.NonNull;
+import org.geysermc.geyser.item.TooltipOptions;
 import org.geysermc.geyser.item.components.Rarity;
 import org.geysermc.geyser.level.block.type.Block;
 import org.geysermc.geyser.session.GeyserSession;
@@ -35,6 +36,7 @@ import org.geysermc.geyser.translator.item.BedrockItemBuilder;
 import org.geysermc.mcprotocollib.auth.GameProfile;
 import org.geysermc.mcprotocollib.protocol.data.game.item.component.DataComponentTypes;
 import org.geysermc.mcprotocollib.protocol.data.game.item.component.DataComponents;
+import org.jetbrains.annotations.NotNull;
 
 public class PlayerHeadItem extends BlockItem {
     public PlayerHeadItem(Builder builder, Block block, Block... otherBlocks) {
@@ -42,8 +44,8 @@ public class PlayerHeadItem extends BlockItem {
     }
 
     @Override
-    public void translateComponentsToBedrock(@NonNull GeyserSession session, @NonNull DataComponents components, @NonNull BedrockItemBuilder builder) {
-        super.translateComponentsToBedrock(session, components, builder);
+    public void translateComponentsToBedrock(@NonNull GeyserSession session, @NonNull DataComponents components, @NotNull TooltipOptions tooltip, @NonNull BedrockItemBuilder builder) {
+        super.translateComponentsToBedrock(session, components, tooltip, builder);
 
         // Use the correct color, determined by the rarity of the item
         char rarity = Rarity.fromId(components.get(DataComponentTypes.RARITY)).getColor();

--- a/core/src/main/java/org/geysermc/geyser/item/type/ShieldItem.java
+++ b/core/src/main/java/org/geysermc/geyser/item/type/ShieldItem.java
@@ -32,7 +32,6 @@ import org.geysermc.geyser.translator.item.BedrockItemBuilder;
 import org.geysermc.mcprotocollib.protocol.data.game.item.component.BannerPatternLayer;
 import org.geysermc.mcprotocollib.protocol.data.game.item.component.DataComponentTypes;
 import org.geysermc.mcprotocollib.protocol.data.game.item.component.DataComponents;
-import org.jetbrains.annotations.NotNull;
 
 import java.util.List;
 
@@ -42,7 +41,7 @@ public class ShieldItem extends Item {
     }
 
     @Override
-    public void translateComponentsToBedrock(@NonNull GeyserSession session, @NonNull DataComponents components, @NotNull TooltipOptions tooltip, @NonNull BedrockItemBuilder builder) {
+    public void translateComponentsToBedrock(@NonNull GeyserSession session, @NonNull DataComponents components, @NonNull TooltipOptions tooltip, @NonNull BedrockItemBuilder builder) {
         super.translateComponentsToBedrock(session, components, tooltip, builder);
 
         List<BannerPatternLayer> patterns = components.get(DataComponentTypes.BANNER_PATTERNS);

--- a/core/src/main/java/org/geysermc/geyser/item/type/ShieldItem.java
+++ b/core/src/main/java/org/geysermc/geyser/item/type/ShieldItem.java
@@ -26,11 +26,13 @@
 package org.geysermc.geyser.item.type;
 
 import org.checkerframework.checker.nullness.qual.NonNull;
+import org.geysermc.geyser.item.TooltipOptions;
 import org.geysermc.geyser.session.GeyserSession;
 import org.geysermc.geyser.translator.item.BedrockItemBuilder;
 import org.geysermc.mcprotocollib.protocol.data.game.item.component.BannerPatternLayer;
 import org.geysermc.mcprotocollib.protocol.data.game.item.component.DataComponentTypes;
 import org.geysermc.mcprotocollib.protocol.data.game.item.component.DataComponents;
+import org.jetbrains.annotations.NotNull;
 
 import java.util.List;
 
@@ -40,8 +42,8 @@ public class ShieldItem extends Item {
     }
 
     @Override
-    public void translateComponentsToBedrock(@NonNull GeyserSession session, @NonNull DataComponents components, @NonNull BedrockItemBuilder builder) {
-        super.translateComponentsToBedrock(session, components, builder);
+    public void translateComponentsToBedrock(@NonNull GeyserSession session, @NonNull DataComponents components, @NotNull TooltipOptions tooltip, @NonNull BedrockItemBuilder builder) {
+        super.translateComponentsToBedrock(session, components, tooltip, builder);
 
         List<BannerPatternLayer> patterns = components.get(DataComponentTypes.BANNER_PATTERNS);
         if (patterns != null) {

--- a/core/src/main/java/org/geysermc/geyser/item/type/ShulkerBoxItem.java
+++ b/core/src/main/java/org/geysermc/geyser/item/type/ShulkerBoxItem.java
@@ -32,6 +32,7 @@ import org.cloudburstmc.nbt.NbtType;
 import org.cloudburstmc.protocol.bedrock.data.definitions.ItemDefinition;
 import org.geysermc.geyser.inventory.item.Potion;
 import org.geysermc.geyser.item.Items;
+import org.geysermc.geyser.item.TooltipOptions;
 import org.geysermc.geyser.level.block.type.Block;
 import org.geysermc.geyser.registry.type.ItemMapping;
 import org.geysermc.geyser.session.GeyserSession;
@@ -43,6 +44,7 @@ import org.geysermc.mcprotocollib.protocol.data.game.item.ItemStack;
 import org.geysermc.mcprotocollib.protocol.data.game.item.component.DataComponentTypes;
 import org.geysermc.mcprotocollib.protocol.data.game.item.component.DataComponents;
 import org.geysermc.mcprotocollib.protocol.data.game.item.component.PotionContents;
+import org.jetbrains.annotations.NotNull;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -53,8 +55,8 @@ public class ShulkerBoxItem extends BlockItem {
     }
 
     @Override
-    public void translateComponentsToBedrock(@NonNull GeyserSession session, @NonNull DataComponents components, @NonNull BedrockItemBuilder builder) {
-        super.translateComponentsToBedrock(session, components, builder);
+    public void translateComponentsToBedrock(@NonNull GeyserSession session, @NonNull DataComponents components, @NotNull TooltipOptions tooltip, @NonNull BedrockItemBuilder builder) {
+        super.translateComponentsToBedrock(session, components, tooltip, builder);
 
         List<ItemStack> contents = components.get(DataComponentTypes.CONTAINER);
         if (contents == null || contents.isEmpty()) {

--- a/core/src/main/java/org/geysermc/geyser/item/type/ShulkerBoxItem.java
+++ b/core/src/main/java/org/geysermc/geyser/item/type/ShulkerBoxItem.java
@@ -55,7 +55,7 @@ public class ShulkerBoxItem extends BlockItem {
     }
 
     @Override
-    public void translateComponentsToBedrock(@NonNull GeyserSession session, @NonNull DataComponents components, @NotNull TooltipOptions tooltip, @NonNull BedrockItemBuilder builder) {
+    public void translateComponentsToBedrock(@NonNull GeyserSession session, @NonNull DataComponents components, @NonNull TooltipOptions tooltip, @NonNull BedrockItemBuilder builder) {
         super.translateComponentsToBedrock(session, components, tooltip, builder);
 
         List<ItemStack> contents = components.get(DataComponentTypes.CONTAINER);

--- a/core/src/main/java/org/geysermc/geyser/item/type/ShulkerBoxItem.java
+++ b/core/src/main/java/org/geysermc/geyser/item/type/ShulkerBoxItem.java
@@ -44,7 +44,6 @@ import org.geysermc.mcprotocollib.protocol.data.game.item.ItemStack;
 import org.geysermc.mcprotocollib.protocol.data.game.item.component.DataComponentTypes;
 import org.geysermc.mcprotocollib.protocol.data.game.item.component.DataComponents;
 import org.geysermc.mcprotocollib.protocol.data.game.item.component.PotionContents;
-import org.jetbrains.annotations.NotNull;
 
 import java.util.ArrayList;
 import java.util.List;

--- a/core/src/main/java/org/geysermc/geyser/item/type/TropicalFishBucketItem.java
+++ b/core/src/main/java/org/geysermc/geyser/item/type/TropicalFishBucketItem.java
@@ -38,7 +38,6 @@ import org.geysermc.geyser.translator.item.BedrockItemBuilder;
 import org.geysermc.geyser.translator.text.MessageTranslator;
 import org.geysermc.mcprotocollib.protocol.data.game.item.component.DataComponentTypes;
 import org.geysermc.mcprotocollib.protocol.data.game.item.component.DataComponents;
-import org.jetbrains.annotations.NotNull;
 
 import java.util.List;
 
@@ -50,7 +49,7 @@ public class TropicalFishBucketItem extends Item {
     }
 
     @Override
-    public void translateComponentsToBedrock(@NonNull GeyserSession session, @NonNull DataComponents components, @NotNull TooltipOptions tooltip, @NonNull BedrockItemBuilder builder) {
+    public void translateComponentsToBedrock(@NonNull GeyserSession session, @NonNull DataComponents components, @NonNull TooltipOptions tooltip, @NonNull BedrockItemBuilder builder) {
         super.translateComponentsToBedrock(session, components, tooltip, builder);
 
         // Prevent name from appearing as "Bucket of"

--- a/core/src/main/java/org/geysermc/geyser/item/type/TropicalFishBucketItem.java
+++ b/core/src/main/java/org/geysermc/geyser/item/type/TropicalFishBucketItem.java
@@ -60,7 +60,8 @@ public class TropicalFishBucketItem extends Item {
         // Add Java's client side lore tag
         // Do you know how frequently Java NBT used to be before 1.20.5? It was a lot. And now it's just this lowly check.
         NbtMap entityTag = components.get(DataComponentTypes.BUCKET_ENTITY_DATA);
-        if (entityTag != null && !entityTag.isEmpty()) {
+        if (entityTag != null && !entityTag.isEmpty()) { // TODO test how components are hidden
+            // TODO in 1.21.5 this is switched to a tropical fish pattern, tropical fish base colour and tropical fish pattern colour component
             //TODO test
             int bucketVariant = entityTag.getInt("BucketVariantTag");
             List<String> lore = builder.getOrCreateLore();

--- a/core/src/main/java/org/geysermc/geyser/item/type/TropicalFishBucketItem.java
+++ b/core/src/main/java/org/geysermc/geyser/item/type/TropicalFishBucketItem.java
@@ -30,7 +30,6 @@ import net.kyori.adventure.text.format.NamedTextColor;
 import net.kyori.adventure.text.format.Style;
 import net.kyori.adventure.text.format.TextDecoration;
 import org.checkerframework.checker.nullness.qual.NonNull;
-import org.cloudburstmc.nbt.NbtMap;
 import org.geysermc.geyser.entity.type.living.animal.TropicalFishEntity;
 import org.geysermc.geyser.item.TooltipOptions;
 import org.geysermc.geyser.session.GeyserSession;
@@ -57,32 +56,48 @@ public class TropicalFishBucketItem extends Item {
         // Prevent name from appearing as "Bucket of"
         builder.putByte("AppendCustomName", (byte) 1);
         builder.putString("CustomName", MinecraftLocale.getLocaleString("entity.minecraft.tropical_fish", session.locale()));
+
         // Add Java's client side lore tag
-        // Do you know how frequently Java NBT used to be before 1.20.5? It was a lot. And now it's just this lowly check.
-        NbtMap entityTag = components.get(DataComponentTypes.BUCKET_ENTITY_DATA);
-        if (entityTag != null && !entityTag.isEmpty()) { // TODO test how components are hidden
-            // TODO in 1.21.5 this is switched to a tropical fish pattern, tropical fish base colour and tropical fish pattern colour component
-            //TODO test
-            int bucketVariant = entityTag.getInt("BucketVariantTag");
+        Integer pattern = components.get(DataComponentTypes.TROPICAL_FISH_PATTERN);
+        Integer baseColor = components.get(DataComponentTypes.TROPICAL_FISH_BASE_COLOR);
+        Integer patternColor = components.get(DataComponentTypes.TROPICAL_FISH_PATTERN_COLOR);
+
+        // The pattern component decides whether to show the tooltip of all 3 components, as of Java 1.21.5
+        if ((pattern != null || (baseColor != null && patternColor != null)) && tooltip.showInTooltip(DataComponentTypes.TROPICAL_FISH_PATTERN)) {
+            //TODO test this for 1.21.5
+            int packedVariant = getPackedVariant(pattern, baseColor, patternColor);
             List<String> lore = builder.getOrCreateLore();
 
-            int predefinedVariantId = TropicalFishEntity.getPredefinedId(bucketVariant);
+            int predefinedVariantId = TropicalFishEntity.getPredefinedId(packedVariant);
             if (predefinedVariantId != -1) {
-                Component tooltip = Component.translatable("entity.minecraft.tropical_fish.predefined." + predefinedVariantId, LORE_STYLE);
-                lore.add(0, MessageTranslator.convertMessage(tooltip, session.locale()));
+                Component line = Component.translatable("entity.minecraft.tropical_fish.predefined." + predefinedVariantId, LORE_STYLE);
+                lore.add(0, MessageTranslator.convertMessage(line, session.locale()));
             } else {
-                Component typeTooltip = Component.translatable("entity.minecraft.tropical_fish.type." + TropicalFishEntity.getVariantName(bucketVariant), LORE_STYLE);
+                Component typeTooltip = Component.translatable("entity.minecraft.tropical_fish.type." + TropicalFishEntity.getVariantName(packedVariant), LORE_STYLE);
                 lore.add(0, MessageTranslator.convertMessage(typeTooltip, session.locale()));
 
-                byte baseColor = TropicalFishEntity.getBaseColor(bucketVariant);
-                byte patternColor = TropicalFishEntity.getPatternColor(bucketVariant);
-                Component colorTooltip = Component.translatable("color.minecraft." + TropicalFishEntity.getColorName(baseColor), LORE_STYLE);
-                if (baseColor != patternColor) {
-                    colorTooltip = colorTooltip.append(Component.text(", ", LORE_STYLE))
-                            .append(Component.translatable("color.minecraft." + TropicalFishEntity.getColorName(patternColor), LORE_STYLE));
+                if (baseColor != null && patternColor != null) {
+                    Component colorTooltip = Component.translatable("color.minecraft." + TropicalFishEntity.getColorName(baseColor.byteValue()), LORE_STYLE);
+                    if (!baseColor.equals(patternColor)) {
+                        colorTooltip = colorTooltip.append(Component.text(", ", LORE_STYLE))
+                            .append(Component.translatable("color.minecraft." + TropicalFishEntity.getColorName(patternColor.byteValue()), LORE_STYLE));
+                    }
+                    lore.add(1, MessageTranslator.convertMessage(colorTooltip, session.locale()));
                 }
-                lore.add(1, MessageTranslator.convertMessage(colorTooltip, session.locale()));
             }
         }
+    }
+
+    private static int getPackedVariant(Integer pattern, Integer baseColor, Integer patternColor) {
+        if (pattern == null) {
+            pattern = 0;
+        }
+        if (baseColor == null) {
+            baseColor = 0;
+        }
+        if (patternColor == null) {
+            patternColor = 0;
+        }
+        return TropicalFishEntity.getPackedVariant(pattern, baseColor, patternColor);
     }
 }

--- a/core/src/main/java/org/geysermc/geyser/item/type/TropicalFishBucketItem.java
+++ b/core/src/main/java/org/geysermc/geyser/item/type/TropicalFishBucketItem.java
@@ -32,12 +32,14 @@ import net.kyori.adventure.text.format.TextDecoration;
 import org.checkerframework.checker.nullness.qual.NonNull;
 import org.cloudburstmc.nbt.NbtMap;
 import org.geysermc.geyser.entity.type.living.animal.TropicalFishEntity;
+import org.geysermc.geyser.item.TooltipOptions;
 import org.geysermc.geyser.session.GeyserSession;
 import org.geysermc.geyser.text.MinecraftLocale;
 import org.geysermc.geyser.translator.item.BedrockItemBuilder;
 import org.geysermc.geyser.translator.text.MessageTranslator;
 import org.geysermc.mcprotocollib.protocol.data.game.item.component.DataComponentTypes;
 import org.geysermc.mcprotocollib.protocol.data.game.item.component.DataComponents;
+import org.jetbrains.annotations.NotNull;
 
 import java.util.List;
 
@@ -49,8 +51,8 @@ public class TropicalFishBucketItem extends Item {
     }
 
     @Override
-    public void translateComponentsToBedrock(@NonNull GeyserSession session, @NonNull DataComponents components, @NonNull BedrockItemBuilder builder) {
-        super.translateComponentsToBedrock(session, components, builder);
+    public void translateComponentsToBedrock(@NonNull GeyserSession session, @NonNull DataComponents components, @NotNull TooltipOptions tooltip, @NonNull BedrockItemBuilder builder) {
+        super.translateComponentsToBedrock(session, components, tooltip, builder);
 
         // Prevent name from appearing as "Bucket of"
         builder.putByte("AppendCustomName", (byte) 1);

--- a/core/src/main/java/org/geysermc/geyser/item/type/WolfArmorItem.java
+++ b/core/src/main/java/org/geysermc/geyser/item/type/WolfArmorItem.java
@@ -30,7 +30,6 @@ import org.geysermc.geyser.item.TooltipOptions;
 import org.geysermc.geyser.session.GeyserSession;
 import org.geysermc.geyser.translator.item.BedrockItemBuilder;
 import org.geysermc.mcprotocollib.protocol.data.game.item.component.DataComponents;
-import org.jetbrains.annotations.NotNull;
 
 public class WolfArmorItem extends Item {
     public WolfArmorItem(String javaIdentifier, Builder builder) {
@@ -38,7 +37,7 @@ public class WolfArmorItem extends Item {
     }
 
     @Override
-    public void translateComponentsToBedrock(@NonNull GeyserSession session, @NonNull DataComponents components, @NotNull TooltipOptions tooltip, @NonNull BedrockItemBuilder builder) {
+    public void translateComponentsToBedrock(@NonNull GeyserSession session, @NonNull DataComponents components, @NonNull TooltipOptions tooltip, @NonNull BedrockItemBuilder builder) {
         super.translateComponentsToBedrock(session, components, tooltip, builder);
 
         // Note that this is handled as of 1.21 in the ItemColors class.

--- a/core/src/main/java/org/geysermc/geyser/item/type/WritableBookItem.java
+++ b/core/src/main/java/org/geysermc/geyser/item/type/WritableBookItem.java
@@ -29,6 +29,7 @@ import org.checkerframework.checker.nullness.qual.NonNull;
 import org.cloudburstmc.nbt.NbtMap;
 import org.cloudburstmc.nbt.NbtMapBuilder;
 import org.cloudburstmc.nbt.NbtType;
+import org.geysermc.geyser.item.TooltipOptions;
 import org.geysermc.geyser.session.GeyserSession;
 import org.geysermc.geyser.translator.item.BedrockItemBuilder;
 import org.geysermc.geyser.translator.text.MessageTranslator;
@@ -36,6 +37,7 @@ import org.geysermc.mcprotocollib.protocol.data.game.item.component.DataComponen
 import org.geysermc.mcprotocollib.protocol.data.game.item.component.DataComponents;
 import org.geysermc.mcprotocollib.protocol.data.game.item.component.Filterable;
 import org.geysermc.mcprotocollib.protocol.data.game.item.component.WritableBookContent;
+import org.jetbrains.annotations.NotNull;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -46,8 +48,8 @@ public class WritableBookItem extends Item {
     }
 
     @Override
-    public void translateComponentsToBedrock(@NonNull GeyserSession session, @NonNull DataComponents components, @NonNull BedrockItemBuilder builder) {
-        super.translateComponentsToBedrock(session, components, builder);
+    public void translateComponentsToBedrock(@NonNull GeyserSession session, @NonNull DataComponents components, @NotNull TooltipOptions tooltip, @NonNull BedrockItemBuilder builder) {
+        super.translateComponentsToBedrock(session, components, tooltip, builder);
 
         WritableBookContent bookContent = components.get(DataComponentTypes.WRITABLE_BOOK_CONTENT);
         if (bookContent == null) {

--- a/core/src/main/java/org/geysermc/geyser/item/type/WritableBookItem.java
+++ b/core/src/main/java/org/geysermc/geyser/item/type/WritableBookItem.java
@@ -37,7 +37,6 @@ import org.geysermc.mcprotocollib.protocol.data.game.item.component.DataComponen
 import org.geysermc.mcprotocollib.protocol.data.game.item.component.DataComponents;
 import org.geysermc.mcprotocollib.protocol.data.game.item.component.Filterable;
 import org.geysermc.mcprotocollib.protocol.data.game.item.component.WritableBookContent;
-import org.jetbrains.annotations.NotNull;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -48,7 +47,7 @@ public class WritableBookItem extends Item {
     }
 
     @Override
-    public void translateComponentsToBedrock(@NonNull GeyserSession session, @NonNull DataComponents components, @NotNull TooltipOptions tooltip, @NonNull BedrockItemBuilder builder) {
+    public void translateComponentsToBedrock(@NonNull GeyserSession session, @NonNull DataComponents components, @NonNull TooltipOptions tooltip, @NonNull BedrockItemBuilder builder) {
         super.translateComponentsToBedrock(session, components, tooltip, builder);
 
         WritableBookContent bookContent = components.get(DataComponentTypes.WRITABLE_BOOK_CONTENT);

--- a/core/src/main/java/org/geysermc/geyser/item/type/WrittenBookItem.java
+++ b/core/src/main/java/org/geysermc/geyser/item/type/WrittenBookItem.java
@@ -38,7 +38,6 @@ import org.geysermc.mcprotocollib.protocol.data.game.item.component.DataComponen
 import org.geysermc.mcprotocollib.protocol.data.game.item.component.DataComponents;
 import org.geysermc.mcprotocollib.protocol.data.game.item.component.Filterable;
 import org.geysermc.mcprotocollib.protocol.data.game.item.component.WrittenBookContent;
-import org.jetbrains.annotations.NotNull;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -53,7 +52,7 @@ public class WrittenBookItem extends Item {
     }
 
     @Override
-    public void translateComponentsToBedrock(@NonNull GeyserSession session, @NonNull DataComponents components, @NotNull TooltipOptions tooltip, @NonNull BedrockItemBuilder builder) {
+    public void translateComponentsToBedrock(@NonNull GeyserSession session, @NonNull DataComponents components, @NonNull TooltipOptions tooltip, @NonNull BedrockItemBuilder builder) {
         super.translateComponentsToBedrock(session, components, tooltip, builder);
 
         WrittenBookContent bookContent = components.get(DataComponentTypes.WRITTEN_BOOK_CONTENT);

--- a/core/src/main/java/org/geysermc/geyser/item/type/WrittenBookItem.java
+++ b/core/src/main/java/org/geysermc/geyser/item/type/WrittenBookItem.java
@@ -30,6 +30,7 @@ import org.checkerframework.checker.nullness.qual.NonNull;
 import org.cloudburstmc.nbt.NbtMap;
 import org.cloudburstmc.nbt.NbtMapBuilder;
 import org.cloudburstmc.nbt.NbtType;
+import org.geysermc.geyser.item.TooltipOptions;
 import org.geysermc.geyser.session.GeyserSession;
 import org.geysermc.geyser.translator.item.BedrockItemBuilder;
 import org.geysermc.geyser.translator.text.MessageTranslator;
@@ -37,6 +38,7 @@ import org.geysermc.mcprotocollib.protocol.data.game.item.component.DataComponen
 import org.geysermc.mcprotocollib.protocol.data.game.item.component.DataComponents;
 import org.geysermc.mcprotocollib.protocol.data.game.item.component.Filterable;
 import org.geysermc.mcprotocollib.protocol.data.game.item.component.WrittenBookContent;
+import org.jetbrains.annotations.NotNull;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -51,8 +53,8 @@ public class WrittenBookItem extends Item {
     }
 
     @Override
-    public void translateComponentsToBedrock(@NonNull GeyserSession session, @NonNull DataComponents components, @NonNull BedrockItemBuilder builder) {
-        super.translateComponentsToBedrock(session, components, builder);
+    public void translateComponentsToBedrock(@NonNull GeyserSession session, @NonNull DataComponents components, @NotNull TooltipOptions tooltip, @NonNull BedrockItemBuilder builder) {
+        super.translateComponentsToBedrock(session, components, tooltip, builder);
 
         WrittenBookContent bookContent = components.get(DataComponentTypes.WRITTEN_BOOK_CONTENT);
         if (bookContent == null) {

--- a/core/src/main/java/org/geysermc/geyser/session/cache/RegistryCache.java
+++ b/core/src/main/java/org/geysermc/geyser/session/cache/RegistryCache.java
@@ -51,6 +51,7 @@ import org.geysermc.geyser.session.cache.registry.JavaRegistries;
 import org.geysermc.geyser.session.cache.registry.JavaRegistry;
 import org.geysermc.geyser.session.cache.registry.JavaRegistryKey;
 import org.geysermc.geyser.session.cache.registry.RegistryEntryContext;
+import org.geysermc.geyser.session.cache.registry.RegistryEntryData;
 import org.geysermc.geyser.session.cache.registry.SimpleJavaRegistry;
 import org.geysermc.geyser.text.ChatDecoration;
 import org.geysermc.geyser.translator.level.BiomeTranslator;
@@ -189,7 +190,7 @@ public final class RegistryCache {
                 entryIdMap.put(entries.get(i).getId(), i);
             }
 
-            List<T> builder = new ArrayList<>(entries.size());
+            List<RegistryEntryData<T>> builder = new ArrayList<>(entries.size());
             for (int i = 0; i < entries.size(); i++) {
                 RegistryEntry entry = entries.get(i);
                 // If the data is null, that's the server telling us we need to use our default values.
@@ -203,7 +204,7 @@ public final class RegistryCache {
                 RegistryEntryContext context = new RegistryEntryContext(entry, entryIdMap, registryCache.session);
                 // This is what Geyser wants to keep as a value for this registry.
                 T cacheEntry = reader.apply(context);
-                builder.add(i, cacheEntry);
+                builder.add(i, new RegistryEntryData<>(entry.getId(), cacheEntry));
             }
             localCache.reset(builder);
         });

--- a/core/src/main/java/org/geysermc/geyser/session/cache/registry/JavaRegistryKey.java
+++ b/core/src/main/java/org/geysermc/geyser/session/cache/registry/JavaRegistryKey.java
@@ -26,9 +26,8 @@
 package org.geysermc.geyser.session.cache.registry;
 
 import net.kyori.adventure.key.Key;
+import org.checkerframework.checker.nullness.qual.Nullable;
 import org.geysermc.geyser.session.GeyserSession;
-
-import javax.annotation.Nullable;
 
 /**
  * Defines a Java registry, which can be hardcoded or data-driven. This class doesn't store registry contents itself, that is handled by {@link org.geysermc.geyser.session.cache.RegistryCache} in the case of

--- a/core/src/main/java/org/geysermc/geyser/session/cache/registry/RegistryEntryData.java
+++ b/core/src/main/java/org/geysermc/geyser/session/cache/registry/RegistryEntryData.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019-2024 GeyserMC. http://geysermc.org
+ * Copyright (c) 2025 GeyserMC. http://geysermc.org
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -26,47 +26,6 @@
 package org.geysermc.geyser.session.cache.registry;
 
 import net.kyori.adventure.key.Key;
-import org.checkerframework.checker.index.qual.NonNegative;
 
-import java.util.List;
-
-/**
- * A wrapper for a list, holding Java registry values.
- */
-public interface JavaRegistry<T> {
-
-    /**
-     * Looks up a registry entry by its ID. The object can be null, or not present.
-     */
-    T byId(@NonNegative int id);
-
-    /**
-     * Looks up a registry entry by its key. The object can be null, or not present.
-     */
-    T byKey(Key key);
-
-    /**
-     * Looks up a registry entry by its ID, and returns it wrapped in {@link RegistryEntryData} so that its registered key is also known. The object can be null, or not present.
-     */
-    RegistryEntryData<T> entryById(@NonNegative int id);
-
-    /**
-     * Reverse looks-up an object to return its network ID, or -1.
-     */
-    int byValue(T value);
-
-    /**
-     * Reverse looks-up an object to return it wrapped in {@link RegistryEntryData}, or null.
-     */
-    RegistryEntryData<T> entryByValue(T value);
-
-    /**
-     * Resets the objects by these IDs.
-     */
-    void reset(List<RegistryEntryData<T>> values);
-
-    /**
-     * All values of this registry, as a list.
-     */
-    List<T> values();
+public record RegistryEntryData<T>(Key key, T data) {
 }

--- a/core/src/main/java/org/geysermc/geyser/session/cache/registry/SimpleJavaRegistry.java
+++ b/core/src/main/java/org/geysermc/geyser/session/cache/registry/SimpleJavaRegistry.java
@@ -26,15 +26,34 @@
 package org.geysermc.geyser.session.cache.registry;
 
 import it.unimi.dsi.fastutil.objects.ObjectArrayList;
+import net.kyori.adventure.key.Key;
 import org.checkerframework.checker.index.qual.NonNegative;
 
 import java.util.List;
 
 public class SimpleJavaRegistry<T> implements JavaRegistry<T> {
-    protected final ObjectArrayList<T> values = new ObjectArrayList<>();
+    protected final ObjectArrayList<RegistryEntryData<T>> values = new ObjectArrayList<>();
 
     @Override
     public T byId(@NonNegative int id) {
+        if (id < 0 || id >= this.values.size()) {
+            return null;
+        }
+        return this.values.get(id).data();
+    }
+
+    @Override
+    public T byKey(Key key) {
+        for (RegistryEntryData<T> entry : values) {
+            if (entry.key().equals(key)) {
+                return entry.data();
+            }
+        }
+        return null;
+    }
+
+    @Override
+    public RegistryEntryData<T> entryById(@NonNegative int id) {
         if (id < 0 || id >= this.values.size()) {
             return null;
         }
@@ -43,11 +62,26 @@ public class SimpleJavaRegistry<T> implements JavaRegistry<T> {
 
     @Override
     public int byValue(T value) {
-        return this.values.indexOf(value);
+        for (int i = 0; i < this.values.size(); i++) {
+            if (values.get(i).data().equals(value)) {
+                return i;
+            }
+        }
+        return -1;
     }
 
     @Override
-    public void reset(List<T> values) {
+    public RegistryEntryData<T> entryByValue(T value) {
+        for (RegistryEntryData<T> entry : this.values) {
+            if (entry.data().equals(value)) {
+                return entry;
+            }
+        }
+        return null;
+    }
+
+    @Override
+    public void reset(List<RegistryEntryData<T>> values) {
         this.values.clear();
         this.values.addAll(values);
         this.values.trim();
@@ -55,7 +89,7 @@ public class SimpleJavaRegistry<T> implements JavaRegistry<T> {
 
     @Override
     public List<T> values() {
-        return this.values;
+        return this.values.stream().map(RegistryEntryData::data).toList();
     }
 
     @Override

--- a/core/src/main/java/org/geysermc/geyser/translator/item/ItemTranslator.java
+++ b/core/src/main/java/org/geysermc/geyser/translator/item/ItemTranslator.java
@@ -180,16 +180,13 @@ public final class ItemTranslator {
         String customName = getCustomName(session, customComponents, bedrockItem, rarity.getColor(), false, false);
         if (customName != null) {
             PotionContents potionContents = components.get(DataComponentTypes.POTION_CONTENTS);
-            // Make custom effect information visible
-            // Ignore when item have "hide_additional_tooltip" component
-            if (potionContents != null) { // && components.get(DataComponentTypes.HIDE_ADDITIONAL_TOOLTIP) == null) {
+            // Make custom effect information visible when shown in tooltip
+            if (potionContents != null && tooltip.showInTooltip(DataComponentTypes.POTION_CONTENTS)) {
                 customName += getPotionEffectInfo(potionContents, session.locale());
             }
 
             nbtBuilder.setCustomName(customName);
         }
-
-        //boolean hideTooltips = components.get(DataComponentTypes.HIDE_TOOLTIP) != null;
 
         ItemAttributeModifiers attributeModifiers = components.get(DataComponentTypes.ATTRIBUTE_MODIFIERS);
         if (attributeModifiers != null && tooltip.showInTooltip(DataComponentTypes.ATTRIBUTE_MODIFIERS )) {

--- a/core/src/main/java/org/geysermc/geyser/translator/item/ItemTranslator.java
+++ b/core/src/main/java/org/geysermc/geyser/translator/item/ItemTranslator.java
@@ -46,6 +46,7 @@ import org.geysermc.geyser.item.Items;
 import org.geysermc.geyser.item.TooltipOptions;
 import org.geysermc.geyser.item.components.Rarity;
 import org.geysermc.geyser.item.type.Item;
+import org.geysermc.geyser.item.type.PotionItem;
 import org.geysermc.geyser.level.block.type.Block;
 import org.geysermc.geyser.registry.BlockRegistries;
 import org.geysermc.geyser.registry.Registries;
@@ -182,7 +183,7 @@ public final class ItemTranslator {
             PotionContents potionContents = components.get(DataComponentTypes.POTION_CONTENTS);
             // Make custom effect information visible when shown in tooltip
             if (potionContents != null && tooltip.showInTooltip(DataComponentTypes.POTION_CONTENTS)) {
-                customName += getPotionEffectInfo(potionContents, session.locale());
+                customName += getPotionEffectInfo(potionContents, session.locale()); // TODO should this be done with lore instead?
             }
 
             nbtBuilder.setCustomName(customName);
@@ -387,7 +388,7 @@ public final class ItemTranslator {
         return finalText.toString();
     }
 
-    public static String getPotionName(PotionContents contents, ItemMapping mapping, boolean hideAdditionalTooltip, String language) {
+    public static String getPotionName(PotionContents contents, ItemMapping mapping, String language) {
         String customPotionName = contents.getCustomName();
         Potion potion = Potion.getByJavaId(contents.getPotionId());
 
@@ -397,22 +398,10 @@ public final class ItemTranslator {
                 Component.translatable(mapping.getJavaItem().translationKey() + ".effect." + customPotionName),
                 language);
         }
-        if (!hideAdditionalTooltip && !contents.getCustomEffects().isEmpty()) {
+        if (!contents.getCustomEffects().isEmpty()) {
             // Make a name when has custom effects
-            String potionName;
-            if (potion != null) {
-                potionName = potion.toString().toLowerCase(Locale.ROOT);
-                if (potionName.startsWith("strong_")) {
-                    potionName = potionName.substring(6);
-                } else if (potionName.startsWith("long_")) {
-                    potionName = potionName.substring(4);
-                }
-            } else {
-                potionName = "empty";
-            }
-            return MessageTranslator.convertMessage(
-                Component.translatable(mapping.getJavaItem().translationKey() + ".effect." + potionName),
-                language);
+            String potionName = potion == null ? "empty" : potion.toString().toLowerCase(Locale.ROOT);
+            return MessageTranslator.convertMessage(Component.translatable(mapping.getJavaItem().translationKey() + ".effect." + potionName), language);
         }
         return null;
     }
@@ -534,22 +523,31 @@ public final class ItemTranslator {
      * @param translationColor if this item is not available on Java, the color that the new name should be.
      *                         Normally, this should just be white, but for shulker boxes this should be gray.
      */
-    public static String getCustomName(GeyserSession session, DataComponents components, ItemMapping mapping, char translationColor, boolean customNameOnly, boolean includeAll) {
+    public static String getCustomName(GeyserSession session, DataComponents components, ItemMapping mapping,
+                                       char translationColor, boolean customNameOnly, boolean includeAll) {
         if (components != null) {
+            // If the tooltip is hidden entirely, return an empty custom name
+            if (TooltipOptions.hideTooltip(components)) {
+                return ""; // TODO test this
+            }
+
             // ItemStack#getHoverName as of 1.20.5
             Component customName = components.get(DataComponentTypes.CUSTOM_NAME);
             if (customName != null) {
                 return MessageTranslator.convertMessage(customName, session.locale());
             }
+
             if (!customNameOnly) {
-                PotionContents potionContents = components.get(DataComponentTypes.POTION_CONTENTS);
-                if (potionContents != null) {
-                    // TODO 1.21.5
-                    String potionName = getPotionName(potionContents, mapping, false /*components.get(DataComponentTypes.HIDE_ADDITIONAL_TOOLTIP) != null */, session.locale());
-                    if (potionName != null) {
-                        return ChatColor.RESET + ChatColor.ESCAPE + translationColor + potionName;
+                if (mapping.getJavaItem() instanceof PotionItem) {
+                    PotionContents potionContents = components.get(DataComponentTypes.POTION_CONTENTS);
+                    if (potionContents != null) {
+                        String potionName = getPotionName(potionContents, mapping, session.locale()); // TODO also test this
+                        if (potionName != null) {
+                            return ChatColor.RESET + ChatColor.ESCAPE + translationColor + potionName;
+                        }
                     }
                 }
+
                 if (includeAll) {
                     // Fix book title display in tooltips of shulker box
                     WrittenBookContent bookContent = components.get(DataComponentTypes.WRITTEN_BOOK_CONTENT);
@@ -557,6 +555,7 @@ public final class ItemTranslator {
                         return ChatColor.RESET + ChatColor.ESCAPE + translationColor + bookContent.getTitle().getRaw();
                     }
                 }
+
                 customName = components.get(DataComponentTypes.ITEM_NAME);
                 if (customName != null) {
                     // Get the translated name and prefix it with a reset char to prevent italics - matches Java Edition

--- a/core/src/main/java/org/geysermc/geyser/translator/item/ItemTranslator.java
+++ b/core/src/main/java/org/geysermc/geyser/translator/item/ItemTranslator.java
@@ -194,7 +194,7 @@ public final class ItemTranslator {
             addAttributeLore(session, attributeModifiers, nbtBuilder, session.locale());
         }
 
-        if (session.isAdvancedTooltips()) { // TODO check how this is hidden
+        if (session.isAdvancedTooltips() && !TooltipOptions.hideTooltip(components)) {
             addAdvancedTooltips(components, nbtBuilder, javaItem, session.locale());
         }
 

--- a/core/src/main/java/org/geysermc/geyser/translator/item/ItemTranslator.java
+++ b/core/src/main/java/org/geysermc/geyser/translator/item/ItemTranslator.java
@@ -43,6 +43,7 @@ import org.geysermc.geyser.entity.attribute.GeyserAttributeType;
 import org.geysermc.geyser.inventory.GeyserItemStack;
 import org.geysermc.geyser.inventory.item.Potion;
 import org.geysermc.geyser.item.Items;
+import org.geysermc.geyser.item.TooltipOptions;
 import org.geysermc.geyser.item.components.Rarity;
 import org.geysermc.geyser.item.type.Item;
 import org.geysermc.geyser.level.block.type.Block;
@@ -168,14 +169,12 @@ public final class ItemTranslator {
     public static ItemData.@NonNull Builder translateToBedrock(GeyserSession session, Item javaItem, ItemMapping bedrockItem, int count, @Nullable DataComponents customComponents) {
         BedrockItemBuilder nbtBuilder = new BedrockItemBuilder();
 
-        // TODO 1.21.5:
-        // - Hiding components
-
         // Populates default components that aren't sent over the network
         DataComponents components = javaItem.gatherComponents(customComponents);
+        TooltipOptions tooltip = TooltipOptions.fromComponents(components);
 
         // Translate item-specific components
-        javaItem.translateComponentsToBedrock(session, components, nbtBuilder);
+        javaItem.translateComponentsToBedrock(session, components, tooltip, nbtBuilder);
 
         Rarity rarity = Rarity.fromId(components.getOrDefault(DataComponentTypes.RARITY, 0));
         String customName = getCustomName(session, customComponents, bedrockItem, rarity.getColor(), false, false);
@@ -193,12 +192,12 @@ public final class ItemTranslator {
         //boolean hideTooltips = components.get(DataComponentTypes.HIDE_TOOLTIP) != null;
 
         ItemAttributeModifiers attributeModifiers = components.get(DataComponentTypes.ATTRIBUTE_MODIFIERS);
-        if (attributeModifiers != null) { //&& attributeModifiers.isShowInTooltip() && !hideTooltips) {
+        if (attributeModifiers != null && tooltip.showInTooltip(DataComponentTypes.ATTRIBUTE_MODIFIERS )) {
             // only add if attribute modifiers do not indicate to hide them
             addAttributeLore(session, attributeModifiers, nbtBuilder, session.locale());
         }
 
-        if (session.isAdvancedTooltips()) { //&& !hideTooltips) {
+        if (session.isAdvancedTooltips()) { // TODO check how this is hidden
             addAdvancedTooltips(components, nbtBuilder, javaItem, session.locale());
         }
 


### PR DESCRIPTION
Couple of 1.21.5 things:

- Adds back proper support for hiding tooltips from components, using a new `TooltipOptions` functional interface that uses the `minecraft:tooltip_display` component.
  - Also fixes tropical fish variant tooltips.
- Fixes custom saddle items (in 1.21.5, any item can be a saddle by adding a `minecraft:equippable` component for the `saddle` equipment slot).
- Fixes goat horns (needed to port `RegistryEntryData<T>` from #5189 to get objects from data driven registries by their resource locations).

Preferably the following things would be tested once 1.21.5 is running:
- Hiding of some components in tooltips.
- Tropical fish tooltips.
- Potion names/lore.
- Goat horns.