### PR TITLE
Fix Cape Elytra textures

### DIFF
--- a/core/src/main/java/org/geysermc/geyser/skin/SkinManager.java
+++ b/core/src/main/java/org/geysermc/geyser/skin/SkinManager.java
@@ -200,7 +200,7 @@ public class SkinManager {
             .skinId(skinId)
             .skinResourcePatch(geometry.geometryName())
             .skinData(ImageData.of(skin.skinData()))
-            //.capeId(cape.capeId())
+            .capeId(cape.capeId())
             .capeData(ImageData.of(cape.capeData()))
             .geometryData(geometry.geometryData().isBlank() ? GEOMETRY : geometry.geometryData())
             .geometryDataEngineVersion(session.getClientData().getGameVersion())


### PR DESCRIPTION
Closes #4374.

However, due to a bug in the Bedrock Edition client, the elytras will swap with another player (see video below).

https://github.com/user-attachments/assets/517cb11c-6653-4152-8e5d-0c39bf67937a

