### PR TITLE
Fix: don't lock jumping input for minecart.

### DIFF
--- a/core/src/main/java/org/geysermc/geyser/entity/type/MinecartEntity.java
+++ b/core/src/main/java/org/geysermc/geyser/entity/type/MinecartEntity.java
@@ -212,8 +212,8 @@ public class MinecartEntity extends Entity implements Tickable {
 
     @Override
     public boolean doesJumpDismount() {
-        // This is misleading because jumping is literally the only way to dismount for Touch users.
-        // Therefore, do this so we won't lock jumping, prevent Touch user from getting out.
+        // This is a little bit misleading because jumping is literally the only way to dismount for Touch users.
+        // Therefore, do this so we won't lock jumping to let Touch user able to dismount.
         return false;
     }
 


### PR DESCRIPTION
Seems to be the case for just minecart... Resolve #5955. Tested on a Windows 10 device that supports screen touch (1.21.114)