### PR TITLE
Fix dynamic recipe input ingredient matching

### DIFF
--- a/core/src/main/java/org/geysermc/geyser/inventory/GeyserItemStack.java
+++ b/core/src/main/java/org/geysermc/geyser/inventory/GeyserItemStack.java
@@ -260,11 +260,15 @@ public class GeyserItemStack {
         return session.getItemMappings().getMapping(this.javaId);
     }
 
-    public SlotDisplay asSlotDisplay() {
-        if (isEmpty()) {
+    public SlotDisplay asIngredient() {
+        ItemStack itemStack = getItemStack(1);
+        if (itemStack == null) {
             return EmptySlotDisplay.INSTANCE;
         }
-        return new ItemStackSlotDisplay(this.getItemStack());
+        if (itemStack.getDataComponentsPatch() == null) {
+            return new ItemSlotDisplay(itemStack.getId());
+        }
+        return new ItemStackSlotDisplay(itemStack);
     }
 
     public int getMaxStackSize() {

--- a/core/src/main/java/org/geysermc/geyser/translator/protocol/java/inventory/JavaContainerSetSlotTranslator.java
+++ b/core/src/main/java/org/geysermc/geyser/translator/protocol/java/inventory/JavaContainerSetSlotTranslator.java
@@ -171,7 +171,7 @@ public class JavaContainerSetSlotTranslator extends PacketTranslator<Clientbound
                 for (int col = firstCol; col < width + firstCol; col++) {
                     GeyserItemStack geyserItemStack = holder.inventory().getItem(col + (row * gridDimensions) + 1);
                     ingredients[index] = geyserItemStack.getItemData(session);
-                    javaIngredients.add(geyserItemStack.asSlotDisplay());
+                    javaIngredients.add(geyserItemStack.asIngredient());
 
                     InventorySlotPacket slotPacket = new InventorySlotPacket();
                     slotPacket.setContainerId(ContainerId.UI);
@@ -254,9 +254,9 @@ public class JavaContainerSetSlotTranslator extends PacketTranslator<Clientbound
             }
 
             session.getSmithingRecipes().add(new GeyserSmithingRecipe(
-                template.asSlotDisplay(),
-                input.asSlotDisplay(),
-                material.asSlotDisplay(),
+                template.asIngredient(),
+                input.asIngredient(),
+                material.asIngredient(),
                 new ItemStackSlotDisplay(output)
             ));
 


### PR DESCRIPTION
Ingredients should always have a count of 1 especially for dynamic ones, as even if a recipe would require multiple of an item, which I never came across even in modded Minecraft, is this a better assumption then creating dozen of recipes every time you craft smth which isn't in the recipe book.