### PR TITLE
Workaround to make firework boosting server controlled.

### DIFF
--- a/core/src/main/java/org/geysermc/geyser/item/hashing/data/FireworkExplosionShape.java
+++ b/core/src/main/java/org/geysermc/geyser/item/hashing/data/FireworkExplosionShape.java
@@ -25,11 +25,18 @@
 
 package org.geysermc.geyser.item.hashing.data;
 
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
 // Ordered and named by Java ID
+@RequiredArgsConstructor
+@Getter
 public enum FireworkExplosionShape {
-    SMALL_BALL,
-    LARGE_BALL,
-    STAR,
-    CREEPER,
-    BURST
+    SMALL_BALL("Small ball"),
+    LARGE_BALL("Large Ball"),
+    STAR("Star-shaped"),
+    CREEPER("Creeper-shaped"),
+    BURST("Burst");
+
+    private final String bedrockName;
 }

--- a/core/src/main/java/org/geysermc/geyser/level/FireworkColor.java
+++ b/core/src/main/java/org/geysermc/geyser/level/FireworkColor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019-2022 GeyserMC. http://geysermc.org
+ * Copyright (c) 2019-2025 GeyserMC. http://geysermc.org
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -25,34 +25,38 @@
 
 package org.geysermc.geyser.level;
 
+import lombok.Getter;
 import net.kyori.adventure.text.format.TextColor;
 import net.kyori.adventure.util.HSVLike;
 import org.checkerframework.checker.nullness.qual.NonNull;
 
 public enum FireworkColor {
-    BLACK(1973019),
-    RED(11743532),
-    GREEN(3887386),
-    BROWN(5320730),
-    BLUE(2437522),
-    PURPLE(8073150),
-    CYAN(2651799),
-    LIGHT_GRAY(11250603),
-    GRAY(4408131),
-    PINK(14188952),
-    LIME(4312372),
-    YELLOW(14602026),
-    LIGHT_BLUE(6719955),
-    MAGENTA(12801229),
-    ORANGE(15435844),
-    WHITE(15790320);
+    BLACK(1973019, "Black"),
+    RED(11743532, "Red"),
+    GREEN(3887386, "Green"),
+    BROWN(5320730, "Brown"),
+    BLUE(2437522, "Blue"),
+    PURPLE(8073150, "Purple"),
+    CYAN(2651799, "Cyan"),
+    LIGHT_GRAY(11250603, "Silver"),
+    GRAY(4408131, "Gray"),
+    PINK(14188952, "Pink"),
+    LIME(4312372, "Lime"),
+    YELLOW(14602026, "Yellow"),
+    LIGHT_BLUE(6719955, "Light Blue"),
+    MAGENTA(12801229, "Magenta"),
+    ORANGE(15435844, "Orange"),
+    WHITE(15790320, "White");
 
     private static final FireworkColor[] VALUES = values();
 
     private final TextColor color;
+    @Getter
+    private final String bedrockName;
 
-    FireworkColor(int rgbValue) {
+    FireworkColor(int rgbValue, String bedrockName) {
         this.color = TextColor.color(rgbValue);
+        this.bedrockName = bedrockName;
     }
 
     private static HSVLike toHSV(int rgbValue) {

--- a/core/src/main/java/org/geysermc/geyser/registry/populator/ItemRegistryPopulator.java
+++ b/core/src/main/java/org/geysermc/geyser/registry/populator/ItemRegistryPopulator.java
@@ -618,7 +618,7 @@ public class ItemRegistryPopulator {
                             .bedrockDefinition(fireworkRocketDefinition)
                             .bedrockData(0)
                             .bedrockBlockDefinition(null)
-                            .customItemOptions(Collections.emptyList()) // TODO check for custom items with furnace minecart
+                            .customItemOptions(Collections.emptyList())
                             .build());
 
                     // We have to replace all the real firework rocket in the creative menu with our fake fireworks rocket.


### PR DESCRIPTION
Resolve: #5409 and also match Java behaviour now.

This works by overriding the vanilla fireworks rocket with a custom item that is basically the same, making player unable to boost client-sided until the server send a movement effect packet, which was already implemented in #5658.

- [x] Working custom fake fireworks item.
- [x] Translate the fireworks tag to lore so it's visible on the fake fireworks rocket. 

Potential issues:
- Will now only show english since everything are translated into lore (except the item name).
- Some resource pack that messes around with fireworks rocket item might not works anymore, ofc this only applied to the fireworks item and not other thing that the resource pack have to offer.

Feel free to play around, test and comment on this as much as you'd like :D