### PR TITLE
Fix zombie nautilus variant not displaying on Bedrock clients

### DIFF
--- a/core/src/main/java/org/geysermc/geyser/entity/EntityDefinitions.java
+++ b/core/src/main/java/org/geysermc/geyser/entity/EntityDefinitions.java
@@ -1229,7 +1229,7 @@ public final class EntityDefinitions {
             ZOMBIE_NAUTILUS = EntityDefinition.inherited(ZombieNautilusEntity::new, abstractNautilusBase)
                 .type(EntityType.ZOMBIE_NAUTILUS)
                 .identifier("minecraft:zombie_nautilus")
-                .property(TemperatureVariantAnimal.TEMPERATE_VARIANT_PROPERTY)
+                .property(ZombieNautilusEntity.VARIANT_ENUM_PROPERTY)
                 .addTranslator(MetadataTypes.ZOMBIE_NAUTILUS_VARIANT, ZombieNautilusEntity::setVariant)
                 .build();
         }

--- a/core/src/main/java/org/geysermc/geyser/entity/type/living/animal/TemperatureVariantAnimal.java
+++ b/core/src/main/java/org/geysermc/geyser/entity/type/living/animal/TemperatureVariantAnimal.java
@@ -53,6 +53,6 @@ public abstract class TemperatureVariantAnimal extends AnimalEntity implements V
     public enum BuiltInVariant implements VariantHolder.BuiltIn {
         TEMPERATE,
         WARM,
-        COLD;
+        COLD
     }
 }

--- a/core/src/main/java/org/geysermc/geyser/entity/type/living/animal/nautilus/ZombieNautilusEntity.java
+++ b/core/src/main/java/org/geysermc/geyser/entity/type/living/animal/nautilus/ZombieNautilusEntity.java
@@ -25,25 +25,54 @@
 
 package org.geysermc.geyser.entity.type.living.animal.nautilus;
 
+import net.kyori.adventure.key.Key;
+import org.geysermc.geyser.entity.properties.type.EnumProperty;
 import org.geysermc.geyser.entity.spawn.EntitySpawnContext;
-import org.geysermc.geyser.entity.type.living.animal.TemperatureVariantAnimal;
 import org.geysermc.geyser.entity.type.living.animal.VariantHolder;
+import org.geysermc.geyser.impl.IdentifierImpl;
+import org.geysermc.geyser.session.cache.RegistryCache;
 import org.geysermc.geyser.session.cache.registry.JavaRegistries;
 import org.geysermc.geyser.session.cache.registry.JavaRegistryKey;
+import org.geysermc.geyser.util.MinecraftKey;
 
