### PR TITLE
Don't send too large number for fireworks boosting.

### DIFF
--- a/core/src/main/java/org/geysermc/geyser/entity/type/FireworkEntity.java
+++ b/core/src/main/java/org/geysermc/geyser/entity/type/FireworkEntity.java
@@ -113,6 +113,7 @@ public class FireworkEntity extends Entity {
         movementEffect.setDuration(duration);
         movementEffect.setEffectType(MovementEffectType.GLIDE_BOOST);
         movementEffect.setEntityRuntimeId(session.getPlayerEntity().getGeyserId());
+        movementEffect.setTick(session.getClientTicks());
         session.sendUpstreamPacket(movementEffect);
     }
 }

--- a/core/src/main/java/org/geysermc/geyser/entity/type/FireworkEntity.java
+++ b/core/src/main/java/org/geysermc/geyser/entity/type/FireworkEntity.java
@@ -75,10 +75,11 @@ public class FireworkEntity extends Entity {
         if (optional.isPresent() && optional.getAsInt() == session.getPlayerEntity().getEntityId()) {
             // If we don't send this, the bedrock client will always stop boosting after 20 ticks
             // However this is not the case for Java as the player will stop boosting after entity despawn.
-            // So we let player boost "infinitely" and then only stop them when the entity despawn.
+            // So we let player boost for a really long time and then only stop them when the entity despawn.
             // Also doing this allow player to boost simply by having a fireworks rocket attached to them
             // and not necessary have to use a rocket (as some plugin do this to boost player)
-            sendElytraBoost(Integer.MAX_VALUE);
+            // You can't really send Integer.MAX_VALUE since Bedrock client doesn't seem to like way too large number very much.
+            sendElytraBoost(1000000);
             this.attachedToSession = true;
 
             // We need to keep track of the fireworks rockets.
@@ -99,7 +100,7 @@ public class FireworkEntity extends Entity {
         // Else player will stop boosting even if the fireworks is not attached to them or there is a fireworks that is boosting them
         // and not just this one.
         if (this.attachedToSession && session.getAttachedFireworkRockets().isEmpty()) {
-            // Since we send an effect packet for player to boost "infinitely", we have to stop them when the entity despawn.
+            // Since we send an effect packet for player to boost really long, we have to stop them when the entity despawn.
             sendElytraBoost(0);
             this.attachedToSession = false;
         }

--- a/core/src/main/java/org/geysermc/geyser/entity/type/FireworkEntity.java
+++ b/core/src/main/java/org/geysermc/geyser/entity/type/FireworkEntity.java
@@ -78,7 +78,7 @@ public class FireworkEntity extends Entity {
             // So we let player boost for a really long time and then only stop them when the entity despawn.
             // Also doing this allow player to boost simply by having a fireworks rocket attached to them
             // and not necessary have to use a rocket (as some plugin do this to boost player)
-            // You can't really send Integer.MAX_VALUE since Bedrock client doesn't seem to like way too large number very much.
+            // You can't really send Integer.MAX_VALUE since Bedrock client doesn't seem to like way too large number very much (as of 1.21.73).
             sendElytraBoost(1000000);
             this.attachedToSession = true;
 

--- a/core/src/main/java/org/geysermc/geyser/session/GeyserSession.java
+++ b/core/src/main/java/org/geysermc/geyser/session/GeyserSession.java
@@ -677,6 +677,12 @@ public class GeyserSession implements GeyserConnection, GeyserCommandSource {
     private int ticks;
 
     /**
+     * The number of ticks that have elapsed since the start of this session according to the client.
+     */
+    @Setter
+    private long clientTicks;
+
+    /**
      * The world time in ticks according to the server
      * <p>
      * Note: The TickingStatePacket is currently ignored.

--- a/core/src/main/java/org/geysermc/geyser/translator/protocol/bedrock/entity/player/input/BedrockPlayerAuthInputTranslator.java
+++ b/core/src/main/java/org/geysermc/geyser/translator/protocol/bedrock/entity/player/input/BedrockPlayerAuthInputTranslator.java
@@ -75,6 +75,8 @@ public final class BedrockPlayerAuthInputTranslator extends PacketTranslator<Pla
     public void translate(GeyserSession session, PlayerAuthInputPacket packet) {
         SessionPlayerEntity entity = session.getPlayerEntity();
 
+        session.setClientTicks(packet.getTick());
+
         boolean wasJumping = session.getInputCache().wasJumping();
         session.getInputCache().processInputs(entity, packet);
 


### PR DESCRIPTION
This is a follow up of PR #5658, turn out if you send a too large number, like Integer.MAX_VALUE for example, the client is going to ignore it and just default back to 1 (yes, no idea why), so this PR changes that it send 1000000 which is still a really large number and basically won't run out before the fireworks die but still ensure that the client still accept the number. So this time the amount of time you gliding should now actually match JE. Also you have to send the tick for it to work properly.