### PR TITLE
Add a getter for the current protocol state

### DIFF
--- a/core/src/main/java/org/geysermc/geyser/session/GeyserSession.java
+++ b/core/src/main/java/org/geysermc/geyser/session/GeyserSession.java
@@ -1981,6 +1981,15 @@ public class GeyserSession implements GeyserConnection, GeyserCommandSource {
     }
 
     /**
+     * Used for getting the current protocol state in order to send packets more reliably.
+     *
+     * @return the protocol state.
+     */
+    public ProtocolState getProtocolState() {
+        return protocol.getOutboundState();
+    }
+
+    /**
      * Send a packet to the remote server.
      *
      * @param packet the java edition packet from MCProtocolLib


### PR DESCRIPTION
The only place where emotecraft uses reflection
I use this to correctly configure the mod, since the configuration and play states differ slightly:

https://github.com/KosmX/emotes/blob/geyser-ext/geyser/src/main/java/org/redlance/dima_dencep/mods/emotecraft/geyser/EmotecraftExt.java#L115
https://github.com/KosmX/emotes/blob/geyser-ext/geyser/src/main/java/org/redlance/dima_dencep/mods/emotecraft/geyser/EmotecraftExt.java#L131