### PR TITLE
Add a processor name parser for macOS

### DIFF
--- a/core/src/main/java/org/geysermc/geyser/util/CpuUtils.java
+++ b/core/src/main/java/org/geysermc/geyser/util/CpuUtils.java
@@ -47,7 +47,7 @@ public final class CpuUtils {
             } else if (osName.contains("mac")) {
                 return getMacProcessorName();
             } else {
-                GeyserImpl.getInstance().getLogger().warning("Couldn't determine OS to get processor name!");
+                GeyserImpl.getInstance().getLogger().warning("Couldn't determine OS to get processor name! The OS name is " + osName);
                 return "unknown";
             }
         } catch (Exception e) {


### PR DESCRIPTION
Fixes #6140 by adding a parser for processor names on macOS.
Used https://stackoverflow.com/a/62718963 as a reference.

Also redid the OS detection, so it'd be a bit less janky and allow for more OS to be supported (geyser on bsd when)