### PR TITLE
Some fixes related to flags.

### DIFF
--- a/core/src/main/java/org/geysermc/geyser/entity/type/living/monster/ShulkerEntity.java
+++ b/core/src/main/java/org/geysermc/geyser/entity/type/living/monster/ShulkerEntity.java
@@ -52,6 +52,12 @@ public class ShulkerEntity extends GolemEntity {
         // As of 1.19.4, it seems Java no longer sends the shulker color if it's the default color on initial spawn
         // We still need the special case for 16 color in setShulkerColor though as it will send it for an entity metadata update
         dirtyMetadata.put(EntityDataTypes.VARIANT, 16);
+
+        setFlag(EntityFlag.COLLIDABLE, true);
+
+        // This is vanilla behaviour yes (BDS does this), without this as of 1.21.93 entity became fully invisible.
+        // Doing this allow the invisible parity support inside GeyserOptionalPack to works again.
+        setFlag(EntityFlag.RENDER_WHEN_INVISIBLE, true);
     }
 
     public void setAttachedFace(EntityMetadata<Direction, ?> entityMetadata) {

--- a/core/src/main/java/org/geysermc/geyser/entity/type/player/PlayerEntity.java
+++ b/core/src/main/java/org/geysermc/geyser/entity/type/player/PlayerEntity.java
@@ -51,6 +51,7 @@ import org.geysermc.geyser.entity.attribute.GeyserAttributeType;
 import org.geysermc.geyser.entity.type.Entity;
 import org.geysermc.geyser.entity.type.LivingEntity;
 import org.geysermc.geyser.entity.type.living.animal.tameable.ParrotEntity;
+import org.geysermc.geyser.level.block.Blocks;
 import org.geysermc.geyser.session.GeyserSession;
 import org.geysermc.geyser.util.ChunkUtils;
 import org.geysermc.mcprotocollib.protocol.data.game.entity.metadata.EntityMetadata;
@@ -420,6 +421,32 @@ public class PlayerEntity extends LivingEntity implements GeyserPlayerEntity {
             return;
         }
         dirtyMetadata.put(EntityDataTypes.SCORE, show ? cachedScore : "");
+    }
+
+    @Override
+    public void setPose(Pose pose) {
+        super.setPose(pose);
+        setFlag(EntityFlag.SWIMMING, false);
+        setFlag(EntityFlag.CRAWLING, false);
+
+        if (pose == Pose.SWIMMING) {
+            // This is just for, so we know if player is swimming or crawling.
+            if (session.getGeyser().getWorldManager().blockAt(session, this.position().toInt()).is(Blocks.WATER)) {
+                setFlag(EntityFlag.SWIMMING, true);
+            } else {
+                setFlag(EntityFlag.CRAWLING, true);
+            }
+        }
+
+        // Look at https://github.com/GeyserMC/Geyser/issues/5316, we're fixing this by spoofing player yaw to 0.
+        if (getFlag(EntityFlag.CRAWLING)) {
+            updateRotation(this.yaw, 0, this.onGround);
+        }
+    }
+
+    @Override
+    public void setPitch(float pitch) {
+        super.setPitch(getFlag(EntityFlag.CRAWLING) ? 0 : pitch);
     }
 
     @Override

--- a/core/src/main/java/org/geysermc/geyser/entity/type/player/PlayerEntity.java
+++ b/core/src/main/java/org/geysermc/geyser/entity/type/player/PlayerEntity.java
@@ -438,7 +438,7 @@ public class PlayerEntity extends LivingEntity implements GeyserPlayerEntity {
             }
         }
 
-        // Look at https://github.com/GeyserMC/Geyser/issues/5316, we're fixing this by spoofing player yaw to 0.
+        // Look at https://github.com/GeyserMC/Geyser/issues/5316, we're fixing this by spoofing player pitch to 0.
         if (getFlag(EntityFlag.CRAWLING)) {
             updateRotation(this.yaw, 0, this.onGround);
         }

--- a/core/src/main/java/org/geysermc/geyser/entity/type/player/PlayerEntity.java
+++ b/core/src/main/java/org/geysermc/geyser/entity/type/player/PlayerEntity.java
@@ -435,12 +435,9 @@ public class PlayerEntity extends LivingEntity implements GeyserPlayerEntity {
                 setFlag(EntityFlag.SWIMMING, true);
             } else {
                 setFlag(EntityFlag.CRAWLING, true);
+                // Look at https://github.com/GeyserMC/Geyser/issues/5316, we're fixing this by spoofing player pitch to 0.
+                updateRotation(this.yaw, 0, this.onGround);
             }
-        }
-
-        // Look at https://github.com/GeyserMC/Geyser/issues/5316, we're fixing this by spoofing player pitch to 0.
-        if (getFlag(EntityFlag.CRAWLING)) {
-            updateRotation(this.yaw, 0, this.onGround);
         }
     }
 

--- a/core/src/main/java/org/geysermc/geyser/entity/type/player/SessionPlayerEntity.java
+++ b/core/src/main/java/org/geysermc/geyser/entity/type/player/SessionPlayerEntity.java
@@ -125,6 +125,14 @@ public class SessionPlayerEntity extends PlayerEntity {
     }
 
     @Override
+    protected void initializeMetadata() {
+        super.initializeMetadata();
+
+        // This allows player to be slowly push towards the closet space when stuck inside block instead of instantly moved out.
+        setFlag(EntityFlag.PUSH_TOWARDS_CLOSEST_SPACE, true);
+    }
+
+    @Override
     protected void setClientSideSilent() {
         // Do nothing, since we want the session player to hear their own footstep sounds for example.
     }


### PR DESCRIPTION
Changes:
- Sending PUSH_TOWARDS_CLOSEST_SPACE to session player so the behaviour is now more Java like when you're "stuck" inside a block and can easily enter for ex: crawl mode using a trapdoor more easily.
- Added COLLIDABLE for shulker and also allow shulker to be visible when it's invisible (again) so https://github.com/GeyserMC/GeyserOptionalPack/ shulker invisibility parity trick works again.
- Now send pitch 0 if you're crawling, resolve #5316, but this will only fix it for other player, not the session itself, and it's a "hack".