### PR TITLE
Packet event

### DIFF
--- a/api/build.gradle.kts
+++ b/api/build.gradle.kts
@@ -2,12 +2,15 @@ plugins {
     // Allow blossom to mark sources root of templates
     idea
     id("geyser.publish-conventions")
+    id("io.freefair.lombok")
     alias(libs.plugins.blossom)
 }
 
 dependencies {
     api(libs.base.api)
     api(libs.math)
+    api(libs.bundles.protocol)
+
 }
 
 version = property("version")!!

--- a/api/src/main/java/org/geysermc/geyser/api/event/bedrock/SessionReceiveBedrockPacket.java
+++ b/api/src/main/java/org/geysermc/geyser/api/event/bedrock/SessionReceiveBedrockPacket.java
@@ -23,30 +23,26 @@
  * @link https://github.com/GeyserMC/Geyser
  */
 
-package org.geysermc.geyser.network;
+package org.geysermc.geyser.api.event.bedrock;
 
-import org.cloudburstmc.protocol.bedrock.BedrockPeer;
-import org.cloudburstmc.protocol.bedrock.netty.BedrockPacketWrapper;
+import lombok.Getter;
+import lombok.Setter;
+import org.checkerframework.checker.nullness.qual.NonNull;
 import org.cloudburstmc.protocol.bedrock.packet.BedrockPacket;
-import org.geysermc.geyser.api.event.bedrock.SessionReceiveBedrockPacket;
-import org.geysermc.geyser.session.GeyserSession;
+import org.geysermc.event.Cancellable;
+import org.geysermc.geyser.api.connection.GeyserConnection;
+import org.geysermc.geyser.api.event.connection.ConnectionEvent;
 
