### PR TITLE
happy ghast movement

### DIFF
--- a/core/src/main/java/org/geysermc/geyser/entity/type/DisplayBaseEntity.java
+++ b/core/src/main/java/org/geysermc/geyser/entity/type/DisplayBaseEntity.java
@@ -66,7 +66,7 @@ public class DisplayBaseEntity extends Entity {
             this.setRiderSeatPosition(this.baseTranslation);
             this.moveRelative(this.baseTranslation.getX(), this.baseTranslation.getY(), this.baseTranslation.getZ(), yaw, pitch, headYaw, false);
         } else {
-            EntityUtils.updateMountOffset(this, this.vehicle, true, true, false);
+            EntityUtils.updateMountOffset(this, this.vehicle, true, true, 0, 1);
             this.updateBedrockMetadata();
         }
     }

--- a/core/src/main/java/org/geysermc/geyser/entity/type/Entity.java
+++ b/core/src/main/java/org/geysermc/geyser/entity/type/Entity.java
@@ -621,7 +621,7 @@ public class Entity implements GeyserEntity {
             Entity passenger = passengers.get(i);
             if (passenger != null) {
                 boolean rider = i == 0;
-                EntityUtils.updateMountOffset(passenger, this, rider, true, passengers.size() > 1);
+                EntityUtils.updateMountOffset(passenger, this, rider, true, i, passengers.size());
                 passenger.updateBedrockMetadata();
             }
         }
@@ -633,7 +633,7 @@ public class Entity implements GeyserEntity {
     protected void updateMountOffset() {
         if (vehicle != null) {
             boolean rider = vehicle.getPassengers().get(0) == this;
-            EntityUtils.updateMountOffset(this, vehicle, rider, true, vehicle.getPassengers().size() > 1);
+            EntityUtils.updateMountOffset(this, vehicle, rider, true, vehicle.getPassengers().indexOf(this), vehicle.getPassengers().size());
             updateBedrockMetadata();
         }
     }

--- a/core/src/main/java/org/geysermc/geyser/entity/type/LivingEntity.java
+++ b/core/src/main/java/org/geysermc/geyser/entity/type/LivingEntity.java
@@ -41,7 +41,9 @@ import org.cloudburstmc.protocol.bedrock.packet.MobEquipmentPacket;
 import org.cloudburstmc.protocol.bedrock.packet.UpdateAttributesPacket;
 import org.geysermc.geyser.entity.EntityDefinition;
 import org.geysermc.geyser.entity.attribute.GeyserAttributeType;
+import org.geysermc.geyser.entity.type.living.animal.HappyGhastEntity;
 import org.geysermc.geyser.entity.vehicle.ClientVehicle;
+import org.geysermc.geyser.entity.vehicle.HappyGhastVehicleComponent;
 import org.geysermc.geyser.inventory.GeyserItemStack;
 import org.geysermc.geyser.item.Items;
 import org.geysermc.geyser.registry.type.ItemMapping;
@@ -510,7 +512,14 @@ public class LivingEntity extends Entity {
                     }
                 }
                 case ATTACK_DAMAGE -> newAttributes.add(calculateAttribute(javaAttribute, GeyserAttributeType.ATTACK_DAMAGE));
-                case FLYING_SPEED -> newAttributes.add(calculateAttribute(javaAttribute, GeyserAttributeType.FLYING_SPEED));
+                case FLYING_SPEED -> {
+                    AttributeData attributeData = calculateAttribute(javaAttribute, GeyserAttributeType.FLYING_SPEED);
+                    newAttributes.add(attributeData);
+                    if (this instanceof HappyGhastEntity happyGhast &&
+                            happyGhast.getVehicleComponent() instanceof HappyGhastVehicleComponent vehicleComponent) {
+                        vehicleComponent.setFlyingSpeed(attributeData.getValue());
+                    }
+                }
                 case FOLLOW_RANGE -> newAttributes.add(calculateAttribute(javaAttribute, GeyserAttributeType.FOLLOW_RANGE));
                 case KNOCKBACK_RESISTANCE -> newAttributes.add(calculateAttribute(javaAttribute, GeyserAttributeType.KNOCKBACK_RESISTANCE));
                 case JUMP_STRENGTH -> newAttributes.add(calculateAttribute(javaAttribute, GeyserAttributeType.HORSE_JUMP_STRENGTH));

--- a/core/src/main/java/org/geysermc/geyser/entity/type/LivingEntity.java
+++ b/core/src/main/java/org/geysermc/geyser/entity/type/LivingEntity.java
@@ -51,6 +51,7 @@ import org.geysermc.geyser.scoreboard.Team;
 import org.geysermc.geyser.session.GeyserSession;
 import org.geysermc.geyser.translator.item.ItemTranslator;
 import org.geysermc.geyser.util.AttributeUtils;
+import org.geysermc.geyser.util.EntityUtils;
 import org.geysermc.geyser.util.InteractionResult;
 import org.geysermc.geyser.util.MathUtils;
 import org.geysermc.mcprotocollib.protocol.data.game.entity.EquipmentSlot;
@@ -535,6 +536,32 @@ public class LivingEntity extends Entity {
                 }
             }
         }
