### PR TITLE
More accurate ground status translation.

### DIFF
--- a/core/src/main/java/org/geysermc/geyser/entity/type/player/SessionPlayerEntity.java
+++ b/core/src/main/java/org/geysermc/geyser/entity/type/player/SessionPlayerEntity.java
@@ -420,12 +420,12 @@ public class SessionPlayerEntity extends PlayerEntity {
      * Used to calculate player jumping velocity for ground status calculation.
      */
     public float getJumpVelocity() {
-        float f = 0.42F;
+        float velocity = 0.42F;
 
         if (session.getGeyser().getWorldManager().blockAt(session, this.getPosition().sub(0, EntityDefinitions.PLAYER.offset() + 0.1F, 0).toInt()).is(Blocks.HONEY_BLOCK)) {
-            f *= 0.6F;
+            velocity *= 0.6F;
         }
 
-        return f + 0.1F * session.getEffectCache().getJumpPower();
+        return velocity + 0.1F * session.getEffectCache().getJumpPower();
     }
 }

--- a/core/src/main/java/org/geysermc/geyser/entity/type/player/SessionPlayerEntity.java
+++ b/core/src/main/java/org/geysermc/geyser/entity/type/player/SessionPlayerEntity.java
@@ -36,9 +36,11 @@ import org.cloudburstmc.protocol.bedrock.data.entity.EntityDataTypes;
 import org.cloudburstmc.protocol.bedrock.data.entity.EntityFlag;
 import org.cloudburstmc.protocol.bedrock.packet.MovePlayerPacket;
 import org.cloudburstmc.protocol.bedrock.packet.UpdateAttributesPacket;
+import org.geysermc.geyser.entity.EntityDefinitions;
 import org.geysermc.geyser.entity.attribute.GeyserAttributeType;
 import org.geysermc.geyser.item.Items;
 import org.geysermc.geyser.level.BedrockDimension;
+import org.geysermc.geyser.level.block.Blocks;
 import org.geysermc.geyser.session.GeyserSession;
 import org.geysermc.geyser.util.AttributeUtils;
 import org.geysermc.geyser.util.DimensionUtils;
@@ -87,6 +89,12 @@ public class SessionPlayerEntity extends PlayerEntity {
     private int vehicleJumpStrength;
 
     private int lastAirSupply = getMaxAir();
+
+    /**
+     * The client last tick end velocity, used for calculating player onGround.
+     */
+    @Getter @Setter
+    private Vector3f lastTickEndVelocity = Vector3f.ZERO;
 
     /**
      * Determines if our position is currently out-of-sync with the Java server
@@ -406,5 +414,18 @@ public class SessionPlayerEntity extends PlayerEntity {
         movePlayerPacket.setMode(MovePlayerPacket.Mode.TELEPORT);
         movePlayerPacket.setTeleportationCause(MovePlayerPacket.TeleportationCause.BEHAVIOR);
         session.sendUpstreamPacketImmediately(movePlayerPacket);
+    }
+
+    /**
+     * Used to calculate player jumping velocity for ground status calculation.
+     */
+    public float getJumpVelocity() {
+        float f = 0.42F;
+
+        if (session.getGeyser().getWorldManager().blockAt(session, this.getPosition().sub(0, EntityDefinitions.PLAYER.offset() + 0.1F, 0).toInt()).is(Blocks.HONEY_BLOCK)) {
+            f *= 0.6F;
+        }
+
+        return f + 0.1F * session.getEffectCache().getJumpPower();
     }
 }

