### PR TITLE
Fixed invalid recipe (non-vanilla item).

### DIFF
--- a/core/src/main/java/org/geysermc/geyser/translator/protocol/java/JavaRecipeBookAddTranslator.java
+++ b/core/src/main/java/org/geysermc/geyser/translator/protocol/java/JavaRecipeBookAddTranslator.java
@@ -310,6 +310,10 @@ public class JavaRecipeBookAddTranslator extends PacketTranslator<ClientboundRec
             return ItemDescriptorWithCount.EMPTY;
         }
         ItemMapping mapping = session.getItemMappings().getMapping(item);
+        if (mapping.getJavaItem().javaId() == Items.AIR_ID) {
+            return ItemDescriptorWithCount.EMPTY;
+        }
+
         return new ItemDescriptorWithCount(new DefaultDescriptor(mapping.getBedrockDefinition(), mapping.getBedrockData()), 1); // Need to check count
     }
 
@@ -362,6 +366,11 @@ public class JavaRecipeBookAddTranslator extends PacketTranslator<ClientboundRec
             if (translated == null) {
                 continue;
             }
+
+            if (translated.contains(ItemDescriptorWithCount.EMPTY)) {
+                continue;
+            }
+
             inputs.add(translated);
             if (translated.size() != 1 || translated.get(0) != ItemDescriptorWithCount.EMPTY) {
                 empty = false;

--- a/core/src/main/java/org/geysermc/geyser/translator/protocol/java/JavaRecipeBookAddTranslator.java
+++ b/core/src/main/java/org/geysermc/geyser/translator/protocol/java/JavaRecipeBookAddTranslator.java
@@ -310,6 +310,8 @@ public class JavaRecipeBookAddTranslator extends PacketTranslator<ClientboundRec
             return ItemDescriptorWithCount.EMPTY;
         }
         ItemMapping mapping = session.getItemMappings().getMapping(item);
+
+        // This is likely a modded java item or some item Geyser haven't mapped.
         if (mapping.getJavaItem().javaId() == Items.AIR_ID) {
             return ItemDescriptorWithCount.EMPTY;
         }
@@ -367,6 +369,7 @@ public class JavaRecipeBookAddTranslator extends PacketTranslator<ClientboundRec
                 continue;
             }
 
+            // As of 1.21.82, Bedrock will crash if we tried to send invalid descriptor.
             if (translated.contains(ItemDescriptorWithCount.EMPTY)) {
                 continue;
             }


### PR DESCRIPTION
This doesn't seems to be happening on vanilla (obviously), however it does happened on Fabric with Hydraulic (Biomes O' Plenty) and caused client to crash when open inventory/crafting table, this is likely item-api-v2/hydraulic fault but it would still be better to check/account for this on Geyser end.