### PR TITLE
Ensure no more than 1000 entries are in a PlayerListPacket

### DIFF
--- a/core/src/main/java/org/geysermc/geyser/entity/type/living/animal/farm/TemperatureVariantAnimal.java
+++ b/core/src/main/java/org/geysermc/geyser/entity/type/living/animal/farm/TemperatureVariantAnimal.java
@@ -58,7 +58,7 @@ public abstract class TemperatureVariantAnimal extends AnimalEntity implements V
         updateBedrockEntityProperties();
     }
 
-    public enum BuiltInVariant implements BuiltIn {
+    public enum BuiltInVariant implements VariantHolder.BuiltIn {
         COLD,
         TEMPERATE,
         WARM

--- a/core/src/main/java/org/geysermc/geyser/translator/protocol/java/JavaFinishConfigurationTranslator.java
+++ b/core/src/main/java/org/geysermc/geyser/translator/protocol/java/JavaFinishConfigurationTranslator.java
@@ -34,8 +34,10 @@ import org.geysermc.geyser.registry.Registries;
 import org.geysermc.geyser.session.GeyserSession;
 import org.geysermc.geyser.translator.protocol.PacketTranslator;
 import org.geysermc.geyser.translator.protocol.Translator;
+import org.geysermc.geyser.util.PlayerListUtils;
 import org.geysermc.mcprotocollib.protocol.packet.configuration.clientbound.ClientboundFinishConfigurationPacket;
 
+import java.util.ArrayList;
 import java.util.List;
 import java.util.UUID;
 
@@ -56,12 +58,11 @@ public class JavaFinishConfigurationTranslator extends PacketTranslator<Clientbo
     @Override
     public void translate(GeyserSession session, ClientboundFinishConfigurationPacket packet) {
         // Clear the player list, as on Java the player list is cleared after transitioning from config to play phase
-        PlayerListPacket playerListPacket = new PlayerListPacket();
-        playerListPacket.setAction(PlayerListPacket.Action.REMOVE);
+        List<PlayerListPacket.Entry> entries = new ArrayList<>();
         for (PlayerEntity otherEntity : session.getEntityCache().getAllPlayerEntities()) {
-            playerListPacket.getEntries().add(new PlayerListPacket.Entry(otherEntity.getTabListUuid()));
+            entries.add(new PlayerListPacket.Entry(otherEntity.getTabListUuid()));
         }
-        session.sendUpstreamPacket(playerListPacket);
+        PlayerListUtils.batchSendPlayerList(session, entries, PlayerListPacket.Action.REMOVE);
         session.getEntityCache().removeAllPlayerEntities();
 
         // Potion mixes are registered by default, as they are needed to be able to put ingredients into the brewing stand.

--- a/core/src/main/java/org/geysermc/geyser/translator/protocol/java/entity/player/JavaPlayerInfoRemoveTranslator.java
+++ b/core/src/main/java/org/geysermc/geyser/translator/protocol/java/entity/player/JavaPlayerInfoRemoveTranslator.java
@@ -31,15 +31,17 @@ import org.geysermc.geyser.entity.type.player.PlayerEntity;
 import org.geysermc.geyser.session.GeyserSession;
 import org.geysermc.geyser.translator.protocol.PacketTranslator;
 import org.geysermc.geyser.translator.protocol.Translator;
+import org.geysermc.geyser.util.PlayerListUtils;
 
+import java.util.ArrayList;
+import java.util.List;
 import java.util.UUID;
 
 @Translator(packet = ClientboundPlayerInfoRemovePacket.class)
 public class JavaPlayerInfoRemoveTranslator extends PacketTranslator<ClientboundPlayerInfoRemovePacket> {
     @Override
     public void translate(GeyserSession session, ClientboundPlayerInfoRemovePacket packet) {
-        PlayerListPacket translate = new PlayerListPacket();
-        translate.setAction(PlayerListPacket.Action.REMOVE);
+        List<PlayerListPacket.Entry> entries = new ArrayList<>();
 
         for (UUID id : packet.getProfileIds()) {
             // As the player entity is no longer present, we can remove the entry
@@ -52,9 +54,9 @@ public class JavaPlayerInfoRemoveTranslator extends PacketTranslator<Clientbound
             } else {
                 removeId = id;
             }
-            translate.getEntries().add(new PlayerListPacket.Entry(removeId));
+            entries.add(new PlayerListPacket.Entry(removeId));
         }
 
-        session.sendUpstreamPacket(translate);
+        PlayerListUtils.batchSendPlayerList(session, entries, PlayerListPacket.Action.REMOVE);
     }
 }

--- a/core/src/main/java/org/geysermc/geyser/translator/protocol/java/entity/player/JavaPlayerInfoUpdateTranslator.java
+++ b/core/src/main/java/org/geysermc/geyser/translator/protocol/java/entity/player/JavaPlayerInfoUpdateTranslator.java
@@ -34,6 +34,7 @@ import org.geysermc.geyser.session.GeyserSession;
 import org.geysermc.geyser.skin.SkinManager;
 import org.geysermc.geyser.translator.protocol.PacketTranslator;
 import org.geysermc.geyser.translator.protocol.Translator;
+import org.geysermc.geyser.util.PlayerListUtils;
 import org.geysermc.mcprotocollib.auth.GameProfile;
 import org.geysermc.mcprotocollib.protocol.data.game.PlayerListEntry;
 import org.geysermc.mcprotocollib.protocol.data.game.PlayerListEntryAction;
@@ -119,16 +120,10 @@ public class JavaPlayerInfoUpdateTranslator extends PacketTranslator<Clientbound
             }
 
             if (!toAdd.isEmpty()) {
-                PlayerListPacket tabListPacket = new PlayerListPacket();
-                tabListPacket.setAction(PlayerListPacket.Action.ADD);
-                tabListPacket.getEntries().addAll(toAdd);
-                session.sendUpstreamPacket(tabListPacket);
+                PlayerListUtils.batchSendPlayerList(session, toAdd, PlayerListPacket.Action.ADD);
             }
             if (!toRemove.isEmpty()) {
-                PlayerListPacket tabListPacket = new PlayerListPacket();
-                tabListPacket.setAction(PlayerListPacket.Action.REMOVE);
-                tabListPacket.getEntries().addAll(toRemove);
-                session.sendUpstreamPacket(tabListPacket);
+                PlayerListUtils.batchSendPlayerList(session, toRemove, PlayerListPacket.Action.REMOVE);
             }
         }
     }

