### PR TITLE
Fix: properly map item data back to item mapping.

### DIFF
--- a/core/src/main/java/org/geysermc/geyser/registry/type/ItemMappings.java
+++ b/core/src/main/java/org/geysermc/geyser/registry/type/ItemMappings.java
@@ -159,7 +159,7 @@ public class ItemMappings implements DefinitionRegistry<ItemDefinition> {
         for (ItemMapping mapping : this.items) {
             if (mapping.getBedrockDefinition().getRuntimeId() == definition.getRuntimeId()) {
                 if (isBlock && !hasDamage) { // Pre-1.16.220 will not use block runtime IDs at all, so we shouldn't check either
-                    if (data.getBlockDefinition() != mapping.getBedrockBlockDefinition()) {
+                    if (data.getBlockDefinition() != mapping.getBedrockBlockDefinition() && !(data.getBlockDefinition() != null && data.getBlockDefinition().getRuntimeId() == 0 && mapping.getBedrockBlockDefinition() == null)) {
                         continue;
                     }
                 } else {


### PR DESCRIPTION
It seems like the client seems to be sending runtimeId=0 for items without a block definition, this causing repeatealy spam of `Missing mapping for bedrock item` in `debug-mode: true` and also places where this `getMapping` was used is broken eg: https://github.com/GeyserMC/Geyser/blob/f67cd24af4cd086dcf991a75b444573c0068f428/core/src/main/java/org/geysermc/geyser/translator/protocol/bedrock/BedrockInventoryTransactionTranslator.java#L290, in this case causing multiple entities to spawn when you interact with a water block and also other problems where this method is used, which this pr fix.