### PR TITLE
Fixed a concurrency issue with sidebar scoreboard

### DIFF
--- a/core/src/main/java/org/geysermc/geyser/text/ChatColor.java
+++ b/core/src/main/java/org/geysermc/geyser/text/ChatColor.java
@@ -87,7 +87,7 @@ public class ChatColor {
         return string;
     }
 
-    public static String styleOrder(int index) {
+    public static String colorDisplayOrder(int index) {
         // https://bugs.mojang.com/browse/MCPE-41729
         // strikethrough and underlined do not exist on Bedrock
         return switch (index) {


### PR DESCRIPTION
Fixed a concurrency issue for sidebars without using locks, by using a second list.
There was also a potential problem with the one-list solution, which would be that technically scores (unless you put the lock around the whole newDisplayScores block ofc.)