+    }
+
+    protected boolean hasBodyArmor() {
+        return this.hasValidEquippableItemForSlot(EquipmentSlot.BODY);
+    }
+
+    private boolean hasValidEquippableItemForSlot(EquipmentSlot slot) {
+        // MojMap LivingEntity#hasItemInSlot
+        GeyserItemStack itemInSlot = equipment.get(slot);
+        if (itemInSlot != null) {
+            // MojMap LivingEntity#isEquippableInSlot
+            Equippable equippable = itemInSlot.getComponent(DataComponentTypes.EQUIPPABLE);
+            if (equippable != null) {
+                return slot == equippable.slot() &&
+                    canUseSlot(slot) &&
+                    EntityUtils.equipmentUsableByEntity(session, equippable, this.definition.entityType());
+            } else {
+                return slot == EquipmentSlot.MAIN_HAND && canUseSlot(EquipmentSlot.MAIN_HAND);
+            }
+        }
+
+        return false;
+    }
+
+    protected boolean canUseSlot(EquipmentSlot slot) {
+        return true;
     }
 
     /**

--- a/core/src/main/java/org/geysermc/geyser/entity/type/LivingEntity.java
+++ b/core/src/main/java/org/geysermc/geyser/entity/type/LivingEntity.java
@@ -528,6 +528,11 @@ public class LivingEntity extends Entity {
                     setAttributeScale((float) AttributeUtils.calculateValue(javaAttribute));
                     updateBedrockMetadata();
                 }
+                case WATER_MOVEMENT_EFFICIENCY -> {
+                    if (this instanceof ClientVehicle clientVehicle) {
+                        clientVehicle.getVehicleComponent().setWaterMovementEfficiency(AttributeUtils.calculateValue(javaAttribute));
+                    }
+                }
             }
         }
     }

--- a/core/src/main/java/org/geysermc/geyser/entity/type/LivingEntity.java
+++ b/core/src/main/java/org/geysermc/geyser/entity/type/LivingEntity.java
@@ -516,9 +516,8 @@ public class LivingEntity extends Entity {
                 case FLYING_SPEED -> {
                     AttributeData attributeData = calculateAttribute(javaAttribute, GeyserAttributeType.FLYING_SPEED);
                     newAttributes.add(attributeData);
-                    if (this instanceof HappyGhastEntity happyGhast &&
-                            happyGhast.getVehicleComponent() instanceof HappyGhastVehicleComponent vehicleComponent) {
-                        vehicleComponent.setFlyingSpeed(attributeData.getValue());
+                    if (this instanceof HappyGhastEntity ghast && ghast.getVehicleComponent() instanceof HappyGhastVehicleComponent component) {
+                        component.setFlyingSpeed(attributeData.getValue());
                     }
                 }
                 case FOLLOW_RANGE -> newAttributes.add(calculateAttribute(javaAttribute, GeyserAttributeType.FOLLOW_RANGE));

--- a/core/src/main/java/org/geysermc/geyser/entity/type/living/animal/HappyGhastEntity.java
+++ b/core/src/main/java/org/geysermc/geyser/entity/type/living/animal/HappyGhastEntity.java
@@ -33,7 +33,6 @@ import org.cloudburstmc.math.vector.Vector3f;
 import org.cloudburstmc.protocol.bedrock.data.AttributeData;
 import org.cloudburstmc.protocol.bedrock.data.entity.EntityFlag;
 import org.geysermc.geyser.entity.EntityDefinition;
-import org.geysermc.geyser.entity.attribute.GeyserAttributeType;
 import org.geysermc.geyser.entity.type.Entity;
 import org.geysermc.geyser.entity.type.player.SessionPlayerEntity;
 import org.geysermc.geyser.entity.vehicle.ClientVehicle;
@@ -201,14 +200,8 @@ public class HappyGhastEntity extends AnimalEntity implements ClientVehicle {
     protected void updateAttribute(Attribute javaAttribute, List<AttributeData> newAttributes) {
         super.updateAttribute(javaAttribute, newAttributes);
         if (javaAttribute.getType() instanceof AttributeType.Builtin type) {
-            switch (type) {
-                case FLYING_SPEED -> {
-                    AttributeData attributeData = calculateAttribute(javaAttribute, GeyserAttributeType.FLYING_SPEED);
-                    vehicleComponent.setFlyingSpeed(attributeData.getValue());
-                }
-                case CAMERA_DISTANCE -> {
-                    vehicleComponent.setCameraDistance((float) AttributeUtils.calculateValue(javaAttribute));
-                }
+            if (type == AttributeType.Builtin.CAMERA_DISTANCE) {
+                vehicleComponent.setCameraDistance((float) AttributeUtils.calculateValue(javaAttribute));
             }
         }
     }

--- a/core/src/main/java/org/geysermc/geyser/entity/type/living/animal/HappyGhastEntity.java
+++ b/core/src/main/java/org/geysermc/geyser/entity/type/living/animal/HappyGhastEntity.java
@@ -51,6 +51,9 @@ import java.util.UUID;
 
 public class HappyGhastEntity extends AnimalEntity implements ClientVehicle {
 
+    public static final float[] X_OFFSETS = {0.0F, -1.7F, 0.0F, 1.7F};
+    public static final float[] Z_OFFSETS = {1.7F, 0.0F, -1.7F, 0.0F};
+
     private final HappyGhastVehicleComponent vehicleComponent = new HappyGhastVehicleComponent(this, 0.0f);
     private boolean staysStill;
     private float speed;

--- a/core/src/main/java/org/geysermc/geyser/entity/type/living/animal/HappyGhastEntity.java
+++ b/core/src/main/java/org/geysermc/geyser/entity/type/living/animal/HappyGhastEntity.java
@@ -27,6 +27,7 @@ package org.geysermc.geyser.entity.type.living.animal;
 
 import org.checkerframework.checker.nullness.qual.NonNull;
 import org.checkerframework.checker.nullness.qual.Nullable;
+import org.cloudburstmc.math.TrigMath;
 import org.cloudburstmc.math.vector.Vector2f;
 import org.cloudburstmc.math.vector.Vector3f;
 import org.cloudburstmc.protocol.bedrock.data.entity.EntityFlag;
@@ -56,7 +57,6 @@ public class HappyGhastEntity extends AnimalEntity implements ClientVehicle {
 
     private final HappyGhastVehicleComponent vehicleComponent = new HappyGhastVehicleComponent(this, 0.0f);
     private boolean staysStill;
-    private float speed;
 
     public HappyGhastEntity(GeyserSession session, int entityId, long geyserId, UUID uuid, EntityDefinition<?> definition, Vector3f position, Vector3f motion, float yaw, float pitch, float headYaw) {
         super(session, entityId, geyserId, uuid, definition, position, motion, yaw, pitch, headYaw);
@@ -151,14 +151,31 @@ public class HappyGhastEntity extends AnimalEntity implements ClientVehicle {
     }
 
     @Override
-    public Vector2f getAdjustedInput(Vector2f input) {
-        // not used; calculations look a bit different for the happy ghast
-        return Vector2f.ZERO;
+    public Vector3f getRiddenInput(Vector2f input) {
+        float x = input.getX();
+        float y = 0.0f;
+        float z = 0.0f;
+
+        if (input.getY() != 0.0f) {
+            float pitch = session.getPlayerEntity().getPitch();
+            z = TrigMath.cos(pitch * TrigMath.DEG_TO_RAD);
+            y = -TrigMath.sin(pitch * TrigMath.DEG_TO_RAD);
+            if (input.getY() < 0.0f) {
+                z *= -0.5f;
+                y *= -0.5f;
+            }
+        }
+
+        if (session.getInputCache().wasJumping()) {
+            y += 0.5f;
+        }
+
+        return Vector3f.from(x, y, z).mul(3.9f * vehicleComponent.getFlyingSpeed());
     }
 
     @Override
     public float getVehicleSpeed() {
-        return speed; // TODO this doesnt seem right?
+        return 1; // TODO this doesnt seem right?
     }
 
     @Override

--- a/core/src/main/java/org/geysermc/geyser/entity/type/living/animal/StriderEntity.java
+++ b/core/src/main/java/org/geysermc/geyser/entity/type/living/animal/StriderEntity.java
@@ -47,6 +47,7 @@ import org.geysermc.geyser.session.cache.tags.Tag;
 import org.geysermc.geyser.util.EntityUtils;
 import org.geysermc.geyser.util.InteractionResult;
 import org.geysermc.geyser.util.InteractiveTag;
+import org.geysermc.mcprotocollib.protocol.data.game.entity.EquipmentSlot;
 import org.geysermc.mcprotocollib.protocol.data.game.entity.metadata.type.BooleanEntityMetadata;
 import org.geysermc.mcprotocollib.protocol.data.game.entity.metadata.type.IntEntityMetadata;
 import org.geysermc.mcprotocollib.protocol.data.game.entity.player.Hand;
@@ -194,5 +195,10 @@ public class StriderEntity extends AnimalEntity implements Tickable, ClientVehic
     @Override
     public boolean canWalkOnLava() {
         return true;
+    }
+
+    @Override
+    protected boolean canUseSlot(EquipmentSlot slot) {
+        return slot != EquipmentSlot.SADDLE ? super.canUseSlot(slot) : this.isAlive() && !this.isBaby();
     }
 }

--- a/core/src/main/java/org/geysermc/geyser/entity/type/living/animal/StriderEntity.java
+++ b/core/src/main/java/org/geysermc/geyser/entity/type/living/animal/StriderEntity.java
@@ -169,8 +169,8 @@ public class StriderEntity extends AnimalEntity implements Tickable, ClientVehic
     }
 
     @Override
-    public Vector2f getAdjustedInput(Vector2f input) {
-        return Vector2f.UNIT_Y;
+    public Vector3f getRiddenInput(Vector2f input) {
+        return Vector3f.UNIT_Z;
     }
 
     @Override

--- a/core/src/main/java/org/geysermc/geyser/entity/type/living/animal/farm/PigEntity.java
+++ b/core/src/main/java/org/geysermc/geyser/entity/type/living/animal/farm/PigEntity.java
@@ -128,8 +128,8 @@ public class PigEntity extends TemperatureVariantAnimal implements Tickable, Cli
     }
 
     @Override
-    public Vector2f getAdjustedInput(Vector2f input) {
-        return Vector2f.UNIT_Y;
+    public Vector3f getRiddenInput(Vector2f input) {
+        return Vector3f.UNIT_Z;
     }
 
     @Override

--- a/core/src/main/java/org/geysermc/geyser/entity/type/living/animal/farm/PigEntity.java
+++ b/core/src/main/java/org/geysermc/geyser/entity/type/living/animal/farm/PigEntity.java
@@ -48,6 +48,7 @@ import org.geysermc.geyser.session.cache.tags.Tag;
 import org.geysermc.geyser.util.EntityUtils;
 import org.geysermc.geyser.util.InteractionResult;
 import org.geysermc.geyser.util.InteractiveTag;
+import org.geysermc.mcprotocollib.protocol.data.game.entity.EquipmentSlot;
 import org.geysermc.mcprotocollib.protocol.data.game.entity.metadata.type.IntEntityMetadata;
 import org.geysermc.mcprotocollib.protocol.data.game.entity.player.Hand;
 
@@ -153,5 +154,10 @@ public class PigEntity extends TemperatureVariantAnimal implements Tickable, Cli
     @Override
     public JavaRegistryKey<BuiltInVariant> variantRegistry() {
         return JavaRegistries.PIG_VARIANT;
+    }
+
+    @Override
+    protected boolean canUseSlot(EquipmentSlot slot) {
+        return slot != EquipmentSlot.SADDLE ? super.canUseSlot(slot) : this.isAlive() && !this.isBaby();
     }
 }

--- a/core/src/main/java/org/geysermc/geyser/entity/type/living/animal/horse/AbstractHorseEntity.java
+++ b/core/src/main/java/org/geysermc/geyser/entity/type/living/animal/horse/AbstractHorseEntity.java
@@ -45,6 +45,7 @@ import org.geysermc.geyser.session.cache.tags.ItemTag;
 import org.geysermc.geyser.session.cache.tags.Tag;
 import org.geysermc.geyser.util.InteractionResult;
 import org.geysermc.geyser.util.InteractiveTag;
+import org.geysermc.mcprotocollib.protocol.data.game.entity.EquipmentSlot;
 import org.geysermc.mcprotocollib.protocol.data.game.entity.metadata.type.ByteEntityMetadata;
 import org.geysermc.mcprotocollib.protocol.data.game.entity.player.Hand;
 
@@ -284,6 +285,15 @@ public class AbstractHorseEntity extends AnimalEntity {
         } else {
             // The client tests for saddle but it doesn't matter for us at this point.
             return InteractionResult.SUCCESS;
+        }
+    }
+
+    @Override
+    protected boolean canUseSlot(EquipmentSlot slot) {
+        if (slot != EquipmentSlot.SADDLE) {
+            return super.canUseSlot(slot);
+        } else {
+            return isAlive() && !isBaby() && getFlag(EntityFlag.TAMED);
         }
     }
 }

--- a/core/src/main/java/org/geysermc/geyser/entity/type/living/animal/horse/CamelEntity.java
+++ b/core/src/main/java/org/geysermc/geyser/entity/type/living/animal/horse/CamelEntity.java
@@ -155,8 +155,9 @@ public class CamelEntity extends AbstractHorseEntity implements ClientVehicle {
     }
 
     @Override
-    public Vector2f getAdjustedInput(Vector2f input) {
-        return input.mul(0.5f, input.getY() < 0 ? 0.25f : 1.0f);
+    public Vector3f getRiddenInput(Vector2f input) {
+        input = input.mul(0.5f, input.getY() < 0 ? 0.25f : 1.0f);
+        return Vector3f.from(input.getX(), 0.0, input.getY());
     }
 
     @Override

--- a/core/src/main/java/org/geysermc/geyser/entity/type/living/animal/horse/HorseEntity.java
+++ b/core/src/main/java/org/geysermc/geyser/entity/type/living/animal/horse/HorseEntity.java
@@ -29,6 +29,7 @@ import org.cloudburstmc.math.vector.Vector3f;
 import org.cloudburstmc.protocol.bedrock.data.entity.EntityDataTypes;
 import org.geysermc.geyser.entity.EntityDefinition;
 import org.geysermc.geyser.session.GeyserSession;
+import org.geysermc.mcprotocollib.protocol.data.game.entity.EquipmentSlot;
 import org.geysermc.mcprotocollib.protocol.data.game.entity.metadata.type.IntEntityMetadata;
 
 import java.util.UUID;
@@ -43,5 +44,10 @@ public class HorseEntity extends AbstractHorseEntity {
         int value = entityMetadata.getPrimitiveValue();
         dirtyMetadata.put(EntityDataTypes.VARIANT, value & 255);
         dirtyMetadata.put(EntityDataTypes.MARK_VARIANT, (value >> 8) % 5);
+    }
+
+    @Override
+    protected boolean canUseSlot(EquipmentSlot slot) {
+        return true;
     }
 }

--- a/core/src/main/java/org/geysermc/geyser/entity/type/living/animal/horse/LlamaEntity.java
+++ b/core/src/main/java/org/geysermc/geyser/entity/type/living/animal/horse/LlamaEntity.java
@@ -35,6 +35,7 @@ import org.geysermc.geyser.session.GeyserSession;
 import org.geysermc.geyser.session.cache.tags.ItemTag;
 import org.geysermc.geyser.session.cache.tags.Tag;
 import org.geysermc.geyser.util.MathUtils;
+import org.geysermc.mcprotocollib.protocol.data.game.entity.EquipmentSlot;
 import org.geysermc.mcprotocollib.protocol.data.game.entity.metadata.type.IntEntityMetadata;
 
 import java.util.UUID;
@@ -60,5 +61,10 @@ public class LlamaEntity extends ChestedHorseEntity {
     @Override
     protected @Nullable Tag<Item> getFoodTag() {
         return ItemTag.LLAMA_FOOD;
+    }
+
+    @Override
+    protected boolean canUseSlot(EquipmentSlot slot) {
+        return true;
     }
 }

--- a/core/src/main/java/org/geysermc/geyser/entity/vehicle/CamelVehicleComponent.java
+++ b/core/src/main/java/org/geysermc/geyser/entity/vehicle/CamelVehicleComponent.java
@@ -90,13 +90,13 @@ public class CamelVehicleComponent extends VehicleComponent<CamelEntity> {
     }
 
     @Override
-    protected Vector3f getInputVelocity(VehicleContext ctx, float speed) {
+    protected Vector3f getInputVector(VehicleContext ctx, float speed, Vector3f input) {
         if (isStationary()) {
             return Vector3f.ZERO;
         }
 
         SessionPlayerEntity player = vehicle.getSession().getPlayerEntity();
-        Vector3f inputVelocity = super.getInputVelocity(ctx, speed);
+        Vector3f inputVelocity = super.getInputVector(ctx, speed, input);
         float jumpStrength = player.getVehicleJumpStrength();
 
         if (jumpStrength > 0) {
@@ -117,11 +117,11 @@ public class CamelVehicleComponent extends VehicleComponent<CamelEntity> {
     }
 
     @Override
-    protected Vector2f getVehicleRotation() {
+    protected Vector2f getRiddenRotation() {
         if (isStationary()) {
             return Vector2f.from(vehicle.getYaw(), vehicle.getPitch());
         }
-        return super.getVehicleRotation();
+        return super.getRiddenRotation();
     }
 
     /**

--- a/core/src/main/java/org/geysermc/geyser/entity/vehicle/ClientVehicle.java
+++ b/core/src/main/java/org/geysermc/geyser/entity/vehicle/ClientVehicle.java
@@ -26,12 +26,13 @@
 package org.geysermc.geyser.entity.vehicle;
 
 import org.cloudburstmc.math.vector.Vector2f;
+import org.cloudburstmc.math.vector.Vector3f;
 
 public interface ClientVehicle {
     VehicleComponent<?> getVehicleComponent();
 
     // LivingEntity#getRiddenInput
-    Vector2f getAdjustedInput(Vector2f input);
+    Vector3f getRiddenInput(Vector2f input);
 
     // MojMap LivingEntity#getRiddenSpeed
     float getVehicleSpeed();

--- a/core/src/main/java/org/geysermc/geyser/entity/vehicle/ClientVehicle.java
+++ b/core/src/main/java/org/geysermc/geyser/entity/vehicle/ClientVehicle.java
@@ -31,7 +31,7 @@ import org.cloudburstmc.math.vector.Vector3f;
 public interface ClientVehicle {
     VehicleComponent<?> getVehicleComponent();
 
-    // LivingEntity#getRiddenInput
+    // MojMap LivingEntity#getRiddenInput
     Vector3f getRiddenInput(Vector2f input);
 
     // MojMap LivingEntity#getRiddenSpeed

--- a/core/src/main/java/org/geysermc/geyser/entity/vehicle/HappyGhastVehicleComponent.java
+++ b/core/src/main/java/org/geysermc/geyser/entity/vehicle/HappyGhastVehicleComponent.java
@@ -25,10 +25,13 @@
 
 package org.geysermc.geyser.entity.vehicle;
 
+import it.unimi.dsi.fastutil.objects.ObjectDoublePair;
 import lombok.Setter;
 import org.cloudburstmc.math.vector.Vector2f;
 import org.cloudburstmc.math.vector.Vector3f;
 import org.geysermc.geyser.entity.type.living.animal.HappyGhastEntity;
+import org.geysermc.geyser.level.block.Fluid;
+import org.geysermc.mcprotocollib.protocol.data.game.entity.attribute.AttributeType;
 
 public class HappyGhastVehicleComponent extends VehicleComponent<HappyGhastEntity> {
 
@@ -37,6 +40,35 @@ public class HappyGhastVehicleComponent extends VehicleComponent<HappyGhastEntit
 
     public HappyGhastVehicleComponent(HappyGhastEntity vehicle, float stepHeight) {
         super(vehicle, stepHeight);
+        flyingSpeed = (float) AttributeType.Builtin.FLYING_SPEED.getDef();
+    }
+
+    /**
+     * Called every session tick while the player is mounted on the vehicle.
+     */
+    public void tickVehicle() {
+        if (!vehicle.isClientControlled()) {
+            return;
+        }
+
+        // LivingEntity#travelFlying
+        VehicleContext ctx = new VehicleContext();
+        ctx.loadSurroundingBlocks();
+
+        // TODO tickRidden here (deals with rotations)
+
+        // TODO verify that updateFluidMovement applies to happy ghasts
+        ObjectDoublePair<Fluid> fluidHeight = updateFluidMovement(ctx);
+
+        // HappyGhast#travel
+        float speed = flyingSpeed * 5.0f / 3.0f;
+
+        // TODO implement LivingEntity#travelFlying cases
+//        switch (fluidHeight.left()) {
+//            default -> {
+//                throw new GoodLuckImplementingThisException();
+//            }
+//        }
     }
 
     protected Vector3f getInputVelocity(VehicleContext ctx, float speed) {
@@ -65,5 +97,8 @@ public class HappyGhastVehicleComponent extends VehicleComponent<HappyGhastEntit
         }
 
         return Vector3f.from(x, y, z).mul(3.9F * flyingSpeed);
