### PR TITLE
Fix loading of trim materials with an empty description

### DIFF
--- a/core/src/main/java/org/geysermc/geyser/inventory/recipe/TrimRecipe.java
+++ b/core/src/main/java/org/geysermc/geyser/inventory/recipe/TrimRecipe.java
@@ -26,7 +26,6 @@
 package org.geysermc.geyser.inventory.recipe;
 
 import net.kyori.adventure.text.Component;
-import net.kyori.adventure.text.serializer.legacy.CharacterAndFormat;
 import org.cloudburstmc.protocol.bedrock.data.TrimMaterial;
 import org.cloudburstmc.protocol.bedrock.data.TrimPattern;
 import org.cloudburstmc.protocol.bedrock.data.inventory.descriptor.ItemDescriptorWithCount;


### PR DESCRIPTION
This PR fixes loading trim materials with an empty description. The description is translated to a bedrock string to get a colour code for the bedrock trim material data, but this fails if the string is empty. This is changed to default to `§f` instead.