### PR TITLE
Don't send sneaking if player is already outside the vehicle.

### DIFF
--- a/core/src/main/java/org/geysermc/geyser/translator/protocol/bedrock/entity/player/BedrockInteractTranslator.java
+++ b/core/src/main/java/org/geysermc/geyser/translator/protocol/bedrock/entity/player/BedrockInteractTranslator.java
@@ -75,14 +75,14 @@ public class BedrockInteractTranslator extends PacketTranslator<InteractPacket> 
                 session.sendDownstreamGamePacket(attackPacket);
                 break;
             case LEAVE_VEHICLE:
-                session.setShouldSendSneak(true);
-
                 // Reset steering to avoid these accidentally triggering session#isHandsBusy
                 session.setSteeringLeft(false);
                 session.setSteeringRight(false);
 
                 Entity currentVehicle = session.getPlayerEntity().getVehicle();
                 if (currentVehicle != null) {
+                    session.setShouldSendSneak(true);
+
                     session.setMountVehicleScheduledFuture(session.scheduleInEventLoop(() -> {
                         if (session.getPlayerEntity().getVehicle() == null) {
                             return;


### PR DESCRIPTION
Resolve #5766, player still send LEAVE_VEHICLE when getting kicked off a vehicle when receive link packet, but since we send sneaking after player already out, server don't send sneaking false back, causing the player to keep stop sneaking and then re sneaking making player unable to sprint (and move slower).