+    }
+
+    public class GoodLuckImplementingThisException extends RuntimeException {
     }
 }

--- a/core/src/main/java/org/geysermc/geyser/entity/vehicle/HappyGhastVehicleComponent.java
+++ b/core/src/main/java/org/geysermc/geyser/entity/vehicle/HappyGhastVehicleComponent.java
@@ -44,13 +44,13 @@ public class HappyGhastVehicleComponent extends VehicleComponent<HappyGhastEntit
         input = input.mul(0.98f); // ?
 
         float x = input.getX();
-        float y = 0.0f;
-        float z = 0.0f;
+        float y = 0.0F;
+        float z = 0.0F;
 
         float playerZ = input.getY();
         if (playerZ != 0.0F) {
-            float i = Mth.cos(player.getXRot() * (float) (Math.PI / 180.0));
-            float j = -Mth.sin(player.getXRot() * (float) (Math.PI / 180.0));
+            float i = (float) Math.cos(vehicle.getSession().getPlayerEntity().getPitch() * (Math.PI / 180.0F));
+            float j = (float) -Math.sin(vehicle.getSession().getPlayerEntity().getPitch() * (Math.PI / 180.0F));
             if (playerZ < 0.0F) {
                 i *= -0.5F;
                 j *= -0.5F;
@@ -60,10 +60,10 @@ public class HappyGhastVehicleComponent extends VehicleComponent<HappyGhastEntit
             z = i;
         }
 
-        if (session.isJumping()) {
+        if (vehicle.getSession().getInputCache().wasJumping()) {
             y += 0.5F;
         }
 
-        return Vector3f.from((double) x, (double) y, (double)z).mul(3.9F * flyingSpeed);
+        return Vector3f.from(x, y, z).mul(3.9F * flyingSpeed);
     }
 }

