### PR TITLE
More accurate explosion translation.

### DIFF
--- a/core/src/main/java/org/geysermc/geyser/translator/protocol/bedrock/entity/player/input/BedrockMovePlayer.java
+++ b/core/src/main/java/org/geysermc/geyser/translator/protocol/bedrock/entity/player/input/BedrockMovePlayer.java
@@ -108,6 +108,7 @@ final class BedrockMovePlayer {
         }
 
         entity.setLastTickEndVelocity(packet.getDelta());
+        entity.setMotion(packet.getDelta());
 
         // This takes into account no movement sent from the client, but the player is trying to move anyway.
         // (Press into a wall in a corner - you're trying to move but nothing actually happens)

--- a/core/src/main/java/org/geysermc/geyser/translator/protocol/java/level/JavaExplodeTranslator.java
+++ b/core/src/main/java/org/geysermc/geyser/translator/protocol/java/level/JavaExplodeTranslator.java
@@ -31,6 +31,7 @@ import org.cloudburstmc.nbt.NbtMapBuilder;
 import org.cloudburstmc.protocol.bedrock.data.LevelEvent;
 import org.cloudburstmc.protocol.bedrock.packet.LevelEventGenericPacket;
 import org.cloudburstmc.protocol.bedrock.packet.SetEntityMotionPacket;
+import org.geysermc.geyser.entity.type.player.SessionPlayerEntity;
 import org.geysermc.geyser.session.GeyserSession;
 import org.geysermc.geyser.translator.protocol.PacketTranslator;
 import org.geysermc.geyser.translator.protocol.Translator;
@@ -68,9 +69,12 @@ public class JavaExplodeTranslator extends PacketTranslator<ClientboundExplodePa
         SoundUtils.playSound(session, packet.getExplosionSound(), vector, 4.0f, pitch);
 
         if (packet.getPlayerKnockback() != null) {
+            SessionPlayerEntity entity = session.getPlayerEntity();
+            entity.setMotion(entity.getMotion().add(packet.getPlayerKnockback().toFloat()));
+
             SetEntityMotionPacket motionPacket = new SetEntityMotionPacket();
-            motionPacket.setRuntimeEntityId(session.getPlayerEntity().getGeyserId());
-            motionPacket.setMotion(packet.getPlayerKnockback().toFloat());
+            motionPacket.setRuntimeEntityId(entity.getGeyserId());
+            motionPacket.setMotion(entity.getMotion());
             session.sendUpstreamPacket(motionPacket);
         }
     }


### PR DESCRIPTION
Explosion motion should be relative to player current motion.
Here is 3 videos that show how this would look on Java and how it would look on Bedrock before and after the changes.
BDS also seems to do something similar to this.
https://github.com/user-attachments/assets/2a7f7690-d9e1-4435-9d11-094fa5be7b61
https://github.com/user-attachments/assets/460a99a9-7685-461e-9d9b-94c76f832e64
https://github.com/user-attachments/assets/252c9ca3-d33c-41f8-a5de-90ed7da5be93


