### PR TITLE
Form duplicate fix

### DIFF
--- a/core/src/main/java/org/geysermc/geyser/session/GeyserSession.java
+++ b/core/src/main/java/org/geysermc/geyser/session/GeyserSession.java
@@ -1678,7 +1678,7 @@ public class GeyserSession implements GeyserConnection, GeyserCommandSource {
         dialogManager.close();
         // Also close all currently open forms.
         if (formCache.hasFormOpen()) {
-            return false;
+            closeForm();
         }
 
         // Cache this form, let's see whether we can open it immediately

--- a/core/src/main/java/org/geysermc/geyser/translator/protocol/bedrock/BedrockServerSettingsRequestTranslator.java
+++ b/core/src/main/java/org/geysermc/geyser/translator/protocol/bedrock/BedrockServerSettingsRequestTranslator.java
@@ -57,10 +57,6 @@ public class BedrockServerSettingsRequestTranslator extends PacketTranslator<Ser
             session.sendUpstreamPacket(setDifficultyPacket);
         }
 
-        if (session.getFormCache().hasFormOpen()) {
-            return;
-        }
-
         CustomForm form = SettingsUtils.buildForm(session);
         int formId = session.getFormCache().addForm(form);
 

--- a/core/src/main/java/org/geysermc/geyser/translator/protocol/java/JavaCustomPayloadTranslator.java
+++ b/core/src/main/java/org/geysermc/geyser/translator/protocol/java/JavaCustomPayloadTranslator.java
@@ -100,9 +100,11 @@ public class JavaCustomPayloadTranslator extends PacketTranslator<ClientboundCus
 
                     session.sendDownstreamPacket(new ServerboundCustomPayloadPacket(packet.getChannel(), finalData));
                 });
-                if (!session.sendForm(form)) {
+                if (session.hasFormOpen()) {
                     session.sendDownstreamPacket(new ServerboundCustomPayloadPacket(packet.getChannel(), new byte[]{data[1], data[2]}));
+                    return;
                 }
+                session.sendForm(form);
             });
         } else if (channel.equals(PluginMessageChannels.TRANSFER)) {
             session.ensureInEventLoop(() -> {


### PR DESCRIPTION
Before the fix, many forms could open, which caused issues with closing them and form spam. This solution fixes that problem.