### PR TITLE
Revert bad changes in PR " Prevent player from jumping out of vehicle by input locking".

### DIFF
--- a/core/src/main/java/org/geysermc/geyser/entity/type/Entity.java
+++ b/core/src/main/java/org/geysermc/geyser/entity/type/Entity.java
@@ -614,14 +614,6 @@ public class Entity implements GeyserEntity {
     protected boolean isShaking() {
         return false;
     }
-    /**
-     * If true, the entity can be dismounted by pressing jump.
-     *
-     * @return whether the entity can be dismounted when pressing jump.
-     */
-    public boolean doesJumpDismount() {
-        return true;
-    }
 
     /**
      * x = Pitch, y = Yaw, z = HeadYaw

--- a/core/src/main/java/org/geysermc/geyser/entity/type/living/animal/horse/AbstractHorseEntity.java
+++ b/core/src/main/java/org/geysermc/geyser/entity/type/living/animal/horse/AbstractHorseEntity.java
@@ -86,17 +86,6 @@ public class AbstractHorseEntity extends AnimalEntity {
         // Shows the jump meter
         setFlag(EntityFlag.CAN_POWER_JUMP, saddled);
         super.updateSaddled(saddled);
-
-        if (this.passengers.contains(session.getPlayerEntity())) {
-            // We want to allow player to press jump again if pressing jump doesn't dismount the entity.
-            this.session.setLockInput(InputLocksFlag.JUMP, this.doesJumpDismount());
-            this.session.updateInputLocks();
-        }
-    }
-
-    @Override
-    public boolean doesJumpDismount() {
-        return !this.getFlag(EntityFlag.SADDLED);
     }
 
     public void setHorseFlags(ByteEntityMetadata entityMetadata) {

--- a/core/src/main/java/org/geysermc/geyser/entity/type/player/SessionPlayerEntity.java
+++ b/core/src/main/java/org/geysermc/geyser/entity/type/player/SessionPlayerEntity.java
@@ -477,10 +477,6 @@ public class SessionPlayerEntity extends PlayerEntity {
             this.vehicle.updateBedrockMetadata();
         }
 
-        // Bedrock player can dismount by pressing jump while Java cannot, so we need to prevent player from jumping to match vanilla behaviour.
-        this.session.setLockInput(InputLocksFlag.JUMP, entity != null && entity.doesJumpDismount());
-        this.session.updateInputLocks();
-
         super.setVehicle(entity);
     }
   


### PR DESCRIPTION
Seems like it isn't ideal to do this unless the vehicle is like a non-rideable vehicle in vanilla like armour stand or smth. Not really sure... We can still expose the input locking to the api so people can do it themselves. Resolve #5955