### PR TITLE
Use app creds for previous release fetching

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -28,7 +28,8 @@ jobs:
         id: release-info
         uses: GeyserMC/actions/previous-release@master
         with:
-          data: ${{ vars.RELEASEACTION_PREVRELEASE }}
+          appID: ${{ secrets.RELEASE_APP_ID }}
+          appPrivateKey: ${{ secrets.RELEASE_APP_PK }}
 
       - name: Setup Gradle
         uses: GeyserMC/actions/setup-gradle-composite@master


### PR DESCRIPTION
Hopefully, this will resolve queued actions flows ending up with the  wrong build numbers when other branches are built.

This makes use of https://github.com/GeyserMC/actions/commit/6151fb231bf2baa55381333c3adda0c0da31767d

Last happened:
https://github.com/GeyserMC/Geyser/commit/b641d78923d2a02a9daf3598226668659f043127 - Published as build `#1059` - Built as `#1058`
https://github.com/GeyserMC/Geyser/commit/3b9e8bb906f1ce270be4aa4e43cc605372177c92 - Published as build `#1058` - Built as `#1058`