### PR TITLE
Correct the TextDisplayEntity offset logic for multiple lines

### DIFF
--- a/core/src/main/java/org/geysermc/geyser/entity/type/TextDisplayEntity.java
+++ b/core/src/main/java/org/geysermc/geyser/entity/type/TextDisplayEntity.java
@@ -76,7 +76,9 @@ public class TextDisplayEntity extends DisplayBaseEntity {
      * @return the Y offset to apply based on the number of lines
      */
     private float calculateLineOffset() {
-        if (lineCount == 0) return 0;
+        if (lineCount == 0) {
+            return 0;
+        } 
         return LINE_HEIGHT_OFFSET * lineCount;
     }
 


### PR DESCRIPTION
This pull request improves the vertical alignment of multi-line text for `TextDisplayEntity` to better match Java Edition's centering behavior. The main changes introduce a new line height offset constant and logic to recalculate and apply the correct Y offset whenever the line count changes.

The case for this change is to improve Bedrock user experience on all servers where Text Display Entities are used instead of holograms. In the current implementation, bedrock users see the hologram much lower than they should resulting in text being inside of blocks or other text. 

Issues that this closes for reference:  
Resolve #5794 
Resolve #5308 

Screenshots:

Before (Java & Bedrock): 
<img width="480" height="252" alt="image" src="https://github.com/user-attachments/assets/8f2cc022-661a-4ea5-b8ef-27fb5b180b5f" />
<img width="480" height="270" alt="image" src="https://github.com/user-attachments/assets/59a47f11-7ab8-4a3c-821e-abe499c3fdc2" />

After (Java & Bedrock):
<img width="480" height="252" alt="image" src="https://github.com/user-attachments/assets/d75d4aca-5df9-452c-9889-528117dbbc3c" />
<img width="480" height="270" alt="image" src="https://github.com/user-attachments/assets/b60427df-02c6-4345-935d-796c46b9fe26" />

Text No Longer Floats inside of NPC
<img width="1061" height="671" alt="image" src="https://github.com/user-attachments/assets/e8a64e1e-d9ee-4068-a6a7-33950f9d58ec" />

It is also important to note that this does not break any nametag support for bedrock:
<img width="557" height="499" alt="image" src="https://github.com/user-attachments/assets/1db9c68b-eeb0-4bf7-8854-644d713e3976" />
