### PR TITLE
Fix: Don't send forms that are supposed to have been closed 

### DIFF
--- a/core/src/main/java/org/geysermc/geyser/session/cache/FormCache.java
+++ b/core/src/main/java/org/geysermc/geyser/session/cache/FormCache.java
@@ -136,6 +136,8 @@ public class FormCache {
             // Copy them to ensure any response handler's sent form isn't instantly cleared
             Int2ObjectMap<Form> copy = new Int2ObjectOpenHashMap<>(this.forms);
             this.forms.clear();
+            // Now close it
+            session.sendUpstreamPacket(new ClientboundCloseFormPacket());
 
             for (Form form : copy.values()) {
                 try {
@@ -144,8 +146,6 @@ public class FormCache {
                     GeyserImpl.getInstance().getLogger().error("Error while closing form!", e);
                 }
             }
-            // Now close it
-            session.sendUpstreamPacket(new ClientboundCloseFormPacket());
         }
     }
 }


### PR DESCRIPTION
With this change, all forms are cleared on Geyser's end when they're closed. This ensures that forms aren't accidentally re-sent when a new form is send, since that calls FormCache#resendAllForms()