### PR TITLE
Fix the remaining concurrency issues with scoreboard display slots

### DIFF
--- a/core/src/main/java/org/geysermc/geyser/translator/protocol/java/JavaFinishConfigurationTranslator.java
+++ b/core/src/main/java/org/geysermc/geyser/translator/protocol/java/JavaFinishConfigurationTranslator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024 GeyserMC. http://geysermc.org
+ * Copyright (c) 2024-2025 GeyserMC. http://geysermc.org
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -29,7 +29,6 @@ import org.cloudburstmc.protocol.bedrock.data.inventory.crafting.recipe.MultiRec
 import org.cloudburstmc.protocol.bedrock.data.inventory.crafting.recipe.RecipeData;
 import org.cloudburstmc.protocol.bedrock.packet.CraftingDataPacket;
 import org.cloudburstmc.protocol.bedrock.packet.PlayerListPacket;
-import org.geysermc.geyser.entity.type.player.PlayerEntity;
 import org.geysermc.geyser.registry.Registries;
 import org.geysermc.geyser.session.GeyserSession;
 import org.geysermc.geyser.translator.protocol.PacketTranslator;
@@ -59,9 +58,9 @@ public class JavaFinishConfigurationTranslator extends PacketTranslator<Clientbo
     public void translate(GeyserSession session, ClientboundFinishConfigurationPacket packet) {
         // Clear the player list, as on Java the player list is cleared after transitioning from config to play phase
         List<PlayerListPacket.Entry> entries = new ArrayList<>();
-        for (PlayerEntity otherEntity : session.getEntityCache().getAllPlayerEntities()) {
-            entries.add(new PlayerListPacket.Entry(otherEntity.getTabListUuid()));
-        }
+        session.getEntityCache().forEachPlayerEntity(otherPlayer -> {
+            entries.add(new PlayerListPacket.Entry(otherPlayer.getTabListUuid()));
+        });
         PlayerListUtils.batchSendPlayerList(session, entries, PlayerListPacket.Action.REMOVE);
         session.getEntityCache().removeAllPlayerEntities();
 


### PR DESCRIPTION
With the scoreboard updater thread, there can be multiple threads editing specific bits which can result in concurrency issues. This PR aims to remove those remaining concurrency issues.