### PR TITLE
Use the right javaId when registering nonvanilla block states

### DIFF
--- a/core/src/main/java/org/geysermc/geyser/level/block/type/Block.java
+++ b/core/src/main/java/org/geysermc/geyser/level/block/type/Block.java
@@ -306,11 +306,15 @@ public class Block {
 
         private List<BlockState> build(Block block) {
             if (states.isEmpty()) {
+                BlockState state;
                 if (javaId == null) {
-                    javaId = BlockRegistries.BLOCK_STATES.get().size();
+                    state = new BlockState(block, BlockRegistries.BLOCK_STATES.get().size());
+                    BlockRegistries.BLOCK_STATES.get().add(state);
+                } else {
+                    state = new BlockState(block, javaId);
+                    BlockRegistries.BLOCK_STATES.registerWithAnyIndex(javaId, state, Blocks.AIR.defaultBlockState());
                 }
-                BlockState state = new BlockState(block, javaId);
-                BlockRegistries.BLOCK_STATES.get().add(state);
+
                 return List.of(state);
             } else if (states.size() == 1) {
                 // We can optimize because we don't need to worry about combinations


### PR DESCRIPTION
This PR adjusts the `Block.Builder#build` method to use the right `javaId` when registering its block states in the `BLOCK_STATES` registry. This should fix bugs with some non-vanilla blocks.