### PR TITLE
Attempt to resolve 1.21.70 inventory issues

### DIFF
--- a/bootstrap/mod/src/main/java/org/geysermc/geyser/platform/mod/GeyserModLogger.java
+++ b/bootstrap/mod/src/main/java/org/geysermc/geyser/platform/mod/GeyserModLogger.java
@@ -87,7 +87,7 @@ public class GeyserModLogger implements GeyserLogger {
     @Override
     public void debug(String message, Object... arguments) {
         if (debug) {
-            logger.info(message, arguments);
+            logger.info(String.format(message, arguments));
         }
     }
 

--- a/bootstrap/standalone/src/main/java/org/geysermc/geyser/platform/standalone/GeyserStandaloneLogger.java
+++ b/bootstrap/standalone/src/main/java/org/geysermc/geyser/platform/standalone/GeyserStandaloneLogger.java
@@ -117,7 +117,8 @@ public class GeyserStandaloneLogger extends SimpleTerminalConsole implements Gey
 
     @Override
     public void debug(String message, Object... arguments) {
-        log.debug(ChatColor.GRAY + message, arguments);
+        // We can't use the debug call that would format for us as we're using Java's string formatting
+        log.debug(ChatColor.GRAY + String.format(message, arguments));
     }
 
     @Override

--- a/bootstrap/velocity/src/main/java/org/geysermc/geyser/platform/velocity/GeyserVelocityLogger.java
+++ b/bootstrap/velocity/src/main/java/org/geysermc/geyser/platform/velocity/GeyserVelocityLogger.java
@@ -77,7 +77,7 @@ public class GeyserVelocityLogger implements GeyserLogger {
     @Override
     public void debug(String message, Object... arguments) {
         if (debug) {
-            logger.info(message, arguments);
+            logger.info(String.format(message, arguments));
         }
     }
 }

--- a/core/src/main/java/org/geysermc/geyser/GeyserLogger.java
+++ b/core/src/main/java/org/geysermc/geyser/GeyserLogger.java
@@ -125,7 +125,7 @@ public interface GeyserLogger extends GeyserCommandSource {
      */
     default void debug(GeyserSession session, String message, Object... arguments) {
         if (isDebug()) {
-            debug("( " + session.bedrockUsername() + " ) " + message, arguments);
+            debug("(" + session.bedrockUsername() + ") " + message, arguments);
         }
     }
 

--- a/core/src/main/java/org/geysermc/geyser/GeyserLogger.java
+++ b/core/src/main/java/org/geysermc/geyser/GeyserLogger.java
@@ -29,6 +29,7 @@ import net.kyori.adventure.text.Component;
 import org.checkerframework.checker.nullness.qual.NonNull;
 import org.checkerframework.checker.nullness.qual.Nullable;
 import org.geysermc.geyser.command.GeyserCommandSource;
+import org.geysermc.geyser.session.GeyserSession;
 
 import java.util.UUID;
 
@@ -118,6 +119,10 @@ public interface GeyserLogger extends GeyserCommandSource {
      * @param debug if the logger should print debug messages
      */
     void setDebug(boolean debug);
+
+    default void sessionDebugLog(GeyserSession session, String message) {
+        debug("(" + session.bedrockUsername() + "): " + message);
+    }
 
     /**
      * If debug is enabled for this logger

--- a/core/src/main/java/org/geysermc/geyser/GeyserLogger.java
+++ b/core/src/main/java/org/geysermc/geyser/GeyserLogger.java
@@ -120,8 +120,13 @@ public interface GeyserLogger extends GeyserCommandSource {
      */
     void setDebug(boolean debug);
 
-    default void sessionDebugLog(GeyserSession session, String message) {
-        debug("(" + session.bedrockUsername() + "): " + message);
+    /**
+     * A method to debug information specific to a session.
+     */
+    default void debug(GeyserSession session, String message, Object... arguments) {
+        if (isDebug()) {
+            debug("( %s ) " + message, session.bedrockUsername(), arguments);
+        }
     }
 
     /**

--- a/core/src/main/java/org/geysermc/geyser/GeyserLogger.java
+++ b/core/src/main/java/org/geysermc/geyser/GeyserLogger.java
@@ -125,7 +125,7 @@ public interface GeyserLogger extends GeyserCommandSource {
      */
     default void debug(GeyserSession session, String message, Object... arguments) {
         if (isDebug()) {
-            debug("( %s ) " + message, session.bedrockUsername(), arguments);
+            debug("( " + session.bedrockUsername() + " ) " + message, arguments);
         }
     }
 

--- a/core/src/main/java/org/geysermc/geyser/command/defaults/AdvancedTooltipsCommand.java
+++ b/core/src/main/java/org/geysermc/geyser/command/defaults/AdvancedTooltipsCommand.java
@@ -51,6 +51,6 @@ public class AdvancedTooltipsCommand extends GeyserCommand {
             + MinecraftLocale.getLocaleString("debug.prefix", session.locale())
             + " " + ChatColor.RESET
             + MinecraftLocale.getLocaleString("debug.advanced_tooltips." + onOrOff, session.locale()));
-        session.getPlayerInventory().updateInventory(session);
+        session.getPlayerInventory().updateInventory();
     }
 }

--- a/core/src/main/java/org/geysermc/geyser/command/defaults/AdvancedTooltipsCommand.java
+++ b/core/src/main/java/org/geysermc/geyser/command/defaults/AdvancedTooltipsCommand.java
@@ -31,6 +31,7 @@ import org.geysermc.geyser.command.GeyserCommandSource;
 import org.geysermc.geyser.session.GeyserSession;
 import org.geysermc.geyser.text.ChatColor;
 import org.geysermc.geyser.text.MinecraftLocale;
+import org.geysermc.geyser.util.InventoryUtils;
 import org.incendo.cloud.context.CommandContext;
 
 import java.util.Objects;
@@ -51,6 +52,6 @@ public class AdvancedTooltipsCommand extends GeyserCommand {
             + MinecraftLocale.getLocaleString("debug.prefix", session.locale())
             + " " + ChatColor.RESET
             + MinecraftLocale.getLocaleString("debug.advanced_tooltips." + onOrOff, session.locale()));
-        session.getInventoryTranslator().updateInventory(session, session.getPlayerInventory());
+        InventoryUtils.getInventoryTranslator(session).updateInventory(session, session.getPlayerInventory());
     }
 }

--- a/core/src/main/java/org/geysermc/geyser/command/defaults/AdvancedTooltipsCommand.java
+++ b/core/src/main/java/org/geysermc/geyser/command/defaults/AdvancedTooltipsCommand.java
@@ -31,7 +31,6 @@ import org.geysermc.geyser.command.GeyserCommandSource;
 import org.geysermc.geyser.session.GeyserSession;
 import org.geysermc.geyser.text.ChatColor;
 import org.geysermc.geyser.text.MinecraftLocale;
-import org.geysermc.geyser.util.InventoryUtils;
 import org.incendo.cloud.context.CommandContext;
 
 import java.util.Objects;
@@ -52,6 +51,6 @@ public class AdvancedTooltipsCommand extends GeyserCommand {
             + MinecraftLocale.getLocaleString("debug.prefix", session.locale())
             + " " + ChatColor.RESET
             + MinecraftLocale.getLocaleString("debug.advanced_tooltips." + onOrOff, session.locale()));
-        InventoryUtils.getInventoryTranslator(session).updateInventory(session, session.getPlayerInventory());
+        session.getPlayerInventory().updateInventory(session);
     }
 }

--- a/core/src/main/java/org/geysermc/geyser/inventory/AnvilContainer.java
+++ b/core/src/main/java/org/geysermc/geyser/inventory/AnvilContainer.java
@@ -30,6 +30,7 @@ import lombok.Setter;
 import net.kyori.adventure.text.Component;
 import org.checkerframework.checker.nullness.qual.Nullable;
 import org.geysermc.geyser.session.GeyserSession;
+import org.geysermc.geyser.translator.inventory.InventoryTranslator;
 import org.geysermc.geyser.translator.text.MessageTranslator;
 import org.geysermc.mcprotocollib.protocol.data.game.inventory.ContainerType;
 import org.geysermc.mcprotocollib.protocol.data.game.item.component.DataComponentTypes;
