### PR TITLE
Fix block breaking

### DIFF
--- a/core/src/main/java/org/geysermc/geyser/translator/protocol/bedrock/entity/player/input/BedrockPlayerAuthInputTranslator.java
+++ b/core/src/main/java/org/geysermc/geyser/translator/protocol/bedrock/entity/player/input/BedrockPlayerAuthInputTranslator.java
@@ -207,7 +207,7 @@ public final class BedrockPlayerAuthInputTranslator extends PacketTranslator<Pla
             session.sendDownstreamGamePacket(sprintPacket);
         }
 
-        BedrockMovePlayer.translate(session, packet)
+        BedrockMovePlayer.translate(session, packet); 
         session.getBlockBreakHandler().handlePlayerAuthInputPacket(packet);
 
         // This is the best way send this since most modern anticheat will expect this to be in sync with the player movement packet.

--- a/core/src/main/java/org/geysermc/geyser/translator/protocol/bedrock/entity/player/input/BedrockPlayerAuthInputTranslator.java
+++ b/core/src/main/java/org/geysermc/geyser/translator/protocol/bedrock/entity/player/input/BedrockPlayerAuthInputTranslator.java
@@ -77,8 +77,6 @@ public final class BedrockPlayerAuthInputTranslator extends PacketTranslator<Pla
 
         boolean wasJumping = session.getInputCache().wasJumping();
         session.getInputCache().processInputs(entity, packet);
-        session.getBlockBreakHandler().handlePlayerAuthInputPacket(packet);
-
         ServerboundPlayerCommandPacket sprintPacket = null;
 
         Set<PlayerAuthInputData> inputData = packet.getInputData();
@@ -185,7 +183,7 @@ public final class BedrockPlayerAuthInputTranslator extends PacketTranslator<Pla
                     }
 
                     // Java edition sends a cooldown when hitting air.
-                    CooldownUtils.sendCooldown(session);
+                    CooldownUtils.setCooldownHitTime(session);
                 }
             }
         }
@@ -209,7 +207,8 @@ public final class BedrockPlayerAuthInputTranslator extends PacketTranslator<Pla
             session.sendDownstreamGamePacket(sprintPacket);
         }
 
-        BedrockMovePlayer.translate(session, packet);
+        BedrockMovePlayer.translate(session, packet)
+        session.getBlockBreakHandler().handlePlayerAuthInputPacket(packet);
 
         // This is the best way send this since most modern anticheat will expect this to be in sync with the player movement packet.
         if (session.isSpawned()) {

--- a/core/src/main/java/org/geysermc/geyser/util/BlockUtils.java
+++ b/core/src/main/java/org/geysermc/geyser/util/BlockUtils.java
@@ -133,7 +133,7 @@ public final class BlockUtils {
             destroySpeed *= (float) session.getPlayerEntity().getSubmergedMiningSpeed();
         }
 
-        if (!session.getPlayerEntity().isOnGround()) {
+        if (!session.getPlayerEntity().isOnGround() && !session.isFlying()) {
             destroySpeed /= 5.0F;
         }
 


### PR DESCRIPTION
This fix resolves the issue with breaking blocks while flying. Before the fix, blocks did not break on the first try and also did not drop on the first try. This solution fixes the problem.