### PR TITLE
Remove collision expansion when when correct playing position.

### DIFF
--- a/core/src/main/java/org/geysermc/geyser/translator/collision/BlockCollision.java
+++ b/core/src/main/java/org/geysermc/geyser/translator/collision/BlockCollision.java
@@ -53,11 +53,6 @@ public class BlockCollision {
      * Silently move player bounding box/position out of block when needed to.
      */
     public void correctPosition(GeyserSession session, int x, int y, int z, BoundingBox playerCollision) {
-        final double collisionExpansion = CollisionManager.COLLISION_TOLERANCE * 2;
-        // Make player collision slightly bigger to pick up on blocks that could cause problems with Passable
-        // TODO: Is this still needed? This should be removed if it's not needed anymore.
-        playerCollision.expand(collisionExpansion);
-
         // Due to floating points errors, or possibly how collision is handled on Bedrock, player could be slightly clipping into the block.
         // So we check if the player is intersecting the block, if they do then push them out. This fixes NoCheatPlus's Passable check and other anticheat checks.
         // This check doesn't allow players right up against the block, so they must be pushed slightly away. However, we should only do it if the
@@ -82,9 +77,6 @@ public class BlockCollision {
             boundingBox.pushOutOfBoundingBox(playerCollision, Direction.UP, pushAwayTolerance);
             boundingBox.pushOutOfBoundingBox(playerCollision, Direction.DOWN, pushAwayTolerance);
         }
-
-        // Set the collision size back to normal
-        playerCollision.expand(-collisionExpansion);
     }
 
     public boolean checkIntersection(double x, double y, double z, BoundingBox playerCollision) {


### PR DESCRIPTION
This one on me, resolve #5796. This only a problem now because my previous PR removed the step up "correction" but both is wrong and should be removed. We only want to push player out when player is actually inside the block.