### PR TITLE
Fix: Display a number instead of 'false' in the connection test command.

### DIFF
--- a/core/src/main/java/org/geysermc/geyser/command/defaults/ConnectionTestCommand.java
+++ b/core/src/main/java/org/geysermc/geyser/command/defaults/ConnectionTestCommand.java
@@ -184,7 +184,7 @@ public class ConnectionTestCommand extends GeyserCommand {
                     JsonObject cache = output.getAsJsonObject("cache");
                     String when;
                     if (cache.get("fromCache").isJsonPrimitive()) {
-                        when = cache.get("secondsSince").getAsBoolean() + " seconds ago";
+                        when = cache.get("secondsSince").getAsInt() + " seconds ago";
                     } else {
                         when = "now";
                     }


### PR DESCRIPTION
### Problem
When server operators execute the `/geyser connectiontest example.com` command, the response displays "false seconds ago" even when everything is fine. This can mislead some users into thinking that an error has occurred.

**BEFORE:**
<img width="664" height="50" alt="image" src="https://github.com/user-attachments/assets/f1d73faa-743b-4697-8f12-aa66df8eb8ba" />

After changing `getAsBoolean()` to `getAsInt()`, it will display seconds properly instead of always showing "false".

I'd also like to see more improvements, such as using the word "now" instead of "0 seconds ago" (when `fromCache` is false) if possible.