### PR TITLE
Fix: Issues related to Geyser's reload command

### DIFF
--- a/bootstrap/standalone/src/main/java/org/geysermc/geyser/platform/standalone/GeyserStandaloneBootstrap.java
+++ b/bootstrap/standalone/src/main/java/org/geysermc/geyser/platform/standalone/GeyserStandaloneBootstrap.java
@@ -180,9 +180,6 @@ public class GeyserStandaloneBootstrap implements GeyserBootstrap {
             // Event must be fired after CommandRegistry has subscribed its listener.
             // Also, the subscription for the Permissions class is created when Geyser is initialized.
             cloud.fireRegisterPermissionsEvent();
-        } else {
-            // This isn't ideal - but geyserLogger#start won't ever finish, leading to a reloading deadlock
-            geyser.setReloading(false);
         }
 
         if (gui != null) {
@@ -191,7 +188,10 @@ public class GeyserStandaloneBootstrap implements GeyserBootstrap {
 
         geyserPingPassthrough = GeyserLegacyPingPassthrough.init(geyser);
 
-        geyserLogger.start();
+        if (!reloading) {
+            // Only start logger once; no need to re-start it on reload
+            geyserLogger.start();
+        }
     }
 
     @Override

--- a/core/src/main/java/org/geysermc/geyser/GeyserImpl.java
+++ b/core/src/main/java/org/geysermc/geyser/GeyserImpl.java
@@ -312,7 +312,7 @@ public class GeyserImpl implements GeyserApi, EventRegistrar {
         GeyserLogger logger = bootstrap.getGeyserLogger();
         GeyserConfig config = bootstrap.config();
 
-        ScoreboardUpdater.init();
+        ScoreboardUpdater.init(this);
 
         SkinProvider.registerCacheImageTask(this);
 
@@ -668,6 +668,7 @@ public class GeyserImpl implements GeyserApi, EventRegistrar {
         newsHandler.handleNews(null, NewsItemAction.ON_SERVER_STARTED);
 
         if (isReloading) {
+            isReloading = false;
             this.eventBus.fire(new GeyserPostReloadEvent(this.extensionManager, this.eventBus));
         } else {
             this.eventBus.fire(new GeyserPostInitializeEvent(this.extensionManager, this.eventBus));
@@ -743,6 +744,7 @@ public class GeyserImpl implements GeyserApi, EventRegistrar {
             bootstrap.getGeyserLogger().info(GeyserLocale.getLocaleStringLog("geyser.core.shutdown.kick.done"));
         }
 
+        runIfNonNull(metrics, MetricsBase::shutdown);
         runIfNonNull(scheduledThread, ScheduledExecutorService::shutdown);
         runIfNonNull(geyserServer, GeyserServer::shutdown);
         runIfNonNull(skinUploader, FloodgateSkinUploader::close);
@@ -778,8 +780,6 @@ public class GeyserImpl implements GeyserApi, EventRegistrar {
 
         bootstrap.onGeyserDisable();
         bootstrap.onGeyserEnable();
-
-        isReloading = false;
     }
 
     /**

--- a/core/src/main/java/org/geysermc/geyser/translator/protocol/java/scoreboard/JavaResetScorePacket.java
+++ b/core/src/main/java/org/geysermc/geyser/translator/protocol/java/scoreboard/JavaResetScorePacket.java
@@ -66,7 +66,7 @@ public class JavaResetScorePacket extends PacketTranslator<ClientboundResetScore
 
         // ScoreboardUpdater will handle it for us if the packets per second
         // (for score and team packets) is higher than the first threshold
-        if (pps < ScoreboardUpdater.FIRST_SCORE_PACKETS_PER_SECOND_THRESHOLD) {
+        if (pps < ScoreboardUpdater.firstScorePacketsPerSecondThreshold) {
             scoreboard.onUpdate();
         }
     }

--- a/core/src/main/java/org/geysermc/geyser/translator/protocol/java/scoreboard/JavaSetDisplayObjectiveTranslator.java
+++ b/core/src/main/java/org/geysermc/geyser/translator/protocol/java/scoreboard/JavaSetDisplayObjectiveTranslator.java
@@ -46,7 +46,7 @@ public class JavaSetDisplayObjectiveTranslator extends PacketTranslator<Clientbo
 
         // ScoreboardUpdater will handle it for us if the packets per second
         // (for score and team packets) is higher than the first threshold
-        if (pps < ScoreboardUpdater.FIRST_SCORE_PACKETS_PER_SECOND_THRESHOLD) {
+        if (pps < ScoreboardUpdater.firstScorePacketsPerSecondThreshold) {
             scoreboard.onUpdate();
         }
     }

--- a/core/src/main/java/org/geysermc/geyser/translator/protocol/java/scoreboard/JavaSetObjectiveTranslator.java
+++ b/core/src/main/java/org/geysermc/geyser/translator/protocol/java/scoreboard/JavaSetObjectiveTranslator.java
@@ -69,7 +69,7 @@ public class JavaSetObjectiveTranslator extends PacketTranslator<ClientboundSetO
 
         // ScoreboardUpdater will handle it for us if the packets per second
         // (for score and team packets) is higher than the first threshold
-        if (pps < ScoreboardUpdater.FIRST_SCORE_PACKETS_PER_SECOND_THRESHOLD) {
+        if (pps < ScoreboardUpdater.firstScorePacketsPerSecondThreshold) {
             scoreboard.onUpdate();
         }
     }

--- a/core/src/main/java/org/geysermc/geyser/translator/protocol/java/scoreboard/JavaSetPlayerTeamTranslator.java
+++ b/core/src/main/java/org/geysermc/geyser/translator/protocol/java/scoreboard/JavaSetPlayerTeamTranslator.java
@@ -95,7 +95,7 @@ public class JavaSetPlayerTeamTranslator extends PacketTranslator<ClientboundSet
 
         // ScoreboardUpdater will handle it for us if the packets per second
         // (for score and team packets) is higher than the first threshold
-        if (pps < ScoreboardUpdater.FIRST_SCORE_PACKETS_PER_SECOND_THRESHOLD) {
+        if (pps < ScoreboardUpdater.firstScorePacketsPerSecondThreshold) {
             scoreboard.onUpdate();
         }
     }

--- a/core/src/main/java/org/geysermc/geyser/translator/protocol/java/scoreboard/JavaSetScoreTranslator.java
+++ b/core/src/main/java/org/geysermc/geyser/translator/protocol/java/scoreboard/JavaSetScoreTranslator.java
@@ -61,7 +61,7 @@ public class JavaSetScoreTranslator extends PacketTranslator<ClientboundSetScore
 
         // ScoreboardUpdater will handle it for us if the packets per second
         // (for score and team packets) is higher than the first threshold
-        if (pps < ScoreboardUpdater.FIRST_SCORE_PACKETS_PER_SECOND_THRESHOLD) {
+        if (pps < ScoreboardUpdater.firstScorePacketsPerSecondThreshold) {
             scoreboard.onUpdate();
         }
     }


### PR DESCRIPTION
- ScoreboardUpdater and GeyserLegacyPingPassthrough should be started after the reload finishes
- Metrics should be shut down to avoid thread leaking
- Don't start multiple console readers (standalone-specific)

This would resolve https://github.com/GeyserMC/Geyser/issues/6169 and allow re-configuring the scoreboard update threshold with a reload.