### PR TITLE
Feature: Reloadable Mappings

### DIFF
--- a/core/src/main/java/org/geysermc/geyser/GeyserImpl.java
+++ b/core/src/main/java/org/geysermc/geyser/GeyserImpl.java
@@ -83,6 +83,7 @@ import org.geysermc.geyser.level.BedrockDimension;
 import org.geysermc.geyser.level.WorldManager;
 import org.geysermc.geyser.network.GameProtocol;
 import org.geysermc.geyser.network.netty.GeyserServer;
+import org.geysermc.geyser.pack.SkullResourcePackManager;
 import org.geysermc.geyser.ping.GeyserLegacyPingPassthrough;
 import org.geysermc.geyser.registry.BlockRegistries;
 import org.geysermc.geyser.registry.Registries;
@@ -305,6 +306,10 @@ public class GeyserImpl implements GeyserApi, EventRegistrar {
         if (isReloading) {
             // If we're reloading, the default locale in the config might have changed.
             GeyserLocale.finalizeDefaultLocale(this);
+
+            Registries.load();
+            BlockRegistries.populate();
+            Registries.populate();
         } else {
             CodeOfConductManager.load();
         }
@@ -777,6 +782,11 @@ public class GeyserImpl implements GeyserApi, EventRegistrar {
         this.eventBus.fire(new GeyserPreReloadEvent(this.extensionManager, this.eventBus));
 
         bootstrap.onGeyserDisable();
+
+        BlockRegistries.reset();
+        Registries.reset();
+        SkullResourcePackManager.SKULL_SKINS.clear();
+
         bootstrap.onGeyserEnable();
 
         isReloading = false;

--- a/core/src/main/java/org/geysermc/geyser/registry/ArrayRegistry.java
+++ b/core/src/main/java/org/geysermc/geyser/registry/ArrayRegistry.java
@@ -28,6 +28,7 @@ package org.geysermc.geyser.registry;
 import org.checkerframework.checker.nullness.qual.Nullable;
 import org.geysermc.geyser.registry.loader.RegistryLoader;
 
+import java.util.Arrays;
 import java.util.function.Supplier;
 
 /**
@@ -147,5 +148,10 @@ public class ArrayRegistry<M> extends Registry<M[]> {
      */
     public static <I, M> ArrayRegistry<M> create(I input, RegistryLoader<I, M[]> registryLoader) {
         return new ArrayRegistry<>(input, registryLoader);
+    }
+
+    @Override
+    public void clear() {
+        Arrays.fill(this.mappings, null);
     }
 }

--- a/core/src/main/java/org/geysermc/geyser/registry/BlockRegistries.java
+++ b/core/src/main/java/org/geysermc/geyser/registry/BlockRegistries.java
@@ -148,4 +148,21 @@ public class BlockRegistries {
         BlockRegistryPopulator.populate(BlockRegistryPopulator.Stage.INIT_BEDROCK);
         BlockRegistryPopulator.populate(BlockRegistryPopulator.Stage.POST_INIT);
     }
+
+    public static void reset() {
+        BLOCKS.clear();
+        JAVA_BLOCK_STATE_IDENTIFIER_TO_ID.clear();
+        NON_VANILLA_BLOCK_IDS.clear();
+        WATERLOGGED.clear();
+        INTERACTIVE.clear();
+        INTERACTIVE_MAY_BUILD.clear();
+        CUSTOM_BLOCKS.clear();
+        CUSTOM_BLOCK_STATE_OVERRIDES.clear();
+        NON_VANILLA_BLOCK_STATE_OVERRIDES.clear();
+        CUSTOM_BLOCK_ITEM_OVERRIDES.clear();
+        EXTENDED_COLLISION_BOXES.clear();
+        CUSTOM_SKULLS.clear();
+
+        COLLISIONS.clear();
+    }
 }

--- a/core/src/main/java/org/geysermc/geyser/registry/DeferredRegistry.java
+++ b/core/src/main/java/org/geysermc/geyser/registry/DeferredRegistry.java
@@ -123,6 +123,14 @@ class DeferredRegistry<M, R extends IRegistry<M>> implements IRegistry<M> {
         return this.loaded;
     }
 
+    @Override
+    public void clear() {
+        if (!this.loaded) {
+            return;
+        }
+        this.backingRegistry.clear();
+    }
+
     /**
      * A registry initializer.
      *

--- a/core/src/main/java/org/geysermc/geyser/registry/IRegistry.java
+++ b/core/src/main/java/org/geysermc/geyser/registry/IRegistry.java
@@ -57,4 +57,12 @@ interface IRegistry<M> {
      * @param consumer the consumer
      */
     void register(Consumer<M> consumer);
+
+    /**
+     * Clears The Underlying Mappings.
+     * Throws {@link UnsupportedOperationException} When The Registry Doesn't Support It.
+     */
+    default void clear() {
+        throw new UnsupportedOperationException("Registry does not support clear.");
+    }
 }

--- a/core/src/main/java/org/geysermc/geyser/registry/Registries.java
+++ b/core/src/main/java/org/geysermc/geyser/registry/Registries.java
@@ -239,6 +239,14 @@ public final class Registries {
         DANGEROUS_ENTITIES.load();
     }
 
+    public static void reset() {
+        loaded = false;
+
+        ITEMS.clear();
+        TAGS.clear();
+        POTION_MIXES.clear();
+    }
+
     public static void populate() {
         PacketRegistryPopulator.populate();
         DataComponentRegistryPopulator.populate();

--- a/core/src/main/java/org/geysermc/geyser/registry/Registry.java
+++ b/core/src/main/java/org/geysermc/geyser/registry/Registry.java
@@ -25,6 +25,9 @@
 
 package org.geysermc.geyser.registry;
 
+import java.util.BitSet;
+import java.util.Collection;
+import java.util.Map;
 import java.util.function.Consumer;
 import org.geysermc.geyser.registry.loader.RegistryLoader;
 
@@ -109,5 +112,21 @@ public abstract class Registry<M> implements IRegistry<M> {
     @Override
     public void register(Consumer<M> consumer) {
         consumer.accept(this.mappings);
+    }
+
+    /**
+     * Clears The Mappings.
+     */
+    @Override
+    public void clear() {
+        if (this.mappings instanceof Collection) {
+            ((Collection<?>) this.mappings).clear();
+        } else if (this.mappings instanceof Map) {
+            ((Map<?, ?>) this.mappings).clear();
+        } else if (this.mappings instanceof BitSet) {
+            ((BitSet) this.mappings).clear();
+        } else {
+            throw new UnsupportedOperationException("Cannot clear registry of type " + (this.mappings == null ? "null" : this.mappings.getClass().getName()));
+        }
     }
 }


### PR DESCRIPTION
I've made relevant mappings reloadable, by adding the ability for registries to be clear-able.
This can be done specifically with the `/geyser reloadmappings` command, or implicitly with the normal reload command.
This is very useful for an easier mcpacks development workflow, without a full restart, requested by a ResourcePack converter developer.