--- a/core/src/main/java/org/geysermc/geyser/util/PlayerListUtils.java
+++ b/core/src/main/java/org/geysermc/geyser/util/PlayerListUtils.java
@@ -1,0 +1,63 @@
+/*
+ * Copyright (c) 2019-2025 GeyserMC. http://geysermc.org
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ *
+ * @author GeyserMC
+ * @link https://github.com/GeyserMC/Geyser
+ */
+
+package org.geysermc.geyser.util;
+
+import org.cloudburstmc.protocol.bedrock.packet.PlayerListPacket;
+import org.geysermc.geyser.session.GeyserSession;
+
+import java.util.List;
+
+public class PlayerListUtils {
+    static final int MAX_PLAYER_LIST_PACKET_ENTRIES = 1000;
+
+    /**
+     * Sends a player list packet to the client with the given entries.
+     * If there are too many provided entries, multiple packets will be sent.
+     *
+     * @param session the Geyser session
+     * @param entries the list of player list packet entries to send
+     * @param action  the action to perform with the player list
+     */
+    public static void batchSendPlayerList(GeyserSession session, List<PlayerListPacket.Entry> entries, PlayerListPacket.Action action) {
+        if (entries.size() > MAX_PLAYER_LIST_PACKET_ENTRIES) {
+            int batches = entries.size() / MAX_PLAYER_LIST_PACKET_ENTRIES + 1;
+            for (int i = 0; i < batches; i++) {
+                int start = i * MAX_PLAYER_LIST_PACKET_ENTRIES;
+                int end = Math.min(start + MAX_PLAYER_LIST_PACKET_ENTRIES, entries.size());
+
+                PlayerListPacket packet = new PlayerListPacket();
+                packet.setAction(action);
+                packet.getEntries().addAll(entries.subList(start, end));
+                session.sendUpstreamPacket(packet);
+            }
+        } else {
+            PlayerListPacket packet = new PlayerListPacket();
+            packet.setAction(action);
+            packet.getEntries().addAll(entries);
+            session.sendUpstreamPacket(packet);
+        }
+    }
+}

--- a/core/src/main/java/org/geysermc/geyser/util/PlayerListUtils.java
+++ b/core/src/main/java/org/geysermc/geyser/util/PlayerListUtils.java
@@ -43,7 +43,7 @@ public class PlayerListUtils {
      */
     public static void batchSendPlayerList(GeyserSession session, List<PlayerListPacket.Entry> entries, PlayerListPacket.Action action) {
         if (entries.size() > MAX_PLAYER_LIST_PACKET_ENTRIES) {
-            int batches = entries.size() / MAX_PLAYER_LIST_PACKET_ENTRIES + 1;
+            int batches = entries.size() / MAX_PLAYER_LIST_PACKET_ENTRIES + (entries.size() % MAX_PLAYER_LIST_PACKET_ENTRIES > 0 ? 1 : 0);
             for (int i = 0; i < batches; i++) {
                 int start = i * MAX_PLAYER_LIST_PACKET_ENTRIES;
                 int end = Math.min(start + MAX_PLAYER_LIST_PACKET_ENTRIES, entries.size());


### PR DESCRIPTION
Currently, the Bedrock client will automatically disconnect if there are more than 1000 entries in a [Player List](https://mojang.github.io/bedrock-protocol-docs/html/PlayerListPacket.html) packet. This PR batches into multiple packets when this value is exceeded.