### PR TITLE
Reintroduce player place null check in BlockPlaceMixin

### DIFF
--- a/bootstrap/mod/src/main/java/org/geysermc/geyser/platform/mod/mixin/server/BlockPlaceMixin.java
+++ b/bootstrap/mod/src/main/java/org/geysermc/geyser/platform/mod/mixin/server/BlockPlaceMixin.java
@@ -49,6 +49,10 @@ public class BlockPlaceMixin {
     @Inject(method = "place", at = @At(value = "INVOKE", target = "Lnet/minecraft/world/level/Level;playSound(Lnet/minecraft/world/entity/Entity;Lnet/minecraft/core/BlockPos;Lnet/minecraft/sounds/SoundEvent;Lnet/minecraft/sounds/SoundSource;FF)V"))
     private void geyser$hijackPlaySound(BlockPlaceContext blockPlaceContext, CallbackInfoReturnable<InteractionResult> callbackInfoReturnable,
                                         @Local BlockPos pos, @Local Player player, @Local(ordinal = 1) BlockState placedState) {
+        if (player == null) {
+            return;
+        }
+
         GeyserSession session = GeyserImpl.getInstance().connectionByUuid(player.getUUID());
         if (session == null) {
             return;


### PR DESCRIPTION
This PR fixes a small bug. The `player == null` check was removed on accident in Geyser's 1.21.5 update, leading to bugs when the player in the `BlockItem#place` method is null (this occurs when dispensers place shulker boxes, as they use this method).

This PR reintroduces this null check.