-public class ZombieNautilusEntity extends AbstractNautilusEntity implements VariantHolder<TemperatureVariantAnimal.BuiltInVariant> {
+public class ZombieNautilusEntity extends AbstractNautilusEntity implements VariantHolder<ZombieNautilusEntity.BuiltInVariant> {
+
+    public static final EnumProperty<BuiltInVariant> VARIANT_ENUM_PROPERTY = new EnumProperty<>(
+        IdentifierImpl.of("variant"),
+        BuiltInVariant.class,
+        BuiltInVariant.DEFAULT
+    );
+
+    public static final RegistryCache.RegistryReader<BuiltInVariant> VARIANT_READER = VariantHolder.reader(BuiltInVariant.class, BuiltInVariant.DEFAULT);
+
     public ZombieNautilusEntity(EntitySpawnContext context) {
         super(context, 1.1f);
     }
 
     @Override
-    public void setBedrockVariant(TemperatureVariantAnimal.BuiltInVariant variant) {
-        TemperatureVariantAnimal.TEMPERATE_VARIANT_PROPERTY.apply(propertyManager, variant);
+    public void setBedrockVariant(BuiltInVariant variant) {
+        VARIANT_ENUM_PROPERTY.apply(propertyManager, variant);
         updateBedrockEntityProperties();
     }
 
     @Override
-    public JavaRegistryKey<TemperatureVariantAnimal.BuiltInVariant> variantRegistry() {
+    public JavaRegistryKey<BuiltInVariant> variantRegistry() {
         return JavaRegistries.ZOMBIE_NAUTILUS_VARIANT;
+    }
+
+    public enum BuiltInVariant implements VariantHolder.BuiltIn {
+        DEFAULT("temperate"),
+        CORAL("warm");
+
+        private final String javaId;
+
+        BuiltInVariant(String javaId) {
+            this.javaId = javaId;
+        }
+
+        @Override
+        public Key javaIdentifier() {
+            return MinecraftKey.key(javaId);
+        }
     }
 }

--- a/core/src/main/java/org/geysermc/geyser/session/cache/RegistryCache.java
+++ b/core/src/main/java/org/geysermc/geyser/session/cache/RegistryCache.java
@@ -36,6 +36,7 @@ import org.geysermc.geyser.GeyserImpl;
 import org.geysermc.geyser.entity.type.living.animal.FrogEntity;
 import org.geysermc.geyser.entity.type.living.animal.VariantHolder;
 import org.geysermc.geyser.entity.type.living.animal.TemperatureVariantAnimal;
+import org.geysermc.geyser.entity.type.living.animal.nautilus.ZombieNautilusEntity;
 import org.geysermc.geyser.entity.type.living.animal.tameable.CatEntity;
 import org.geysermc.geyser.entity.type.living.animal.tameable.WolfEntity;
 import org.geysermc.geyser.inventory.item.BannerPattern;
@@ -102,7 +103,7 @@ public final class RegistryCache implements JavaRegistryProvider {
         register(JavaRegistries.PIG_VARIANT, TemperatureVariantAnimal.VARIANT_READER);
         register(JavaRegistries.COW_VARIANT, TemperatureVariantAnimal.VARIANT_READER);
         register(JavaRegistries.CHICKEN_VARIANT, TemperatureVariantAnimal.VARIANT_READER);
-        register(JavaRegistries.ZOMBIE_NAUTILUS_VARIANT, TemperatureVariantAnimal.VARIANT_READER);
+        register(JavaRegistries.ZOMBIE_NAUTILUS_VARIANT, ZombieNautilusEntity.VARIANT_READER);
 
         // Load from MCProtocolLib's classloader
         NbtMap tag = MinecraftProtocol.loadNetworkCodec();

--- a/core/src/main/java/org/geysermc/geyser/session/cache/registry/JavaRegistries.java
+++ b/core/src/main/java/org/geysermc/geyser/session/cache/registry/JavaRegistries.java
@@ -31,6 +31,7 @@ import org.cloudburstmc.protocol.bedrock.data.TrimMaterial;
 import org.cloudburstmc.protocol.bedrock.data.TrimPattern;
 import org.geysermc.geyser.entity.type.living.animal.FrogEntity;
 import org.geysermc.geyser.entity.type.living.animal.TemperatureVariantAnimal;
+import org.geysermc.geyser.entity.type.living.animal.nautilus.ZombieNautilusEntity;
 import org.geysermc.geyser.entity.type.living.animal.tameable.CatEntity;
 import org.geysermc.geyser.entity.type.living.animal.tameable.WolfEntity;
 import org.geysermc.geyser.inventory.item.BannerPattern;
@@ -98,7 +99,7 @@ public class JavaRegistries {
     public static final JavaRegistryKey<TemperatureVariantAnimal.BuiltInVariant> PIG_VARIANT = create("pig_variant");
     public static final JavaRegistryKey<TemperatureVariantAnimal.BuiltInVariant> COW_VARIANT = create("cow_variant");
     public static final JavaRegistryKey<TemperatureVariantAnimal.BuiltInVariant> CHICKEN_VARIANT = create("chicken_variant");
-    public static final JavaRegistryKey<TemperatureVariantAnimal.BuiltInVariant> ZOMBIE_NAUTILUS_VARIANT = create("zombie_nautilus_variant");
+    public static final JavaRegistryKey<ZombieNautilusEntity.BuiltInVariant> ZOMBIE_NAUTILUS_VARIANT = create("zombie_nautilus_variant");
 
     private static <T> JavaRegistryKey<T> create(String key, JavaRegistryKey.RegistryLookup<T> registryLookup) {
         JavaRegistryKey<T> registry = new JavaRegistryKey<>(MinecraftKey.key(key), registryLookup);


### PR DESCRIPTION
The coral zombie nautilus variant (warm ocean biome) is not displaying correctly on Bedrock clients. This is likely because the entity definition was missing the property registration and metadata translator.

Added:
- .property(TemperatureVariantAnimal.TEMPERATE_VARIANT_PROPERTY) to register the Bedrock entity property
- .addTranslator(MetadataTypes.ZOMBIE_NAUTILUS_VARIANT, ZombieNautilusEntity::setVariant) to translate Java variant metadata to Bedrock

This follows the same pattern as other temperature variant animals (chicken, cow, pig).

Should resolve https://github.com/GeyserMC/Geyser/issues/6130