### PR TITLE
Fixed chest edge collision fix.

### DIFF
--- a/core/src/main/java/org/geysermc/geyser/translator/collision/fixes/ChestCollision.java
+++ b/core/src/main/java/org/geysermc/geyser/translator/collision/fixes/ChestCollision.java
@@ -26,6 +26,7 @@
 package org.geysermc.geyser.translator.collision.fixes;
 
 import lombok.EqualsAndHashCode;
+import org.cloudburstmc.math.vector.Vector3d;
 import org.geysermc.geyser.entity.type.player.SessionPlayerEntity;
 import org.geysermc.geyser.level.block.type.BlockState;
 import org.geysermc.geyser.level.physics.Axis;
@@ -74,7 +75,9 @@ public class ChestCollision extends BlockCollision {
         // We grab the player velocity from last tick then apply collision on it, if the player can still fall then we correct
         // their position to fall down. If not then just use the player current position. Also do the same when player is jumping, if player
         // haven't collided yet, then correct them. Resolve #3277 and #4955
-        double yVelocity = Math.max(beforeYVelocity, this.computeCollisionOffset(x, y, z, previous, Axis.Y, beforeYVelocity));
+
+        Vector3d corrected = session.getCollisionManager().correctMovementForCollisions(Vector3d.from(0, beforeYVelocity, 0), previous, true, false);
+        double yVelocity = Math.max(beforeYVelocity, corrected.getY());
         // Player velocity is close enough, no need to correct, avoid moving player position silently if possible. Also don't move the player upwards.
         if (Math.abs(beforeYVelocity - yVelocity) <= CollisionManager.COLLISION_TOLERANCE || yVelocity > CollisionManager.COLLISION_TOLERANCE) {
             return;


### PR DESCRIPTION
The chest collision fix doesn't account for player standing on other blocks near chest before, causing pulling down when not needed, this should fix it.