### PR TITLE
Fix items not displaying on brushable blocks

### DIFF
--- a/core/src/main/java/org/geysermc/geyser/translator/level/block/entity/BrushableBlockEntityTranslator.java
+++ b/core/src/main/java/org/geysermc/geyser/translator/level/block/entity/BrushableBlockEntityTranslator.java
@@ -73,7 +73,10 @@ public class BrushableBlockEntityTranslator extends BlockEntityTranslator implem
         bedrockNbt.putInt("brush_count", blockState.getValue(Properties.DUSTED));
 
         // The type of brushable block, not sure why bedrock requires this
-        ItemMapping brushableMapping = session.getItemMappings().getMapping(blockState.block().javaIdentifier().toString());
-        bedrockNbt.putString("type", brushableMapping.getBedrockDefinition().getIdentifier());
+        String identifier = session.getBlockMappings().getJavaToBedrockIdentifiers().get(blockState.block().javaId());
+        if (identifier == null) {
+            identifier = blockState.block().javaIdentifier().value();
+        }
+        bedrockNbt.putString("type", identifier);
     }
 }


### PR DESCRIPTION
Bedrock now seems to require this new `type` field in the NBT which seems to always be equal to the block you are brushing, without this field the brushed item doesn't show.