### PR TITLE
Add .DS_Store to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -237,6 +237,9 @@ nbdist/
 
 # End of https://www.gitignore.io/api/git,java,maven,eclipse,netbeans,jetbrains+all,visualstudiocode
 
+### macOS ##
+.DS_Store
+
 ### Gradle ###
 .gradle
 


### PR DESCRIPTION
macOS shoves the .DS_Store metadata file everywhere it can, they are absolutely not needed in this repository, so to avoid them, I propose adding them to the .gitignore, just in case:tm: