### PR TITLE
Don't set deprecated property on area-effect-cloud entities

### DIFF
--- a/core/src/main/java/org/geysermc/geyser/entity/type/AreaEffectCloudEntity.java
+++ b/core/src/main/java/org/geysermc/geyser/entity/type/AreaEffectCloudEntity.java
@@ -54,7 +54,6 @@ public class AreaEffectCloudEntity extends Entity {
 
         // This disabled client side shrink of the cloud
         dirtyMetadata.put(EntityDataTypes.AREA_EFFECT_CLOUD_RADIUS, 3.0f);
-        dirtyMetadata.put(EntityDataTypes.AREA_EFFECT_CLOUD_CHANGE_RATE, Float.MIN_VALUE);
         dirtyMetadata.put(EntityDataTypes.AREA_EFFECT_CLOUD_CHANGE_ON_PICKUP, Float.MIN_VALUE);
 
         setFlag(EntityFlag.FIRE_IMMUNE, true);


### PR DESCRIPTION
This should avoid black particles when none are set - resolves https://github.com/GeyserMC/Geyser/issues/5219