### PR TITLE
Add native Mojmaps to Compression and Login Finish packet

### DIFF
--- a/bootstrap/spigot/src/main/java/org/geysermc/geyser/platform/spigot/GeyserSpigotCompressionDisabler.java
+++ b/bootstrap/spigot/src/main/java/org/geysermc/geyser/platform/spigot/GeyserSpigotCompressionDisabler.java
@@ -96,19 +96,31 @@ public class GeyserSpigotCompressionDisabler extends ChannelOutboundHandlerAdapt
 
     private static Class<?> findCompressionPacket() throws ClassNotFoundException {
         try {
-            return Class.forName("net.minecraft.network.protocol.login.PacketLoginOutSetCompression");
+            // Mojmaps
+            return Class.forName("net.minecraft.network.protocol.login.ClientboundLoginCompressionPacket");
         } catch (ClassNotFoundException e) {
-            String prefix = Bukkit.getServer().getClass().getPackage().getName().replace("org.bukkit.craftbukkit", "net.minecraft.server");
-            return Class.forName(prefix + ".PacketLoginOutSetCompression");
+            try {
+                // Spigot mappings
+                return Class.forName("net.minecraft.network.protocol.login.PacketLoginOutSetCompression");
+            } catch (ClassNotFoundException ex) {
+                String prefix = Bukkit.getServer().getClass().getPackage().getName().replace("org.bukkit.craftbukkit", "net.minecraft.server");
+                return Class.forName(prefix + ".PacketLoginOutSetCompression");
+            }
         }
     }
 
     private static Class<?> findLoginSuccessPacket() throws ClassNotFoundException {
         try {
-            return Class.forName("net.minecraft.network.protocol.login.PacketLoginOutSuccess");
+            // Mojmaps
+            return Class.forName("net.minecraft.network.protocol.login.ClientboundLoginFinishedPacket");
         } catch (ClassNotFoundException e) {
-            String prefix = Bukkit.getServer().getClass().getPackage().getName().replace("org.bukkit.craftbukkit", "net.minecraft.server");
-            return Class.forName(prefix + ".PacketLoginOutSuccess");
+            try {
+                // Spigot mappings
+                return Class.forName("net.minecraft.network.protocol.login.PacketLoginOutSuccess");
+            } catch (ClassNotFoundException ex) {
+                String prefix = Bukkit.getServer().getClass().getPackage().getName().replace("org.bukkit.craftbukkit", "net.minecraft.server");
+                return Class.forName(prefix + ".PacketLoginOutSuccess");
+            }
         }
     }
 }


### PR DESCRIPTION
This prevents a big scary warning on boot when using paper with remapping (happens when paper releases before spigot), the spigot mappings are still supported for backwards compatibility