### PR TITLE
Added Java version to build.gradle.kts

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -3,3 +3,9 @@ plugins {
     eclipse
     id("geyser.base-conventions")
 }
+
+java {
+    toolchain {
+        languageVersion = JavaLanguageVersion.of(21)
+    }
+}


### PR DESCRIPTION
#### This (simple) pull request adds the java version (21) to the root build.gradle.kts file.

What does this do?
---
For CLI users mainly nothing, however for IDEs and tools (like jitpack) it will help them find the right JDK version to use, as the build fails if we use something older than Java 21, it makes sense to ask tools to use that version.

And in practice, what does it do?
---
This will allow JitPack to find the right version to use to allow JitPack to build the project without failing before it even starts, and will make so IDEs like IntelliJ IDEA automatically knows which version of Java to use.