### PR TITLE
Fixed pose de-sync.

### DIFF
--- a/core/src/main/java/org/geysermc/geyser/session/GeyserSession.java
+++ b/core/src/main/java/org/geysermc/geyser/session/GeyserSession.java
@@ -1312,7 +1312,7 @@ public class GeyserSession implements GeyserConnection, GeyserCommandSource {
     }
 
     private void switchPose(boolean value, EntityFlag flag, Pose pose) {
-        this.pose = value ? pose : Pose.STANDING;
+        this.pose = value ? pose : this.pose;
         playerEntity.setDimensionsFromPose(this.pose);
         playerEntity.setFlag(flag, value);
         playerEntity.updateBedrockMetadata();

--- a/core/src/main/java/org/geysermc/geyser/session/GeyserSession.java
+++ b/core/src/main/java/org/geysermc/geyser/session/GeyserSession.java
@@ -1312,7 +1312,7 @@ public class GeyserSession implements GeyserConnection, GeyserCommandSource {
     }
 
     private void switchPose(boolean value, EntityFlag flag, Pose pose) {
-        this.pose = value ? pose : this.pose;
+        this.pose = value ? pose : this.pose == pose ? Pose.STANDING : this.pose;
         playerEntity.setDimensionsFromPose(this.pose);
         playerEntity.setFlag(flag, value);
         playerEntity.updateBedrockMetadata();


### PR DESCRIPTION
Resolve #5587, if value is false then we should use the current pose, not the STANDING pose, for example setFlags method line 401, if player is sneaking but not gliding then player switch pose will set the pose to standing (since gliding is called after sneaking) : https://github.com/GeyserMC/Geyser/blob/b3716c77b190d182086b3ca003faf107d033b2ba/core/src/main/java/org/geysermc/geyser/entity/type/Entity.java#L401