### PR TITLE
Anvil updater refactor and other small refactors

### DIFF
--- a/core/src/main/java/org/geysermc/geyser/item/type/CompassItem.java
+++ b/core/src/main/java/org/geysermc/geyser/item/type/CompassItem.java
@@ -25,6 +25,7 @@
 
 package org.geysermc.geyser.item.type;
 
+import net.kyori.adventure.text.Component;
 import org.checkerframework.checker.nullness.qual.NonNull;
 import org.checkerframework.checker.nullness.qual.Nullable;
 import org.cloudburstmc.protocol.bedrock.data.inventory.ItemData;
@@ -39,8 +40,15 @@ import org.geysermc.mcprotocollib.protocol.data.game.item.component.DataComponen
 import org.geysermc.mcprotocollib.protocol.data.game.item.component.LodestoneTracker;
 
 public class CompassItem extends Item {
+    private static final Component LODESTONE_NAME = Component.translatable("item.minecraft.lodestone_compass");
+
     public CompassItem(String javaIdentifier, Builder builder) {
         super(javaIdentifier, builder);
+    }
+
+    @Override
+    public Component getName(GeyserItemStack stack) {
+        return stack.hasComponent(DataComponentTypes.LODESTONE_TRACKER) ? LODESTONE_NAME : super.getName(stack);
     }
 
     @Override

--- a/core/src/main/java/org/geysermc/geyser/item/type/Item.java
+++ b/core/src/main/java/org/geysermc/geyser/item/type/Item.java
@@ -134,6 +134,10 @@ public class Item {
         return baseComponents.get(type);
     }
 
+    public Component getName(GeyserItemStack stack) {
+        return baseComponents.getOrDefault(DataComponentTypes.ITEM_NAME, Component.empty());
+    }
+
     public String translationKey() {
         return "item." + javaIdentifier.namespace() + "." + javaIdentifier.value();
     }

--- a/core/src/main/java/org/geysermc/geyser/item/type/PlayerHeadItem.java
+++ b/core/src/main/java/org/geysermc/geyser/item/type/PlayerHeadItem.java
@@ -25,7 +25,9 @@
 
 package org.geysermc.geyser.item.type;
 
+import net.kyori.adventure.text.Component;
 import org.checkerframework.checker.nullness.qual.NonNull;
+import org.geysermc.geyser.inventory.GeyserItemStack;
 import org.geysermc.geyser.item.TooltipOptions;
 import org.geysermc.geyser.item.components.Rarity;
 import org.geysermc.geyser.level.block.type.Block;
@@ -40,6 +42,14 @@ import org.geysermc.mcprotocollib.protocol.data.game.item.component.DataComponen
 public class PlayerHeadItem extends BlockItem {
     public PlayerHeadItem(Builder builder, Block block, Block... otherBlocks) {
         super(builder, block, otherBlocks);
+    }
+
+    @Override
+    public Component getName(GeyserItemStack stack) {
+        GameProfile profile = stack.getComponent(DataComponentTypes.PROFILE);
+        return profile != null && profile.getName() != null
+            ? Component.translatable(translationKey() + ".named", profile.getName())
+            : super.getName(stack);
     }
 
     @Override

--- a/core/src/main/java/org/geysermc/geyser/item/type/PotionItem.java
+++ b/core/src/main/java/org/geysermc/geyser/item/type/PotionItem.java
@@ -25,6 +25,7 @@
 
 package org.geysermc.geyser.item.type;
 
+import net.kyori.adventure.text.Component;
 import org.checkerframework.checker.nullness.qual.NonNull;
 import org.cloudburstmc.protocol.bedrock.data.definitions.ItemDefinition;
 import org.cloudburstmc.protocol.bedrock.data.inventory.ItemData;
@@ -39,9 +40,18 @@ import org.geysermc.mcprotocollib.protocol.data.game.item.component.DataComponen
 import org.geysermc.mcprotocollib.protocol.data.game.item.component.DataComponents;
 import org.geysermc.mcprotocollib.protocol.data.game.item.component.PotionContents;
 
+import java.util.Locale;
+import java.util.Objects;
+import java.util.function.Function;
+
 public class PotionItem extends Item {
     public PotionItem(String javaIdentifier, Builder builder) {
         super(javaIdentifier, builder);
+    }
+
+    @Override
+    public Component getName(GeyserItemStack stack) {
+        return getName(stack, translationKey(), super::getName);
     }
 
     @Override
@@ -81,5 +91,18 @@ public class PotionItem extends Item {
     @Override
     public boolean ignoreDamage() {
         return true;
+    }
+
+    public static Component getName(GeyserItemStack stack, String translationKey, Function<GeyserItemStack, Component> fallback) {
+        PotionContents contents = stack.getComponent(DataComponentTypes.POTION_CONTENTS);
+        return contents != null ? potionName(contents, translationKey + ".effect.") : fallback.apply(stack);
+    }
+
+    private static Component potionName(PotionContents contents, String baseTranslation) {
+        String name = contents.getCustomName() != null
+            ? contents.getCustomName()
+            : contents.getPotionId() == -1 ? "empty"
+            : Objects.requireNonNull(Potion.getByJavaId(contents.getPotionId())).getJavaIdentifier().toLowerCase(Locale.ROOT);
+        return Component.translatable(baseTranslation + name);
     }
 }

--- a/core/src/main/java/org/geysermc/geyser/item/type/ShieldItem.java
+++ b/core/src/main/java/org/geysermc/geyser/item/type/ShieldItem.java
@@ -25,7 +25,10 @@
 
 package org.geysermc.geyser.item.type;
 
+import net.kyori.adventure.text.Component;
 import org.checkerframework.checker.nullness.qual.NonNull;
+import org.geysermc.geyser.inventory.GeyserItemStack;
+import org.geysermc.geyser.inventory.item.DyeColor;
 import org.geysermc.geyser.item.TooltipOptions;
 import org.geysermc.geyser.session.GeyserSession;
 import org.geysermc.geyser.translator.item.BedrockItemBuilder;
@@ -34,10 +37,19 @@ import org.geysermc.mcprotocollib.protocol.data.game.item.component.DataComponen
 import org.geysermc.mcprotocollib.protocol.data.game.item.component.DataComponents;
 
 import java.util.List;
+import java.util.Objects;
 
 public class ShieldItem extends Item {
     public ShieldItem(String javaIdentifier, Builder builder) {
         super(javaIdentifier, builder);
+    }
+
+    @Override
+    public Component getName(GeyserItemStack stack) {
+        Integer color = stack.getComponent(DataComponentTypes.BASE_COLOR);
+        return color != null
+            ? Component.translatable(translationKey() + "." + Objects.requireNonNull(DyeColor.getById(color)).getJavaIdentifier())
+            : super.getName(stack);
     }
 
     @Override

--- a/core/src/main/java/org/geysermc/geyser/item/type/TippedArrowItem.java
+++ b/core/src/main/java/org/geysermc/geyser/item/type/TippedArrowItem.java
@@ -25,8 +25,10 @@
 
 package org.geysermc.geyser.item.type;
 
+import net.kyori.adventure.text.Component;
 import org.cloudburstmc.protocol.bedrock.data.inventory.ItemData;
 import org.geysermc.geyser.GeyserImpl;
+import org.geysermc.geyser.inventory.GeyserItemStack;
 import org.geysermc.geyser.inventory.item.Potion;
 import org.geysermc.geyser.registry.type.ItemMapping;
 import org.geysermc.geyser.registry.type.ItemMappings;
@@ -38,6 +40,11 @@ import org.geysermc.mcprotocollib.protocol.data.game.item.component.PotionConten
 public class TippedArrowItem extends ArrowItem {
     public TippedArrowItem(String javaIdentifier, Builder builder) {
         super(javaIdentifier, builder);
+    }
+
+    @Override
+    public Component getName(GeyserItemStack stack) {
+        return PotionItem.getName(stack, translationKey(), super::getName);
     }
 
     @Override

--- a/core/src/main/java/org/geysermc/geyser/session/cache/TagCache.java
+++ b/core/src/main/java/org/geysermc/geyser/session/cache/TagCache.java
@@ -134,7 +134,7 @@ public final class TagCache {
      * Accessible via the {@link #isItem(HolderSet, Item)} method.
      * @return true if the specified network ID is in the given {@link HolderSet} set.
      */
-    private  <T> boolean is(@Nullable HolderSet holderSet, @NonNull JavaRegistryKey<T> registry, int id) {
+    private <T> boolean is(@Nullable HolderSet holderSet, @NonNull JavaRegistryKey<T> registry, int id) {
         if (holderSet == null) {
             return false;
         }

--- a/core/src/main/java/org/geysermc/geyser/session/cache/tags/GeyserHolderSet.java
+++ b/core/src/main/java/org/geysermc/geyser/session/cache/tags/GeyserHolderSet.java
@@ -126,6 +126,10 @@ public final class GeyserHolderSet<T> {
         return tagCache.getRaw(Objects.requireNonNull(tag, "HolderSet must have a tag if it doesn't have a list of IDs"));
     }
 
+    public boolean contains(GeyserSession session, T value) {
+        return contains(resolveRaw(session.getTagCache()), registry.toNetworkId(session, value));
+    }
+
     /**
      * Reads a HolderSet from a NBT object. Does not support reading HolderSets that can hold inline values.
      *
@@ -194,5 +198,15 @@ public final class GeyserHolderSet<T> {
             : "either a tag, a string ID, an inline registry element, a list of string IDs, or a list of inline registry elements";
         GeyserImpl.getInstance().getLogger().warning("Failed parsing HolderSet for registry + " + registry + "! Expected " + expected + ", found " + holderSet);
         return new GeyserHolderSet<>(registry);
+    }
+
+    // TODO
+    private static boolean contains(int[] array, int i) {
+        for (int item : array) {
+            if (item == i) {
+                return true;
+            }
+        }
+        return false;
     }
 }

--- a/core/src/main/java/org/geysermc/geyser/translator/item/ItemTranslator.java
+++ b/core/src/main/java/org/geysermc/geyser/translator/item/ItemTranslator.java
@@ -415,6 +415,7 @@ public final class ItemTranslator {
         return finalText.toString();
     }
 
+    // TODO
     public static String getPotionName(PotionContents contents, ItemMapping mapping, String language) {
         String customPotionName = contents.getCustomName();
         Potion potion = Potion.getByJavaId(contents.getPotionId());


### PR DESCRIPTION
This PR applies some refactors to the `AnvilInventoryUpdater` class and makes some other small refactors around the code, most notably some utility methods in `GeyserItemStack`, and of course, some tag/registry cache refactors. Still in the works, most notably I noticed some bugs with repair cost not being calculated correctly when renaming items and repair cost being set incorrect when switching items around in the anvil menu.

This PR should fix #5545 and might fix #5584.