### PR TITLE
Fix: optimize pattern compilation for java to reduce memory

### DIFF
--- a/core/src/main/java/org/geysermc/geyser/translator/text/MessageTranslator.java
+++ b/core/src/main/java/org/geysermc/geyser/translator/text/MessageTranslator.java
@@ -57,6 +57,7 @@ import org.geysermc.mcprotocollib.protocol.data.game.chat.ChatTypeDecoration;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.regex.Pattern;
 
 public class MessageTranslator {
     // These are used for handling the translations of the messages
@@ -74,6 +75,7 @@ public class MessageTranslator {
 
     // Reset character
     private static final String RESET = BASE + "r";
+    private static final Pattern RESET_PATTERN = Pattern.compile("(" + RESET + "){2,}");
 
     static {
         // Temporary fix for https://github.com/KyoriPowered/adventure/issues/447 - TODO resolve properly
@@ -197,7 +199,7 @@ public class MessageTranslator {
             String finalLegacyString = finalLegacy.toString();
 
             // Remove duplicate resets and trailing resets
-            finalLegacyString = finalLegacyString.replaceAll("(" + RESET + "){2,}", RESET);
+            finalLegacyString = RESET_PATTERN.matcher(finalLegacyString).replaceAll(RESET);
             if (finalLegacyString.endsWith(RESET)) {
                 finalLegacyString = finalLegacyString.substring(0, finalLegacyString.length() - 2);
             }


### PR DESCRIPTION
# Using Pattern.compile() vs replaceAll() for Regular Expressions in Java

This PR optimizes the memory usage for reset pattern in Java.

## Why Pattern.compile() is Preferred Over replaceAll()

When working with regular expressions in Java, using `Pattern.compile()` is significantly more efficient than `replaceAll()` for several reasons:

1. **Performance Optimization**: `replaceAll()` recompiles the regex pattern on each call, while `Pattern.compile()` only compiles it once.

2. **Memory Efficiency**: Precompiled patterns reduce memory usage and garbage collection overhead.

3. **Reusability**: A compiled pattern can be reused across multiple operations.

According to the [Java documentation](https://docs.oracle.com/javase/8/docs/api/java/lang/String.html#replaceAll-java.lang.String-java.lang.String-), `String.replaceAll()` internally creates a new `Pattern` object each time it's called.

```java
// Inefficient - pattern recompiled on each iteration
for (String s : strings) {
    s = s.replaceAll("regex", "replacement");
}

// Efficient - pattern compiled once
Pattern pattern = Pattern.compile("regex");
for (String s : strings) {
    s = pattern.matcher(s).replaceAll("replacement");
}
```
