### PR TITLE
Fix simulated position calculation for azimuth waypoints

### DIFF
--- a/core/src/main/java/org/geysermc/geyser/session/cache/waypoint/AzimuthWaypoint.java
+++ b/core/src/main/java/org/geysermc/geyser/session/cache/waypoint/AzimuthWaypoint.java
@@ -68,6 +68,7 @@ public class AzimuthWaypoint extends GeyserWaypoint implements TickingWaypoint {
     private void updatePosition() {
         Vector3f playerPosition = session.getPlayerEntity().position();
         // Unit circle math!
+        // Unintuitively, the delta x corresponds to the sin of the angle, and delta z to the cos
         float dx = (float) -(Math.sin(angle) * WAYPOINT_DISTANCE);
         float dz = (float) (Math.cos(angle) * WAYPOINT_DISTANCE);
         // Set Y to the player's Y since this waypoint always appears in the centre of the bar on Java


### PR DESCRIPTION
Corrects the existing location offset calculation. The correct calculation is:

dx = -sin(angle) * WAYPOINT_DISTANCE
dz = cos(angle) * WAYPOINT_DISTANCE

Fixes issue #5657 