--- a/core/src/main/java/org/geysermc/geyser/entity/vehicle/HappyGhastVehicleComponent.java
+++ b/core/src/main/java/org/geysermc/geyser/entity/vehicle/HappyGhastVehicleComponent.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019-2023 GeyserMC. http://geysermc.org
+ * Copyright (c) 2025 GeyserMC. http://geysermc.org
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -25,25 +25,45 @@
 
 package org.geysermc.geyser.entity.vehicle;
 
+import lombok.Setter;
 import org.cloudburstmc.math.vector.Vector2f;
+import org.cloudburstmc.math.vector.Vector3f;
+import org.geysermc.geyser.entity.type.living.animal.HappyGhastEntity;
 
-public interface ClientVehicle {
-    VehicleComponent<?> getVehicleComponent();
+public class HappyGhastVehicleComponent extends VehicleComponent<HappyGhastEntity> {
 
-    // LivingEntity#getRiddenInput
-    Vector2f getAdjustedInput(Vector2f input);
+    @Setter
+    private float flyingSpeed;
 
-    // MojMap LivingEntity#getRiddenSpeed
-    float getVehicleSpeed();
-
-    // MojMap Mob#getControllingPassenger
-    boolean isClientControlled();
-
-    default boolean canWalkOnLava() {
-        return false;
+    public HappyGhastVehicleComponent(HappyGhastEntity vehicle, float stepHeight) {
+        super(vehicle, stepHeight);
     }
 
-    default boolean canClimb() {
-        return true;
+    protected Vector3f getInputVelocity(VehicleContext ctx, float speed) {
+        Vector2f input = vehicle.getSession().getPlayerEntity().getVehicleInput();
+        input = input.mul(0.98f); // ?
+
+        float x = input.getX();
+        float y = 0.0f;
+        float z = 0.0f;
+
+        float playerZ = input.getY();
+        if (playerZ != 0.0F) {
+            float i = Mth.cos(player.getXRot() * (float) (Math.PI / 180.0));
+            float j = -Mth.sin(player.getXRot() * (float) (Math.PI / 180.0));
+            if (playerZ < 0.0F) {
+                i *= -0.5F;
+                j *= -0.5F;
+            }
+
+            y = j;
+            z = i;
+        }
+
+        if (session.isJumping()) {
+            y += 0.5F;
+        }
+
+        return Vector3f.from((double) x, (double) y, (double)z).mul(3.9F * flyingSpeed);
     }
 }

--- a/core/src/main/java/org/geysermc/geyser/entity/vehicle/VehicleComponent.java
+++ b/core/src/main/java/org/geysermc/geyser/entity/vehicle/VehicleComponent.java
@@ -592,7 +592,7 @@ public class VehicleComponent<T extends LivingEntity & ClientVehicle> {
      *
      * @return true if there was a horizontal collision
      */
-    // Mojmap: LivingEntity#moveRelative
+    // Mojmap: LivingEntity#moveRelative / LivingEntity#move
     protected boolean travel(VehicleContext ctx, float speed) {
         Vector3f motion = vehicle.getMotion();
 

--- a/core/src/main/java/org/geysermc/geyser/item/hashing/MapHasher.java
+++ b/core/src/main/java/org/geysermc/geyser/item/hashing/MapHasher.java
@@ -213,9 +213,6 @@ public class MapHasher<Type> {
     }
 
     public HashCode build() {
-        if (unhashed != null) {
-            System.out.println(unhashed);
-        }
         return encoder.map(map);
     }
 }

--- a/core/src/main/java/org/geysermc/geyser/session/cache/registry/JavaRegistries.java
+++ b/core/src/main/java/org/geysermc/geyser/session/cache/registry/JavaRegistries.java
@@ -48,9 +48,12 @@ import org.geysermc.geyser.session.GeyserSession;
 import org.geysermc.geyser.session.dialog.Dialog;
 import org.geysermc.geyser.util.MinecraftKey;
 import org.geysermc.mcprotocollib.protocol.data.game.chat.ChatType;
+import org.geysermc.mcprotocollib.protocol.data.game.entity.type.EntityType;
 
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.List;
+import java.util.Locale;
 import java.util.Objects;
 import java.util.Optional;
 
@@ -64,6 +67,9 @@ public class JavaRegistries {
         Block::javaId, Block::javaIdentifier, key -> Optional.ofNullable(BlockRegistries.JAVA_IDENTIFIER_TO_ID.get(key.asString())).orElse(-1));
     public static final JavaRegistryKey<Item> ITEM = createHardcoded("item", Registries.JAVA_ITEMS,
         Item::javaId, Item::javaKey, key -> Optional.ofNullable(Registries.JAVA_ITEM_IDENTIFIERS.get(key.asString())).map(Item::javaId).orElse(-1));
+    public static JavaRegistryKey<EntityType> ENTITY_TYPE = createHardcoded("entity_type", Arrays.asList(EntityType.values()), EntityType::ordinal,
+        type -> MinecraftKey.key(type.name().toLowerCase(Locale.ROOT)),
+        key -> EntityType.valueOf(key.value().toUpperCase(Locale.ROOT)).ordinal());
 
     public static final JavaRegistryKey<ChatType> CHAT_TYPE = create("chat_type");
     public static final JavaRegistryKey<JavaDimension> DIMENSION_TYPE = create("dimension_type");
@@ -94,6 +100,11 @@ public class JavaRegistries {
     }
 
     private static <T> JavaRegistryKey<T> createHardcoded(String key, ListRegistry<T> registry, RegistryNetworkMapper<T> networkSerializer,
+                                                          RegistryIdentifierMapper<T> identifierMapper, RegistryIdMapper idMapper) {
+        return createHardcoded(key, registry.get(), networkSerializer, identifierMapper, idMapper);
+    }
+
+    private static <T> JavaRegistryKey<T> createHardcoded(String key, List<T> registry, RegistryNetworkMapper<T> networkSerializer,
                                                           RegistryIdentifierMapper<T> identifierMapper, RegistryIdMapper idMapper) {
         return create(key, new HardcodedLookup<>(registry, networkSerializer, identifierMapper, idMapper));
     }
@@ -130,8 +141,12 @@ public class JavaRegistries {
         int get(Key key);
     }
 
-    private record HardcodedLookup<T>(ListRegistry<T> registry, RegistryNetworkMapper<T> networkMapper, RegistryIdentifierMapper<T> identifierMapper,
+    private record HardcodedLookup<T>(List<T> registry, RegistryNetworkMapper<T> networkMapper, RegistryIdentifierMapper<T> identifierMapper,
                                       RegistryIdMapper idMapper) implements JavaRegistryKey.RegistryLookup<T> {
+
+        public HardcodedLookup {
+            System.out.println(registry);
+        }
 
         @Override
         public Optional<RegistryEntryData<T>> entry(GeyserSession session, JavaRegistryKey<T> registryKey, int networkId) {

--- a/core/src/main/java/org/geysermc/geyser/session/cache/registry/JavaRegistries.java
+++ b/core/src/main/java/org/geysermc/geyser/session/cache/registry/JavaRegistries.java
@@ -149,10 +149,6 @@ public class JavaRegistries {
     private record HardcodedLookup<T>(List<T> registry, RegistryNetworkMapper<T> networkMapper, RegistryIdentifierMapper<T> identifierMapper,
                                       RegistryIdMapper idMapper) implements JavaRegistryKey.RegistryLookup<T> {
 
-        public HardcodedLookup {
-            System.out.println(registry);
-        }
-
         @Override
         public Optional<RegistryEntryData<T>> entry(GeyserSession session, JavaRegistryKey<T> registryKey, int networkId) {
             return Optional.ofNullable(registry.get(networkId))

--- a/core/src/main/java/org/geysermc/geyser/session/cache/registry/JavaRegistries.java
+++ b/core/src/main/java/org/geysermc/geyser/session/cache/registry/JavaRegistries.java
@@ -68,8 +68,13 @@ public class JavaRegistries {
     public static final JavaRegistryKey<Item> ITEM = createHardcoded("item", Registries.JAVA_ITEMS,
         Item::javaId, Item::javaKey, key -> Optional.ofNullable(Registries.JAVA_ITEM_IDENTIFIERS.get(key.asString())).map(Item::javaId).orElse(-1));
     public static JavaRegistryKey<EntityType> ENTITY_TYPE = createHardcoded("entity_type", Arrays.asList(EntityType.values()), EntityType::ordinal,
-        type -> MinecraftKey.key(type.name().toLowerCase(Locale.ROOT)),
-        key -> EntityType.valueOf(key.value().toUpperCase(Locale.ROOT)).ordinal());
+        type -> MinecraftKey.key(type.name().toLowerCase(Locale.ROOT)), key -> {
+        try {
+            return EntityType.valueOf(key.value().toUpperCase(Locale.ROOT)).ordinal();
+        } catch (IllegalArgumentException exception) {
+            return -1; // Non-existent entity type
+        }
+    });
 
     public static final JavaRegistryKey<ChatType> CHAT_TYPE = create("chat_type");
     public static final JavaRegistryKey<JavaDimension> DIMENSION_TYPE = create("dimension_type");

--- a/core/src/main/java/org/geysermc/geyser/translator/protocol/java/entity/JavaSetPassengersTranslator.java
+++ b/core/src/main/java/org/geysermc/geyser/translator/protocol/java/entity/JavaSetPassengersTranslator.java
@@ -25,7 +25,7 @@
 
 package org.geysermc.geyser.translator.protocol.java.entity;
 
-import lombok.NonNull;
+import org.checkerframework.checker.nullness.qual.NonNull;
 import org.cloudburstmc.protocol.bedrock.data.entity.EntityDataTypes;
 import org.cloudburstmc.protocol.bedrock.data.entity.EntityLinkData;
 import org.cloudburstmc.protocol.bedrock.packet.SetEntityLinkPacket;
@@ -54,7 +54,6 @@ public class JavaSetPassengersTranslator extends PacketTranslator<ClientboundSet
         int @NonNull [] passengerIds = packet.getPassengerIds();
         for (int i = 0; i < passengerIds.length; i++) {
             int passengerId = passengerIds[i];
-
             Entity passenger = session.getEntityCache().getEntityByJavaId(passengerId);
             if (passenger == session.getPlayerEntity()) {
                 session.getPlayerEntity().setVehicle(entity);

--- a/core/src/main/java/org/geysermc/geyser/translator/protocol/java/entity/JavaSetPassengersTranslator.java
+++ b/core/src/main/java/org/geysermc/geyser/translator/protocol/java/entity/JavaSetPassengersTranslator.java
@@ -25,6 +25,7 @@
 
 package org.geysermc.geyser.translator.protocol.java.entity;
 
+import lombok.NonNull;
 import org.cloudburstmc.protocol.bedrock.data.entity.EntityDataTypes;
 import org.cloudburstmc.protocol.bedrock.data.entity.EntityLinkData;
 import org.cloudburstmc.protocol.bedrock.packet.SetEntityLinkPacket;
@@ -50,7 +51,10 @@ public class JavaSetPassengersTranslator extends PacketTranslator<ClientboundSet
 
         // Handle new/existing passengers
         List<Entity> newPassengers = new ArrayList<>();
-        for (int passengerId : packet.getPassengerIds()) {
+        int @NonNull [] passengerIds = packet.getPassengerIds();
+        for (int i = 0; i < passengerIds.length; i++) {
+            int passengerId = passengerIds[i];
+
             Entity passenger = session.getEntityCache().getEntityByJavaId(passengerId);
             if (passenger == session.getPlayerEntity()) {
                 session.getPlayerEntity().setVehicle(entity);
@@ -76,13 +80,15 @@ public class JavaSetPassengersTranslator extends PacketTranslator<ClientboundSet
 
             passenger.setVehicle(entity);
             EntityUtils.updateRiderRotationLock(passenger, entity, true);
-            EntityUtils.updateMountOffset(passenger, entity, rider, true, (packet.getPassengerIds().length > 1));
+            EntityUtils.updateMountOffset(passenger, entity, rider, true, i, packet.getPassengerIds().length);
             // Force an update to the passenger metadata
             passenger.updateBedrockMetadata();
         }
 
         // Handle passengers that were removed
-        for (Entity passenger : entity.getPassengers()) {
+        List<Entity> passengers = entity.getPassengers();
+        for (int i = 0; i < passengers.size(); i++) {
+            Entity passenger = passengers.get(i);
             if (passenger == null) {
                 continue;
             }
@@ -93,7 +99,7 @@ public class JavaSetPassengersTranslator extends PacketTranslator<ClientboundSet
 
                 passenger.setVehicle(null);
                 EntityUtils.updateRiderRotationLock(passenger, entity, false);
-                EntityUtils.updateMountOffset(passenger, entity, false, false, (packet.getPassengerIds().length > 1));
+                EntityUtils.updateMountOffset(passenger, entity, false, false, i, packet.getPassengerIds().length);
                 // Force an update to the passenger metadata
                 passenger.updateBedrockMetadata();
 

--- a/core/src/main/java/org/geysermc/geyser/util/EntityUtils.java
+++ b/core/src/main/java/org/geysermc/geyser/util/EntityUtils.java
@@ -226,7 +226,6 @@ public final class EntityUtils {
                     }
                 }
                 case HAPPY_GHAST -> {
-                    // 0.0, 5.02001, 1.7 BDS
                     int seatingIndex = Math.min(index, 4);
                     xOffset = HappyGhastEntity.X_OFFSETS[seatingIndex];
                     yOffset = 3.4f;
@@ -279,14 +278,12 @@ public final class EntityUtils {
     }
 
     public static void updateRiderRotationLock(Entity passenger, Entity mount, boolean isRiding) {
-        if (isRiding) {
-            if (mount instanceof BoatEntity) {
-                // Head rotation is locked while riding in a boat
-                passenger.getDirtyMetadata().put(EntityDataTypes.SEAT_LOCK_RIDER_ROTATION, true);
-                passenger.getDirtyMetadata().put(EntityDataTypes.SEAT_LOCK_RIDER_ROTATION_DEGREES, 90f);
-                passenger.getDirtyMetadata().put(EntityDataTypes.SEAT_HAS_ROTATION, true);
-                passenger.getDirtyMetadata().put(EntityDataTypes.SEAT_ROTATION_OFFSET_DEGREES, -90f);
-            }
+        if (isRiding && mount instanceof BoatEntity) {
+            // Head rotation is locked while riding in a boat
+            passenger.getDirtyMetadata().put(EntityDataTypes.SEAT_LOCK_RIDER_ROTATION, true);
+            passenger.getDirtyMetadata().put(EntityDataTypes.SEAT_LOCK_RIDER_ROTATION_DEGREES, 90f);
+            passenger.getDirtyMetadata().put(EntityDataTypes.SEAT_HAS_ROTATION, true);
+            passenger.getDirtyMetadata().put(EntityDataTypes.SEAT_ROTATION_OFFSET_DEGREES, -90f);
         } else {
             passenger.getDirtyMetadata().put(EntityDataTypes.SEAT_LOCK_RIDER_ROTATION, false);
             passenger.getDirtyMetadata().put(EntityDataTypes.SEAT_LOCK_RIDER_ROTATION_DEGREES, 0f);

--- a/core/src/main/java/org/geysermc/geyser/util/EntityUtils.java
+++ b/core/src/main/java/org/geysermc/geyser/util/EntityUtils.java
@@ -44,11 +44,14 @@ import org.geysermc.geyser.entity.type.living.animal.horse.CamelEntity;
 import org.geysermc.geyser.inventory.GeyserItemStack;
 import org.geysermc.geyser.item.Items;
 import org.geysermc.geyser.session.GeyserSession;
+import org.geysermc.geyser.session.cache.registry.JavaRegistries;
+import org.geysermc.geyser.session.cache.tags.GeyserHolderSet;
 import org.geysermc.geyser.text.MinecraftLocale;
 import org.geysermc.mcprotocollib.protocol.data.game.entity.Effect;
 import org.geysermc.mcprotocollib.protocol.data.game.entity.player.GameMode;
 import org.geysermc.mcprotocollib.protocol.data.game.entity.player.Hand;
 import org.geysermc.mcprotocollib.protocol.data.game.entity.type.EntityType;
+import org.geysermc.mcprotocollib.protocol.data.game.item.component.Equippable;
 
 import java.util.Locale;
 
@@ -283,23 +286,12 @@ public final class EntityUtils {
                 passenger.getDirtyMetadata().put(EntityDataTypes.SEAT_LOCK_RIDER_ROTATION_DEGREES, 90f);
                 passenger.getDirtyMetadata().put(EntityDataTypes.SEAT_HAS_ROTATION, true);
                 passenger.getDirtyMetadata().put(EntityDataTypes.SEAT_ROTATION_OFFSET_DEGREES, -90f);
-            } else if (mount instanceof HappyGhastEntity) {
-                passenger.getDirtyMetadata().put(EntityDataTypes.SEAT_LOCK_RIDER_ROTATION, false);
-                passenger.getDirtyMetadata().put(EntityDataTypes.SEAT_LOCK_RIDER_ROTATION_DEGREES, 181f);
-                passenger.getDirtyMetadata().put(EntityDataTypes.SEAT_THIRD_PERSON_CAMERA_RADIUS, 8f);
-                passenger.getDirtyMetadata().put(EntityDataTypes.SEAT_CAMERA_RELAX_DISTANCE_SMOOTHING, 6f);
-
-                passenger.getDirtyMetadata().put(EntityDataTypes.CONTROLLING_RIDER_SEAT_INDEX, (byte) 0);
             }
         } else {
             passenger.getDirtyMetadata().put(EntityDataTypes.SEAT_LOCK_RIDER_ROTATION, false);
             passenger.getDirtyMetadata().put(EntityDataTypes.SEAT_LOCK_RIDER_ROTATION_DEGREES, 0f);
             passenger.getDirtyMetadata().put(EntityDataTypes.SEAT_HAS_ROTATION, false);
             passenger.getDirtyMetadata().put(EntityDataTypes.SEAT_ROTATION_OFFSET_DEGREES, 0f);
-            // TODO what are defaults here???
-            passenger.getDirtyMetadata().put(EntityDataTypes.SEAT_THIRD_PERSON_CAMERA_RADIUS, 8f);
-            passenger.getDirtyMetadata().put(EntityDataTypes.SEAT_CAMERA_RELAX_DISTANCE_SMOOTHING, 6f);
-            passenger.getDirtyMetadata().put(EntityDataTypes.CONTROLLING_RIDER_SEAT_INDEX, (byte) 0);
         }
     }
 
@@ -361,6 +353,15 @@ public final class EntityUtils {
         // this works at least with all 1.20.5 entities, except the killer bunny since that's not an entity type.
         String typeName = type.name().toLowerCase(Locale.ROOT);
         return translatedEntityName("minecraft", typeName, session);
+    }
+
+    public static boolean equipmentUsableByEntity(GeyserSession session, Equippable equippable, EntityType entity) {
+        if (equippable.allowedEntities() == null) {
+            return true;
+        }
+
+        GeyserHolderSet<EntityType> holderSet = GeyserHolderSet.fromHolderSet(JavaRegistries.ENTITY_TYPE, equippable.allowedEntities());
+        return session.getTagCache().is(holderSet, entity);
     }
 
     private EntityUtils() {

--- a/core/src/main/java/org/geysermc/geyser/util/EntityUtils.java
+++ b/core/src/main/java/org/geysermc/geyser/util/EntityUtils.java
@@ -39,6 +39,7 @@ import org.geysermc.geyser.entity.type.Entity;
 import org.geysermc.geyser.entity.type.TextDisplayEntity;
 import org.geysermc.geyser.entity.type.living.ArmorStandEntity;
 import org.geysermc.geyser.entity.type.living.animal.AnimalEntity;
+import org.geysermc.geyser.entity.type.living.animal.HappyGhastEntity;
 import org.geysermc.geyser.entity.type.living.animal.horse.CamelEntity;
 import org.geysermc.geyser.inventory.GeyserItemStack;
 import org.geysermc.geyser.item.Items;
@@ -221,6 +222,13 @@ public final class EntityUtils {
                         }
                     }
                 }
+                case HAPPY_GHAST -> {
+                    // TODO seat index matters here, likely
+                    // 0.0, 5.02001, 1.7 BDS
+                    xOffset = 0;
+                    yOffset = 3.4f;
+                    zOffset = 1.7f;
+                }
             }
             if (mount instanceof ChestBoatEntity) {
                 xOffset = 0.15F;
@@ -268,17 +276,30 @@ public final class EntityUtils {
     }
 
     public static void updateRiderRotationLock(Entity passenger, Entity mount, boolean isRiding) {
-        if (isRiding && mount instanceof BoatEntity) {
-            // Head rotation is locked while riding in a boat
-            passenger.getDirtyMetadata().put(EntityDataTypes.SEAT_LOCK_RIDER_ROTATION, true);
-            passenger.getDirtyMetadata().put(EntityDataTypes.SEAT_LOCK_RIDER_ROTATION_DEGREES, 90f);
-            passenger.getDirtyMetadata().put(EntityDataTypes.SEAT_HAS_ROTATION, true);
-            passenger.getDirtyMetadata().put(EntityDataTypes.SEAT_ROTATION_OFFSET_DEGREES, -90f);
+        if (isRiding) {
+            if (mount instanceof BoatEntity) {
+                // Head rotation is locked while riding in a boat
+                passenger.getDirtyMetadata().put(EntityDataTypes.SEAT_LOCK_RIDER_ROTATION, true);
+                passenger.getDirtyMetadata().put(EntityDataTypes.SEAT_LOCK_RIDER_ROTATION_DEGREES, 90f);
+                passenger.getDirtyMetadata().put(EntityDataTypes.SEAT_HAS_ROTATION, true);
+                passenger.getDirtyMetadata().put(EntityDataTypes.SEAT_ROTATION_OFFSET_DEGREES, -90f);
+            } else if (mount instanceof HappyGhastEntity) {
+                passenger.getDirtyMetadata().put(EntityDataTypes.SEAT_LOCK_RIDER_ROTATION, false);
+                passenger.getDirtyMetadata().put(EntityDataTypes.SEAT_LOCK_RIDER_ROTATION_DEGREES, 181f);
+                passenger.getDirtyMetadata().put(EntityDataTypes.SEAT_THIRD_PERSON_CAMERA_RADIUS, 8f);
+                passenger.getDirtyMetadata().put(EntityDataTypes.SEAT_CAMERA_RELAX_DISTANCE_SMOOTHING, 6f);
+
+                passenger.getDirtyMetadata().put(EntityDataTypes.CONTROLLING_RIDER_SEAT_INDEX, (byte) 0);
+            }
         } else {
             passenger.getDirtyMetadata().put(EntityDataTypes.SEAT_LOCK_RIDER_ROTATION, false);
             passenger.getDirtyMetadata().put(EntityDataTypes.SEAT_LOCK_RIDER_ROTATION_DEGREES, 0f);
             passenger.getDirtyMetadata().put(EntityDataTypes.SEAT_HAS_ROTATION, false);
             passenger.getDirtyMetadata().put(EntityDataTypes.SEAT_ROTATION_OFFSET_DEGREES, 0f);
+            // TODO what are defaults here???
+            passenger.getDirtyMetadata().put(EntityDataTypes.SEAT_THIRD_PERSON_CAMERA_RADIUS, 8f);
+            passenger.getDirtyMetadata().put(EntityDataTypes.SEAT_CAMERA_RELAX_DISTANCE_SMOOTHING, 6f);
+            passenger.getDirtyMetadata().put(EntityDataTypes.CONTROLLING_RIDER_SEAT_INDEX, (byte) 0);
         }
     }
 

--- a/core/src/main/java/org/geysermc/geyser/util/EntityUtils.java
+++ b/core/src/main/java/org/geysermc/geyser/util/EntityUtils.java
@@ -167,7 +167,7 @@ public final class EntityUtils {
     /**
      * Adjust an entity's height if they have mounted/dismounted an entity.
      */
-    public static void updateMountOffset(Entity passenger, Entity mount, boolean rider, boolean riding, boolean moreThanOneEntity) {
+    public static void updateMountOffset(Entity passenger, Entity mount, boolean rider, boolean riding, int index, int passengers) {
         passenger.setFlag(EntityFlag.RIDING, riding);
         if (riding) {
             // Without the Y offset, Bedrock players will find themselves in the floor when mounting
@@ -180,7 +180,7 @@ public final class EntityUtils {
             switch (mount.getDefinition().entityType()) {
                 case CAMEL -> {
                     zOffset = 0.5f;
-                    if (moreThanOneEntity) {
+                    if (passengers > 1) {
                         if (!rider) {
                             zOffset = -0.7f;
                         }
@@ -223,18 +223,18 @@ public final class EntityUtils {
                     }
                 }
                 case HAPPY_GHAST -> {
-                    // TODO seat index matters here, likely
                     // 0.0, 5.02001, 1.7 BDS
-                    xOffset = 0;
+                    int seatingIndex = Math.min(index, 4);
+                    xOffset = HappyGhastEntity.X_OFFSETS[seatingIndex];
                     yOffset = 3.4f;
-                    zOffset = 1.7f;
+                    zOffset = HappyGhastEntity.Z_OFFSETS[seatingIndex];
                 }
             }
             if (mount instanceof ChestBoatEntity) {
                 xOffset = 0.15F;
             } else if (mount instanceof BoatEntity) {
                 // Without the X offset, more than one entity on a boat is stacked on top of each other
-                if (moreThanOneEntity) {
+                if (passengers > 1) {
                     xOffset = rider ? 0.2f : -0.6f;
                     if (passenger instanceof AnimalEntity) {
                         xOffset += 0.2f;


### PR DESCRIPTION
Fun thing about happy ghasts - they're client-sided on Java, server-sided on Bedrock. Opening as separate PR if we decide to merge 1.21.6 changes without ridable happy ghasts

Good news: This will be, once finished, close to the real deal.
Bad news: We need to implement this manually.

Relevant mojmap:
LivingEntity#getRiddenInput, getRiddenSpeed, tickRidden, etc

TO-DO's:
- [x] get compiling
- [x] various seat offsets 
- [x] proper isClientControlled check
