### PR TITLE
Set ground status to false for teleports

### DIFF
--- a/core/src/main/java/org/geysermc/geyser/translator/protocol/java/entity/player/JavaPlayerPositionTranslator.java
+++ b/core/src/main/java/org/geysermc/geyser/translator/protocol/java/entity/player/JavaPlayerPositionTranslator.java
@@ -126,7 +126,7 @@ public class JavaPlayerPositionTranslator extends PacketTranslator<ClientboundPl
         Vector3f lastPlayerPosition = entity.getPosition().down(EntityDefinitions.PLAYER.offset());
         float lastPlayerPitch = entity.getPitch();
         Vector3f teleportDestination = Vector3f.from(newX, newY, newZ);
-        entity.moveAbsolute(teleportDestination, newYaw, newPitch, true, true);
+        entity.moveAbsolute(teleportDestination, newYaw, newPitch, false, true);
 
         session.getGeyser().getLogger().debug("to " + entity.getPosition().getX() + " " + (entity.getPosition().getY() - EntityDefinitions.PLAYER.offset()) + " " + entity.getPosition().getZ());
 


### PR DESCRIPTION
By setting the bedrock player's ground status to `true` on teleports, this means they can do things like jump after a teleport, which is bad for things like setbacks. Using `false` matches closer with how a Java player would behave.