### PR TITLE
Moved ServerboundClientTickEndPacket to PlayerAuthInput translator.

### DIFF
--- a/core/src/main/java/org/geysermc/geyser/session/GeyserSession.java
+++ b/core/src/main/java/org/geysermc/geyser/session/GeyserSession.java
@@ -1277,12 +1277,6 @@ public class GeyserSession implements GeyserConnection, GeyserCommandSource {
 
             this.bundleCache.tick();
 
-            if (spawned && protocol.getOutboundState() == ProtocolState.GAME) {
-                // Could move this to the PlayerAuthInput translator, in the event the player lags
-                // but this will work once we implement matching Java custom tick cycles
-                sendDownstreamGamePacket(ServerboundClientTickEndPacket.INSTANCE);
-            }
-
             dialogManager.tick();
             waypointCache.tick();
         } catch (Throwable throwable) {


### PR DESCRIPTION
Sending ServerboundClientTickEndPacket in GeyserSession tick is EXTREMLY RISKY because the ticking doesn't match java that well and is not in sync with player movement packet especially if for ex: lags, while the server/anticheat might expect the movement packet and tick end packet to be in sync.

This will causes a lot of issues with anticheat (eg: Grim), if you join a server running Grim using standalone geyser you will flag **Timer** and **TickTimer** like crazy and unable to move at all.