### PR TITLE
Disable packet limit to prevent proxy ips from getting banned

### DIFF
--- a/core/src/main/java/org/geysermc/geyser/network/netty/GeyserServer.java
+++ b/core/src/main/java/org/geysermc/geyser/network/netty/GeyserServer.java
@@ -219,7 +219,10 @@ public final class GeyserServer {
         playerGroup = serverInitializer.getEventLoopGroup();
         this.geyser.getLogger().debug("Setting MTU to " + this.geyser.getConfig().getMtu());
 
-        int rakPacketLimit = positivePropOrDefault("Geyser.RakPacketLimit", DEFAULT_PACKET_LIMIT);
+        int rakPacketLimit = positivePropOrDefault(
+            "Geyser.RakPacketLimit",
+            this.geyser.getConfig().getBedrock().isEnableProxyProtocol() ? 0 : DEFAULT_PACKET_LIMIT
+        );
         this.geyser.getLogger().debug("Setting RakNet packet limit to " + rakPacketLimit);
 
         int rakGlobalPacketLimit = positivePropOrDefault("Geyser.RakGlobalPacketLimit", DEFAULT_GLOBAL_PACKET_LIMIT);


### PR DESCRIPTION
It should not be possible for an individual player to cause other players getting kicked when sending malicious packets (or TCPShield doing some weird 

Geyser.RakPacketLimit still doesn't allow 0, but this is on purpose, as you may want to use proxy protocol in this scenario anyway