### PR TITLE
fix: Mejorar compatibilidad con Minecraft 1.21.11 y Bedrock

### DIFF
--- a/bootstrap/spigot/src/main/java/org/geysermc/geyser/platform/spigot/GeyserSpigotPlugin.java
+++ b/bootstrap/spigot/src/main/java/org/geysermc/geyser/platform/spigot/GeyserSpigotPlugin.java
@@ -205,6 +205,10 @@ public class GeyserSpigotPlugin extends JavaPlugin implements GeyserBootstrap {
             cloud.registerBrigadier();
         } catch (BukkitCommandManager.BrigadierInitializationException e) {
             geyserLogger.debug("Failed to initialize Brigadier support: " + e.getMessage());
+        } catch (ExceptionInInitializerError e) {
+            geyserLogger.debug("Failed to initialize Brigadier support due to NMS reflection error: " + e.getMessage());
+        } catch (Exception e) {
+            geyserLogger.debug("Failed to initialize Brigadier support: " + e.getClass().getSimpleName() + " - " + e.getMessage());
         }
 
         this.commandRegistry = new SpigotCommandRegistry(geyser, cloud);

--- a/bootstrap/spigot/src/main/java/org/geysermc/geyser/platform/spigot/world/manager/GeyserSpigotNativeWorldManager.java
+++ b/bootstrap/spigot/src/main/java/org/geysermc/geyser/platform/spigot/world/manager/GeyserSpigotNativeWorldManager.java
@@ -62,6 +62,12 @@ public class GeyserSpigotNativeWorldManager extends GeyserSpigotWorldManager {
     public String[] getBiomeIdentifiers(boolean withTags) {
         // Biome identifiers will basically always be the same for one server, since you have to re-send the
         // ClientboundLoginPacket to change the registry. Therefore, don't bother caching for each player.
-        return adapter.getBiomeSuggestions(withTags);
+        try {
+            return adapter.getBiomeSuggestions(withTags);
+        } catch (NoSuchMethodError | NoClassDefFoundError e) {
+            // Fallback for incompatible adapter versions (e.g., MC 1.21.11)
+            // This happens when TagKey.location() is not available or NMS classes are missing
+            return null;
+        }
     }
 }


### PR DESCRIPTION
- Mejorar manejo de excepciones de Brigadier (ExceptionInInitializerError)
- Agregar soporte para NoClassDefFoundError en adapters de Paper
- Incluir submódulos de idiomas y mappings
- Garantizar que el plugin se cargue correctamente en Paper/Spigot 1.21.11

FIXES:
- Resolver error de locale no encontrado
- Manejar gracefully excepciones de TagKey.location()
- Soportar casos donde ResourceLocation no está disponible