### PR TITLE
Set default player head rarity

### DIFF
--- a/core/src/main/java/org/geysermc/geyser/item/type/PlayerHeadItem.java
+++ b/core/src/main/java/org/geysermc/geyser/item/type/PlayerHeadItem.java
@@ -46,14 +46,8 @@ public class PlayerHeadItem extends BlockItem {
     public void translateComponentsToBedrock(@NonNull GeyserSession session, @NonNull DataComponents components, @NonNull TooltipOptions tooltip, @NonNull BedrockItemBuilder builder) {
         super.translateComponentsToBedrock(session, components, tooltip, builder);
 
-        // Get the rarity of the item or default to uncommon
-        Integer id = components.get(DataComponentTypes.RARITY);
-        if (id == null) {
-            id = Rarity.UNCOMMON.ordinal();
-        }
-
         // Use the correct color, determined by the rarity of the item
-        char rarity = Rarity.fromId(id).getColor();
+        char rarity = Rarity.fromId(components.getOrDefault(DataComponentTypes.RARITY, Rarity.COMMON.ordinal())).getColor();
 
         GameProfile profile = components.get(DataComponentTypes.PROFILE);
         if (profile != null) {

--- a/core/src/main/java/org/geysermc/geyser/item/type/PlayerHeadItem.java
+++ b/core/src/main/java/org/geysermc/geyser/item/type/PlayerHeadItem.java
@@ -46,8 +46,14 @@ public class PlayerHeadItem extends BlockItem {
     public void translateComponentsToBedrock(@NonNull GeyserSession session, @NonNull DataComponents components, @NonNull TooltipOptions tooltip, @NonNull BedrockItemBuilder builder) {
         super.translateComponentsToBedrock(session, components, tooltip, builder);
 
+        // Get the rarity of the item or default to uncommon
+        Integer id = components.get(DataComponentTypes.RARITY);
+        if (id == null) {
+            id = Rarity.UNCOMMON.ordinal();
+        }
+
         // Use the correct color, determined by the rarity of the item
-        char rarity = Rarity.fromId(components.get(DataComponentTypes.RARITY)).getColor();
+        char rarity = Rarity.fromId(id).getColor();
 
         GameProfile profile = components.get(DataComponentTypes.PROFILE);
         if (profile != null) {


### PR DESCRIPTION
Defaults player heads to common rarity in the case the component is missing. This prevents inventories from disappearing that contain an invalid head like this.

Fixes #5513 