### PR TITLE
Fix #5647

### DIFF
--- a/core/src/main/java/org/geysermc/geyser/entity/type/ThrowableEggEntity.java
+++ b/core/src/main/java/org/geysermc/geyser/entity/type/ThrowableEggEntity.java
@@ -33,6 +33,7 @@ import org.geysermc.geyser.entity.EntityDefinition;
 import org.geysermc.geyser.entity.properties.VanillaEntityProperties;
 import org.geysermc.geyser.entity.type.living.animal.farm.TemperatureVariantAnimal;
 import org.geysermc.geyser.inventory.GeyserItemStack;
+import org.geysermc.geyser.item.Items;
 import org.geysermc.geyser.session.GeyserSession;
 import org.geysermc.geyser.session.cache.registry.JavaRegistries;
 import org.geysermc.mcprotocollib.protocol.data.game.Holder;
@@ -47,7 +48,7 @@ import java.util.UUID;
 public class ThrowableEggEntity extends ThrowableItemEntity {
 
     // Used for egg break particles
-    private GeyserItemStack itemStack = GeyserItemStack.EMPTY;
+    private GeyserItemStack itemStack = GeyserItemStack.of(Items.EGG.javaId(), 1);
 
     public ThrowableEggEntity(GeyserSession session, int entityId, long geyserId, UUID uuid, EntityDefinition<?> definition, Vector3f position, Vector3f motion, float yaw, float pitch, float headYaw) {
         super(session, entityId, geyserId, uuid, definition, position, motion, yaw, pitch, headYaw);


### PR DESCRIPTION
This *should* fix the NPE that occurs in #5647. The server doesn't have to send us item stack metadata for the throwable egg entity, so we should default to an empty item stack when it doesn't.

For context, here's the code causing the NPE in `JavaEntityEventTranslator`:

```java
case LIVING_DEATH:
    entityEventPacket.setType(EntityEventType.DEATH);
    if (entity instanceof ThrowableEggEntity egg) {
        LevelEventPacket particlePacket = new LevelEventPacket();
        particlePacket.setType(ParticleType.ICON_CRACK);
        particlePacket.setData(ItemTranslator.getBedrockItemDefinition(session, egg.getItemStack()).getRuntimeId() << 16);
        particlePacket.setPosition(entity.getPosition());
        for (int i = 0; i < 6; i++) {
            session.sendUpstreamPacket(particlePacket);
        }
```

`ItemTranslator#getBedrockItemDefinition` throws when `egg.getItemStack()` returns null.