### PR TITLE
Fix jukebox action bar message

### DIFF
--- a/core/src/main/java/org/geysermc/geyser/translator/protocol/java/level/JavaLevelEventTranslator.java
+++ b/core/src/main/java/org/geysermc/geyser/translator/protocol/java/level/JavaLevelEventTranslator.java
@@ -43,7 +43,6 @@ import org.geysermc.geyser.registry.Registries;
 import org.geysermc.geyser.registry.type.SoundMapping;
 import org.geysermc.geyser.session.GeyserSession;
 import org.geysermc.geyser.session.cache.registry.JavaRegistries;
-import org.geysermc.geyser.text.MinecraftLocale;
 import org.geysermc.geyser.translator.level.event.LevelEventTranslator;
 import org.geysermc.geyser.translator.protocol.PacketTranslator;
 import org.geysermc.geyser.translator.protocol.Translator;
@@ -128,7 +127,7 @@ public class JavaLevelEventTranslator extends PacketTranslator<ClientboundLevelE
             textPacket.setPlatformChatId("");
             textPacket.setSourceName(null);
             textPacket.setMessage("record.nowPlaying");
-            textPacket.setParameters(Collections.singletonList(MinecraftLocale.getLocaleString(jukeboxSong.description(), session.locale())));
+            textPacket.setParameters(Collections.singletonList(jukeboxSong.description()));
             session.sendUpstreamPacket(textPacket);
             return;
         }


### PR DESCRIPTION
`JukeboxSong#description` is already translated when parsing the song from NBT data:

```java
NbtMap data = context.data();
String soundEvent = SoundUtils.readSoundEvent(data, "jukebox song " + context.id());
String description = MessageTranslator.deserializeDescription(context.session(), data);
return new JukeboxSong(soundEvent, description);
```

So we shouldn't try to translate it again in the level event translator. This one is on me, should have caught it in #5029.