-public class BedrockServerSession extends org.cloudburstmc.protocol.bedrock.BedrockServerSession {
+@Getter
+public class SessionReceiveBedrockPacket extends ConnectionEvent implements Cancellable {
 
-    public GeyserSession session;
+    private final BedrockPacket bedrockPacket;
+    @Setter
+    private boolean cancelled;
 
-    public BedrockServerSession(BedrockPeer peer, int subClientId) {
-        super(peer, subClientId);
-    }
 
-    @Override
-    protected void onPacket(BedrockPacketWrapper wrapper) {
-        BedrockPacket packet = wrapper.getPacket();
-        var ev = new SessionReceiveBedrockPacket(packet, session);
-        session.getGeyser().eventBus().fire(ev);
-        if(ev.isCancelled()){
-            return;
-        }
-        super.onPacket(wrapper);
+    public SessionReceiveBedrockPacket(@NonNull BedrockPacket bedrockPacket, @NonNull GeyserConnection connection) {
+        super(connection);
+        this.bedrockPacket = bedrockPacket;
     }
 }

--- a/api/src/main/java/org/geysermc/geyser/api/event/bedrock/SessionSendBedrockPacket.java
+++ b/api/src/main/java/org/geysermc/geyser/api/event/bedrock/SessionSendBedrockPacket.java
@@ -23,24 +23,27 @@
  * @link https://github.com/GeyserMC/Geyser
  */
 
-package org.geysermc.geyser.event.type;
+package org.geysermc.geyser.api.event.bedrock;
 
 import lombok.Getter;
 import lombok.Setter;
 import org.checkerframework.checker.nullness.qual.NonNull;
 import org.cloudburstmc.protocol.bedrock.packet.BedrockPacket;
-import org.geysermc.event.Event;
-import org.geysermc.geyser.session.GeyserSession;
+import org.geysermc.event.Cancellable;
+import org.geysermc.geyser.api.connection.GeyserConnection;
+import org.geysermc.geyser.api.event.connection.ConnectionEvent;
+
 
 @Getter
-public class SessionSendBedrockPacket implements Event {
-    private final BedrockPacket bedrockPacket;
-    private final GeyserSession session;
-    @Setter
-    private boolean cancel = false;
+public class SessionSendBedrockPacket extends ConnectionEvent implements Cancellable {
 
-    public SessionSendBedrockPacket(@NonNull BedrockPacket bedrockPacket, @NonNull GeyserSession session) {
+    private final BedrockPacket bedrockPacket;
+    @Setter
+    private boolean cancelled;
+
+
+    public SessionSendBedrockPacket(@NonNull BedrockPacket bedrockPacket, @NonNull GeyserConnection connection) {
+        super(connection);
         this.bedrockPacket = bedrockPacket;
-        this.session = session;
     }
 }

--- a/core/src/main/java/org/geysermc/geyser/event/type/SessionSendBedrockPacket.java
+++ b/core/src/main/java/org/geysermc/geyser/event/type/SessionSendBedrockPacket.java
@@ -1,0 +1,46 @@
+/*
+ * Copyright (c) 2025 GeyserMC. http://geysermc.org
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ *
+ * @author GeyserMC
+ * @link https://github.com/GeyserMC/Geyser
+ */
+
+package org.geysermc.geyser.event.type;
+
+import lombok.Getter;
+import lombok.Setter;
+import org.checkerframework.checker.nullness.qual.NonNull;
+import org.cloudburstmc.protocol.bedrock.packet.BedrockPacket;
+import org.geysermc.event.Event;
+import org.geysermc.geyser.session.GeyserSession;
+
+@Getter
+public class SessionSendBedrockPacket implements Event {
+    private final BedrockPacket bedrockPacket;
+    private final GeyserSession session;
+    @Setter
+    private boolean cancel = false;
+
+    public SessionSendBedrockPacket(@NonNull BedrockPacket bedrockPacket, @NonNull GeyserSession session) {
+        this.bedrockPacket = bedrockPacket;
+        this.session = session;
+    }
+}

--- a/core/src/main/java/org/geysermc/geyser/network/BedrockServerSession.java
+++ b/core/src/main/java/org/geysermc/geyser/network/BedrockServerSession.java
@@ -1,0 +1,52 @@
+/*
+ * Copyright (c) 2025 GeyserMC. http://geysermc.org
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ *
+ * @author GeyserMC
+ * @link https://github.com/GeyserMC/Geyser
+ */
+
+package org.geysermc.geyser.network;
+
+import org.cloudburstmc.protocol.bedrock.BedrockPeer;
+import org.cloudburstmc.protocol.bedrock.netty.BedrockPacketWrapper;
+import org.cloudburstmc.protocol.bedrock.packet.BedrockPacket;
+import org.geysermc.geyser.event.type.SessionSendBedrockPacket;
+import org.geysermc.geyser.session.GeyserSession;
+
+public class BedrockServerSession extends org.cloudburstmc.protocol.bedrock.BedrockServerSession {
+
+    public GeyserSession session;
+
+    public BedrockServerSession(BedrockPeer peer, int subClientId) {
+        super(peer, subClientId);
+    }
+
+    @Override
+    protected void onPacket(BedrockPacketWrapper wrapper) {
+        BedrockPacket packet = wrapper.getPacket();
+        var ev = new SessionSendBedrockPacket(packet, session);
+        session.getGeyser().eventBus().fire(ev);
+        if(ev.isCancel()){
+            return;
+        }
+        super.onPacket(wrapper);
+    }
+}

--- a/core/src/main/java/org/geysermc/geyser/network/BedrockServerSession.java
+++ b/core/src/main/java/org/geysermc/geyser/network/BedrockServerSession.java
@@ -41,8 +41,7 @@ public class BedrockServerSession extends org.cloudburstmc.protocol.bedrock.Bedr
 
     @Override
     protected void onPacket(BedrockPacketWrapper wrapper) {
-        BedrockPacket packet = wrapper.getPacket();
-        var ev = new SessionReceiveBedrockPacket(packet, session);
+        var ev = new SessionReceiveBedrockPacket(wrapper.getPacket(), session);
         session.getGeyser().eventBus().fire(ev);
         if(ev.isCancelled()){
             return;

--- a/core/src/main/java/org/geysermc/geyser/session/GeyserSession.java
+++ b/core/src/main/java/org/geysermc/geyser/session/GeyserSession.java
@@ -59,7 +59,6 @@ import org.cloudburstmc.nbt.NbtMap;
 import org.cloudburstmc.netty.channel.raknet.RakChildChannel;
 import org.cloudburstmc.netty.handler.codec.raknet.common.RakSessionCodec;
 import org.cloudburstmc.protocol.bedrock.BedrockDisconnectReasons;
-import org.cloudburstmc.protocol.bedrock.BedrockServerSession;
 import org.cloudburstmc.protocol.bedrock.data.Ability;
 import org.cloudburstmc.protocol.bedrock.data.AbilityLayer;
 import org.cloudburstmc.protocol.bedrock.data.AuthoritativeMovementMode;
@@ -153,6 +152,7 @@ import org.geysermc.geyser.item.type.Item;
 import org.geysermc.geyser.level.BedrockDimension;
 import org.geysermc.geyser.level.JavaDimension;
 import org.geysermc.geyser.level.physics.CollisionManager;
+import org.geysermc.geyser.network.BedrockServerSession;
 import org.geysermc.geyser.network.GameProtocol;
 import org.geysermc.geyser.network.netty.LocalSession;
 import org.geysermc.geyser.registry.Registries;
@@ -736,7 +736,7 @@ public class GeyserSession implements GeyserConnection, GeyserCommandSource {
 
     public GeyserSession(GeyserImpl geyser, BedrockServerSession bedrockServerSession, EventLoop tickEventLoop) {
         this.geyser = geyser;
-        this.upstream = new UpstreamSession(bedrockServerSession, this);
+        this.upstream = new UpstreamSession(bedrockServerSession);
         this.tickEventLoop = tickEventLoop;
 
         this.erosionHandler = new GeyserboundHandshakePacketHandler(this);

--- a/core/src/main/java/org/geysermc/geyser/session/GeyserSession.java
+++ b/core/src/main/java/org/geysermc/geyser/session/GeyserSession.java
@@ -736,7 +736,7 @@ public class GeyserSession implements GeyserConnection, GeyserCommandSource {
 
     public GeyserSession(GeyserImpl geyser, BedrockServerSession bedrockServerSession, EventLoop tickEventLoop) {
         this.geyser = geyser;
-        this.upstream = new UpstreamSession(bedrockServerSession);
+        this.upstream = new UpstreamSession(bedrockServerSession, this);
         this.tickEventLoop = tickEventLoop;
 
         this.erosionHandler = new GeyserboundHandshakePacketHandler(this);

--- a/core/src/main/java/org/geysermc/geyser/session/UpstreamSession.java
+++ b/core/src/main/java/org/geysermc/geyser/session/UpstreamSession.java
@@ -32,6 +32,8 @@ import org.checkerframework.checker.nullness.qual.NonNull;
 import org.cloudburstmc.protocol.bedrock.BedrockServerSession;
 import org.cloudburstmc.protocol.bedrock.codec.BedrockCodecHelper;
 import org.cloudburstmc.protocol.bedrock.packet.BedrockPacket;
+import org.geysermc.geyser.GeyserImpl;
+import org.geysermc.geyser.event.type.SessionSendBedrockPacket;
 import org.geysermc.geyser.network.GeyserBedrockPeer;
 
 import java.net.InetSocketAddress;
@@ -41,12 +43,18 @@ import java.util.Queue;
 @RequiredArgsConstructor
 public class UpstreamSession {
     @Getter private final BedrockServerSession session;
+    @Getter private final GeyserSession geyserSession;
     @Getter @Setter
     private boolean initialized = false;
     private Queue<BedrockPacket> postStartGamePackets = new ArrayDeque<>();
 
     public void sendPacket(@NonNull BedrockPacket packet) {
         if (!isClosed()) {
+            var ev = new SessionSendBedrockPacket(packet, this.geyserSession);
+            GeyserImpl.getInstance().eventBus().fire(ev);
+            if(ev.isCancel()){
+                return;
+            }
             session.sendPacket(packet);
         }
     }

--- a/core/src/main/java/org/geysermc/geyser/session/UpstreamSession.java
+++ b/core/src/main/java/org/geysermc/geyser/session/UpstreamSession.java
@@ -33,7 +33,7 @@ import org.cloudburstmc.protocol.bedrock.BedrockServerSession;
 import org.cloudburstmc.protocol.bedrock.codec.BedrockCodecHelper;
 import org.cloudburstmc.protocol.bedrock.packet.BedrockPacket;
 import org.geysermc.geyser.GeyserImpl;
-import org.geysermc.geyser.event.type.SessionSendBedrockPacket;
+import org.geysermc.geyser.api.event.bedrock.SessionSendBedrockPacket;
 import org.geysermc.geyser.network.GeyserBedrockPeer;
 
 import java.net.InetSocketAddress;
@@ -52,7 +52,7 @@ public class UpstreamSession {
         if (!isClosed()) {
             var ev = new SessionSendBedrockPacket(packet, this.geyserSession);
             GeyserImpl.getInstance().eventBus().fire(ev);
-            if(ev.isCancel()){
+            if(ev.isCancelled()){
                 return;
             }
             session.sendPacket(packet);

--- a/core/src/main/java/org/geysermc/geyser/session/UpstreamSession.java
+++ b/core/src/main/java/org/geysermc/geyser/session/UpstreamSession.java
@@ -29,11 +29,11 @@ import lombok.Getter;
 import lombok.RequiredArgsConstructor;
 import lombok.Setter;
 import org.checkerframework.checker.nullness.qual.NonNull;
-import org.cloudburstmc.protocol.bedrock.BedrockServerSession;
 import org.cloudburstmc.protocol.bedrock.codec.BedrockCodecHelper;
 import org.cloudburstmc.protocol.bedrock.packet.BedrockPacket;
 import org.geysermc.geyser.GeyserImpl;
 import org.geysermc.geyser.api.event.bedrock.SessionSendBedrockPacket;
+import org.geysermc.geyser.network.BedrockServerSession;
 import org.geysermc.geyser.network.GeyserBedrockPeer;
 
 import java.net.InetSocketAddress;
@@ -43,14 +43,13 @@ import java.util.Queue;
 @RequiredArgsConstructor
 public class UpstreamSession {
     @Getter private final BedrockServerSession session;
-    @Getter private final GeyserSession geyserSession;
     @Getter @Setter
     private boolean initialized = false;
     private Queue<BedrockPacket> postStartGamePackets = new ArrayDeque<>();
 
     public void sendPacket(@NonNull BedrockPacket packet) {
         if (!isClosed()) {
-            var ev = new SessionSendBedrockPacket(packet, this.geyserSession);
+            var ev = new SessionSendBedrockPacket(packet, this.session.session);
             GeyserImpl.getInstance().eventBus().fire(ev);
             if(ev.isCancelled()){
                 return;


### PR DESCRIPTION
In the current implementation of Geyser, the packet sending logic limits the ability of third-party extensions to interact with outgoing packets. This approach hinders the safe interception or modification of packets at the extension level, which can lead to conflicts between extensions. An example of this issue can be seen in the Boar project (https://github.com/oryxel1/Boar/blob/7c4bcef543cf4ca674272f93a98acaa7e994b4e3/src/main/java/ac/boar/geyser/util/GeyserUtil.java), where accessing packet sending requires unsafe workarounds. This pull request introduces support for the SessionSendBedrockPacket and SessionReceiveBedrockPacket events, allowing extensions to safely intercept, cancel, or modify Bedrock packets before they are sent. This change simplifies the development of compatible extensions and reduces the risk of conflicts.