### PR TITLE
Catch slot IDs under 0 when checking inventory bounds in set slot packet

### DIFF
--- a/core/src/main/java/org/geysermc/geyser/inventory/Inventory.java
+++ b/core/src/main/java/org/geysermc/geyser/inventory/Inventory.java
@@ -139,7 +139,7 @@ public abstract class Inventory {
     public abstract int getOffsetForHotbar(@Range(from = 0, to = 8) int slot);
 
     public void setItem(int slot, @NonNull GeyserItemStack newItem, GeyserSession session) {
-        if (slot < 0 || slot > this.size) {
+        if (slot < 0 || slot >= this.size) {
             session.getGeyser().getLogger().debug("Tried to set an item out of bounds (slot was " + slot + ")! " + this);
             return;
         }

--- a/core/src/main/java/org/geysermc/geyser/inventory/Inventory.java
+++ b/core/src/main/java/org/geysermc/geyser/inventory/Inventory.java
@@ -139,8 +139,8 @@ public abstract class Inventory {
     public abstract int getOffsetForHotbar(@Range(from = 0, to = 8) int slot);
 
     public void setItem(int slot, @NonNull GeyserItemStack newItem, GeyserSession session) {
-        if (slot > this.size) {
-            session.getGeyser().getLogger().debug("Tried to set an item out of bounds! " + this);
+        if (slot < 0 || slot > this.size) {
+            session.getGeyser().getLogger().debug("Tried to set an item out of bounds (slot was " + slot + ")! " + this);
             return;
         }
         GeyserItemStack oldItem = items[slot];

--- a/core/src/main/java/org/geysermc/geyser/translator/protocol/java/inventory/JavaContainerSetSlotTranslator.java
+++ b/core/src/main/java/org/geysermc/geyser/translator/protocol/java/inventory/JavaContainerSetSlotTranslator.java
@@ -70,10 +70,10 @@ public class JavaContainerSetSlotTranslator extends PacketTranslator<Clientbound
 
         Inventory inventory = holder.inventory();
         int slot = packet.getSlot();
-        if (slot >= inventory.getSize()) {
+        if (slot < 0 || slot >= inventory.getSize()) {
             GeyserLogger logger = session.getGeyser().getLogger();
-            logger.warning("ClientboundContainerSetSlotPacket sent to " + session.bedrockUsername()
-                    + " that exceeds inventory size!");
+            logger.warning("Slot of ClientboundContainerSetSlotPacket sent to " + session.bedrockUsername()
+                    + " is out of bounds! Was: " + slot + " for container: " + packet.getContainerId());
             if (logger.isDebug()) {
                 logger.debug(packet.toString());
                 logger.debug(inventory.toString());


### PR DESCRIPTION
This PR should prevent an `ArrayIndexOutOfBoundsException` by checking for slot values below 0, which should never happen. It also improves some log messages to give a bit more information.