--- a/core/src/main/java/org/geysermc/geyser/session/cache/EntityEffectCache.java
+++ b/core/src/main/java/org/geysermc/geyser/session/cache/EntityEffectCache.java
@@ -46,7 +46,7 @@ public class EntityEffectCache {
     @Getter
     private int miningFatigue;
 
-    /* Used to calculate jumping velocity jumping */
+    /* Used to calculate jumping velocity */
     @Getter
     private int jumpPower;
 

--- a/core/src/main/java/org/geysermc/geyser/session/cache/EntityEffectCache.java
+++ b/core/src/main/java/org/geysermc/geyser/session/cache/EntityEffectCache.java
@@ -46,11 +46,16 @@ public class EntityEffectCache {
     @Getter
     private int miningFatigue;
 
+    /* Used to calculate jumping velocity jumping */
+    @Getter
+    private int jumpPower;
+
     public void setEffect(Effect effect, int effectAmplifier) {
         switch (effect) {
             case CONDUIT_POWER -> conduitPower = effectAmplifier + 1;
             case HASTE -> haste = effectAmplifier + 1;
             case MINING_FATIGUE -> miningFatigue = effectAmplifier + 1;
+            case JUMP_BOOST -> jumpPower = effectAmplifier + 1;
         }
         entityEffects.add(effect);
     }
@@ -60,6 +65,7 @@ public class EntityEffectCache {
             case CONDUIT_POWER -> conduitPower = 0;
             case HASTE -> haste = 0;
             case MINING_FATIGUE -> miningFatigue = 0;
+            case JUMP_BOOST -> jumpPower = 0;
         }
         entityEffects.remove(effect);
     }

--- a/core/src/main/java/org/geysermc/geyser/translator/protocol/bedrock/entity/player/input/BedrockMovePlayer.java
+++ b/core/src/main/java/org/geysermc/geyser/translator/protocol/bedrock/entity/player/input/BedrockMovePlayer.java
@@ -33,6 +33,7 @@ import org.geysermc.geyser.entity.EntityDefinitions;
 import org.geysermc.geyser.entity.type.player.SessionPlayerEntity;
 import org.geysermc.geyser.level.physics.CollisionResult;
 import org.geysermc.geyser.session.GeyserSession;
+import org.geysermc.geyser.session.cache.tags.BlockTag;
 import org.geysermc.geyser.text.ChatColor;
 import org.geysermc.mcprotocollib.network.packet.Packet;
 import org.geysermc.mcprotocollib.protocol.packet.ingame.serverbound.player.ServerboundMovePlayerPosPacket;
@@ -86,19 +87,32 @@ final class BedrockMovePlayer {
             session.setLookBackScheduledFuture(null);
         }
 
-        // Client is telling us it wants to move down, but something is blocking it from doing so.
-        boolean isOnGround;
-        if (hasVehicle) {
-            // VERTICAL_COLLISION is not accurate while in a vehicle (as of 1.21.62)
-            isOnGround = Math.abs(packet.getDelta().getY()) < 0.1;
-        } else {
-            isOnGround = packet.getInputData().contains(PlayerAuthInputData.VERTICAL_COLLISION) && packet.getDelta().getY() < 0;
-        }
-
         // This takes into account no movement sent from the client, but the player is trying to move anyway.
         // (Press into a wall in a corner - you're trying to move but nothing actually happens)
         // This isn't sent when a player is riding a vehicle (as of 1.21.62)
         boolean horizontalCollision = packet.getInputData().contains(PlayerAuthInputData.HORIZONTAL_COLLISION);
+
+        // Simulate jumping since it happened this tick, not from the last tick end.
+        if (entity.isOnGround() && packet.getInputData().contains(PlayerAuthInputData.START_JUMPING)) {
+            entity.setLastTickEndVelocity(Vector3f.from(entity.getLastTickEndVelocity().getX(), Math.max(entity.getLastTickEndVelocity().getY(), entity.getJumpVelocity()), entity.getLastTickEndVelocity().getZ()));
+        }
+
+        // Due to how ladder works on Bedrock, we won't get climbing velocity from tick end unless if you're colliding horizontally. So we account for it ourselves.
+        boolean onClimbableBlock = session.getTagCache().is(BlockTag.CLIMBABLE, session.getGeyser().getWorldManager().blockAt(session, entity.getPosition().sub(0, EntityDefinitions.PLAYER.offset(), 0).toInt()).block());
+        if (onClimbableBlock && (packet.getInputData().contains(PlayerAuthInputData.JUMPING) || horizontalCollision)) {
+            entity.setLastTickEndVelocity(Vector3f.from(entity.getLastTickEndVelocity().getX(), 0.2F, entity.getLastTickEndVelocity().getZ()));
+        }
+
+        // Client is telling us it wants to move down, but something is blocking it from doing so.
+        boolean isOnGround;
+        if (hasVehicle) {
+            // VERTICAL_COLLISION is not accurate while in a vehicle (as of 1.21.62)
+            isOnGround = Math.abs(entity.getLastTickEndVelocity().getY()) < 0.1;
+        } else {
+            isOnGround = packet.getInputData().contains(PlayerAuthInputData.VERTICAL_COLLISION) && entity.getLastTickEndVelocity().getY() < 0;
+        }
+
+        entity.setLastTickEndVelocity(packet.getDelta());
 
         // If only the pitch and yaw changed
         // This isn't needed, but it makes the packets closer to vanilla

--- a/core/src/main/java/org/geysermc/geyser/translator/protocol/bedrock/entity/player/input/BedrockMovePlayer.java
+++ b/core/src/main/java/org/geysermc/geyser/translator/protocol/bedrock/entity/player/input/BedrockMovePlayer.java
@@ -87,11 +87,6 @@ final class BedrockMovePlayer {
             session.setLookBackScheduledFuture(null);
         }
 
-        // This takes into account no movement sent from the client, but the player is trying to move anyway.
-        // (Press into a wall in a corner - you're trying to move but nothing actually happens)
-        // This isn't sent when a player is riding a vehicle (as of 1.21.62)
-        boolean horizontalCollision = packet.getInputData().contains(PlayerAuthInputData.HORIZONTAL_COLLISION);
-
         // Simulate jumping since it happened this tick, not from the last tick end.
         if (entity.isOnGround() && packet.getInputData().contains(PlayerAuthInputData.START_JUMPING)) {
             entity.setLastTickEndVelocity(Vector3f.from(entity.getLastTickEndVelocity().getX(), Math.max(entity.getLastTickEndVelocity().getY(), entity.getJumpVelocity()), entity.getLastTickEndVelocity().getZ()));
@@ -99,7 +94,7 @@ final class BedrockMovePlayer {
 
         // Due to how ladder works on Bedrock, we won't get climbing velocity from tick end unless if you're colliding horizontally. So we account for it ourselves.
         boolean onClimbableBlock = session.getTagCache().is(BlockTag.CLIMBABLE, session.getGeyser().getWorldManager().blockAt(session, entity.getPosition().sub(0, EntityDefinitions.PLAYER.offset(), 0).toInt()).block());
-        if (onClimbableBlock && (packet.getInputData().contains(PlayerAuthInputData.JUMPING) || horizontalCollision)) {
+        if (onClimbableBlock && packet.getInputData().contains(PlayerAuthInputData.JUMPING)) {
             entity.setLastTickEndVelocity(Vector3f.from(entity.getLastTickEndVelocity().getX(), 0.2F, entity.getLastTickEndVelocity().getZ()));
         }
 
@@ -113,6 +108,11 @@ final class BedrockMovePlayer {
         }
 
         entity.setLastTickEndVelocity(packet.getDelta());
+
+        // This takes into account no movement sent from the client, but the player is trying to move anyway.
+        // (Press into a wall in a corner - you're trying to move but nothing actually happens)
+        // This isn't sent when a player is riding a vehicle (as of 1.21.62)
+        boolean horizontalCollision = packet.getInputData().contains(PlayerAuthInputData.HORIZONTAL_COLLISION);
 
         // If only the pitch and yaw changed
         // This isn't needed, but it makes the packets closer to vanilla


### PR DESCRIPTION
Does what it said, this issue was previously mentioned by cotander (@SamB440) in a thread on the main discord server, this is his video showing the issues https://youtu.be/px0tzkzOzMQ

There is 2 main problems causing this:

1. Geyser is using the packet.getDelta() which is inaccurate since VERTICAL_COLLISION is the result of last tick delta after applied collision. 
Ex: This is easily reproduceable by jumping with a block two blocks above you (again mentioned by cotander) since when we collide our y velocity got reset and then applied gravity (-0.0784) which is what the client send this tick -0.0784 < 0 and VERTICAL_COLLISION is true so Geyser thinks that player ground is true but VERTICAL_COLLISION is actually use the last tick delta to calculate stuff (aka around 0.3332 or 0.248136) which means Geyser is going to be wrong!

2. Climbing ladder being wrong is actually caused by Bedrock movement differences, if it acts the same as Java the y tick end we received should be 0.2 but it acts differently, it actually applied the 0.2 motion BEFORE collision got calculate, then when we're colliding our y motion got reset to 0 again (since we're are colliding on y axis) then applied gravity -0.0784 and then it send the server that value, therefore it never lets server know the 0.2 motion exist, I won't talk too much about this, I already documented this here (https://github.com/Oryxel/Boar/blob/new-engine/DIFFERENCES_WIKI.md#climbing-ladder) which should explains why this is the case (this should be accurate since it is according to BDS).

This is fixed by use the right tick end velocity and accounting for both jumping and climbing ladder at tick start.