### PR TITLE
Add Xbox split-screen support

### DIFF
--- a/core/src/main/java/org/geysermc/geyser/network/CodecProcessor.java
+++ b/core/src/main/java/org/geysermc/geyser/network/CodecProcessor.java
@@ -82,7 +82,6 @@ import org.cloudburstmc.protocol.bedrock.packet.SetEntityMotionPacket;
 import org.cloudburstmc.protocol.bedrock.packet.SettingsCommandPacket;
 import org.cloudburstmc.protocol.bedrock.packet.SimpleEventPacket;
 import org.cloudburstmc.protocol.bedrock.packet.SubChunkRequestPacket;
-import org.cloudburstmc.protocol.bedrock.packet.SubClientLoginPacket;
 import org.cloudburstmc.protocol.common.util.VarInts;
 
 /**
@@ -92,7 +91,7 @@ import org.cloudburstmc.protocol.common.util.VarInts;
  */
 @SuppressWarnings("deprecation")
 class CodecProcessor {
-    
+
     /**
      * Generic serializer that throws an exception when trying to serialize or deserialize a packet, leading to client disconnection.
      */
@@ -264,7 +263,7 @@ class CodecProcessor {
             .updateSerializer(CraftingEventPacket.class, ILLEGAL_SERIALIZER)
             // Illegal unusued serverbound packets that relate to unused features
             .updateSerializer(ClientCacheBlobStatusPacket.class, ILLEGAL_SERIALIZER)
-            .updateSerializer(SubClientLoginPacket.class, ILLEGAL_SERIALIZER)
+            // SubClientLoginPacket is now allowed for split-screen support
             .updateSerializer(SubChunkRequestPacket.class, ILLEGAL_SERIALIZER)
             .updateSerializer(GameTestRequestPacket.class, ILLEGAL_SERIALIZER)
             // Ignored serverbound packets
@@ -315,7 +314,7 @@ class CodecProcessor {
 
     /**
      * Fake reading an item from the buffer to improve performance.
-     * 
+     *
      * @param buffer
      */
     private static void fakeItemRead(ByteBuf buffer) {

--- a/core/src/main/java/org/geysermc/geyser/network/LoggingPacketHandler.java
+++ b/core/src/main/java/org/geysermc/geyser/network/LoggingPacketHandler.java
@@ -38,11 +38,15 @@ import org.geysermc.geyser.session.GeyserSession;
  */
 public class LoggingPacketHandler implements BedrockPacketHandler {
     protected final GeyserImpl geyser;
-    protected final GeyserSession session;
+    protected GeyserSession session;
 
     LoggingPacketHandler(GeyserImpl geyser, GeyserSession session) {
         this.geyser = geyser;
         this.session = session;
+    }
+
+    protected void replaceSession(GeyserSession newSession) {
+        this.session = newSession;
     }
 
     PacketSignal defaultHandler(BedrockPacket packet) {

--- a/core/src/main/java/org/geysermc/geyser/network/netty/GeyserServer.java
+++ b/core/src/main/java/org/geysermc/geyser/network/netty/GeyserServer.java
@@ -103,6 +103,7 @@ public final class GeyserServer {
     // Split childGroup may improve IO
     private EventLoopGroup childGroup;
     private final ServerBootstrap bootstrap;
+    @Getter
     private EventLoopGroup playerGroup;
 
     @Getter

--- a/core/src/main/java/org/geysermc/geyser/session/GeyserSessionAdapter.java
+++ b/core/src/main/java/org/geysermc/geyser/session/GeyserSessionAdapter.java
@@ -91,7 +91,7 @@ public class GeyserSessionAdapter extends SessionAdapter {
                         session.bedrockUsername(),
                         session.xuid(),
                         clientData.getDeviceOs().ordinal(),
-                        clientData.getLanguageCode(),
+                        session.locale(),
                         clientData.getUiProfile().ordinal(),
                         clientData.getCurrentInputMode().ordinal(),
                         bedrockAddress,
@@ -147,7 +147,7 @@ public class GeyserSessionAdapter extends SessionAdapter {
         session.getPlayerEntity().setUuid(uuid);
         session.getPlayerEntity().setUsername(session.getProtocol().getProfile().getName());
 
-        String locale = session.getClientData().getLanguageCode();
+        String locale = session.locale();
 
         // Let the user know there locale may take some time to download
         // as it has to be extracted from a JAR

--- a/core/src/main/java/org/geysermc/geyser/session/SessionManager.java
+++ b/core/src/main/java/org/geysermc/geyser/session/SessionManager.java
@@ -124,6 +124,20 @@ public final class SessionManager {
         return false;
     }
 
+    public @Nullable GeyserSession pendingSessionByXuid(@NonNull String xuid) {
+        Objects.requireNonNull(xuid);
+        for (GeyserSession session : pendingSessions) {
+            if (session.xuid().equals(xuid)) {
+                return session;
+            }
+        }
+        return null;
+    }
+
+    public void removePendingSession(GeyserSession session) {
+        pendingSessions.remove(session);
+    }
+
     public @Nullable GeyserSession sessionByXuid(@NonNull String xuid) {
         Objects.requireNonNull(xuid);
         for (GeyserSession session : sessions.values()) {

--- a/core/src/main/java/org/geysermc/geyser/session/auth/BedrockClientData.java
+++ b/core/src/main/java/org/geysermc/geyser/session/auth/BedrockClientData.java
@@ -54,10 +54,12 @@ public final class BedrockClientData {
     @SerializedName(value = "GameVersion")
     private String gameVersion;
     @SerializedName(value = "ServerAddress")
+    @Setter
     private String serverAddress;
     @SerializedName(value = "ThirdPartyName")
     private String username;
     @SerializedName(value = "LanguageCode")
+    @Setter
     private String languageCode;
 
     @SerializedName(value = "SkinId")


### PR DESCRIPTION
## Summary

Adds Xbox split-screen (couch co-op) support, allowing multiple players to join from a single Xbox console.

## Background

This feature has been requested by the community (see [Reddit](https://www.reddit.com/r/admincraft/comments/1jyg79q/problem_with_splitscreen_console_bedrock_players/), #750, #1459, #2521). Previous attempts were made in #976 and #3109 but were never merged.

## Implementation

### Sub-client handling
- Enabled `SubClientLoginPacket` processing (removed from `ILLEGAL_SERIALIZER`)
- Added `setupSubClientSession()` in `LoginEncryptionUtils` to authenticate sub-clients
- Sub-clients inherit locale and server address from parent session (not included in their JWT)

### Disconnect detection
- Added `DisconnectPacket` handler to properly detect when sub-client leaves split-screen
- Sub-clients share the upstream connection with parent, so we don't close it on sub-client disconnect

### Reconnect handling
- When sub-client rejoins after disconnect, CloudburstMC reuses the same `BedrockServerSession`
- We detect closed session and create a fresh `GeyserSession` for clean rejoin

### Session tracking
- Added `parentSession` field to track sub-client relationships
- Added `sessionByXuid()` lookup in `SessionManager`

## Testing

Tested on Xbox Series X with split-screen:
- Two players joining simultaneously
- Sub-client leaving and rejoining
- Parent disconnecting (sub-clients also disconnect)
- Server transfers between backend servers


## Download
Binary file can be found here: https://github.com/psalkowski/Geyser/releases/download/v2.9.2-splitscreen/Geyser-Velocity-2.9.2-splitscreen.jar