### PR TITLE
Add concurrency configuration to build workflow

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -17,6 +17,9 @@ on:
       - 'Jenkinsfile '
       - 'README.md'
 
+concurrency:
+  group: ci-${{ github.ref }}
+
 jobs:
   build:
     runs-on: ubuntu-latest


### PR DESCRIPTION
This will prevent builds getting published out of order and causing update checkers to get confused.

This will keep the build pending until the previous one in the same group is done. If one is already pending it will be cancelled so only the latest is pending.