### PR TITLE
Update mcpl to resolve `Can't join: ByteToMessageCodec$1.decode()" error

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -15,8 +15,7 @@ protocol-common = "3.0.0.Beta6-20250324.162731-5"
 protocol-codec = "3.0.0.Beta6-20250324.162731-5"
 raknet = "1.0.0.CR3-20250218.160705-18"
 minecraftauth = "4.1.1"
-#mcprotocollib = "1.21.5-20250405.134100-23"
-mcprotocollib = "feature~decode-fix-SNAPSHOT"
+mcprotocollib = "1.21.5-20250410.194555-25"
 adventure = "4.14.0"
 adventure-platform = "4.3.0"
 junit = "5.9.2"
@@ -131,8 +130,7 @@ guava = { group = "com.google.guava", name = "guava", version.ref = "guava" }
 gson = { group = "com.google.code.gson", name = "gson", version.ref = "gson" }
 junit = { group = "org.junit.jupiter", name = "junit-jupiter", version.ref = "junit" }
 minecraftauth = { group = "net.raphimc", name = "MinecraftAuth", version.ref = "minecraftauth" }
-#mcprotocollib = { group = "org.geysermc.mcprotocollib", name = "protocol", version.ref = "mcprotocollib" }
-mcprotocollib = { group = "com.github.geysermc", name = "mcprotocollib", version.ref = "mcprotocollib" }
+mcprotocollib = { group = "org.geysermc.mcprotocollib", name = "protocol", version.ref = "mcprotocollib" }
 raknet = { group = "org.cloudburstmc.netty", name = "netty-transport-raknet", version.ref = "raknet" }
 terminalconsoleappender = { group = "net.minecrell", name = "terminalconsoleappender", version.ref = "terminalconsoleappender" }
 velocity-api = { group = "com.velocitypowered", name = "velocity-api", version.ref = "velocity" }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -15,7 +15,8 @@ protocol-common = "3.0.0.Beta6-20250324.162731-5"
 protocol-codec = "3.0.0.Beta6-20250324.162731-5"
 raknet = "1.0.0.CR3-20250218.160705-18"
 minecraftauth = "4.1.1"
-mcprotocollib = "1.21.5-20250405.134100-23"
+#mcprotocollib = "1.21.5-20250405.134100-23"
+mcprotocollib = "feature~decode-fix-SNAPSHOT"
 adventure = "4.14.0"
 adventure-platform = "4.3.0"
 junit = "5.9.2"
@@ -130,7 +131,8 @@ guava = { group = "com.google.guava", name = "guava", version.ref = "guava" }
 gson = { group = "com.google.code.gson", name = "gson", version.ref = "gson" }
 junit = { group = "org.junit.jupiter", name = "junit-jupiter", version.ref = "junit" }
 minecraftauth = { group = "net.raphimc", name = "MinecraftAuth", version.ref = "minecraftauth" }
-mcprotocollib = { group = "org.geysermc.mcprotocollib", name = "protocol", version.ref = "mcprotocollib" }
+#mcprotocollib = { group = "org.geysermc.mcprotocollib", name = "protocol", version.ref = "mcprotocollib" }
+mcprotocollib = { group = "com.github.geysermc", name = "mcprotocollib", version.ref = "mcprotocollib" }
 raknet = { group = "org.cloudburstmc.netty", name = "netty-transport-raknet", version.ref = "raknet" }
 terminalconsoleappender = { group = "net.minecrell", name = "terminalconsoleappender", version.ref = "terminalconsoleappender" }
 velocity-api = { group = "com.velocitypowered", name = "velocity-api", version.ref = "velocity" }


### PR DESCRIPTION
Thanks @basaigh for looking into this - related commit: https://github.com/GeyserMC/MCProtocolLib/commit/cda41bf9c964138c0dcbaa0f1e944056fcbfcfea

Should fix https://github.com/GeyserMC/Geyser/issues/5454