@@ -62,8 +63,8 @@ public class AnvilContainer extends Container {
 
     private int lastTargetSlot = -1;
 
-    public AnvilContainer(String title, int id, int size, ContainerType containerType, PlayerInventory playerInventory) {
-        super(title, id, size, containerType, playerInventory);
+    public AnvilContainer(String title, int id, int size, ContainerType containerType, PlayerInventory playerInventory, InventoryTranslator translator) {
+        super(title, id, size, containerType, playerInventory, translator);
     }
 
     /**

--- a/core/src/main/java/org/geysermc/geyser/inventory/AnvilContainer.java
+++ b/core/src/main/java/org/geysermc/geyser/inventory/AnvilContainer.java
@@ -63,8 +63,8 @@ public class AnvilContainer extends Container {
 
     private int lastTargetSlot = -1;
 
-    public AnvilContainer(String title, int id, int size, ContainerType containerType, PlayerInventory playerInventory, InventoryTranslator translator) {
-        super(title, id, size, containerType, playerInventory, translator);
+    public AnvilContainer(GeyserSession session, String title, int id, int size, ContainerType containerType, PlayerInventory playerInventory, InventoryTranslator translator) {
+        super(session, title, id, size, containerType, playerInventory, translator);
     }
 
     /**

--- a/core/src/main/java/org/geysermc/geyser/inventory/BeaconContainer.java
+++ b/core/src/main/java/org/geysermc/geyser/inventory/BeaconContainer.java
@@ -25,6 +25,7 @@
 
 package org.geysermc.geyser.inventory;
 
+import org.geysermc.geyser.translator.inventory.InventoryTranslator;
 import org.geysermc.mcprotocollib.protocol.data.game.inventory.ContainerType;
 import lombok.Getter;
 import lombok.Setter;
@@ -35,7 +36,7 @@ public class BeaconContainer extends Container {
     private int primaryId;
     private int secondaryId;
 
-    public BeaconContainer(String title, int id, int size, ContainerType containerType, PlayerInventory playerInventory) {
-        super(title, id, size, containerType, playerInventory);
+    public BeaconContainer(String title, int id, int size, ContainerType containerType, PlayerInventory playerInventory, InventoryTranslator translator) {
+        super(title, id, size, containerType, playerInventory, translator);
     }
 }

--- a/core/src/main/java/org/geysermc/geyser/inventory/BeaconContainer.java
+++ b/core/src/main/java/org/geysermc/geyser/inventory/BeaconContainer.java
@@ -25,6 +25,7 @@
 
 package org.geysermc.geyser.inventory;
 
+import org.geysermc.geyser.session.GeyserSession;
 import org.geysermc.geyser.translator.inventory.InventoryTranslator;
 import org.geysermc.mcprotocollib.protocol.data.game.inventory.ContainerType;
 import lombok.Getter;
@@ -36,7 +37,7 @@ public class BeaconContainer extends Container {
     private int primaryId;
     private int secondaryId;
 
-    public BeaconContainer(String title, int id, int size, ContainerType containerType, PlayerInventory playerInventory, InventoryTranslator translator) {
-        super(title, id, size, containerType, playerInventory, translator);
+    public BeaconContainer(GeyserSession session, String title, int id, int size, ContainerType containerType, PlayerInventory playerInventory, InventoryTranslator translator) {
+        super(session, title, id, size, containerType, playerInventory, translator);
     }
 }

--- a/core/src/main/java/org/geysermc/geyser/inventory/CartographyContainer.java
+++ b/core/src/main/java/org/geysermc/geyser/inventory/CartographyContainer.java
@@ -25,10 +25,11 @@
 
 package org.geysermc.geyser.inventory;
 
+import org.geysermc.geyser.translator.inventory.InventoryTranslator;
 import org.geysermc.mcprotocollib.protocol.data.game.inventory.ContainerType;
 
 public class CartographyContainer extends Container {
-    public CartographyContainer(String title, int id, int size, ContainerType containerType, PlayerInventory playerInventory) {
-        super(title, id, size, containerType, playerInventory);
+    public CartographyContainer(String title, int id, int size, ContainerType containerType, PlayerInventory playerInventory, InventoryTranslator translator) {
+        super(title, id, size, containerType, playerInventory, translator);
     }
 }

--- a/core/src/main/java/org/geysermc/geyser/inventory/CartographyContainer.java
+++ b/core/src/main/java/org/geysermc/geyser/inventory/CartographyContainer.java
@@ -25,11 +25,12 @@
 
 package org.geysermc.geyser.inventory;
 
+import org.geysermc.geyser.session.GeyserSession;
 import org.geysermc.geyser.translator.inventory.InventoryTranslator;
 import org.geysermc.mcprotocollib.protocol.data.game.inventory.ContainerType;
 
 public class CartographyContainer extends Container {
-    public CartographyContainer(String title, int id, int size, ContainerType containerType, PlayerInventory playerInventory, InventoryTranslator translator) {
-        super(title, id, size, containerType, playerInventory, translator);
+    public CartographyContainer(GeyserSession session, String title, int id, int size, ContainerType containerType, PlayerInventory playerInventory, InventoryTranslator translator) {
+        super(session, title, id, size, containerType, playerInventory, translator);
     }
 }

--- a/core/src/main/java/org/geysermc/geyser/inventory/Container.java
+++ b/core/src/main/java/org/geysermc/geyser/inventory/Container.java
@@ -26,7 +26,6 @@
 package org.geysermc.geyser.inventory;
 
 import lombok.Getter;
-import lombok.Setter;
 import org.checkerframework.checker.nullness.qual.NonNull;
 import org.geysermc.geyser.level.block.type.Block;
 import org.geysermc.geyser.session.GeyserSession;
@@ -47,15 +46,8 @@ public class Container extends Inventory {
      */
     private boolean isUsingRealBlock = false;
 
-    /**
-     * Used to minimize delay when switching between "same" containers.
-     * Currently unused; see {@link org.geysermc.geyser.translator.protocol.java.inventory.JavaOpenScreenTranslator} for info.
-     */
-    @Setter
-    private boolean isReusingBlock = false;
-
-    public Container(String title, int id, int size, ContainerType containerType, PlayerInventory playerInventory, InventoryTranslator translator) {
-        super(title, id, size, containerType, translator);
+    public Container(GeyserSession session, String title, int id, int size, ContainerType containerType, PlayerInventory playerInventory, InventoryTranslator translator) {
+        super(session, title, id, size, containerType, translator);
         this.playerInventory = playerInventory;
         this.containerSize = this.size + InventoryTranslator.PLAYER_INVENTORY_SIZE;
     }

--- a/core/src/main/java/org/geysermc/geyser/inventory/Container.java
+++ b/core/src/main/java/org/geysermc/geyser/inventory/Container.java
@@ -49,6 +49,7 @@ public class Container extends Inventory {
 
     /**
      * Used to minimize delay when switching between "same" containers.
+     * Currently unused; see {@link org.geysermc.geyser.translator.protocol.java.inventory.JavaOpenScreenTranslator} for info.
      */
     @Setter
     private boolean isReusingBlock = false;

--- a/core/src/main/java/org/geysermc/geyser/inventory/Container.java
+++ b/core/src/main/java/org/geysermc/geyser/inventory/Container.java
@@ -26,6 +26,7 @@
 package org.geysermc.geyser.inventory;
 
 import lombok.Getter;
+import lombok.Setter;
 import org.checkerframework.checker.nullness.qual.NonNull;
 import org.geysermc.geyser.level.block.type.Block;
 import org.geysermc.geyser.session.GeyserSession;
@@ -46,8 +47,14 @@ public class Container extends Inventory {
      */
     private boolean isUsingRealBlock = false;
 
-    public Container(String title, int id, int size, ContainerType containerType, PlayerInventory playerInventory) {
-        super(title, id, size, containerType);
+    /**
+     * Used to minimize delay when switching between "same" containers.
+     */
+    @Setter
+    private boolean isReusingBlock = false;
+
+    public Container(String title, int id, int size, ContainerType containerType, PlayerInventory playerInventory, InventoryTranslator translator) {
+        super(title, id, size, containerType, translator);
         this.playerInventory = playerInventory;
         this.containerSize = this.size + InventoryTranslator.PLAYER_INVENTORY_SIZE;
     }

--- a/core/src/main/java/org/geysermc/geyser/inventory/CrafterContainer.java
+++ b/core/src/main/java/org/geysermc/geyser/inventory/CrafterContainer.java
@@ -48,8 +48,8 @@ public class CrafterContainer extends Container {
      */
     private short disabledSlotsMask = 0;
 
-    public CrafterContainer(String title, int id, int size, ContainerType containerType, PlayerInventory playerInventory) {
-        super(title, id, size, containerType, playerInventory);
+    public CrafterContainer(String title, int id, int size, ContainerType containerType, PlayerInventory playerInventory, InventoryTranslator translator) {
+        super(title, id, size, containerType, playerInventory, translator);
     }
 
     @Override

--- a/core/src/main/java/org/geysermc/geyser/inventory/CrafterContainer.java
+++ b/core/src/main/java/org/geysermc/geyser/inventory/CrafterContainer.java
@@ -48,8 +48,8 @@ public class CrafterContainer extends Container {
      */
     private short disabledSlotsMask = 0;
 
-    public CrafterContainer(String title, int id, int size, ContainerType containerType, PlayerInventory playerInventory, InventoryTranslator translator) {
-        super(title, id, size, containerType, playerInventory, translator);
+    public CrafterContainer(GeyserSession session, String title, int id, int size, ContainerType containerType, PlayerInventory playerInventory, InventoryTranslator translator) {
+        super(session, title, id, size, containerType, playerInventory, translator);
     }
 
     @Override

--- a/core/src/main/java/org/geysermc/geyser/inventory/EnchantingContainer.java
+++ b/core/src/main/java/org/geysermc/geyser/inventory/EnchantingContainer.java
@@ -25,25 +25,25 @@
 
 package org.geysermc.geyser.inventory;
 
+import org.geysermc.geyser.session.GeyserSession;
 import org.geysermc.geyser.translator.inventory.InventoryTranslator;
 import org.geysermc.mcprotocollib.protocol.data.game.inventory.ContainerType;
 import org.cloudburstmc.protocol.bedrock.data.inventory.EnchantOptionData;
 import lombok.Getter;
 
+@Getter
 public class EnchantingContainer extends Container {
     /**
      * A cache of what Bedrock sees
      */
-    @Getter
     private final EnchantOptionData[] enchantOptions;
     /**
      * A mutable cache of what the server sends us
      */
-    @Getter
     private final GeyserEnchantOption[] geyserEnchantOptions;
 
-    public EnchantingContainer(String title, int id, int size, ContainerType containerType, PlayerInventory playerInventory, InventoryTranslator translator) {
-        super(title, id, size, containerType, playerInventory, translator);
+    public EnchantingContainer(GeyserSession session, String title, int id, int size, ContainerType containerType, PlayerInventory playerInventory, InventoryTranslator translator) {
+        super(session, title, id, size, containerType, playerInventory, translator);
 
         enchantOptions = new EnchantOptionData[3];
         geyserEnchantOptions = new GeyserEnchantOption[3];

--- a/core/src/main/java/org/geysermc/geyser/inventory/EnchantingContainer.java
+++ b/core/src/main/java/org/geysermc/geyser/inventory/EnchantingContainer.java
@@ -25,6 +25,7 @@
 
 package org.geysermc.geyser.inventory;
 
+import org.geysermc.geyser.translator.inventory.InventoryTranslator;
 import org.geysermc.mcprotocollib.protocol.data.game.inventory.ContainerType;
 import org.cloudburstmc.protocol.bedrock.data.inventory.EnchantOptionData;
 import lombok.Getter;
@@ -41,8 +42,8 @@ public class EnchantingContainer extends Container {
     @Getter
     private final GeyserEnchantOption[] geyserEnchantOptions;
 
-    public EnchantingContainer(String title, int id, int size, ContainerType containerType, PlayerInventory playerInventory) {
-        super(title, id, size, containerType, playerInventory);
+    public EnchantingContainer(String title, int id, int size, ContainerType containerType, PlayerInventory playerInventory, InventoryTranslator translator) {
+        super(title, id, size, containerType, playerInventory, translator);
 
         enchantOptions = new EnchantOptionData[3];
         geyserEnchantOptions = new GeyserEnchantOption[3];

--- a/core/src/main/java/org/geysermc/geyser/inventory/Generic3X3Container.java
+++ b/core/src/main/java/org/geysermc/geyser/inventory/Generic3X3Container.java
@@ -33,17 +33,17 @@ import org.geysermc.geyser.translator.inventory.Generic3X3InventoryTranslator;
 import org.geysermc.geyser.translator.inventory.InventoryTranslator;
 import org.geysermc.mcprotocollib.protocol.data.game.inventory.ContainerType;
 
+@Getter
 public class Generic3X3Container extends Container {
     /**
      * Whether we need to set the container type as {@link org.cloudburstmc.protocol.bedrock.data.inventory.ContainerType#DROPPER}.
      * <p>
      * Used at {@link Generic3X3InventoryTranslator#openInventory(GeyserSession, Inventory)}
      */
-    @Getter
     private boolean isDropper = false;
 
-    public Generic3X3Container(String title, int id, int size, ContainerType containerType, PlayerInventory playerInventory, InventoryTranslator translator) {
-        super(title, id, size, containerType, playerInventory, translator);
+    public Generic3X3Container(GeyserSession session, String title, int id, int size, ContainerType containerType, PlayerInventory playerInventory, InventoryTranslator translator) {
+        super(session, title, id, size, containerType, playerInventory, translator);
     }
 
     @Override

--- a/core/src/main/java/org/geysermc/geyser/inventory/Generic3X3Container.java
+++ b/core/src/main/java/org/geysermc/geyser/inventory/Generic3X3Container.java
@@ -30,6 +30,7 @@ import org.geysermc.geyser.level.block.Blocks;
 import org.geysermc.geyser.level.block.type.Block;
 import org.geysermc.geyser.session.GeyserSession;
 import org.geysermc.geyser.translator.inventory.Generic3X3InventoryTranslator;
+import org.geysermc.geyser.translator.inventory.InventoryTranslator;
 import org.geysermc.mcprotocollib.protocol.data.game.inventory.ContainerType;
 
 public class Generic3X3Container extends Container {
@@ -41,8 +42,8 @@ public class Generic3X3Container extends Container {
     @Getter
     private boolean isDropper = false;
 
-    public Generic3X3Container(String title, int id, int size, ContainerType containerType, PlayerInventory playerInventory) {
-        super(title, id, size, containerType, playerInventory);
+    public Generic3X3Container(String title, int id, int size, ContainerType containerType, PlayerInventory playerInventory, InventoryTranslator translator) {
+        super(title, id, size, containerType, playerInventory, translator);
     }
 
     @Override

--- a/core/src/main/java/org/geysermc/geyser/inventory/Inventory.java
+++ b/core/src/main/java/org/geysermc/geyser/inventory/Inventory.java
@@ -32,6 +32,7 @@ import org.checkerframework.checker.nullness.qual.NonNull;
 import org.cloudburstmc.math.vector.Vector3i;
 import org.cloudburstmc.protocol.bedrock.data.definitions.ItemDefinition;
 import org.geysermc.geyser.GeyserImpl;
+import org.geysermc.geyser.inventory.click.ClickPlan;
 import org.geysermc.geyser.item.Items;
 import org.geysermc.geyser.session.GeyserSession;
 import org.geysermc.geyser.translator.inventory.InventoryTranslator;
@@ -60,7 +61,7 @@ public abstract class Inventory {
     @Setter
     private int stateId;
     /**
-     * See {@link org.geysermc.geyser.inventory.click.ClickPlan#execute(boolean)}; used as a hack
+     * See {@link ClickPlan#execute(boolean)}; used as a hack
      */
     @Getter
     private int nextStateId = -1;
@@ -119,7 +120,7 @@ public abstract class Inventory {
     private boolean delayed = false;
 
     /**
-     * The translator for this inventory. Stored here to avoid de-syncs of the inventory & translator used.
+     * The translator for this inventory. Stored here to avoid de-syncs of the inventory and current translator.
      */
     @Getter
     private final InventoryTranslator translator;

--- a/core/src/main/java/org/geysermc/geyser/inventory/Inventory.java
+++ b/core/src/main/java/org/geysermc/geyser/inventory/Inventory.java
@@ -104,7 +104,7 @@ public abstract class Inventory {
 
     @Getter
     @Setter
-    private boolean isCurrentlyDelayed = false;
+    private boolean delayed = false;
 
     @Getter
     private final InventoryTranslator translator;

--- a/core/src/main/java/org/geysermc/geyser/inventory/Inventory.java
+++ b/core/src/main/java/org/geysermc/geyser/inventory/Inventory.java
@@ -112,14 +112,6 @@ public abstract class Inventory {
     private boolean displayed = false;
 
     /**
-     * Whether this inventory is currently being opened with a delay.
-     * Only applicable for virtual inventories.
-     */
-    @Getter
-    @Setter
-    private boolean delayed = false;
-
-    /**
      * The translator for this inventory. Stored here to avoid de-syncs of the inventory and current translator.
      */
     @Getter

--- a/core/src/main/java/org/geysermc/geyser/inventory/Inventory.java
+++ b/core/src/main/java/org/geysermc/geyser/inventory/Inventory.java
@@ -80,7 +80,7 @@ public abstract class Inventory {
     protected final GeyserItemStack[] items;
 
     /**
-     * The location of the inventory block. Will either be a fake block above the player's head, or the actual block location
+     * The location of the inventory block. Will either be a fake block above the player's head, or the actual block location.
      */
     @Getter
     @Setter
@@ -94,18 +94,33 @@ public abstract class Inventory {
     @Setter
     protected long holderId = -1;
 
+    /**
+     * Whether this inventory is currently pending.
+     * It can be pending if this inventory was opened while another inventory was still open,
+     * or because opening this inventory takes more time (e.g. virtual inventories).
+     */
     @Getter
     @Setter
     private boolean pending = false;
 
+    /**
+     * Whether this inventory is currently shown to the Bedrock player.
+     */
     @Getter
     @Setter
     private boolean displayed = false;
 
+    /**
+     * Whether this inventory is currently being opened with a delay.
+     * Only applicable for virtual inventories.
+     */
     @Getter
     @Setter
     private boolean delayed = false;
 
+    /**
+     * The translator for this inventory. Stored here to avoid de-syncs of the inventory & translator used.
+     */
     @Getter
     private final InventoryTranslator translator;
 
@@ -133,8 +148,10 @@ public abstract class Inventory {
         this.bedrockId = javaId <= 100 ? javaId : (javaId % 100) + 1;
 
         // We occasionally need to re-open inventories with a delay in cases where
-        // Java wouldn't - e.g. for virtual chest menus that switch pages
-        if (session.getOpenInventory() != null && session.getOpenInventory().getBedrockId() == bedrockId) {
+        // Java wouldn't - e.g. for virtual chest menus that switch pages.
+        // And, well, we want to avoid reusing Bedrock inventory id's that are currently being used in a closing inventory;
+        // so to be safe we just deviate in that case as well.
+        if ((session.getOpenInventory() != null && session.getOpenInventory().getBedrockId() == bedrockId) || session.isClosingInventory()) {
             this.bedrockId += 1;
         }
     }

--- a/core/src/main/java/org/geysermc/geyser/inventory/Inventory.java
+++ b/core/src/main/java/org/geysermc/geyser/inventory/Inventory.java
@@ -34,6 +34,7 @@ import org.cloudburstmc.protocol.bedrock.data.definitions.ItemDefinition;
 import org.geysermc.geyser.GeyserImpl;
 import org.geysermc.geyser.item.Items;
 import org.geysermc.geyser.session.GeyserSession;
+import org.geysermc.geyser.translator.inventory.InventoryTranslator;
 import org.geysermc.geyser.translator.item.ItemTranslator;
 import org.geysermc.mcprotocollib.protocol.data.game.inventory.ContainerType;
 import org.geysermc.mcprotocollib.protocol.data.game.item.component.DataComponentTypes;
@@ -81,29 +82,37 @@ public abstract class Inventory {
     @Setter
     protected Vector3i holderPosition = Vector3i.ZERO;
 
+    /**
+     * The entity id of the entity holding the inventory.
+     * Either this, or the holder position must be set in order for Bedrock to open inventories.
+     */
     @Getter
     @Setter
     protected long holderId = -1;
 
     @Getter
     @Setter
-    private boolean pending = false;
+    private boolean displayed = false;
 
     @Getter
     @Setter
-    private boolean displayed = false;
+    private boolean pending = false;
 
-    protected Inventory(int id, int size, ContainerType containerType) {
-        this("Inventory", id, size, containerType);
+    @Getter
+    private final InventoryTranslator translator;
+
+    protected Inventory(int id, int size, ContainerType containerType, InventoryTranslator translator) {
+        this("Inventory", id, size, containerType, translator);
     }
 
-    protected Inventory(String title, int javaId, int size, ContainerType containerType) {
+    protected Inventory(String title, int javaId, int size, ContainerType containerType, InventoryTranslator translator) {
         this.title = title;
         this.javaId = javaId;
         this.size = size;
         this.containerType = containerType;
         this.items = new GeyserItemStack[size];
         Arrays.fill(items, GeyserItemStack.EMPTY);
+        this.translator = translator;
     }
 
     // This is to prevent conflicts with special bedrock inventory IDs.

--- a/core/src/main/java/org/geysermc/geyser/inventory/Inventory.java
+++ b/core/src/main/java/org/geysermc/geyser/inventory/Inventory.java
@@ -99,6 +99,10 @@ public abstract class Inventory {
     private boolean pending = false;
 
     @Getter
+    @Setter
+    private boolean isCurrentlyDelayed = false;
+
+    @Getter
     private final InventoryTranslator translator;
 
     protected Inventory(int id, int size, ContainerType containerType, InventoryTranslator translator) {

--- a/core/src/main/java/org/geysermc/geyser/inventory/Inventory.java
+++ b/core/src/main/java/org/geysermc/geyser/inventory/Inventory.java
@@ -92,11 +92,11 @@ public abstract class Inventory {
 
     @Getter
     @Setter
-    private boolean displayed = false;
+    private boolean pending = false;
 
     @Getter
     @Setter
-    private boolean pending = false;
+    private boolean displayed = false;
 
     @Getter
     @Setter
@@ -191,5 +191,21 @@ public abstract class Inventory {
      */
     public boolean shouldConfirmContainerClose() {
         return true;
+    }
+
+    /*
+     * Helper methods to avoid using the wrong translator to update specific inventories.
+     */
+
+    public void updateInventory(GeyserSession session) {
+        this.translator.updateInventory(session, this);
+    }
+
+    public void updateProperty(GeyserSession session, int rawProperty, int value) {
+        this.translator.updateProperty(session, this, rawProperty, value);
+    }
+
+    public void updateSlot(GeyserSession session, int slot) {
+        this.translator.updateSlot(session, this, slot);
     }
 }

--- a/core/src/main/java/org/geysermc/geyser/inventory/LecternContainer.java
+++ b/core/src/main/java/org/geysermc/geyser/inventory/LecternContainer.java
@@ -46,8 +46,8 @@ public class LecternContainer extends Container {
 
     private boolean isBookInPlayerInventory = false;
 
-    public LecternContainer(String title, int id, int size, ContainerType containerType, PlayerInventory playerInventory, InventoryTranslator translator) {
-        super(title, id, size, containerType, playerInventory, translator);
+    public LecternContainer(GeyserSession session, String title, int id, int size, ContainerType containerType, PlayerInventory playerInventory, InventoryTranslator translator) {
+        super(session, title, id, size, containerType, playerInventory, translator);
     }
 
     /**

--- a/core/src/main/java/org/geysermc/geyser/inventory/LecternContainer.java
+++ b/core/src/main/java/org/geysermc/geyser/inventory/LecternContainer.java
@@ -31,6 +31,7 @@ import org.checkerframework.checker.nullness.qual.NonNull;
 import org.cloudburstmc.math.vector.Vector3i;
 import org.cloudburstmc.nbt.NbtMap;
 import org.geysermc.geyser.session.GeyserSession;
+import org.geysermc.geyser.translator.inventory.InventoryTranslator;
 import org.geysermc.geyser.translator.protocol.java.inventory.JavaOpenBookTranslator;
 import org.geysermc.mcprotocollib.protocol.data.game.inventory.ContainerType;
 
@@ -45,8 +46,8 @@ public class LecternContainer extends Container {
 
     private boolean isBookInPlayerInventory = false;
 
-    public LecternContainer(String title, int id, int size, ContainerType containerType, PlayerInventory playerInventory) {
-        super(title, id, size, containerType, playerInventory);
+    public LecternContainer(String title, int id, int size, ContainerType containerType, PlayerInventory playerInventory, InventoryTranslator translator) {
+        super(title, id, size, containerType, playerInventory, translator);
     }
 
     /**

--- a/core/src/main/java/org/geysermc/geyser/inventory/MerchantContainer.java
+++ b/core/src/main/java/org/geysermc/geyser/inventory/MerchantContainer.java
@@ -35,18 +35,18 @@ import org.geysermc.mcprotocollib.protocol.data.game.inventory.ContainerType;
 import org.geysermc.mcprotocollib.protocol.data.game.inventory.VillagerTrade;
 import org.geysermc.mcprotocollib.protocol.packet.ingame.clientbound.inventory.ClientboundMerchantOffersPacket;
 
+@Setter
 public class MerchantContainer extends Container {
-    @Getter @Setter
+    @Getter
     private Entity villager;
-    @Setter
     private VillagerTrade[] villagerTrades;
-    @Getter @Setter
+    @Getter
     private ClientboundMerchantOffersPacket pendingOffersPacket;
-    @Getter @Setter
+    @Getter
     private int tradeExperience;
 
-    public MerchantContainer(String title, int id, int size, ContainerType containerType, PlayerInventory playerInventory, InventoryTranslator translator) {
-        super(title, id, size, containerType, playerInventory, translator);
+    public MerchantContainer(GeyserSession session, String title, int id, int size, ContainerType containerType, PlayerInventory playerInventory, InventoryTranslator translator) {
+        super(session, title, id, size, containerType, playerInventory, translator);
     }
 
     public void onTradeSelected(GeyserSession session, int slot) {

--- a/core/src/main/java/org/geysermc/geyser/inventory/MerchantContainer.java
+++ b/core/src/main/java/org/geysermc/geyser/inventory/MerchantContainer.java
@@ -30,6 +30,7 @@ import lombok.Setter;
 import org.cloudburstmc.protocol.bedrock.data.entity.EntityDataTypes;
 import org.geysermc.geyser.entity.type.Entity;
 import org.geysermc.geyser.session.GeyserSession;
+import org.geysermc.geyser.translator.inventory.InventoryTranslator;
 import org.geysermc.mcprotocollib.protocol.data.game.inventory.ContainerType;
 import org.geysermc.mcprotocollib.protocol.data.game.inventory.VillagerTrade;
 import org.geysermc.mcprotocollib.protocol.packet.ingame.clientbound.inventory.ClientboundMerchantOffersPacket;
@@ -44,8 +45,8 @@ public class MerchantContainer extends Container {
     @Getter @Setter
     private int tradeExperience;
 
-    public MerchantContainer(String title, int id, int size, ContainerType containerType, PlayerInventory playerInventory) {
-        super(title, id, size, containerType, playerInventory);
+    public MerchantContainer(String title, int id, int size, ContainerType containerType, PlayerInventory playerInventory, InventoryTranslator translator) {
+        super(title, id, size, containerType, playerInventory, translator);
     }
 
     public void onTradeSelected(GeyserSession session, int slot) {

--- a/core/src/main/java/org/geysermc/geyser/inventory/PlayerInventory.java
+++ b/core/src/main/java/org/geysermc/geyser/inventory/PlayerInventory.java
@@ -35,21 +35,20 @@ import org.geysermc.geyser.translator.inventory.InventoryTranslator;
 import org.geysermc.mcprotocollib.protocol.data.game.entity.player.Hand;
 import org.jetbrains.annotations.Range;
 
+@Getter
 public class PlayerInventory extends Inventory {
     /**
      * Stores the held item slot, starting at index 0.
      * Add 36 in order to get the network item slot.
      */
-    @Getter
     @Setter
     private int heldItemSlot;
 
-    @Getter
     @NonNull
     private GeyserItemStack cursor = GeyserItemStack.EMPTY;
 
-    public PlayerInventory() {
-        super(0, 46, null, InventoryTranslator.PLAYER_INVENTORY_TRANSLATOR);
+    public PlayerInventory(GeyserSession session) {
+        super(session, 0, 46, null, InventoryTranslator.PLAYER_INVENTORY_TRANSLATOR);
         heldItemSlot = 0;
     }
 

--- a/core/src/main/java/org/geysermc/geyser/inventory/PlayerInventory.java
+++ b/core/src/main/java/org/geysermc/geyser/inventory/PlayerInventory.java
@@ -31,6 +31,7 @@ import org.checkerframework.checker.nullness.qual.NonNull;
 import org.geysermc.geyser.GeyserImpl;
 import org.geysermc.geyser.item.type.Item;
 import org.geysermc.geyser.session.GeyserSession;
+import org.geysermc.geyser.translator.inventory.InventoryTranslator;
 import org.geysermc.mcprotocollib.protocol.data.game.entity.player.Hand;
 import org.jetbrains.annotations.Range;
 
@@ -48,7 +49,7 @@ public class PlayerInventory extends Inventory {
     private GeyserItemStack cursor = GeyserItemStack.EMPTY;
 
     public PlayerInventory() {
-        super(0, 46, null);
+        super(0, 46, null, InventoryTranslator.PLAYER_INVENTORY_TRANSLATOR);
         heldItemSlot = 0;
     }
 

--- a/core/src/main/java/org/geysermc/geyser/inventory/StonecutterContainer.java
+++ b/core/src/main/java/org/geysermc/geyser/inventory/StonecutterContainer.java
@@ -29,6 +29,7 @@ import lombok.Getter;
 import lombok.Setter;
 import org.checkerframework.checker.nullness.qual.NonNull;
 import org.geysermc.geyser.session.GeyserSession;
+import org.geysermc.geyser.translator.inventory.InventoryTranslator;
 import org.geysermc.mcprotocollib.protocol.data.game.inventory.ContainerType;
 
 public class StonecutterContainer extends Container {
@@ -39,8 +40,8 @@ public class StonecutterContainer extends Container {
     @Setter
     private int stonecutterButton = -1;
 
-    public StonecutterContainer(String title, int id, int size, ContainerType containerType, PlayerInventory playerInventory) {
-        super(title, id, size, containerType, playerInventory);
+    public StonecutterContainer(String title, int id, int size, ContainerType containerType, PlayerInventory playerInventory, InventoryTranslator translator) {
+        super(title, id, size, containerType, playerInventory, translator);
     }
 
     @Override

--- a/core/src/main/java/org/geysermc/geyser/inventory/StonecutterContainer.java
+++ b/core/src/main/java/org/geysermc/geyser/inventory/StonecutterContainer.java
@@ -32,16 +32,16 @@ import org.geysermc.geyser.session.GeyserSession;
 import org.geysermc.geyser.translator.inventory.InventoryTranslator;
 import org.geysermc.mcprotocollib.protocol.data.game.inventory.ContainerType;
 
+@Setter
+@Getter
 public class StonecutterContainer extends Container {
     /**
      * The button that has currently been pressed Java-side
      */
-    @Getter
-    @Setter
     private int stonecutterButton = -1;
 
-    public StonecutterContainer(String title, int id, int size, ContainerType containerType, PlayerInventory playerInventory, InventoryTranslator translator) {
-        super(title, id, size, containerType, playerInventory, translator);
+    public StonecutterContainer(GeyserSession session, String title, int id, int size, ContainerType containerType, PlayerInventory playerInventory, InventoryTranslator translator) {
+        super(session, title, id, size, containerType, playerInventory, translator);
     }
 
     @Override

--- a/core/src/main/java/org/geysermc/geyser/inventory/holder/BlockInventoryHolder.java
+++ b/core/src/main/java/org/geysermc/geyser/inventory/holder/BlockInventoryHolder.java
@@ -93,7 +93,6 @@ public class BlockInventoryHolder extends InventoryHolder {
         // Check if we'd be using the same virtual inventory position.
         Vector3i position = InventoryUtils.findAvailableWorldSpace(session);
         if (Objects.equals(position, previous.getHolderPosition())) {
-            container.setHolderPosition(position);
             return true;
         } else {
             GeyserImpl.getInstance().getLogger().debug(session, "Not reusing inventory (%s) due to virtual block holder changing (%s -> %s)!",

--- a/core/src/main/java/org/geysermc/geyser/inventory/holder/BlockInventoryHolder.java
+++ b/core/src/main/java/org/geysermc/geyser/inventory/holder/BlockInventoryHolder.java
@@ -32,7 +32,6 @@ import org.cloudburstmc.protocol.bedrock.packet.BlockEntityDataPacket;
 import org.cloudburstmc.protocol.bedrock.packet.ContainerClosePacket;
 import org.cloudburstmc.protocol.bedrock.packet.ContainerOpenPacket;
 import org.cloudburstmc.protocol.bedrock.packet.UpdateBlockPacket;
-import org.geysermc.geyser.GeyserImpl;
 import org.geysermc.geyser.inventory.Container;
 import org.geysermc.geyser.inventory.Inventory;
 import org.geysermc.geyser.inventory.LecternContainer;
@@ -40,11 +39,11 @@ import org.geysermc.geyser.level.block.type.Block;
 import org.geysermc.geyser.level.block.type.BlockState;
 import org.geysermc.geyser.registry.BlockRegistries;
 import org.geysermc.geyser.session.GeyserSession;
-import org.geysermc.geyser.translator.inventory.InventoryTranslator;
 import org.geysermc.geyser.util.InventoryUtils;
 
 import java.util.Collections;
 import java.util.HashSet;
+import java.util.Objects;
 import java.util.Set;
 
 /**
@@ -77,24 +76,32 @@ public class BlockInventoryHolder extends InventoryHolder {
     }
 
     @Override
-    public boolean prepareInventory(InventoryTranslator translator, GeyserSession session, Inventory inventory) {
-        // Check to see if there is an existing block we can use that the player just selected.
-        // First, verify that the player's position has not changed, so we don't try to select a block wildly out of range.
-        // (This could be a virtual inventory that the player is opening)
-        if (checkInteractionPosition(session)) {
-            // Then, check to see if the interacted block is valid for this inventory by ensuring the block state identifier is valid
-            // and the bedrock block is vanilla
-            BlockState state = session.getGeyser().getWorldManager().blockAt(session, session.getLastInteractionBlockPosition());
-            if (!BlockRegistries.CUSTOM_BLOCK_STATE_OVERRIDES.get().containsKey(state.javaId())) {
-                if (isValidBlock(state)) {
-                    // We can safely use this block
-                    inventory.setHolderPosition(session.getLastInteractionBlockPosition());
-                    ((Container) inventory).setUsingRealBlock(true, state.block());
-                    setCustomName(session, session.getLastInteractionBlockPosition(), inventory, state);
-
-                    return true;
-                }
+    public boolean canReuseContainer(GeyserSession session, Container container, Container previous) {
+        // We already ensured that the inventories are the same type, size,
+        if (canUseRealBlock(session, container)) {
+            // We can reuse the same holder position.
+            if (container.getHolderPosition() != previous.getHolderPosition()) {
+                return false;
+            } else {
+                container.setReusingBlock(true);
+                return true;
             }
+        }
+
+        // Check if we'd be using the same virtual inventory position.
+        Vector3i position = InventoryUtils.findAvailableWorldSpace(session);
+        if (Objects.equals(position, previous.getHolderPosition())) {
+            container.setReusingBlock(true);
+            return true;
+        }
+
+        return false;
+    }
+
+    @Override
+    public boolean prepareInventory(GeyserSession session, Container inventory) {
+        if (canUseRealBlock(session, inventory)) {
+            return true;
         }
 
         Vector3i position = InventoryUtils.findAvailableWorldSpace(session);
@@ -113,6 +120,29 @@ public class BlockInventoryHolder extends InventoryHolder {
         setCustomName(session, position, inventory, defaultJavaBlockState);
 
         return true;
+    }
+
+    protected boolean canUseRealBlock(GeyserSession session, Container inventory) {
+        // Check to see if there is an existing block we can use that the player just selected.
+        // First, verify that the player's position has not changed, so we don't try to select a block wildly out of range.
+        // (This could be a virtual inventory that the player is opening)
+        if (checkInteractionPosition(session)) {
+            // Then, check to see if the interacted block is valid for this inventory by ensuring the block state identifier is valid
+            // and the bedrock block is vanilla
+            BlockState state = session.getGeyser().getWorldManager().blockAt(session, session.getLastInteractionBlockPosition());
+            if (!BlockRegistries.CUSTOM_BLOCK_STATE_OVERRIDES.get().containsKey(state.javaId())) {
+                if (isValidBlock(state)) {
+                    // We can safely use this block
+                    inventory.setHolderPosition(session.getLastInteractionBlockPosition());
+                    inventory.setUsingRealBlock(true, state.block());
+                    setCustomName(session, session.getLastInteractionBlockPosition(), inventory, state);
+
+                    return true;
+                }
+            }
+        }
+
+        return false;
     }
 
     /**
@@ -145,58 +175,47 @@ public class BlockInventoryHolder extends InventoryHolder {
     }
 
     @Override
-    public void openInventory(InventoryTranslator translator, GeyserSession session, Inventory inventory) {
+    public void openInventory(GeyserSession session, Container container) {
         ContainerOpenPacket containerOpenPacket = new ContainerOpenPacket();
-        containerOpenPacket.setId((byte) inventory.getBedrockId());
+        containerOpenPacket.setId((byte) container.getBedrockId());
         containerOpenPacket.setType(containerType);
-        containerOpenPacket.setBlockPosition(inventory.getHolderPosition());
-        containerOpenPacket.setUniqueEntityId(inventory.getHolderId());
+        containerOpenPacket.setBlockPosition(container.getHolderPosition());
+        containerOpenPacket.setUniqueEntityId(container.getHolderId());
         session.sendUpstreamPacket(containerOpenPacket);
     }
 
     @Override
-    public void closeInventory(InventoryTranslator translator, GeyserSession session, Inventory inventory, ContainerType type) {
-        if (!(inventory instanceof Container container)) {
-            GeyserImpl.getInstance().getLogger().warning("Tried to close a non-container inventory in a block inventory holder! Please report this error on discord.");
-            GeyserImpl.getInstance().getLogger().warning("Current inventory translator: " + translator.getClass().getSimpleName());
-            GeyserImpl.getInstance().getLogger().warning("Current inventory: " + inventory.getClass().getSimpleName());
-            // Try to save ourselves? maybe?
-            // https://github.com/GeyserMC/Geyser/issues/4141
-            // TODO: improve once this issue is pinned down
-            session.setOpenInventory(null);
-            session.setInventoryTranslator(InventoryTranslator.PLAYER_INVENTORY_TRANSLATOR);
-            return;
-        }
-
-
-        // Lecterns are special, and cannot be closed with any of the two methods below.
-        if (container.isUsingRealBlock() && !(container instanceof LecternContainer)) {
+    public void closeInventory(GeyserSession session, Container container, ContainerType type) {
+        if (container.isDisplayed() && !(container instanceof LecternContainer)) {
             // No need to reset a block since we didn't change any blocks
             // But send a container close packet because we aren't destroying the original.
             ContainerClosePacket packet = new ContainerClosePacket();
-            packet.setId((byte) inventory.getBedrockId());
+            packet.setId((byte) container.getBedrockId());
             packet.setServerInitiated(true);
             packet.setType(type != null ? type : containerType);
             session.sendUpstreamPacket(packet);
 
-            // Here comes the ugly part. This is a manual check to filter specific containers
-            // that won't close anymore with "just" a ContainerClosePacket.
-            if (type != null) {
-                return;
+            if (container.isUsingRealBlock()) {
+                // Type being null indicates that the ContainerClosePacket is not effective.
+                // So we yeet away the block!
+                if (type == null) {
+                    Vector3i holderPos = container.getHolderPosition();
+                    UpdateBlockPacket blockPacket = new UpdateBlockPacket();
+                    blockPacket.setDataLayer(0);
+                    blockPacket.setBlockPosition(holderPos);
+                    blockPacket.setDefinition(session.getBlockMappings().getBedrockAir());
+                    blockPacket.getFlags().addAll(UpdateBlockPacket.FLAG_ALL_PRIORITY);
+                    session.sendUpstreamPacket(blockPacket);
+                } else {
+                    // We're using a real block and are able to close the block without destroying it,
+                    // so we can don't need to reset it below.
+                    return;
+                }
             }
-
-            // Destroy the block. There's no inventory to view => it gets closed!
-            Vector3i holderPos = inventory.getHolderPosition();
-            UpdateBlockPacket blockPacket = new UpdateBlockPacket();
-            blockPacket.setDataLayer(0);
-            blockPacket.setBlockPosition(holderPos);
-            blockPacket.setDefinition(session.getBlockMappings().getBedrockAir());
-            blockPacket.getFlags().addAll(UpdateBlockPacket.FLAG_ALL_PRIORITY);
-            session.sendUpstreamPacket(blockPacket);
         }
 
         // Reset to correct block
-        Vector3i holderPos = inventory.getHolderPosition();
+        Vector3i holderPos = container.getHolderPosition();
         int realBlock = session.getGeyser().getWorldManager().getBlockAt(session, holderPos.getX(), holderPos.getY(), holderPos.getZ());
         UpdateBlockPacket blockPacket = new UpdateBlockPacket();
         blockPacket.setDataLayer(0);

--- a/core/src/main/java/org/geysermc/geyser/inventory/holder/BlockInventoryHolder.java
+++ b/core/src/main/java/org/geysermc/geyser/inventory/holder/BlockInventoryHolder.java
@@ -80,14 +80,23 @@ public class BlockInventoryHolder extends InventoryHolder {
     public boolean canReuseContainer(GeyserSession session, Container container, Container previous) {
         // We already ensured that the inventories are using the same type, size, and title
         if (canUseRealBlock(session, container)) {
-            // Only reuse if the position matches
-            return container.getHolderPosition() == previous.getHolderPosition();
+            // Check if we can reuse the same holder position.
+            if (container.getHolderPosition() == previous.getHolderPosition()) {
+                return true;
+            } else {
+                GeyserImpl.getInstance().getLogger().debug(session, "Not reusing inventory (%s) due to real block holder changing! ", InventoryUtils.debugInventory(container));
+                return false;
+            }
         }
 
         // Check if we'd be using the same virtual inventory position.
         Vector3i position = InventoryUtils.findAvailableWorldSpace(session);
-        // Reuse inventory if a virtual inventory position exists and matches
-        return Objects.equals(position, previous.getHolderPosition());
+        if (Objects.equals(position, previous.getHolderPosition())) {
+            return true;
+        } else {
+            GeyserImpl.getInstance().getLogger().debug(session, "Not reusing inventory (%s) due to virtual block holder changing! ", InventoryUtils.debugInventory(container));
+            return false;
+        }
     }
 
     @Override

--- a/core/src/main/java/org/geysermc/geyser/inventory/holder/BlockInventoryHolder.java
+++ b/core/src/main/java/org/geysermc/geyser/inventory/holder/BlockInventoryHolder.java
@@ -84,7 +84,8 @@ public class BlockInventoryHolder extends InventoryHolder {
             if (container.getHolderPosition() == previous.getHolderPosition()) {
                 return true;
             } else {
-                GeyserImpl.getInstance().getLogger().debug(session, "Not reusing inventory (%s) due to real block holder changing! ", InventoryUtils.debugInventory(container));
+                GeyserImpl.getInstance().getLogger().debug(session, "Not reusing inventory (%s) due to real block holder changing (%s -> %s)!",
+                    InventoryUtils.debugInventory(container), previous.getHolderPosition(), container.getHolderPosition());
                 return false;
             }
         }
@@ -92,9 +93,11 @@ public class BlockInventoryHolder extends InventoryHolder {
         // Check if we'd be using the same virtual inventory position.
         Vector3i position = InventoryUtils.findAvailableWorldSpace(session);
         if (Objects.equals(position, previous.getHolderPosition())) {
+            container.setHolderPosition(position);
             return true;
         } else {
-            GeyserImpl.getInstance().getLogger().debug(session, "Not reusing inventory (%s) due to virtual block holder changing! ", InventoryUtils.debugInventory(container));
+            GeyserImpl.getInstance().getLogger().debug(session, "Not reusing inventory (%s) due to virtual block holder changing (%s -> %s)!",
+                InventoryUtils.debugInventory(container), previous.getHolderPosition(), position);
             return false;
         }
     }

--- a/core/src/main/java/org/geysermc/geyser/inventory/holder/BlockInventoryHolder.java
+++ b/core/src/main/java/org/geysermc/geyser/inventory/holder/BlockInventoryHolder.java
@@ -184,7 +184,7 @@ public class BlockInventoryHolder extends InventoryHolder {
         containerOpenPacket.setUniqueEntityId(container.getHolderId());
         session.sendUpstreamPacket(containerOpenPacket);
 
-        GeyserImpl.getInstance().getLogger().sessionDebugLog(session, containerOpenPacket.toString());
+        GeyserImpl.getInstance().getLogger().debug(session, containerOpenPacket.toString());
     }
 
     @Override

--- a/core/src/main/java/org/geysermc/geyser/inventory/holder/BlockInventoryHolder.java
+++ b/core/src/main/java/org/geysermc/geyser/inventory/holder/BlockInventoryHolder.java
@@ -79,15 +79,10 @@ public class BlockInventoryHolder extends InventoryHolder {
     @Override
     public boolean canReuseContainer(GeyserSession session, Container container, Container previous) {
         // We already ensured that the inventories are using the same type, size, and title
-        if (canUseRealBlock(session, container)) {
-            // Check if we can reuse the same holder position.
-            if (container.getHolderPosition() == previous.getHolderPosition()) {
-                return true;
-            } else {
-                GeyserImpl.getInstance().getLogger().debug(session, "Not reusing inventory (%s) due to real block holder changing (%s -> %s)!",
-                    InventoryUtils.debugInventory(container), previous.getHolderPosition(), container.getHolderPosition());
-                return false;
-            }
+
+        // TODO this would currently break, so we're not reusing this
+        if (previous.isUsingRealBlock()) {
+            return false;
         }
 
         // Check if we'd be using the same virtual inventory position.

--- a/core/src/main/java/org/geysermc/geyser/inventory/holder/BlockInventoryHolder.java
+++ b/core/src/main/java/org/geysermc/geyser/inventory/holder/BlockInventoryHolder.java
@@ -32,6 +32,7 @@ import org.cloudburstmc.protocol.bedrock.packet.BlockEntityDataPacket;
 import org.cloudburstmc.protocol.bedrock.packet.ContainerClosePacket;
 import org.cloudburstmc.protocol.bedrock.packet.ContainerOpenPacket;
 import org.cloudburstmc.protocol.bedrock.packet.UpdateBlockPacket;
+import org.geysermc.geyser.GeyserImpl;
 import org.geysermc.geyser.inventory.Container;
 import org.geysermc.geyser.inventory.Inventory;
 import org.geysermc.geyser.inventory.LecternContainer;
@@ -182,6 +183,8 @@ public class BlockInventoryHolder extends InventoryHolder {
         containerOpenPacket.setBlockPosition(container.getHolderPosition());
         containerOpenPacket.setUniqueEntityId(container.getHolderId());
         session.sendUpstreamPacket(containerOpenPacket);
+
+        GeyserImpl.getInstance().getLogger().sessionDebugLog(session, containerOpenPacket.toString());
     }
 
     @Override

--- a/core/src/main/java/org/geysermc/geyser/inventory/holder/BlockInventoryHolder.java
+++ b/core/src/main/java/org/geysermc/geyser/inventory/holder/BlockInventoryHolder.java
@@ -78,25 +78,16 @@ public class BlockInventoryHolder extends InventoryHolder {
 
     @Override
     public boolean canReuseContainer(GeyserSession session, Container container, Container previous) {
-        // We already ensured that the inventories are the same type, size,
+        // We already ensured that the inventories are using the same type, size, and title
         if (canUseRealBlock(session, container)) {
-            // We can reuse the same holder position.
-            if (container.getHolderPosition() != previous.getHolderPosition()) {
-                return false;
-            } else {
-                container.setReusingBlock(true);
-                return true;
-            }
+            // Only reuse if the position matches
+            return container.getHolderPosition() == previous.getHolderPosition();
         }
 
         // Check if we'd be using the same virtual inventory position.
         Vector3i position = InventoryUtils.findAvailableWorldSpace(session);
-        if (Objects.equals(position, previous.getHolderPosition())) {
-            container.setReusingBlock(true);
-            return true;
-        }
-
-        return false;
+        // Reuse inventory if a virtual inventory position exists and matches
+        return Objects.equals(position, previous.getHolderPosition());
     }
 
     @Override

--- a/core/src/main/java/org/geysermc/geyser/inventory/holder/InventoryHolder.java
+++ b/core/src/main/java/org/geysermc/geyser/inventory/holder/InventoryHolder.java
@@ -26,12 +26,12 @@
 package org.geysermc.geyser.inventory.holder;
 
 import org.cloudburstmc.protocol.bedrock.data.inventory.ContainerType;
-import org.geysermc.geyser.inventory.Inventory;
+import org.geysermc.geyser.inventory.Container;
 import org.geysermc.geyser.session.GeyserSession;
-import org.geysermc.geyser.translator.inventory.InventoryTranslator;
 
 public abstract class InventoryHolder {
-    public abstract boolean prepareInventory(InventoryTranslator translator, GeyserSession session, Inventory inventory);
-    public abstract void openInventory(InventoryTranslator translator, GeyserSession session, Inventory inventory);
-    public abstract void closeInventory(InventoryTranslator translator, GeyserSession session, Inventory inventory, ContainerType containerType);
+    public abstract boolean canReuseContainer(GeyserSession session, Container inventory, Container oldInventory);
+    public abstract boolean prepareInventory(GeyserSession session, Container inventory);
+    public abstract void openInventory(GeyserSession session, Container inventory);
+    public abstract void closeInventory(GeyserSession session, Container inventory, ContainerType containerType);
 }

--- a/core/src/main/java/org/geysermc/geyser/session/GeyserSession.java
+++ b/core/src/main/java/org/geysermc/geyser/session/GeyserSession.java
@@ -299,9 +299,10 @@ public class GeyserSession implements GeyserConnection, GeyserCommandSource {
 
     /**
      * Stores the bedrock inventory id of the pending inventory, or -1 if no inventory is pending.
+     * This id is only set when the block that should be opened exists.
      */
     @Setter
-    private int pendingInventoryId = -1;
+    private int pendingOrCurrentBedrockInventoryId = -1;
 
     /**
      * Use {@link #getNextItemNetId()} instead for consistency

--- a/core/src/main/java/org/geysermc/geyser/session/GeyserSession.java
+++ b/core/src/main/java/org/geysermc/geyser/session/GeyserSession.java
@@ -295,9 +295,6 @@ public class GeyserSession implements GeyserConnection, GeyserCommandSource {
     private @Nullable Inventory openInventory;
 
     @Setter
-    private @Nullable Inventory oldInventory;
-
-    @Setter
     private boolean closingInventory;
 
     /**

--- a/core/src/main/java/org/geysermc/geyser/session/GeyserSession.java
+++ b/core/src/main/java/org/geysermc/geyser/session/GeyserSession.java
@@ -298,7 +298,7 @@ public class GeyserSession implements GeyserConnection, GeyserCommandSource {
     private boolean closingInventory;
 
     /**
-     * Stores the java inventory id of the pending inventory, or -1 if no inventory is pending.
+     * Stores the bedrock inventory id of the pending inventory, or -1 if no inventory is pending.
      */
     @Setter
     private int pendingInventoryId = -1;

--- a/core/src/main/java/org/geysermc/geyser/session/GeyserSession.java
+++ b/core/src/main/java/org/geysermc/geyser/session/GeyserSession.java
@@ -174,7 +174,6 @@ import org.geysermc.geyser.session.cache.TeleportCache;
 import org.geysermc.geyser.session.cache.WorldBorder;
 import org.geysermc.geyser.session.cache.WorldCache;
 import org.geysermc.geyser.text.GeyserLocale;
-import org.geysermc.geyser.translator.inventory.InventoryTranslator;
 import org.geysermc.geyser.translator.text.MessageTranslator;
 import org.geysermc.geyser.util.ChunkUtils;
 import org.geysermc.geyser.util.EntityUtils;
@@ -291,13 +290,21 @@ public class GeyserSession implements GeyserConnection, GeyserCommandSource {
     private boolean isInWorldBorderWarningArea = false;
 
     private final PlayerInventory playerInventory;
+
     @Setter
     private @Nullable Inventory openInventory;
+
+    @Setter
+    private @Nullable Inventory oldInventory;
+
     @Setter
     private boolean closingInventory;
 
+    /**
+     * Stores the java inventory id of the pending inventory, or -1 if no inventory is pending.
+     */
     @Setter
-    private @NonNull InventoryTranslator inventoryTranslator = InventoryTranslator.PLAYER_INVENTORY_TRANSLATOR;
+    private int pendingInventoryId = -1;
 
     /**
      * Use {@link #getNextItemNetId()} instead for consistency

--- a/core/src/main/java/org/geysermc/geyser/session/GeyserSession.java
+++ b/core/src/main/java/org/geysermc/geyser/session/GeyserSession.java
@@ -721,7 +721,7 @@ public class GeyserSession implements GeyserConnection, GeyserCommandSource {
         this.playerEntity = new SessionPlayerEntity(this);
         collisionManager.updatePlayerBoundingBox(this.playerEntity.getPosition());
 
-        this.playerInventory = new PlayerInventory();
+        this.playerInventory = new PlayerInventory(this);
         this.openInventory = null;
         this.craftingRecipes = new Int2ObjectOpenHashMap<>();
         this.javaToBedrockRecipeIds = new Int2ObjectOpenHashMap<>();

--- a/core/src/main/java/org/geysermc/geyser/translator/inventory/AbstractBlockInventoryTranslator.java
+++ b/core/src/main/java/org/geysermc/geyser/translator/inventory/AbstractBlockInventoryTranslator.java
@@ -78,7 +78,7 @@ public abstract class AbstractBlockInventoryTranslator extends BaseInventoryTran
     }
 
     @Override
-    public boolean shouldDelayInventoryOpen(GeyserSession session, Inventory inventory) {
+    public boolean requiresOpeningDelay(GeyserSession session, Inventory inventory) {
         return inventory instanceof Container container && !container.isUsingRealBlock();
     }
 

--- a/core/src/main/java/org/geysermc/geyser/translator/inventory/AbstractBlockInventoryTranslator.java
+++ b/core/src/main/java/org/geysermc/geyser/translator/inventory/AbstractBlockInventoryTranslator.java
@@ -25,6 +25,7 @@
 
 package org.geysermc.geyser.translator.inventory;
 
+import org.checkerframework.checker.nullness.qual.NonNull;
 import org.checkerframework.checker.nullness.qual.Nullable;
 import org.cloudburstmc.protocol.bedrock.data.inventory.ContainerType;
 import org.geysermc.geyser.inventory.Container;
@@ -78,11 +79,11 @@ public abstract class AbstractBlockInventoryTranslator extends BaseInventoryTran
 
     @Override
     public boolean shouldDelayInventoryOpen(GeyserSession session, Inventory inventory) {
-        return inventory instanceof Container container && !container.isUsingRealBlock() && !container.isReusingBlock();
+        return inventory instanceof Container container && !container.isUsingRealBlock();
     }
 
     @Override
-    public boolean canReuseInventory(GeyserSession session, Inventory inventory, Inventory previous) {
+    public boolean canReuseInventory(GeyserSession session, @NonNull Inventory inventory, @NonNull Inventory previous) {
         if (super.canReuseInventory(session, inventory, previous)
                 && inventory instanceof Container container
                 && previous instanceof Container previousContainer) {

--- a/core/src/main/java/org/geysermc/geyser/translator/inventory/AbstractBlockInventoryTranslator.java
+++ b/core/src/main/java/org/geysermc/geyser/translator/inventory/AbstractBlockInventoryTranslator.java
@@ -27,6 +27,7 @@ package org.geysermc.geyser.translator.inventory;
 
 import org.checkerframework.checker.nullness.qual.Nullable;
 import org.cloudburstmc.protocol.bedrock.data.inventory.ContainerType;
+import org.geysermc.geyser.inventory.Container;
 import org.geysermc.geyser.inventory.Inventory;
 import org.geysermc.geyser.inventory.holder.BlockInventoryHolder;
 import org.geysermc.geyser.inventory.holder.InventoryHolder;
@@ -76,18 +77,33 @@ public abstract class AbstractBlockInventoryTranslator extends BaseInventoryTran
     }
 
     @Override
+    public boolean shouldDelayInventoryOpen(GeyserSession session, Inventory inventory) {
+        return inventory instanceof Container container && !container.isUsingRealBlock() && !container.isReusingBlock();
+    }
+
+    @Override
+    public boolean canReuseInventory(GeyserSession session, Inventory inventory, Inventory previous) {
+        if (super.canReuseInventory(session, inventory, previous)
+                && inventory instanceof Container container
+                && previous instanceof Container previousContainer) {
+            return holder.canReuseContainer(session, container, previousContainer);
+        }
+        return false;
+    }
+
+    @Override
     public boolean prepareInventory(GeyserSession session, Inventory inventory) {
-        return holder.prepareInventory(this, session, inventory);
+        return holder.prepareInventory(session, (Container) inventory);
     }
 
     @Override
     public void openInventory(GeyserSession session, Inventory inventory) {
-        holder.openInventory(this, session, inventory);
+        holder.openInventory(session, (Container) inventory);
     }
 
     @Override
     public void closeInventory(GeyserSession session, Inventory inventory) {
-        holder.closeInventory(this, session, inventory, closeContainerType(inventory));
+        holder.closeInventory(session, (Container) inventory, closeContainerType(inventory));
     }
 
     @Override

--- a/core/src/main/java/org/geysermc/geyser/translator/inventory/AnvilInventoryTranslator.java
+++ b/core/src/main/java/org/geysermc/geyser/translator/inventory/AnvilInventoryTranslator.java
@@ -103,8 +103,8 @@ public class AnvilInventoryTranslator extends AbstractBlockInventoryTranslator {
     }
 
     @Override
-    public Inventory createInventory(String name, int windowId, ContainerType containerType, PlayerInventory playerInventory) {
-        return new AnvilContainer(name, windowId, this.size, containerType, playerInventory, this);
+    public Inventory createInventory(GeyserSession session, String name, int windowId, ContainerType containerType, PlayerInventory playerInventory) {
+        return new AnvilContainer(session, name, windowId, this.size, containerType, playerInventory, this);
     }
 
     @Override

--- a/core/src/main/java/org/geysermc/geyser/translator/inventory/AnvilInventoryTranslator.java
+++ b/core/src/main/java/org/geysermc/geyser/translator/inventory/AnvilInventoryTranslator.java
@@ -104,7 +104,7 @@ public class AnvilInventoryTranslator extends AbstractBlockInventoryTranslator {
 
     @Override
     public Inventory createInventory(String name, int windowId, ContainerType containerType, PlayerInventory playerInventory) {
-        return new AnvilContainer(name, windowId, this.size, containerType, playerInventory);
+        return new AnvilContainer(name, windowId, this.size, containerType, playerInventory, this);
     }
 
     @Override

--- a/core/src/main/java/org/geysermc/geyser/translator/inventory/BaseInventoryTranslator.java
+++ b/core/src/main/java/org/geysermc/geyser/translator/inventory/BaseInventoryTranslator.java
@@ -91,6 +91,6 @@ public abstract class BaseInventoryTranslator extends InventoryTranslator {
 
     @Override
     public Inventory createInventory(String name, int windowId, ContainerType containerType, PlayerInventory playerInventory) {
-        return new Container(name, windowId, this.size, containerType, playerInventory);
+        return new Container(name, windowId, this.size, containerType, playerInventory, this);
     }
 }

--- a/core/src/main/java/org/geysermc/geyser/translator/inventory/BaseInventoryTranslator.java
+++ b/core/src/main/java/org/geysermc/geyser/translator/inventory/BaseInventoryTranslator.java
@@ -90,7 +90,7 @@ public abstract class BaseInventoryTranslator extends InventoryTranslator {
     }
 
     @Override
-    public Inventory createInventory(String name, int windowId, ContainerType containerType, PlayerInventory playerInventory) {
-        return new Container(name, windowId, this.size, containerType, playerInventory, this);
+    public Inventory createInventory(GeyserSession session, String name, int windowId, ContainerType containerType, PlayerInventory playerInventory) {
+        return new Container(session, name, windowId, this.size, containerType, playerInventory, this);
     }
 }

--- a/core/src/main/java/org/geysermc/geyser/translator/inventory/BeaconInventoryTranslator.java
+++ b/core/src/main/java/org/geysermc/geyser/translator/inventory/BeaconInventoryTranslator.java
@@ -145,8 +145,8 @@ public class BeaconInventoryTranslator extends AbstractBlockInventoryTranslator 
     }
 
     @Override
-    public Inventory createInventory(String name, int windowId, ContainerType containerType, PlayerInventory playerInventory) {
-        return new BeaconContainer(name, windowId, this.size, containerType, playerInventory, this);
+    public Inventory createInventory(GeyserSession session, String name, int windowId, ContainerType containerType, PlayerInventory playerInventory) {
+        return new BeaconContainer(session, name, windowId, this.size, containerType, playerInventory, this);
     }
 
     @Override

--- a/core/src/main/java/org/geysermc/geyser/translator/inventory/BeaconInventoryTranslator.java
+++ b/core/src/main/java/org/geysermc/geyser/translator/inventory/BeaconInventoryTranslator.java
@@ -38,6 +38,7 @@ import org.cloudburstmc.protocol.bedrock.data.inventory.itemstack.response.ItemS
 import org.cloudburstmc.protocol.bedrock.packet.BlockEntityDataPacket;
 import org.geysermc.geyser.inventory.BeaconContainer;
 import org.geysermc.geyser.inventory.BedrockContainerSlot;
+import org.geysermc.geyser.inventory.Container;
 import org.geysermc.geyser.inventory.Inventory;
 import org.geysermc.geyser.inventory.PlayerInventory;
 import org.geysermc.geyser.inventory.holder.BlockInventoryHolder;
@@ -61,12 +62,12 @@ public class BeaconInventoryTranslator extends AbstractBlockInventoryTranslator 
             }
 
             @Override
-            public void openInventory(InventoryTranslator translator, GeyserSession session, Inventory inventory) {
-                if (!((BeaconContainer) inventory).isUsingRealBlock()) {
-                    InventoryUtils.closeInventory(session, inventory.getJavaId(), false);
+            public void openInventory(GeyserSession session, Container container) {
+                if (!container.isUsingRealBlock()) {
+                    InventoryUtils.closeInventory(session, container.getJavaId(), false);
                     return;
                 }
-                super.openInventory(translator, session, inventory);
+                super.openInventory(session, container);
             }
         }, UIInventoryUpdater.INSTANCE);
     }
@@ -145,7 +146,7 @@ public class BeaconInventoryTranslator extends AbstractBlockInventoryTranslator 
 
     @Override
     public Inventory createInventory(String name, int windowId, ContainerType containerType, PlayerInventory playerInventory) {
-        return new BeaconContainer(name, windowId, this.size, containerType, playerInventory);
+        return new BeaconContainer(name, windowId, this.size, containerType, playerInventory, this);
     }
 
     @Override

--- a/core/src/main/java/org/geysermc/geyser/translator/inventory/CartographyInventoryTranslator.java
+++ b/core/src/main/java/org/geysermc/geyser/translator/inventory/CartographyInventoryTranslator.java
@@ -86,8 +86,8 @@ public class CartographyInventoryTranslator extends AbstractBlockInventoryTransl
     }
 
     @Override
-    public Inventory createInventory(String name, int windowId, ContainerType containerType, PlayerInventory playerInventory) {
-        return new CartographyContainer(name, windowId, this.size, containerType, playerInventory, this);
+    public Inventory createInventory(GeyserSession session, String name, int windowId, ContainerType containerType, PlayerInventory playerInventory) {
+        return new CartographyContainer(session, name, windowId, this.size, containerType, playerInventory, this);
     }
 
     @Override

--- a/core/src/main/java/org/geysermc/geyser/translator/inventory/CartographyInventoryTranslator.java
+++ b/core/src/main/java/org/geysermc/geyser/translator/inventory/CartographyInventoryTranslator.java
@@ -87,7 +87,7 @@ public class CartographyInventoryTranslator extends AbstractBlockInventoryTransl
 
     @Override
     public Inventory createInventory(String name, int windowId, ContainerType containerType, PlayerInventory playerInventory) {
-        return new CartographyContainer(name, windowId, this.size, containerType, playerInventory);
+        return new CartographyContainer(name, windowId, this.size, containerType, playerInventory, this);
     }
 
     @Override

--- a/core/src/main/java/org/geysermc/geyser/translator/inventory/CrafterInventoryTranslator.java
+++ b/core/src/main/java/org/geysermc/geyser/translator/inventory/CrafterInventoryTranslator.java
@@ -139,9 +139,9 @@ public class CrafterInventoryTranslator extends AbstractBlockInventoryTranslator
     }
 
     @Override
-    public Inventory createInventory(String name, int windowId, ContainerType containerType, PlayerInventory playerInventory) {
+    public Inventory createInventory(GeyserSession session, String name, int windowId, ContainerType containerType, PlayerInventory playerInventory) {
         // Java sends the triggered and slot bits incrementally through properties, which we store here
-        return new CrafterContainer(name, windowId, this.size, containerType, playerInventory, this);
+        return new CrafterContainer(session, name, windowId, this.size, containerType, playerInventory, this);
     }
 
     private static void updateBlockEntity(GeyserSession session, CrafterContainer container) {

--- a/core/src/main/java/org/geysermc/geyser/translator/inventory/CrafterInventoryTranslator.java
+++ b/core/src/main/java/org/geysermc/geyser/translator/inventory/CrafterInventoryTranslator.java
@@ -141,7 +141,7 @@ public class CrafterInventoryTranslator extends AbstractBlockInventoryTranslator
     @Override
     public Inventory createInventory(String name, int windowId, ContainerType containerType, PlayerInventory playerInventory) {
         // Java sends the triggered and slot bits incrementally through properties, which we store here
-        return new CrafterContainer(name, windowId, this.size, containerType, playerInventory);
+        return new CrafterContainer(name, windowId, this.size, containerType, playerInventory, this);
     }
 
     private static void updateBlockEntity(GeyserSession session, CrafterContainer container) {

--- a/core/src/main/java/org/geysermc/geyser/translator/inventory/EnchantingInventoryTranslator.java
+++ b/core/src/main/java/org/geysermc/geyser/translator/inventory/EnchantingInventoryTranslator.java
@@ -168,8 +168,8 @@ public class EnchantingInventoryTranslator extends AbstractBlockInventoryTransla
     }
 
     @Override
-    public Inventory createInventory(String name, int windowId, ContainerType containerType, PlayerInventory playerInventory) {
-        return new EnchantingContainer(name, windowId, this.size, containerType, playerInventory, this);
+    public Inventory createInventory(GeyserSession session, String name, int windowId, ContainerType containerType, PlayerInventory playerInventory) {
+        return new EnchantingContainer(session, name, windowId, this.size, containerType, playerInventory, this);
     }
 
     @Override

--- a/core/src/main/java/org/geysermc/geyser/translator/inventory/EnchantingInventoryTranslator.java
+++ b/core/src/main/java/org/geysermc/geyser/translator/inventory/EnchantingInventoryTranslator.java
@@ -169,7 +169,7 @@ public class EnchantingInventoryTranslator extends AbstractBlockInventoryTransla
 
     @Override
     public Inventory createInventory(String name, int windowId, ContainerType containerType, PlayerInventory playerInventory) {
-        return new EnchantingContainer(name, windowId, this.size, containerType, playerInventory);
+        return new EnchantingContainer(name, windowId, this.size, containerType, playerInventory, this);
     }
 
     @Override

--- a/core/src/main/java/org/geysermc/geyser/translator/inventory/Generic3X3InventoryTranslator.java
+++ b/core/src/main/java/org/geysermc/geyser/translator/inventory/Generic3X3InventoryTranslator.java
@@ -46,8 +46,8 @@ public class Generic3X3InventoryTranslator extends AbstractBlockInventoryTransla
     }
 
     @Override
-    public Inventory createInventory(String name, int windowId, ContainerType containerType, PlayerInventory playerInventory) {
-        return new Generic3X3Container(name, windowId, this.size, containerType, playerInventory, this);
+    public Inventory createInventory(GeyserSession session, String name, int windowId, ContainerType containerType, PlayerInventory playerInventory) {
+        return new Generic3X3Container(session, name, windowId, this.size, containerType, playerInventory, this);
     }
 
     @Override

--- a/core/src/main/java/org/geysermc/geyser/translator/inventory/Generic3X3InventoryTranslator.java
+++ b/core/src/main/java/org/geysermc/geyser/translator/inventory/Generic3X3InventoryTranslator.java
@@ -47,7 +47,7 @@ public class Generic3X3InventoryTranslator extends AbstractBlockInventoryTransla
 
     @Override
     public Inventory createInventory(String name, int windowId, ContainerType containerType, PlayerInventory playerInventory) {
-        return new Generic3X3Container(name, windowId, this.size, containerType, playerInventory);
+        return new Generic3X3Container(name, windowId, this.size, containerType, playerInventory, this);
     }
 
     @Override

--- a/core/src/main/java/org/geysermc/geyser/translator/inventory/InventoryTranslator.java
+++ b/core/src/main/java/org/geysermc/geyser/translator/inventory/InventoryTranslator.java
@@ -148,13 +148,28 @@ public abstract class InventoryTranslator {
         // Filter for mismatches that require a new inventory.
         if (inventory.getContainerType() == null || previous.getContainerType() == null
             || !Objects.equals(inventory.getContainerType(), previous.getContainerType())
-            || inventory.getJavaId() != previous.getJavaId()
         ) {
+            GeyserImpl.getInstance().getLogger().debug(session, "Not reusing inventory (%s) due to type change! ", InventoryUtils.debugInventory(inventory));
             return false;
         }
 
-        // Inventory size and the title should also match.
-        return inventory.getSize() == previous.getSize() && Objects.equals(inventory.getTitle(), previous.getTitle());
+        if (inventory.getJavaId() != previous.getJavaId()) {
+            GeyserImpl.getInstance().getLogger().debug(session, "Not reusing inventory (%s) due to java id change! ", InventoryUtils.debugInventory(inventory));
+            return false;
+        }
+
+        if (inventory.getSize() != previous.getSize()) {
+            GeyserImpl.getInstance().getLogger().debug(session, "Not reusing inventory (%s) due to size change! ", InventoryUtils.debugInventory(inventory));
+            return false;
+        }
+
+        if (!Objects.equals(inventory.getTitle(), previous.getTitle())) {
+            GeyserImpl.getInstance().getLogger().debug(session, "Not reusing inventory (%s) due to title change! ", InventoryUtils.debugInventory(inventory));
+            return false;
+        }
+
+        // We can likely reuse the inventory!
+        return true;
     }
     public abstract boolean prepareInventory(GeyserSession session, Inventory inventory);
     public abstract void openInventory(GeyserSession session, Inventory inventory);

--- a/core/src/main/java/org/geysermc/geyser/translator/inventory/InventoryTranslator.java
+++ b/core/src/main/java/org/geysermc/geyser/translator/inventory/InventoryTranslator.java
@@ -35,6 +35,7 @@ import it.unimi.dsi.fastutil.ints.IntOpenHashSet;
 import it.unimi.dsi.fastutil.ints.IntSet;
 import it.unimi.dsi.fastutil.ints.IntSortedSet;
 import lombok.AllArgsConstructor;
+import org.checkerframework.checker.nullness.qual.NonNull;
 import org.checkerframework.checker.nullness.qual.Nullable;
 import org.cloudburstmc.protocol.bedrock.data.inventory.ContainerSlotType;
 import org.cloudburstmc.protocol.bedrock.data.inventory.FullContainerName;
@@ -143,23 +144,17 @@ public abstract class InventoryTranslator {
     /**
      * Whether a new inventory should be prepared - or if we can re-use the previous one.
      */
-    public boolean canReuseInventory(GeyserSession session, Inventory inventory, Inventory previous) {
-        // Filter for obvious mismatches that require a new inventory
-        if (previous == null
-            || inventory.getContainerType() == null
-            || previous.getContainerType() == null
-            || !Objects.equals(inventory.getContainerType(), previous.getContainerType())) {
+    public boolean canReuseInventory(GeyserSession session, @NonNull Inventory inventory, @NonNull Inventory previous) {
+        // Filter for mismatches that require a new inventory
+        if (inventory.getContainerType() == null || previous.getContainerType() == null
+            || !Objects.equals(inventory.getContainerType(), previous.getContainerType())
+            || inventory.getJavaId() != previous.getJavaId()
+        ) {
             return false;
         }
 
-        // Inventory size should also match.
-        if (inventory.getSize() != previous.getSize() || !Objects.equals(inventory.getTitle(), previous.getTitle())) {
-            return false;
-        }
-
-        // TODO can we easily set a new inventory name???
-
-        return true;
+        // Inventory size and the title should also match.
+        return inventory.getSize() == previous.getSize() && Objects.equals(inventory.getTitle(), previous.getTitle());
     }
     public abstract boolean prepareInventory(GeyserSession session, Inventory inventory);
     public abstract void openInventory(GeyserSession session, Inventory inventory);
@@ -171,7 +166,7 @@ public abstract class InventoryTranslator {
     public abstract int javaSlotToBedrock(int javaSlot);
     public abstract BedrockContainerSlot javaSlotToBedrockContainer(int javaSlot);
     public abstract SlotType getSlotType(int javaSlot);
-    public abstract Inventory createInventory(String name, int windowId, ContainerType containerType, PlayerInventory playerInventory);
+    public abstract Inventory createInventory(GeyserSession session, String name, int windowId, ContainerType containerType, PlayerInventory playerInventory);
 
     /**
      * Used for crafting-related transactions. Will override in PlayerInventoryTranslator and CraftingInventoryTranslator.

--- a/core/src/main/java/org/geysermc/geyser/translator/inventory/InventoryTranslator.java
+++ b/core/src/main/java/org/geysermc/geyser/translator/inventory/InventoryTranslator.java
@@ -137,7 +137,7 @@ public abstract class InventoryTranslator {
     public final int size;
 
     // Whether the inventory open should be delayed.
-    public boolean shouldDelayInventoryOpen(GeyserSession session, Inventory inventory) {
+    public boolean requiresOpeningDelay(GeyserSession session, Inventory inventory) {
         return false;
     }
 
@@ -145,10 +145,10 @@ public abstract class InventoryTranslator {
      * Whether a new inventory should be prepared - or if we can re-use the previous one.
      */
     public boolean canReuseInventory(GeyserSession session, @NonNull Inventory inventory, @NonNull Inventory previous) {
-        // Filter for mismatches that require a new inventory. Further, if we're closing a current inventory, we cannot reuse it.
+        // Filter for mismatches that require a new inventory.
         if (inventory.getContainerType() == null || previous.getContainerType() == null
             || !Objects.equals(inventory.getContainerType(), previous.getContainerType())
-            || inventory.getJavaId() != previous.getJavaId() || session.isClosingInventory()
+            || inventory.getJavaId() != previous.getJavaId()
         ) {
             return false;
         }

--- a/core/src/main/java/org/geysermc/geyser/translator/inventory/InventoryTranslator.java
+++ b/core/src/main/java/org/geysermc/geyser/translator/inventory/InventoryTranslator.java
@@ -145,10 +145,10 @@ public abstract class InventoryTranslator {
      * Whether a new inventory should be prepared - or if we can re-use the previous one.
      */
     public boolean canReuseInventory(GeyserSession session, @NonNull Inventory inventory, @NonNull Inventory previous) {
-        // Filter for mismatches that require a new inventory
+        // Filter for mismatches that require a new inventory. Further, if we're closing a current inventory, we cannot reuse it.
         if (inventory.getContainerType() == null || previous.getContainerType() == null
             || !Objects.equals(inventory.getContainerType(), previous.getContainerType())
-            || inventory.getJavaId() != previous.getJavaId()
+            || inventory.getJavaId() != previous.getJavaId() || session.isClosingInventory()
         ) {
             return false;
         }

--- a/core/src/main/java/org/geysermc/geyser/translator/inventory/InventoryTranslator.java
+++ b/core/src/main/java/org/geysermc/geyser/translator/inventory/InventoryTranslator.java
@@ -37,6 +37,7 @@ import it.unimi.dsi.fastutil.ints.IntSortedSet;
 import lombok.AllArgsConstructor;
 import org.checkerframework.checker.nullness.qual.NonNull;
 import org.checkerframework.checker.nullness.qual.Nullable;
+import org.cloudburstmc.math.vector.Vector3i;
 import org.cloudburstmc.protocol.bedrock.data.inventory.ContainerSlotType;
 import org.cloudburstmc.protocol.bedrock.data.inventory.FullContainerName;
 import org.cloudburstmc.protocol.bedrock.data.inventory.itemstack.request.ItemStackRequest;
@@ -160,6 +161,11 @@ public abstract class InventoryTranslator {
 
         if (!Objects.equals(inventory.getTitle(), previous.getTitle())) {
             GeyserImpl.getInstance().getLogger().debug(session, "Not reusing inventory (%s) due to title change! ", InventoryUtils.debugInventory(inventory));
+            return false;
+        }
+
+        if (previous.getHolderId() == -1 && previous.getHolderPosition() == Vector3i.ZERO) {
+            GeyserImpl.getInstance().getLogger().debug(session, "Not reusing inventory (%s) since the old was not initialized! ", InventoryUtils.debugInventory(inventory));
             return false;
         }
 

--- a/core/src/main/java/org/geysermc/geyser/translator/inventory/InventoryTranslator.java
+++ b/core/src/main/java/org/geysermc/geyser/translator/inventory/InventoryTranslator.java
@@ -85,6 +85,7 @@ import java.util.EnumMap;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 
 import static org.geysermc.geyser.translator.inventory.BundleInventoryTranslator.isBundle;
 
@@ -134,6 +135,32 @@ public abstract class InventoryTranslator {
 
     public final int size;
 
+    // Whether the inventory open should be delayed.
+    public boolean shouldDelayInventoryOpen(GeyserSession session, Inventory inventory) {
+        return false;
+    }
+
+    /**
+     * Whether a new inventory should be prepared - or if we can re-use the previous one.
+     */
+    public boolean canReuseInventory(GeyserSession session, Inventory inventory, Inventory previous) {
+        // Filter for obvious mismatches that require a new inventory
+        if (previous == null
+            || inventory.getContainerType() == null
+            || previous.getContainerType() == null
+            || !Objects.equals(inventory.getContainerType(), previous.getContainerType())) {
+            return false;
+        }
+
+        // Inventory size should also match.
+        if (inventory.getSize() != previous.getSize() || !Objects.equals(inventory.getTitle(), previous.getTitle())) {
+            return false;
+        }
+
+        // TODO can we easily set a new inventory name???
+
+        return true;
+    }
     public abstract boolean prepareInventory(GeyserSession session, Inventory inventory);
     public abstract void openInventory(GeyserSession session, Inventory inventory);
     public abstract void closeInventory(GeyserSession session, Inventory inventory);

--- a/core/src/main/java/org/geysermc/geyser/translator/inventory/InventoryTranslator.java
+++ b/core/src/main/java/org/geysermc/geyser/translator/inventory/InventoryTranslator.java
@@ -153,11 +153,6 @@ public abstract class InventoryTranslator {
             return false;
         }
 
-        if (inventory.getJavaId() != previous.getJavaId()) {
-            GeyserImpl.getInstance().getLogger().debug(session, "Not reusing inventory (%s) due to java id change! ", InventoryUtils.debugInventory(inventory));
-            return false;
-        }
-
         if (inventory.getSize() != previous.getSize()) {
             GeyserImpl.getInstance().getLogger().debug(session, "Not reusing inventory (%s) due to size change! ", InventoryUtils.debugInventory(inventory));
             return false;

--- a/core/src/main/java/org/geysermc/geyser/translator/inventory/LecternInventoryTranslator.java
+++ b/core/src/main/java/org/geysermc/geyser/translator/inventory/LecternInventoryTranslator.java
@@ -200,6 +200,6 @@ public class LecternInventoryTranslator extends AbstractBlockInventoryTranslator
 
     @Override
     public Inventory createInventory(String name, int windowId, ContainerType containerType, PlayerInventory playerInventory) {
-        return new LecternContainer(name, windowId, this.size + playerInventory.getSize(), containerType, playerInventory);
+        return new LecternContainer(name, windowId, this.size + playerInventory.getSize(), containerType, playerInventory, this);
     }
 }

--- a/core/src/main/java/org/geysermc/geyser/translator/inventory/LecternInventoryTranslator.java
+++ b/core/src/main/java/org/geysermc/geyser/translator/inventory/LecternInventoryTranslator.java
@@ -199,7 +199,7 @@ public class LecternInventoryTranslator extends AbstractBlockInventoryTranslator
     }
 
     @Override
-    public Inventory createInventory(String name, int windowId, ContainerType containerType, PlayerInventory playerInventory) {
-        return new LecternContainer(name, windowId, this.size + playerInventory.getSize(), containerType, playerInventory, this);
+    public Inventory createInventory(GeyserSession session, String name, int windowId, ContainerType containerType, PlayerInventory playerInventory) {
+        return new LecternContainer(session, name, windowId, this.size + playerInventory.getSize(), containerType, playerInventory, this);
     }
 }

--- a/core/src/main/java/org/geysermc/geyser/translator/inventory/MerchantInventoryTranslator.java
+++ b/core/src/main/java/org/geysermc/geyser/translator/inventory/MerchantInventoryTranslator.java
@@ -195,7 +195,7 @@ public class MerchantInventoryTranslator extends BaseInventoryTranslator {
     }
 
     @Override
-    public Inventory createInventory(String name, int windowId, ContainerType containerType, PlayerInventory playerInventory) {
-        return new MerchantContainer(name, windowId, this.size, containerType, playerInventory, this);
+    public Inventory createInventory(GeyserSession session, String name, int windowId, ContainerType containerType, PlayerInventory playerInventory) {
+        return new MerchantContainer(session, name, windowId, this.size, containerType, playerInventory, this);
     }
 }

--- a/core/src/main/java/org/geysermc/geyser/translator/inventory/MerchantInventoryTranslator.java
+++ b/core/src/main/java/org/geysermc/geyser/translator/inventory/MerchantInventoryTranslator.java
@@ -196,6 +196,6 @@ public class MerchantInventoryTranslator extends BaseInventoryTranslator {
 
     @Override
     public Inventory createInventory(String name, int windowId, ContainerType containerType, PlayerInventory playerInventory) {
-        return new MerchantContainer(name, windowId, this.size, containerType, playerInventory);
+        return new MerchantContainer(name, windowId, this.size, containerType, playerInventory, this);
     }
 }

--- a/core/src/main/java/org/geysermc/geyser/translator/inventory/PlayerInventoryTranslator.java
+++ b/core/src/main/java/org/geysermc/geyser/translator/inventory/PlayerInventoryTranslator.java
@@ -28,6 +28,7 @@ package org.geysermc.geyser.translator.inventory;
 import it.unimi.dsi.fastutil.ints.IntIterator;
 import it.unimi.dsi.fastutil.ints.IntOpenHashSet;
 import it.unimi.dsi.fastutil.ints.IntSet;
+import org.checkerframework.checker.nullness.qual.NonNull;
 import org.cloudburstmc.math.vector.Vector3i;
 import org.cloudburstmc.protocol.bedrock.data.definitions.BlockDefinition;
 import org.cloudburstmc.protocol.bedrock.data.inventory.ContainerId;
@@ -569,12 +570,12 @@ public class PlayerInventoryTranslator extends InventoryTranslator {
     }
 
     @Override
-    public Inventory createInventory(String name, int windowId, ContainerType containerType, PlayerInventory playerInventory) {
+    public Inventory createInventory(GeyserSession session, String name, int windowId, ContainerType containerType, PlayerInventory playerInventory) {
         throw new UnsupportedOperationException();
     }
 
     @Override
-    public boolean canReuseInventory(GeyserSession session, Inventory inventory, Inventory previous) {
+    public boolean canReuseInventory(GeyserSession session, @NonNull Inventory inventory, @NonNull Inventory previous) {
         return true;
     }
 

--- a/core/src/main/java/org/geysermc/geyser/translator/inventory/PlayerInventoryTranslator.java
+++ b/core/src/main/java/org/geysermc/geyser/translator/inventory/PlayerInventoryTranslator.java
@@ -574,6 +574,11 @@ public class PlayerInventoryTranslator extends InventoryTranslator {
     }
 
     @Override
+    public boolean canReuseInventory(GeyserSession session, Inventory inventory, Inventory previous) {
+        return true;
+    }
+
+    @Override
     public boolean prepareInventory(GeyserSession session, Inventory inventory) {
         return true;
     }

--- a/core/src/main/java/org/geysermc/geyser/translator/inventory/StonecutterInventoryTranslator.java
+++ b/core/src/main/java/org/geysermc/geyser/translator/inventory/StonecutterInventoryTranslator.java
@@ -123,8 +123,8 @@ public class StonecutterInventoryTranslator extends AbstractBlockInventoryTransl
     }
 
     @Override
-    public Inventory createInventory(String name, int windowId, ContainerType containerType, PlayerInventory playerInventory) {
-        return new StonecutterContainer(name, windowId, this.size, containerType, playerInventory, this);
+    public Inventory createInventory(GeyserSession session, String name, int windowId, ContainerType containerType, PlayerInventory playerInventory) {
+        return new StonecutterContainer(session, name, windowId, this.size, containerType, playerInventory, this);
     }
 
     @Override

--- a/core/src/main/java/org/geysermc/geyser/translator/inventory/StonecutterInventoryTranslator.java
+++ b/core/src/main/java/org/geysermc/geyser/translator/inventory/StonecutterInventoryTranslator.java
@@ -124,7 +124,7 @@ public class StonecutterInventoryTranslator extends AbstractBlockInventoryTransl
 
     @Override
     public Inventory createInventory(String name, int windowId, ContainerType containerType, PlayerInventory playerInventory) {
-        return new StonecutterContainer(name, windowId, this.size, containerType, playerInventory);
+        return new StonecutterContainer(name, windowId, this.size, containerType, playerInventory, this);
     }
 
     @Override

--- a/core/src/main/java/org/geysermc/geyser/translator/inventory/chest/ChestInventoryTranslator.java
+++ b/core/src/main/java/org/geysermc/geyser/translator/inventory/chest/ChestInventoryTranslator.java
@@ -53,7 +53,7 @@ public abstract class ChestInventoryTranslator extends BaseInventoryTranslator {
     }
 
     @Override
-    public boolean shouldDelayInventoryOpen(GeyserSession session, Inventory inventory) {
+    public boolean requiresOpeningDelay(GeyserSession session, Inventory inventory) {
         return inventory instanceof Container container && !container.isUsingRealBlock();
     }
 

--- a/core/src/main/java/org/geysermc/geyser/translator/inventory/chest/ChestInventoryTranslator.java
+++ b/core/src/main/java/org/geysermc/geyser/translator/inventory/chest/ChestInventoryTranslator.java
@@ -27,6 +27,7 @@ package org.geysermc.geyser.translator.inventory.chest;
 
 import org.cloudburstmc.protocol.bedrock.data.inventory.ContainerSlotType;
 import org.geysermc.geyser.inventory.BedrockContainerSlot;
+import org.geysermc.geyser.inventory.Container;
 import org.geysermc.geyser.inventory.Inventory;
 import org.geysermc.geyser.inventory.updater.ChestInventoryUpdater;
 import org.geysermc.geyser.inventory.updater.InventoryUpdater;
@@ -49,6 +50,11 @@ public abstract class ChestInventoryTranslator extends BaseInventoryTranslator {
             return true;
         }
         return bedrockDestinationContainer == ContainerSlotType.LEVEL_ENTITY && javaDestinationSlot >= this.size;
+    }
+
+    @Override
+    public boolean shouldDelayInventoryOpen(GeyserSession session, Inventory inventory) {
+        return inventory instanceof Container container && !container.isUsingRealBlock();
     }
 
     @Override

--- a/core/src/main/java/org/geysermc/geyser/translator/inventory/chest/DoubleChestInventoryTranslator.java
+++ b/core/src/main/java/org/geysermc/geyser/translator/inventory/chest/DoubleChestInventoryTranslator.java
@@ -68,23 +68,17 @@ public class DoubleChestInventoryTranslator extends ChestInventoryTranslator {
      * Mirrors {@link BlockInventoryHolder#canReuseContainer(GeyserSession, Container, Container)}
      */
     @Override
-    public boolean canReuseInventory(GeyserSession session, @NonNull Inventory inventory, @NonNull Inventory previous) {
-        if (!super.canReuseInventory(session, inventory, previous) ||
+    public boolean canReuseInventory(GeyserSession session, @NonNull Inventory inventory, @NonNull Inventory oldInventory) {
+        if (!super.canReuseInventory(session, inventory, oldInventory) ||
             !(inventory instanceof Container container) ||
-            !(previous instanceof Container)
+            !(oldInventory instanceof Container previous)
         ) {
             return false;
         }
 
-        if (canUseRealBlock(session, container)) {
-            // We can reuse the same holder position.
-            if (container.getHolderPosition() == previous.getHolderPosition()) {
-                return true;
-            } else {
-                GeyserImpl.getInstance().getLogger().debug(session, "Not reusing inventory (%s) due to real block holder changing (%s -> %s)!",
-                    InventoryUtils.debugInventory(inventory), previous.getHolderPosition(), container.getHolderPosition());
-                return false;
-            }
+        // FIXME - but these aren't the reason we have this
+        if (previous.isUsingRealBlock()) {
+            return false;
         }
 
         // Check if we'd be using the same virtual inventory position.

--- a/core/src/main/java/org/geysermc/geyser/translator/inventory/chest/DoubleChestInventoryTranslator.java
+++ b/core/src/main/java/org/geysermc/geyser/translator/inventory/chest/DoubleChestInventoryTranslator.java
@@ -90,7 +90,6 @@ public class DoubleChestInventoryTranslator extends ChestInventoryTranslator {
         // Check if we'd be using the same virtual inventory position.
         Vector3i position = InventoryUtils.findAvailableWorldSpace(session);
         if (Objects.equals(position, previous.getHolderPosition())) {
-            container.setHolderPosition(position);
             return true;
         } else {
             GeyserImpl.getInstance().getLogger().debug(session, "Not reusing inventory (%s) due to virtual block holder changing (%s -> %s)!",

--- a/core/src/main/java/org/geysermc/geyser/translator/inventory/chest/DoubleChestInventoryTranslator.java
+++ b/core/src/main/java/org/geysermc/geyser/translator/inventory/chest/DoubleChestInventoryTranslator.java
@@ -94,7 +94,6 @@ public class DoubleChestInventoryTranslator extends ChestInventoryTranslator {
 
     @Override
     public boolean prepareInventory(GeyserSession session, Inventory inventory) {
-        GeyserImpl.getInstance().getLogger().info("double chest inv prep");
         if (canUseRealBlock(session, inventory)) {
             return true;
         }
@@ -148,7 +147,6 @@ public class DoubleChestInventoryTranslator extends ChestInventoryTranslator {
         session.sendUpstreamPacket(dataPacket);
 
         inventory.setHolderPosition(position);
-        GeyserImpl.getInstance().getLogger().info("holder pos: " + position);
 
         return true;
     }

--- a/core/src/main/java/org/geysermc/geyser/translator/inventory/chest/DoubleChestInventoryTranslator.java
+++ b/core/src/main/java/org/geysermc/geyser/translator/inventory/chest/DoubleChestInventoryTranslator.java
@@ -160,7 +160,7 @@ public class DoubleChestInventoryTranslator extends ChestInventoryTranslator {
         containerOpenPacket.setUniqueEntityId(inventory.getHolderId());
         session.sendUpstreamPacket(containerOpenPacket);
 
-        GeyserImpl.getInstance().getLogger().info(containerOpenPacket.toString());
+        GeyserImpl.getInstance().getLogger().sessionDebugLog(session, containerOpenPacket.toString());
     }
 
     @Override

--- a/core/src/main/java/org/geysermc/geyser/translator/inventory/chest/DoubleChestInventoryTranslator.java
+++ b/core/src/main/java/org/geysermc/geyser/translator/inventory/chest/DoubleChestInventoryTranslator.java
@@ -78,12 +78,22 @@ public class DoubleChestInventoryTranslator extends ChestInventoryTranslator {
 
         if (canUseRealBlock(session, container)) {
             // We can reuse the same holder position.
-            return container.getHolderPosition() == previous.getHolderPosition();
+            if (container.getHolderPosition() == previous.getHolderPosition()) {
+                return true;
+            } else {
+                GeyserImpl.getInstance().getLogger().debug(session, "Not reusing inventory (%s) due to real block holder changing! ", InventoryUtils.debugInventory(inventory));
+                return false;
+            }
         }
 
         // Check if we'd be using the same virtual inventory position.
         Vector3i position = InventoryUtils.findAvailableWorldSpace(session);
-        return Objects.equals(position, previous.getHolderPosition());
+        if (Objects.equals(position, previous.getHolderPosition())) {
+            return true;
+        } else {
+            GeyserImpl.getInstance().getLogger().debug(session, "Not reusing inventory (%s) due to virtual block holder changing! ", InventoryUtils.debugInventory(inventory));
+            return false;
+        }
     }
 
     @Override

--- a/core/src/main/java/org/geysermc/geyser/translator/inventory/chest/DoubleChestInventoryTranslator.java
+++ b/core/src/main/java/org/geysermc/geyser/translator/inventory/chest/DoubleChestInventoryTranslator.java
@@ -81,7 +81,8 @@ public class DoubleChestInventoryTranslator extends ChestInventoryTranslator {
             if (container.getHolderPosition() == previous.getHolderPosition()) {
                 return true;
             } else {
-                GeyserImpl.getInstance().getLogger().debug(session, "Not reusing inventory (%s) due to real block holder changing! ", InventoryUtils.debugInventory(inventory));
+                GeyserImpl.getInstance().getLogger().debug(session, "Not reusing inventory (%s) due to real block holder changing (%s -> %s)!",
+                    InventoryUtils.debugInventory(inventory), previous.getHolderPosition(), container.getHolderPosition());
                 return false;
             }
         }
@@ -89,9 +90,11 @@ public class DoubleChestInventoryTranslator extends ChestInventoryTranslator {
         // Check if we'd be using the same virtual inventory position.
         Vector3i position = InventoryUtils.findAvailableWorldSpace(session);
         if (Objects.equals(position, previous.getHolderPosition())) {
+            container.setHolderPosition(position);
             return true;
         } else {
-            GeyserImpl.getInstance().getLogger().debug(session, "Not reusing inventory (%s) due to virtual block holder changing! ", InventoryUtils.debugInventory(inventory));
+            GeyserImpl.getInstance().getLogger().debug(session, "Not reusing inventory (%s) due to virtual block holder changing (%s -> %s)!",
+                InventoryUtils.debugInventory(inventory), previous.getHolderPosition(), position);
             return false;
         }
     }

--- a/core/src/main/java/org/geysermc/geyser/translator/inventory/chest/DoubleChestInventoryTranslator.java
+++ b/core/src/main/java/org/geysermc/geyser/translator/inventory/chest/DoubleChestInventoryTranslator.java
@@ -160,7 +160,7 @@ public class DoubleChestInventoryTranslator extends ChestInventoryTranslator {
         containerOpenPacket.setUniqueEntityId(inventory.getHolderId());
         session.sendUpstreamPacket(containerOpenPacket);
 
-        GeyserImpl.getInstance().getLogger().sessionDebugLog(session, containerOpenPacket.toString());
+        GeyserImpl.getInstance().getLogger().debug(session, containerOpenPacket.toString());
     }
 
     @Override

--- a/core/src/main/java/org/geysermc/geyser/translator/inventory/chest/SingleChestInventoryTranslator.java
+++ b/core/src/main/java/org/geysermc/geyser/translator/inventory/chest/SingleChestInventoryTranslator.java
@@ -26,6 +26,7 @@
 package org.geysermc.geyser.translator.inventory.chest;
 
 import org.cloudburstmc.protocol.bedrock.data.inventory.ContainerType;
+import org.geysermc.geyser.inventory.Container;
 import org.geysermc.geyser.inventory.Inventory;
 import org.geysermc.geyser.inventory.holder.BlockInventoryHolder;
 import org.geysermc.geyser.inventory.holder.InventoryHolder;
@@ -57,16 +58,16 @@ public class SingleChestInventoryTranslator extends ChestInventoryTranslator {
 
     @Override
     public boolean prepareInventory(GeyserSession session, Inventory inventory) {
-        return holder.prepareInventory(this, session, inventory);
+        return holder.prepareInventory(session, (Container) inventory);
     }
 
     @Override
     public void openInventory(GeyserSession session, Inventory inventory) {
-        holder.openInventory(this, session, inventory);
+        holder.openInventory(session, (Container) inventory);
     }
 
     @Override
     public void closeInventory(GeyserSession session, Inventory inventory) {
-        holder.closeInventory(this, session, inventory, ContainerType.CONTAINER);
+        holder.closeInventory(session, (Container) inventory, ContainerType.CONTAINER);
     }
 }

--- a/core/src/main/java/org/geysermc/geyser/translator/protocol/bedrock/BedrockBookEditTranslator.java
+++ b/core/src/main/java/org/geysermc/geyser/translator/protocol/bedrock/BedrockBookEditTranslator.java
@@ -32,7 +32,6 @@ import org.geysermc.geyser.session.GeyserSession;
 import org.geysermc.geyser.translator.protocol.PacketTranslator;
 import org.geysermc.geyser.translator.protocol.Translator;
 import org.geysermc.geyser.translator.text.MessageTranslator;
-import org.geysermc.geyser.util.InventoryUtils;
 import org.geysermc.mcprotocollib.protocol.data.game.item.ItemStack;
 import org.geysermc.mcprotocollib.protocol.data.game.item.component.DataComponentTypes;
 import org.geysermc.mcprotocollib.protocol.data.game.item.component.DataComponents;
@@ -133,7 +132,7 @@ public class BedrockBookEditTranslator extends PacketTranslator<BookEditPacket> 
 
             // Update local copy
             session.getPlayerInventory().setItem(36 + session.getPlayerInventory().getHeldItemSlot(), GeyserItemStack.from(bookItem), session);
-            InventoryUtils.getInventoryTranslator(session).updateInventory(session, session.getPlayerInventory());
+            session.getPlayerInventory().updateInventory(session);
 
             String title;
             if (packet.getAction() == BookEditPacket.Action.SIGN_BOOK) {

--- a/core/src/main/java/org/geysermc/geyser/translator/protocol/bedrock/BedrockBookEditTranslator.java
+++ b/core/src/main/java/org/geysermc/geyser/translator/protocol/bedrock/BedrockBookEditTranslator.java
@@ -25,12 +25,6 @@
 
 package org.geysermc.geyser.translator.protocol.bedrock;
 
-import org.geysermc.mcprotocollib.protocol.data.game.item.ItemStack;
-import org.geysermc.mcprotocollib.protocol.data.game.item.component.DataComponentTypes;
-import org.geysermc.mcprotocollib.protocol.data.game.item.component.DataComponents;
-import org.geysermc.mcprotocollib.protocol.data.game.item.component.Filterable;
-import org.geysermc.mcprotocollib.protocol.data.game.item.component.WritableBookContent;
-import org.geysermc.mcprotocollib.protocol.packet.ingame.serverbound.inventory.ServerboundEditBookPacket;
 import org.cloudburstmc.protocol.bedrock.packet.BookEditPacket;
 import org.geysermc.geyser.inventory.GeyserItemStack;
 import org.geysermc.geyser.item.type.WrittenBookItem;
@@ -38,8 +32,18 @@ import org.geysermc.geyser.session.GeyserSession;
 import org.geysermc.geyser.translator.protocol.PacketTranslator;
 import org.geysermc.geyser.translator.protocol.Translator;
 import org.geysermc.geyser.translator.text.MessageTranslator;
+import org.geysermc.geyser.util.InventoryUtils;
+import org.geysermc.mcprotocollib.protocol.data.game.item.ItemStack;
+import org.geysermc.mcprotocollib.protocol.data.game.item.component.DataComponentTypes;
+import org.geysermc.mcprotocollib.protocol.data.game.item.component.DataComponents;
+import org.geysermc.mcprotocollib.protocol.data.game.item.component.Filterable;
+import org.geysermc.mcprotocollib.protocol.data.game.item.component.WritableBookContent;
+import org.geysermc.mcprotocollib.protocol.packet.ingame.serverbound.inventory.ServerboundEditBookPacket;
 
-import java.util.*;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.LinkedList;
+import java.util.List;
 
 @Translator(packet = BookEditPacket.class)
 public class BedrockBookEditTranslator extends PacketTranslator<BookEditPacket> {
@@ -129,7 +133,7 @@ public class BedrockBookEditTranslator extends PacketTranslator<BookEditPacket> 
 
             // Update local copy
             session.getPlayerInventory().setItem(36 + session.getPlayerInventory().getHeldItemSlot(), GeyserItemStack.from(bookItem), session);
-            session.getInventoryTranslator().updateInventory(session, session.getPlayerInventory());
+            InventoryUtils.getInventoryTranslator(session).updateInventory(session, session.getPlayerInventory());
 
             String title;
             if (packet.getAction() == BookEditPacket.Action.SIGN_BOOK) {

--- a/core/src/main/java/org/geysermc/geyser/translator/protocol/bedrock/BedrockBookEditTranslator.java
+++ b/core/src/main/java/org/geysermc/geyser/translator/protocol/bedrock/BedrockBookEditTranslator.java
@@ -132,7 +132,7 @@ public class BedrockBookEditTranslator extends PacketTranslator<BookEditPacket> 
 
             // Update local copy
             session.getPlayerInventory().setItem(36 + session.getPlayerInventory().getHeldItemSlot(), GeyserItemStack.from(bookItem), session);
-            session.getPlayerInventory().updateInventory(session);
+            session.getPlayerInventory().updateInventory();
 
             String title;
             if (packet.getAction() == BookEditPacket.Action.SIGN_BOOK) {

--- a/core/src/main/java/org/geysermc/geyser/translator/protocol/bedrock/BedrockContainerCloseTranslator.java
+++ b/core/src/main/java/org/geysermc/geyser/translator/protocol/bedrock/BedrockContainerCloseTranslator.java
@@ -82,11 +82,11 @@ public class BedrockContainerCloseTranslator extends PacketTranslator<ContainerC
 
         if (openInventory != null) {
             if (bedrockId == openInventory.getBedrockId()) {
-                GeyserImpl.getInstance().getLogger().debug("bedrock id matches, closing inventory java-side");
+                GeyserImpl.getInstance().getLogger().sessionDebugLog(session, "bedrock id matches, closing inventory java-side");
                 InventoryUtils.sendJavaContainerClose(session, openInventory);
                 InventoryUtils.closeInventory(session, openInventory.getJavaId(), false);
             } else if (openInventory.isPending()) {
-                GeyserImpl.getInstance().getLogger().info("opening pending inventory!");
+                GeyserImpl.getInstance().getLogger().sessionDebugLog(session, "opening pending inventory!");
                 InventoryUtils.displayInventory(session, openInventory);
                 openInventory.setPending(false);
 

--- a/core/src/main/java/org/geysermc/geyser/translator/protocol/bedrock/BedrockContainerCloseTranslator.java
+++ b/core/src/main/java/org/geysermc/geyser/translator/protocol/bedrock/BedrockContainerCloseTranslator.java
@@ -26,8 +26,6 @@
 package org.geysermc.geyser.translator.protocol.bedrock;
 
 import org.cloudburstmc.protocol.bedrock.packet.ContainerClosePacket;
-import org.geysermc.geyser.GeyserImpl;
-import org.geysermc.geyser.inventory.Container;
 import org.geysermc.geyser.inventory.Inventory;
 import org.geysermc.geyser.inventory.MerchantContainer;
 import org.geysermc.geyser.session.GeyserSession;
@@ -53,19 +51,19 @@ public class BedrockContainerCloseTranslator extends PacketTranslator<ContainerC
             // 1.16.200 - window ID is always -1 sent from Bedrock for merchant containers
             bedrockId = (byte) openInventory.getBedrockId();
 
-            // If virtual inventories are opened too quickly, they can be occasionally rejected
-            if (openInventory instanceof Container container && !(container instanceof MerchantContainer) && !container.isUsingRealBlock()) {
-                if (session.getContainerOpenAttempts() < 3) {
-                    session.setContainerOpenAttempts(session.getContainerOpenAttempts() + 1);
-                    session.getInventoryTranslator().openInventory(session, session.getOpenInventory());
-                    session.getInventoryTranslator().updateInventory(session, session.getOpenInventory());
-                    session.getOpenInventory().setDisplayed(true);
-                    return;
-                } else {
-                    GeyserImpl.getInstance().getLogger().debug("Exceeded 3 attempts to open a virtual inventory!");
-                    GeyserImpl.getInstance().getLogger().debug(packet + " " + session.getOpenInventory().getClass().getSimpleName());
-                }
-            }
+//            // If virtual inventories are opened too quickly, they can be occasionally rejected
+//            if (openInventory instanceof Container container && !(container instanceof MerchantContainer) && !container.isUsingRealBlock()) {
+//                if (session.getContainerOpenAttempts() < 3) {
+//                    session.setContainerOpenAttempts(session.getContainerOpenAttempts() + 1);
+//                    session.getInventoryTranslator().openInventory(session, session.getOpenInventory());
+//                    session.getInventoryTranslator().updateInventory(session, session.getOpenInventory());
+//                    session.getOpenInventory().setDisplayed(true);
+//                    return;
+//                } else {
+//                    GeyserImpl.getInstance().getLogger().debug("Exceeded 3 attempts to open a virtual inventory!");
+//                    GeyserImpl.getInstance().getLogger().debug(packet + " " + session.getOpenInventory().getClass().getSimpleName());
+//                }
+//            }
         }
 
         session.setContainerOpenAttempts(0);

--- a/core/src/main/java/org/geysermc/geyser/translator/protocol/bedrock/BedrockContainerCloseTranslator.java
+++ b/core/src/main/java/org/geysermc/geyser/translator/protocol/bedrock/BedrockContainerCloseTranslator.java
@@ -46,7 +46,7 @@ public class BedrockContainerCloseTranslator extends PacketTranslator<ContainerC
 
     @Override
     public void translate(GeyserSession session, ContainerClosePacket packet) {
-        GeyserImpl.getInstance().getLogger().sessionDebugLog(session, packet.toString());
+        GeyserImpl.getInstance().getLogger().debug(session, packet.toString());
         byte bedrockId = packet.getId();
 
         //Client wants close confirmation
@@ -60,7 +60,7 @@ public class BedrockContainerCloseTranslator extends PacketTranslator<ContainerC
             bedrockId = (byte) openInventory.getBedrockId();
 
             // If virtual inventories are opened too quickly, they can be occasionally rejected
-            // We just try and queue a new one
+            // We just try and queue a new one.
             if (openInventory instanceof Container container && !(container instanceof MerchantContainer) && !container.isUsingRealBlock()) {
                 if (session.getContainerOpenAttempts() < 3) {
                     container.setPending(true);
@@ -72,12 +72,12 @@ public class BedrockContainerCloseTranslator extends PacketTranslator<ContainerC
                         latencyPacket.setFromServer(true);
                         latencyPacket.setTimestamp(MAGIC_VIRTUAL_INVENTORY_HACK);
                         session.sendUpstreamPacket(latencyPacket);
-                        GeyserImpl.getInstance().getLogger().sessionDebugLog(session, "New latency packet hack attempt: " + latencyPacket);
+                        GeyserImpl.getInstance().getLogger().debug(session, "Unable to open a virtual inventory, sending another latency packet!");
                     }, 200, TimeUnit.MILLISECONDS);
                     return;
                 } else {
-                    GeyserImpl.getInstance().getLogger().sessionDebugLog(session, "Exceeded 3 attempts to open a virtual inventory!");
-                    GeyserImpl.getInstance().getLogger().sessionDebugLog(session, packet + " " + session.getOpenInventory().getClass().getSimpleName());
+                    GeyserImpl.getInstance().getLogger().debug(session, "Exceeded 3 attempts to open a virtual inventory!");
+                    GeyserImpl.getInstance().getLogger().debug(session, packet + " " + session.getOpenInventory().getClass().getSimpleName());
                 }
             }
         }
@@ -86,11 +86,9 @@ public class BedrockContainerCloseTranslator extends PacketTranslator<ContainerC
 
         if (openInventory != null) {
             if (bedrockId == openInventory.getBedrockId()) {
-                GeyserImpl.getInstance().getLogger().sessionDebugLog(session, "bedrock id matches, closing inventory java-side");
                 InventoryUtils.sendJavaContainerClose(session, openInventory);
                 InventoryUtils.closeInventory(session, openInventory.getJavaId(), false);
             } else if (openInventory.isPending()) {
-                GeyserImpl.getInstance().getLogger().sessionDebugLog(session, "opening pending inventory!");
                 InventoryUtils.displayInventory(session, openInventory);
 
                 if (openInventory instanceof MerchantContainer merchantContainer && merchantContainer.getPendingOffersPacket() != null) {

--- a/core/src/main/java/org/geysermc/geyser/translator/protocol/bedrock/BedrockContainerCloseTranslator.java
+++ b/core/src/main/java/org/geysermc/geyser/translator/protocol/bedrock/BedrockContainerCloseTranslator.java
@@ -67,8 +67,6 @@ public class BedrockContainerCloseTranslator extends PacketTranslator<ContainerC
                 // Before making another attempt to re-open, let's make sure we actually need this inventory open.
                 if (session.getContainerOpenAttempts() < 3) {
                     openInventory.setPending(true);
-                    openInventory.setDelayed(true);
-                    session.setPendingOrCurrentBedrockInventoryId(openInventory.getBedrockId());
 
                     session.scheduleInEventLoop(() -> {
                         NetworkStackLatencyPacket latencyPacket = new NetworkStackLatencyPacket();

--- a/core/src/main/java/org/geysermc/geyser/translator/protocol/bedrock/BedrockContainerCloseTranslator.java
+++ b/core/src/main/java/org/geysermc/geyser/translator/protocol/bedrock/BedrockContainerCloseTranslator.java
@@ -64,8 +64,8 @@ public class BedrockContainerCloseTranslator extends PacketTranslator<ContainerC
             if (openInventory instanceof Container container && !(container instanceof MerchantContainer) && !container.isUsingRealBlock()) {
                 if (session.getContainerOpenAttempts() < 3) {
                     container.setPending(true);
-                    container.setCurrentlyDelayed(true);
-                    session.setPendingInventoryId(container.getJavaId());
+                    container.setDelayed(true);
+                    session.setPendingInventoryId(container.getBedrockId());
 
                     session.scheduleInEventLoop(() -> {
                         NetworkStackLatencyPacket latencyPacket = new NetworkStackLatencyPacket();

--- a/core/src/main/java/org/geysermc/geyser/translator/protocol/bedrock/BedrockFilterTextTranslator.java
+++ b/core/src/main/java/org/geysermc/geyser/translator/protocol/bedrock/BedrockFilterTextTranslator.java
@@ -31,7 +31,6 @@ import org.geysermc.geyser.inventory.CartographyContainer;
 import org.geysermc.geyser.session.GeyserSession;
 import org.geysermc.geyser.translator.protocol.PacketTranslator;
 import org.geysermc.geyser.translator.protocol.Translator;
-import org.geysermc.geyser.util.InventoryUtils;
 
 /**
  * Used to send strings to the server and filter out unwanted words.
@@ -49,7 +48,7 @@ public class BedrockFilterTextTranslator extends PacketTranslator<FilterTextPack
         packet.setFromServer(true);
         if (session.getOpenInventory() instanceof AnvilContainer anvilContainer) {
             packet.setText(anvilContainer.checkForRename(session, packet.getText()));
-            InventoryUtils.getInventoryTranslator(session).updateSlot(session, anvilContainer, 1);
+            anvilContainer.updateSlot(session, 1);
         }
         session.sendUpstreamPacket(packet);
     }

--- a/core/src/main/java/org/geysermc/geyser/translator/protocol/bedrock/BedrockFilterTextTranslator.java
+++ b/core/src/main/java/org/geysermc/geyser/translator/protocol/bedrock/BedrockFilterTextTranslator.java
@@ -31,6 +31,7 @@ import org.geysermc.geyser.inventory.CartographyContainer;
 import org.geysermc.geyser.session.GeyserSession;
 import org.geysermc.geyser.translator.protocol.PacketTranslator;
 import org.geysermc.geyser.translator.protocol.Translator;
+import org.geysermc.geyser.util.InventoryUtils;
 
 /**
  * Used to send strings to the server and filter out unwanted words.
@@ -48,7 +49,7 @@ public class BedrockFilterTextTranslator extends PacketTranslator<FilterTextPack
         packet.setFromServer(true);
         if (session.getOpenInventory() instanceof AnvilContainer anvilContainer) {
             packet.setText(anvilContainer.checkForRename(session, packet.getText()));
-            session.getInventoryTranslator().updateSlot(session, anvilContainer, 1);
+            InventoryUtils.getInventoryTranslator(session).updateSlot(session, anvilContainer, 1);
         }
         session.sendUpstreamPacket(packet);
     }

--- a/core/src/main/java/org/geysermc/geyser/translator/protocol/bedrock/BedrockFilterTextTranslator.java
+++ b/core/src/main/java/org/geysermc/geyser/translator/protocol/bedrock/BedrockFilterTextTranslator.java
@@ -48,7 +48,7 @@ public class BedrockFilterTextTranslator extends PacketTranslator<FilterTextPack
         packet.setFromServer(true);
         if (session.getOpenInventory() instanceof AnvilContainer anvilContainer) {
             packet.setText(anvilContainer.checkForRename(session, packet.getText()));
-            anvilContainer.updateSlot(session, 1);
+            anvilContainer.updateSlot(1);
         }
         session.sendUpstreamPacket(packet);
     }

--- a/core/src/main/java/org/geysermc/geyser/translator/protocol/bedrock/BedrockItemStackRequestTranslator.java
+++ b/core/src/main/java/org/geysermc/geyser/translator/protocol/bedrock/BedrockItemStackRequestTranslator.java
@@ -31,6 +31,7 @@ import org.geysermc.geyser.session.GeyserSession;
 import org.geysermc.geyser.translator.inventory.InventoryTranslator;
 import org.geysermc.geyser.translator.protocol.PacketTranslator;
 import org.geysermc.geyser.translator.protocol.Translator;
+import org.geysermc.geyser.util.InventoryUtils;
 
 /**
  * The packet sent for server-authoritative-style inventory transactions.
@@ -44,7 +45,7 @@ public class BedrockItemStackRequestTranslator extends PacketTranslator<ItemStac
         if (inventory == null)
             return;
 
-        InventoryTranslator translator = session.getInventoryTranslator();
+        InventoryTranslator translator = InventoryUtils.getInventoryTranslator(session);
         translator.translateRequests(session, inventory, packet.getRequests());
     }
 }

--- a/core/src/main/java/org/geysermc/geyser/translator/protocol/bedrock/BedrockLecternUpdateTranslator.java
+++ b/core/src/main/java/org/geysermc/geyser/translator/protocol/bedrock/BedrockLecternUpdateTranslator.java
@@ -29,7 +29,6 @@ import org.cloudburstmc.protocol.bedrock.packet.LecternUpdatePacket;
 import org.geysermc.geyser.inventory.Inventory;
 import org.geysermc.geyser.inventory.LecternContainer;
 import org.geysermc.geyser.session.GeyserSession;
-import org.geysermc.geyser.translator.inventory.LecternInventoryTranslator;
 import org.geysermc.geyser.translator.protocol.PacketTranslator;
 import org.geysermc.geyser.translator.protocol.Translator;
 import org.geysermc.geyser.util.InventoryUtils;
@@ -62,9 +61,8 @@ public class BedrockLecternUpdateTranslator extends PacketTranslator<LecternUpda
             // So, fun fact: We need to separately handle fake lecterns!
             // Since those are not actually a real lectern... the Java server won't respond to our requests.
             if (!lecternContainer.isUsingRealBlock()) {
-                LecternInventoryTranslator translator = (LecternInventoryTranslator) session.getInventoryTranslator();
                 Inventory inventory = session.getOpenInventory();
-                translator.updateProperty(session, inventory, 0, newJavaPage);
+                inventory.getTranslator().updateProperty(session, inventory, 0, newJavaPage);
                 return;
             }
 
@@ -73,12 +71,12 @@ public class BedrockLecternUpdateTranslator extends PacketTranslator<LecternUpda
             // is a byte when transmitted over the network and therefore this stops us at 128
             if (newJavaPage > currentJavaPage) {
                 for (int i = currentJavaPage; i < newJavaPage; i++) {
-                    ServerboundContainerButtonClickPacket clickButtonPacket = new ServerboundContainerButtonClickPacket(session.getOpenInventory().getJavaId(), 2);
+                    ServerboundContainerButtonClickPacket clickButtonPacket = new ServerboundContainerButtonClickPacket(lecternContainer.getJavaId(), 2);
                     session.sendDownstreamGamePacket(clickButtonPacket);
                 }
             } else {
                 for (int i = currentJavaPage; i > newJavaPage; i--) {
-                    ServerboundContainerButtonClickPacket clickButtonPacket = new ServerboundContainerButtonClickPacket(session.getOpenInventory().getJavaId(), 1);
+                    ServerboundContainerButtonClickPacket clickButtonPacket = new ServerboundContainerButtonClickPacket(lecternContainer.getJavaId(), 1);
                     session.sendDownstreamGamePacket(clickButtonPacket);
                 }
             }

--- a/core/src/main/java/org/geysermc/geyser/translator/protocol/bedrock/BedrockNetworkStackLatencyTranslator.java
+++ b/core/src/main/java/org/geysermc/geyser/translator/protocol/bedrock/BedrockNetworkStackLatencyTranslator.java
@@ -32,6 +32,7 @@ import org.geysermc.geyser.entity.attribute.GeyserAttributeType;
 import org.geysermc.geyser.session.GeyserSession;
 import org.geysermc.geyser.translator.protocol.PacketTranslator;
 import org.geysermc.geyser.translator.protocol.Translator;
+import org.geysermc.geyser.util.InventoryUtils;
 import org.geysermc.mcprotocollib.protocol.packet.common.serverbound.ServerboundKeepAlivePacket;
 
 import java.util.Collections;
@@ -64,20 +65,24 @@ public class BedrockNetworkStackLatencyTranslator extends PacketTranslator<Netwo
             return;
         }
 
-        session.scheduleInEventLoop(() -> {
-            // Hack to fix the url image loading bug
-            UpdateAttributesPacket attributesPacket = new UpdateAttributesPacket();
-            attributesPacket.setRuntimeEntityId(session.getPlayerEntity().getGeyserId());
+        if (session.getPendingInventoryId() != -1) {
+            InventoryUtils.openPendingInventory(session);
+        } else {
+            session.scheduleInEventLoop(() -> {
+                // Hack to fix the url image loading bug
+                UpdateAttributesPacket attributesPacket = new UpdateAttributesPacket();
+                attributesPacket.setRuntimeEntityId(session.getPlayerEntity().getGeyserId());
 
-            AttributeData attribute = session.getPlayerEntity().getAttributes().get(GeyserAttributeType.EXPERIENCE_LEVEL);
-            if (attribute != null) {
-                attributesPacket.setAttributes(Collections.singletonList(attribute));
-            } else {
-                attributesPacket.setAttributes(Collections.singletonList(GeyserAttributeType.EXPERIENCE_LEVEL.getAttribute(0)));
-            }
+                AttributeData attribute = session.getPlayerEntity().getAttributes().get(GeyserAttributeType.EXPERIENCE_LEVEL);
+                if (attribute != null) {
+                    attributesPacket.setAttributes(Collections.singletonList(attribute));
+                } else {
+                    attributesPacket.setAttributes(Collections.singletonList(GeyserAttributeType.EXPERIENCE_LEVEL.getAttribute(0)));
+                }
 
-            session.sendUpstreamPacket(attributesPacket);
-        }, 500, TimeUnit.MILLISECONDS);
+                session.sendUpstreamPacket(attributesPacket);
+            }, 500, TimeUnit.MILLISECONDS);
+        }
     }
 
     @Override

--- a/core/src/main/java/org/geysermc/geyser/translator/protocol/bedrock/BedrockNetworkStackLatencyTranslator.java
+++ b/core/src/main/java/org/geysermc/geyser/translator/protocol/bedrock/BedrockNetworkStackLatencyTranslator.java
@@ -65,7 +65,7 @@ public class BedrockNetworkStackLatencyTranslator extends PacketTranslator<Netwo
             return;
         }
 
-        if (session.getPendingInventoryId() != -1) {
+        if (session.getPendingOrCurrentBedrockInventoryId() != -1) {
             InventoryUtils.openPendingInventory(session);
         } else {
             session.scheduleInEventLoop(() -> {

--- a/core/src/main/java/org/geysermc/geyser/translator/protocol/bedrock/BedrockSetLocalPlayerAsInitializedTranslator.java
+++ b/core/src/main/java/org/geysermc/geyser/translator/protocol/bedrock/BedrockSetLocalPlayerAsInitializedTranslator.java
@@ -65,8 +65,8 @@ public class BedrockSetLocalPlayerAsInitializedTranslator extends PacketTranslat
                     session.getEntityCache().updateBossBars();
 
                     // Double sigh - https://github.com/GeyserMC/Geyser/issues/2677 - as of Bedrock 1.18
-                    if (session.getOpenInventory() != null && session.getOpenInventory().isPending()) {
-                        InventoryUtils.openInventory(session, session.getOpenInventory());
+                    if (session.getOpenInventory() != null) {
+                        InventoryUtils.openPendingInventory(session);
                     }
 
                     // What am I to expect - as of Bedrock 1.18

--- a/core/src/main/java/org/geysermc/geyser/translator/protocol/java/JavaRespawnTranslator.java
+++ b/core/src/main/java/org/geysermc/geyser/translator/protocol/java/JavaRespawnTranslator.java
@@ -30,7 +30,6 @@ import org.geysermc.geyser.entity.attribute.GeyserAttributeType;
 import org.geysermc.geyser.entity.type.player.SessionPlayerEntity;
 import org.geysermc.geyser.level.JavaDimension;
 import org.geysermc.geyser.session.GeyserSession;
-import org.geysermc.geyser.translator.inventory.InventoryTranslator;
 import org.geysermc.geyser.translator.protocol.PacketTranslator;
 import org.geysermc.geyser.translator.protocol.Translator;
 import org.geysermc.geyser.util.ChunkUtils;
@@ -61,7 +60,6 @@ public class JavaRespawnTranslator extends PacketTranslator<ClientboundRespawnPa
         entity.setHealth(entity.getMaxHealth());
         entity.getAttributes().put(GeyserAttributeType.HEALTH, entity.createHealthAttribute());
 
-        session.setInventoryTranslator(InventoryTranslator.PLAYER_INVENTORY_TRANSLATOR);
         session.setOpenInventory(null);
         session.setClosingInventory(false);
 

--- a/core/src/main/java/org/geysermc/geyser/translator/protocol/java/inventory/JavaContainerSetContentTranslator.java
+++ b/core/src/main/java/org/geysermc/geyser/translator/protocol/java/inventory/JavaContainerSetContentTranslator.java
@@ -79,7 +79,7 @@ public class JavaContainerSetContentTranslator extends PacketTranslator<Clientbo
         session.getPlayerInventory().setCursor(cursor, session);
         InventoryUtils.updateCursor(session);
 
-        if (session.getInventoryTranslator() instanceof SmithingInventoryTranslator) {
+        if (InventoryUtils.getInventoryTranslator(session) instanceof SmithingInventoryTranslator) {
             // On 1.21.1, the recipe output is sometimes only updated here.
             // This can be replicated with shift-clicking the last item into the smithing table.
             // It seems that something in Via 5.1.1 causes 1.21.3 clients - even Java ones -
@@ -92,11 +92,11 @@ public class JavaContainerSetContentTranslator extends PacketTranslator<Clientbo
     }
 
     private void updateInventory(GeyserSession session, Inventory inventory, int containerId) {
-        InventoryTranslator translator = session.getInventoryTranslator();
+        InventoryTranslator translator = InventoryUtils.getInventoryTranslator(session);
         if (containerId == 0 && !(translator instanceof PlayerInventoryTranslator)) {
             // In rare cases, the window ID can still be 0 but Java treats it as valid
             InventoryTranslator.PLAYER_INVENTORY_TRANSLATOR.updateInventory(session, inventory);
-        } else if (translator != null) {
+        } else {
             translator.updateInventory(session, inventory);
         }
     }

--- a/core/src/main/java/org/geysermc/geyser/translator/protocol/java/inventory/JavaContainerSetDataTranslator.java
+++ b/core/src/main/java/org/geysermc/geyser/translator/protocol/java/inventory/JavaContainerSetDataTranslator.java
@@ -41,6 +41,6 @@ public class JavaContainerSetDataTranslator extends PacketTranslator<Clientbound
         if (inventory == null)
             return;
 
-        inventory.updateProperty(session, packet.getRawProperty(), packet.getValue());
+        inventory.updateProperty(packet.getRawProperty(), packet.getValue());
     }
 }

--- a/core/src/main/java/org/geysermc/geyser/translator/protocol/java/inventory/JavaContainerSetDataTranslator.java
+++ b/core/src/main/java/org/geysermc/geyser/translator/protocol/java/inventory/JavaContainerSetDataTranslator.java
@@ -27,7 +27,6 @@ package org.geysermc.geyser.translator.protocol.java.inventory;
 
 import org.geysermc.geyser.inventory.Inventory;
 import org.geysermc.geyser.session.GeyserSession;
-import org.geysermc.geyser.translator.inventory.InventoryTranslator;
 import org.geysermc.geyser.translator.protocol.PacketTranslator;
 import org.geysermc.geyser.translator.protocol.Translator;
 import org.geysermc.geyser.util.InventoryUtils;
@@ -42,7 +41,6 @@ public class JavaContainerSetDataTranslator extends PacketTranslator<Clientbound
         if (inventory == null)
             return;
 
-        InventoryTranslator translator = InventoryUtils.getInventoryTranslator(session);
-        translator.updateProperty(session, inventory, packet.getRawProperty(), packet.getValue());
+        inventory.updateProperty(session, packet.getRawProperty(), packet.getValue());
     }
 }

--- a/core/src/main/java/org/geysermc/geyser/translator/protocol/java/inventory/JavaContainerSetDataTranslator.java
+++ b/core/src/main/java/org/geysermc/geyser/translator/protocol/java/inventory/JavaContainerSetDataTranslator.java
@@ -42,9 +42,7 @@ public class JavaContainerSetDataTranslator extends PacketTranslator<Clientbound
         if (inventory == null)
             return;
 
-        InventoryTranslator translator = session.getInventoryTranslator();
-        if (translator != null) {
-            translator.updateProperty(session, inventory, packet.getRawProperty(), packet.getValue());
-        }
+        InventoryTranslator translator = InventoryUtils.getInventoryTranslator(session);
+        translator.updateProperty(session, inventory, packet.getRawProperty(), packet.getValue());
     }
 }

--- a/core/src/main/java/org/geysermc/geyser/translator/protocol/java/inventory/JavaContainerSetSlotTranslator.java
+++ b/core/src/main/java/org/geysermc/geyser/translator/protocol/java/inventory/JavaContainerSetSlotTranslator.java
@@ -71,7 +71,7 @@ public class JavaContainerSetSlotTranslator extends PacketTranslator<Clientbound
             return;
         }
 
-        InventoryTranslator translator = session.getInventoryTranslator();
+        InventoryTranslator translator = InventoryUtils.getInventoryTranslator(session);
         if (translator != null) {
             int slot = packet.getSlot();
             if (slot >= inventory.getSize()) {
@@ -285,11 +285,11 @@ public class JavaContainerSetSlotTranslator extends PacketTranslator<Clientbound
             // Just set one of the slots to air, then right back to its proper item.
             InventorySlotPacket slotPacket = new InventorySlotPacket();
             slotPacket.setContainerId(ContainerId.UI);
-            slotPacket.setSlot(session.getInventoryTranslator().javaSlotToBedrock(SmithingInventoryTranslator.MATERIAL));
+            slotPacket.setSlot(InventoryUtils.getInventoryTranslator(session).javaSlotToBedrock(SmithingInventoryTranslator.MATERIAL));
             slotPacket.setItem(ItemData.AIR);
             session.sendUpstreamPacket(slotPacket);
 
-            session.getInventoryTranslator().updateSlot(session, inventory, SmithingInventoryTranslator.MATERIAL);
+            InventoryUtils.getInventoryTranslator(session).updateSlot(session, inventory, SmithingInventoryTranslator.MATERIAL);
         }, 150, TimeUnit.MILLISECONDS));
     }
 }

--- a/core/src/main/java/org/geysermc/geyser/translator/protocol/java/inventory/JavaHorseScreenOpenTranslator.java
+++ b/core/src/main/java/org/geysermc/geyser/translator/protocol/java/inventory/JavaHorseScreenOpenTranslator.java
@@ -25,9 +25,6 @@
 
 package org.geysermc.geyser.translator.protocol.java.inventory;
 
-import org.geysermc.geyser.entity.type.living.animal.horse.SkeletonHorseEntity;
-import org.geysermc.geyser.entity.type.living.animal.horse.ZombieHorseEntity;
-import org.geysermc.mcprotocollib.protocol.packet.ingame.clientbound.inventory.ClientboundHorseScreenOpenPacket;
 import org.cloudburstmc.nbt.NbtMap;
 import org.cloudburstmc.nbt.NbtMapBuilder;
 import org.cloudburstmc.nbt.NbtType;
@@ -38,6 +35,8 @@ import org.geysermc.geyser.entity.type.Entity;
 import org.geysermc.geyser.entity.type.living.animal.horse.CamelEntity;
 import org.geysermc.geyser.entity.type.living.animal.horse.ChestedHorseEntity;
 import org.geysermc.geyser.entity.type.living.animal.horse.LlamaEntity;
+import org.geysermc.geyser.entity.type.living.animal.horse.SkeletonHorseEntity;
+import org.geysermc.geyser.entity.type.living.animal.horse.ZombieHorseEntity;
 import org.geysermc.geyser.inventory.Container;
 import org.geysermc.geyser.session.GeyserSession;
 import org.geysermc.geyser.translator.inventory.InventoryTranslator;
@@ -47,6 +46,7 @@ import org.geysermc.geyser.translator.inventory.horse.LlamaInventoryTranslator;
 import org.geysermc.geyser.translator.protocol.PacketTranslator;
 import org.geysermc.geyser.translator.protocol.Translator;
 import org.geysermc.geyser.util.InventoryUtils;
+import org.geysermc.mcprotocollib.protocol.packet.ingame.clientbound.inventory.ClientboundHorseScreenOpenPacket;
 
 import java.util.ArrayList;
 import java.util.Collections;
@@ -153,7 +153,6 @@ public class JavaHorseScreenOpenTranslator extends PacketTranslator<ClientboundH
         updateEquipPacket.setTag(builder.build());
         session.sendUpstreamPacket(updateEquipPacket);
 
-        session.setInventoryTranslator(inventoryTranslator);
-        InventoryUtils.openInventory(session, new Container(entity.getNametag(), packet.getContainerId(), slotCount, null, session.getPlayerInventory()));
+        InventoryUtils.openInventory(session, new Container(entity.getNametag(), packet.getContainerId(), slotCount, null, session.getPlayerInventory(), inventoryTranslator));
     }
 }

--- a/core/src/main/java/org/geysermc/geyser/translator/protocol/java/inventory/JavaHorseScreenOpenTranslator.java
+++ b/core/src/main/java/org/geysermc/geyser/translator/protocol/java/inventory/JavaHorseScreenOpenTranslator.java
@@ -153,6 +153,6 @@ public class JavaHorseScreenOpenTranslator extends PacketTranslator<ClientboundH
         updateEquipPacket.setTag(builder.build());
         session.sendUpstreamPacket(updateEquipPacket);
 
-        InventoryUtils.openInventory(session, new Container(entity.getNametag(), packet.getContainerId(), slotCount, null, session.getPlayerInventory(), inventoryTranslator));
+        InventoryUtils.openInventory(session, new Container(session, entity.getNametag(), packet.getContainerId(), slotCount, null, session.getPlayerInventory(), inventoryTranslator));
     }
 }

--- a/core/src/main/java/org/geysermc/geyser/translator/protocol/java/inventory/JavaOpenBookTranslator.java
+++ b/core/src/main/java/org/geysermc/geyser/translator/protocol/java/inventory/JavaOpenBookTranslator.java
@@ -63,13 +63,11 @@ public class JavaOpenBookTranslator extends PacketTranslator<ClientboundOpenBook
             Inventory openInventory = session.getOpenInventory();
             if (openInventory != null) {
                 InventoryUtils.closeInventory(session, openInventory.getJavaId(), true);
-
                 InventoryUtils.sendJavaContainerClose(session, openInventory);
             }
 
             InventoryTranslator translator = InventoryTranslator.inventoryTranslator(ContainerType.LECTERN);
             Objects.requireNonNull(translator, "could not find lectern inventory translator!");
-            session.setInventoryTranslator(translator);
 
             // Should never be null
             Objects.requireNonNull(translator, "lectern translator must exist");

--- a/core/src/main/java/org/geysermc/geyser/translator/protocol/java/inventory/JavaOpenBookTranslator.java
+++ b/core/src/main/java/org/geysermc/geyser/translator/protocol/java/inventory/JavaOpenBookTranslator.java
@@ -71,7 +71,7 @@ public class JavaOpenBookTranslator extends PacketTranslator<ClientboundOpenBook
 
             // Should never be null
             Objects.requireNonNull(translator, "lectern translator must exist");
-            Inventory inventory = translator.createInventory("", FAKE_LECTERN_WINDOW_ID, ContainerType.LECTERN, session.getPlayerInventory());
+            Inventory inventory = translator.createInventory(session, "", FAKE_LECTERN_WINDOW_ID, ContainerType.LECTERN, session.getPlayerInventory());
             ((LecternContainer) inventory).setFakeLecternBook(stack, session);
             InventoryUtils.openInventory(session, inventory);
         }

--- a/core/src/main/java/org/geysermc/geyser/translator/protocol/java/inventory/JavaOpenScreenTranslator.java
+++ b/core/src/main/java/org/geysermc/geyser/translator/protocol/java/inventory/JavaOpenScreenTranslator.java
@@ -80,8 +80,7 @@ public class JavaOpenScreenTranslator extends PacketTranslator<ClientboundOpenSc
             // Attempt to re-use existing open inventories, if possible.
             // Pending inventories are also considered, as a Java server can re-request the same inventory.
             if (newTranslator.canReuseInventory(session, newInventory, openInventory)) {
-                // Use the same Bedrock id. The java id is already confirmed to match
-                // in the reuse inventory check.
+                // Use the same Bedrock id
                 newInventory.setBedrockId(openInventory.getBedrockId());
 
                 // Also mirror other properties - in case we're e.g. dealing with a pending virtual inventory

--- a/core/src/main/java/org/geysermc/geyser/translator/protocol/java/inventory/JavaOpenScreenTranslator.java
+++ b/core/src/main/java/org/geysermc/geyser/translator/protocol/java/inventory/JavaOpenScreenTranslator.java
@@ -87,7 +87,6 @@ public class JavaOpenScreenTranslator extends PacketTranslator<ClientboundOpenSc
                 boolean pending = openInventory.isPending();
                 newInventory.setDisplayed(openInventory.isDisplayed());
                 newInventory.setPending(pending);
-                newInventory.setDelayed(openInventory.isDelayed());
                 newInventory.setHolderPosition(openInventory.getHolderPosition());
                 newInventory.setHolderId(openInventory.getHolderId());
                 session.setOpenInventory(newInventory);

--- a/core/src/main/java/org/geysermc/geyser/translator/protocol/java/inventory/JavaOpenScreenTranslator.java
+++ b/core/src/main/java/org/geysermc/geyser/translator/protocol/java/inventory/JavaOpenScreenTranslator.java
@@ -87,11 +87,10 @@ public class JavaOpenScreenTranslator extends PacketTranslator<ClientboundOpenSc
                 boolean pending = openInventory.isPending();
                 newInventory.setDisplayed(openInventory.isDisplayed());
                 newInventory.setPending(pending);
-                newInventory.setCurrentlyDelayed(openInventory.isCurrentlyDelayed());
+                newInventory.setDelayed(openInventory.isDelayed());
                 session.setOpenInventory(newInventory);
 
-                GeyserImpl.getInstance().getLogger().debug(session, "Able to reuse current inventory, matching Bedrock id (%s). Is current pending? %s",
-                    openInventory.getBedrockId(), pending);
+                GeyserImpl.getInstance().getLogger().debug(session, "Able to reuse current inventory. Is current pending? %s", pending);
 
                 // If the current inventory is still pending, it'll be updated once open
                 if (newInventory.isDisplayed()) {

--- a/core/src/main/java/org/geysermc/geyser/translator/protocol/java/inventory/JavaOpenScreenTranslator.java
+++ b/core/src/main/java/org/geysermc/geyser/translator/protocol/java/inventory/JavaOpenScreenTranslator.java
@@ -88,6 +88,8 @@ public class JavaOpenScreenTranslator extends PacketTranslator<ClientboundOpenSc
                 newInventory.setDisplayed(openInventory.isDisplayed());
                 newInventory.setPending(pending);
                 newInventory.setDelayed(openInventory.isDelayed());
+                newInventory.setHolderPosition(openInventory.getHolderPosition());
+                newInventory.setHolderId(openInventory.getHolderId());
                 session.setOpenInventory(newInventory);
 
                 GeyserImpl.getInstance().getLogger().debug(session, "Able to reuse current inventory. Is current pending? %s", pending);

--- a/core/src/main/java/org/geysermc/geyser/translator/protocol/java/inventory/JavaOpenScreenTranslator.java
+++ b/core/src/main/java/org/geysermc/geyser/translator/protocol/java/inventory/JavaOpenScreenTranslator.java
@@ -46,7 +46,7 @@ public class JavaOpenScreenTranslator extends PacketTranslator<ClientboundOpenSc
 
     @Override
     public void translate(GeyserSession session, ClientboundOpenScreenPacket packet) {
-        GeyserImpl.getInstance().getLogger().info(packet.toString());
+        GeyserImpl.getInstance().getLogger().sessionDebugLog(session, packet.toString());
         if (packet.getContainerId() == 0) {
             return;
         }
@@ -77,8 +77,8 @@ public class JavaOpenScreenTranslator extends PacketTranslator<ClientboundOpenSc
 
         Inventory newInventory = newTranslator.createInventory(name, packet.getContainerId(), packet.getType(), session.getPlayerInventory());
         if (openInventory != null) {
-            // TODO properly test. This would allow us to open repeating virtual inventories quite a bit faster
-            // Attempt to re-use existing open inventories, if possible
+//            // TODO this would allow us to open repeating virtual inventories quite a bit faster.
+//            // Attempt to re-use existing open inventories, if possible
 //            if (newTranslator.canReuseInventory(session, newInventory, openInventory)) {
 //                // We need to handle pending virtual block inventories *slightly* different
 //                if (session.getPendingInventoryId() == openInventory.getJavaId()

--- a/core/src/main/java/org/geysermc/geyser/translator/protocol/java/inventory/JavaOpenScreenTranslator.java
+++ b/core/src/main/java/org/geysermc/geyser/translator/protocol/java/inventory/JavaOpenScreenTranslator.java
@@ -77,7 +77,8 @@ public class JavaOpenScreenTranslator extends PacketTranslator<ClientboundOpenSc
 
         Inventory newInventory = newTranslator.createInventory(session, name, packet.getContainerId(), packet.getType(), session.getPlayerInventory());
         if (openInventory != null) {
-            // Attempt to re-use existing open inventories, if possible
+            // Attempt to re-use existing open inventories, if possible.
+            // Pending inventories are also considered, as a Java server can re-request the same inventory.
             if (newTranslator.canReuseInventory(session, newInventory, openInventory)) {
                 // Use the same Bedrock id. The java id is already confirmed to match
                 // in the reuse inventory check.

--- a/core/src/main/java/org/geysermc/geyser/translator/protocol/java/inventory/JavaOpenScreenTranslator.java
+++ b/core/src/main/java/org/geysermc/geyser/translator/protocol/java/inventory/JavaOpenScreenTranslator.java
@@ -46,7 +46,7 @@ public class JavaOpenScreenTranslator extends PacketTranslator<ClientboundOpenSc
 
     @Override
     public void translate(GeyserSession session, ClientboundOpenScreenPacket packet) {
-        GeyserImpl.getInstance().getLogger().sessionDebugLog(session, packet.toString());
+        GeyserImpl.getInstance().getLogger().debug(session, packet.toString());
         if (packet.getContainerId() == 0) {
             return;
         }

--- a/core/src/main/java/org/geysermc/geyser/util/InventoryUtils.java
+++ b/core/src/main/java/org/geysermc/geyser/util/InventoryUtils.java
@@ -104,7 +104,7 @@ public class InventoryUtils {
             // Wait for close confirmation from client before opening the new inventory.
             // Handled in BedrockContainerCloseTranslator
             // or - client hasn't yet loaded in; wait until inventory is shown
-            GeyserImpl.getInstance().getLogger().debug(session, "Inv (%s) set pending: closing inv? %s, pending inv id? %s", inventory.getJavaId(), session.isClosingInventory(), session.getPendingInventoryId());
+            GeyserImpl.getInstance().getLogger().debug(session, "Inventory (%s) set pending: closing inv? %s, pending inv id? %s", inventory.getJavaId(), session.isClosingInventory(), session.getPendingInventoryId());
             inventory.setPending(true);
             return;
         }
@@ -208,9 +208,9 @@ public class InventoryUtils {
                 session.setClosingInventory(true);
             }
             session.getBundleCache().onInventoryClose(inventory);
+            GeyserImpl.getInstance().getLogger().debug(session, "Closed inventory: (java id: %s/bedrock id: %s), waiting on confirm? %s", inventory.getJavaId(), inventory.getBedrockId(), session.isClosingInventory());
         }
 
-        GeyserImpl.getInstance().getLogger().debug(session, "Closed inventory: " + (inventory != null ? inventory.getJavaId() : "null") + " Waiting on confirm? %s", session.isClosingInventory());
         session.setOpenInventory(null);
     }
 

--- a/core/src/main/java/org/geysermc/geyser/util/InventoryUtils.java
+++ b/core/src/main/java/org/geysermc/geyser/util/InventoryUtils.java
@@ -172,7 +172,7 @@ public class InventoryUtils {
 
         Inventory inventory = getInventory(session, javaId);
         if (inventory != null) {
-            InventoryTranslator translator = getInventoryTranslator(session);
+            InventoryTranslator translator = inventory.getTranslator();
             translator.closeInventory(session, inventory);
             if (confirm && inventory.isDisplayed() && !inventory.isPending()
                     && !(translator instanceof LecternInventoryTranslator) // Closing lecterns is not followed with a close confirmation

--- a/core/src/main/java/org/geysermc/geyser/util/InventoryUtils.java
+++ b/core/src/main/java/org/geysermc/geyser/util/InventoryUtils.java
@@ -137,6 +137,16 @@ public class InventoryUtils {
         openInventory(session, currentInventory);
     }
 
+    public static boolean shouldQueueRejectedInventory(GeyserSession session) {
+        Inventory currentInventory = session.getOpenInventory();
+        if (currentInventory == null || !currentInventory.isDelayed() || currentInventory.getBedrockId() != session.getPendingInventoryId()) {
+            GeyserImpl.getInstance().getLogger().debug(session, "Aborting NetworkStackLatency hack as the inventory has changed!");
+            return false;
+        }
+
+        return true;
+    }
+
     /**
      * Prepares and displays the current inventory. If necessary, it will queue the opening of virtual inventories.
      * @param inventory the inventory to display
@@ -144,7 +154,7 @@ public class InventoryUtils {
     public static void displayInventory(GeyserSession session, Inventory inventory) {
         InventoryTranslator translator = inventory.getTranslator();
         if (translator.prepareInventory(session, inventory)) {
-            if (translator.shouldDelayInventoryOpen(session, inventory)) {
+            if (translator.requiresOpeningDelay(session, inventory)) {
                 inventory.setPending(true);
                 inventory.setDelayed(true);
                 session.setPendingInventoryId(inventory.getBedrockId());

--- a/core/src/main/java/org/geysermc/geyser/util/InventoryUtils.java
+++ b/core/src/main/java/org/geysermc/geyser/util/InventoryUtils.java
@@ -97,7 +97,6 @@ public class InventoryUtils {
             inventory.setPending(true);
             return;
         }
-
         displayInventory(session, inventory);
     }
 
@@ -183,7 +182,7 @@ public class InventoryUtils {
             session.getBundleCache().onInventoryClose(inventory);
         }
 
-        GeyserImpl.getInstance().getLogger().info("Closed inventory: " + inventory.getJavaId() + " is waiting on confirm?" + session.isClosingInventory());
+        GeyserImpl.getInstance().getLogger().sessionDebugLog(session, "Closed inventory: " + inventory.getJavaId() + " is waiting on confirm?" + session.isClosingInventory());
         session.setOpenInventory(null);
     }
 

--- a/core/src/main/java/org/geysermc/geyser/util/InventoryUtils.java
+++ b/core/src/main/java/org/geysermc/geyser/util/InventoryUtils.java
@@ -502,7 +502,7 @@ public class InventoryUtils {
         return true;
     }
 
-    private static String debugInventory(@Nullable Inventory inventory) {
+    public static String debugInventory(@Nullable Inventory inventory) {
         if (inventory == null) {
             return "null";
         }

--- a/core/src/main/java/org/geysermc/geyser/util/InventoryUtils.java
+++ b/core/src/main/java/org/geysermc/geyser/util/InventoryUtils.java
@@ -25,6 +25,7 @@
 
 package org.geysermc.geyser.util;
 
+import org.checkerframework.checker.nullness.qual.NonNull;
 import org.checkerframework.checker.nullness.qual.Nullable;
 import org.cloudburstmc.math.vector.Vector3i;
 import org.cloudburstmc.nbt.NbtMap;
@@ -34,8 +35,8 @@ import org.cloudburstmc.protocol.bedrock.data.definitions.ItemDefinition;
 import org.cloudburstmc.protocol.bedrock.data.inventory.ContainerId;
 import org.cloudburstmc.protocol.bedrock.data.inventory.ItemData;
 import org.cloudburstmc.protocol.bedrock.packet.InventorySlotPacket;
+import org.cloudburstmc.protocol.bedrock.packet.NetworkStackLatencyPacket;
 import org.geysermc.geyser.GeyserImpl;
-import org.geysermc.geyser.inventory.Container;
 import org.geysermc.geyser.inventory.GeyserItemStack;
 import org.geysermc.geyser.inventory.Inventory;
 import org.geysermc.geyser.inventory.LecternContainer;
@@ -72,7 +73,6 @@ import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Objects;
-import java.util.concurrent.TimeUnit;
 import java.util.function.IntFunction;
 
 public class InventoryUtils {
@@ -84,45 +84,76 @@ public class InventoryUtils {
     
     public static final ItemStack REFRESH_ITEM = new ItemStack(1, 127, new DataComponents(new HashMap<>()));
 
+    public static final long MAGIC_VIRTUAL_INVENTORY_HACK = -9876543210L;
+
     public static void openInventory(GeyserSession session, Inventory inventory) {
+        session.setOldInventory(session.getOpenInventory());
         session.setOpenInventory(inventory);
-        if (session.isClosingInventory() || !session.getUpstream().isInitialized()) {
+        if (session.isClosingInventory() || !session.getUpstream().isInitialized() || session.getPendingInventoryId() != -1) {
             // Wait for close confirmation from client before opening the new inventory.
             // Handled in BedrockContainerCloseTranslator
             // or - client hasn't yet loaded in; wait until inventory is shown
             inventory.setPending(true);
             return;
         }
+
         displayInventory(session, inventory);
     }
 
+    public static void openPendingInventory(GeyserSession session) {
+        Inventory currentInventory = session.getOpenInventory();
+        if (currentInventory == null || !currentInventory.isPending()) {
+            return;
+        }
+
+        // Current inventory isn't null! Let's see if we need to open it.
+        if (currentInventory.getJavaId() == session.getPendingInventoryId()) {
+            openAndUpdateInventory(session, currentInventory);
+            return;
+        }
+
+        session.setPendingInventoryId(-1);
+        openInventory(session, currentInventory);
+    }
+
     public static void displayInventory(GeyserSession session, Inventory inventory) {
-        InventoryTranslator translator = session.getInventoryTranslator();
+        InventoryTranslator translator = inventory.getTranslator();
         if (translator.prepareInventory(session, inventory)) {
-            // 1.21.70 wants a delay on all virtual inventories: https://github.com/GeyserMC/Geyser/issues/5426
-            if (inventory instanceof Container container && !container.isUsingRealBlock()) {
-                session.scheduleInEventLoop(() -> {
-                    Inventory openInv = session.getOpenInventory();
-                    if (openInv != null && openInv.getJavaId() == inventory.getJavaId()) {
-                        translator.openInventory(session, inventory);
-                        translator.updateInventory(session, inventory);
-                        openInv.setDisplayed(true);
-                    } else if (openInv != null && openInv.isPending()) {
-                        // Presumably, this inventory is no longer relevant, and the client doesn't care about it
-                        displayInventory(session, openInv);
-                    }
-                }, 300, TimeUnit.MILLISECONDS);
+            if (translator.shouldDelayInventoryOpen(session, inventory)) {
+                inventory.setPending(true);
+                session.setPendingInventoryId(inventory.getJavaId());
+
+                NetworkStackLatencyPacket latencyPacket = new NetworkStackLatencyPacket();
+                latencyPacket.setFromServer(true);
+                latencyPacket.setTimestamp(MAGIC_VIRTUAL_INVENTORY_HACK);
+                session.sendUpstreamPacket(latencyPacket);
             } else {
-                translator.openInventory(session, inventory);
-                translator.updateInventory(session, inventory);
-                inventory.setDisplayed(true);
+                openAndUpdateInventory(session, inventory);
             }
         } else {
             // Can occur if we e.g. did not find a spot to put a fake container in
             sendJavaContainerClose(session, inventory);
             session.setOpenInventory(null);
-            session.setInventoryTranslator(InventoryTranslator.PLAYER_INVENTORY_TRANSLATOR);
         }
+    }
+
+    public static void openAndUpdateInventory(GeyserSession session, Inventory inventory) {
+        inventory.getTranslator().openInventory(session, inventory);
+        inventory.getTranslator().updateInventory(session, inventory);
+        inventory.setDisplayed(true);
+        inventory.setPending(false);
+        session.setPendingInventoryId(-1);
+    }
+
+    /**
+     * Returns the current inventory translator.
+     */
+    public static @NonNull InventoryTranslator getInventoryTranslator(GeyserSession session) {
+        Inventory inventory = session.getOpenInventory();
+        if (inventory == null) {
+            return InventoryTranslator.PLAYER_INVENTORY_TRANSLATOR;
+        }
+        return inventory.getTranslator();
     }
 
     public static void closeInventory(GeyserSession session, int javaId, boolean confirm) {
@@ -131,7 +162,7 @@ public class InventoryUtils {
 
         Inventory inventory = getInventory(session, javaId);
         if (inventory != null) {
-            InventoryTranslator translator = session.getInventoryTranslator();
+            InventoryTranslator translator = getInventoryTranslator(session);
             translator.closeInventory(session, inventory);
             if (confirm && inventory.isDisplayed() && !inventory.isPending()
                     && !(translator instanceof LecternInventoryTranslator) // Closing lecterns is not followed with a close confirmation
@@ -140,7 +171,9 @@ public class InventoryUtils {
             }
             session.getBundleCache().onInventoryClose(inventory);
         }
-        session.setInventoryTranslator(InventoryTranslator.PLAYER_INVENTORY_TRANSLATOR);
+
+        session.setPendingInventoryId(-1);
+        session.setOldInventory(null);
         session.setOpenInventory(null);
     }
 


### PR DESCRIPTION
this is yet another attempt to resolve issues related to bedrock clients rejecting inventories instead of opening them.

This PR attempts to address it using multiple methods:
- Queuing opening of virtual containers using a NetworkStackLatencyPacket
- Ensuring current inventories and inventory translators don't get out of sync
- In the rare case that the client still rejects opening an inventory, the BedrockContainerCloseTranslator will attempt to re-open the inventory using yet another NetworkStackLatencyPacket hack

This PR further has quite aggressive debug logging related to inventories. If you, the person reading this, is still experiencing issues with inventories *even with this PR*, do the following:
- Enable `debug-mode` in the Geyser config.yml, and restart the server
- Join the server and play for a while until you (or any user) runs into this issue again
- Write a comment here with a geyser dump, and a full server log showing (ideally uploaded via mclo.gs)

You can download the PR builds here:
-  [Geyser-Bungeecord.jar](https://download.geysermc.org/v2/projects/geyserpreview/versions/pr.5443/builds/latest/downloads/bungeecord)
- [Geyser-Fabric.jar](https://download.geysermc.org/v2/projects/geyserpreview/versions/pr.5443/builds/latest/downloads/fabric)
- [Geyser-NeoForge.jar](https://download.geysermc.org/v2/projects/geyserpreview/versions/pr.5443/builds/latest/downloads/neoforge)
- [Geyser-Spigot.jar](https://download.geysermc.org/v2/projects/geyserpreview/versions/pr.5443/builds/latest/downloads/spigot)
- [Geyser-Standalone.jar](https://download.geysermc.org/v2/projects/geyserpreview/versions/pr.5443/builds/latest/downloads/standalone)
- [Geyser-Velocity.jar](https://download.geysermc.org/v2/projects/geyserpreview/versions/pr.5443/builds/latest/downloads/velocity)
- [Geyser-ViaProxy.jar](https://download.geysermc.org/v2/projects/geyserpreview/versions/pr.5443/builds/latest/downloads/viaproxy)

In my extensive testing, this PR seems to work fine. It is hacky, and ugly, but that is the true nature of Minecraft Bedrock edition, and that cannot change. ~~This PR *initially* attempted to work around that by re-using virtual inventories. That bit of code is currently commented out as it's not clear whether there would be a tangible benefit to implementing it. ~~ hahaha chris very funny. Some plugins send multiple ClientboundContainerOpen packets with the same inventory - not reusing inventories would be very annoying.

fixes https://github.com/GeyserMC/Geyser/issues/5440
fixes https://github.com/GeyserMC/Geyser/issues/5439
fixes https://github.com/GeyserMC/Geyser/issues/5437