### PR TITLE
Fix client crash when custom blocks are registered

### DIFF
--- a/core/src/main/java/org/geysermc/geyser/network/GameProtocol.java
+++ b/core/src/main/java/org/geysermc/geyser/network/GameProtocol.java
@@ -86,7 +86,7 @@ public final class GameProtocol {
         register(Bedrock_v818.CODEC, "1.21.90", "1.21.91", "1.21.92");
         register(Bedrock_v819.CODEC, "1.21.93", "1.21.94");
         register(Bedrock_v827.CODEC, "1.21.100", "1.21.101");
-        register(Bedrock_v844.CODEC, "1.21.110");
+        register(Bedrock_v844.CODEC, "1.21.111");
 
         MinecraftVersion latestBedrock = SUPPORTED_BEDROCK_VERSIONS.get(SUPPORTED_BEDROCK_VERSIONS.size() - 1);
         DEFAULT_BEDROCK_VERSION = latestBedrock.versionString();

--- a/core/src/main/java/org/geysermc/geyser/registry/populator/CustomBlockRegistryPopulator.java
+++ b/core/src/main/java/org/geysermc/geyser/registry/populator/CustomBlockRegistryPopulator.java
@@ -473,7 +473,7 @@ public class CustomBlockRegistryPopulator {
                 if (GameProtocol.is1_21_110orHigher(protocolVersion)) {
                     materialBuilder.putBoolean("packed_bools", materialInstance.faceDimming());
                 } else {
-                    materialsBuilder.putBoolean("face_dimming", materialInstance.faceDimming());
+                    materialBuilder.putBoolean("face_dimming", materialInstance.faceDimming());
                 }
 
                 // Texture can be unspecified when blocks.json is used in RP (https://wiki.bedrock.dev/blocks/blocks-stable.html#minecraft-material-instances)


### PR DESCRIPTION
Fixes a client crash upon logging in with custom blocks registered, caused by a typo. Thanks @Camotoy for pointing it out!