### PR TITLE
Fix breaking of custom blocks or blocks with custom items

### DIFF
--- a/core/src/main/java/org/geysermc/geyser/session/GeyserSession.java
+++ b/core/src/main/java/org/geysermc/geyser/session/GeyserSession.java
@@ -1295,6 +1295,7 @@ public class GeyserSession implements GeyserConnection, GeyserCommandSource {
             this.bundleCache.tick();
             this.dialogManager.tick();
             this.waypointCache.tick();
+            this.blockBreakHandler.tick();
         } catch (Throwable throwable) {
             throwable.printStackTrace();
         }


### PR DESCRIPTION
This PR fixes breaking custom blocks or blocks with custom items, by adding a `tick` method to `BlockBreakHandler`, which manually sends block break progress updates, and destroys the block, as is needed.

Geyser needs to manually check if a block should be destroyed, and send the client progress updates, when mining a custom block, or with a custom item. This is because, in `CustomItemRegistryPopulator#computeToolProperties`, we set a block break speed of 0, meaning the client will only ever send `START_BREAK` for breaking blocks, and nothing else, meaning `handleContinueDestroy` will never get called.