### PR TITLE
Fix: incorrect priority range validation message in PriorityOption

### DIFF
--- a/api/src/main/java/org/geysermc/geyser/api/pack/option/PriorityOption.java
+++ b/api/src/main/java/org/geysermc/geyser/api/pack/option/PriorityOption.java
@@ -52,7 +52,7 @@ public interface PriorityOption extends ResourcePackOption<Integer> {
      */
     static PriorityOption priority(int priority) {
         if (priority < -100 || priority > 100) {
-            throw new IllegalArgumentException("Priority must be between 0 and 10 inclusive!");
+            throw new IllegalArgumentException("Priority must be between -100 and 100 inclusive!");
         }
         return GeyserApi.api().provider(PriorityOption.class, priority);
     }


### PR DESCRIPTION
The message in IllegalArgumentException now says between -100 and 100 instead of 0 and 10.