### PR TITLE
Fix: Don't attempt to modify channel handlers too early

### DIFF
--- a/core/src/main/java/org/geysermc/geyser/network/netty/GeyserServer.java
+++ b/core/src/main/java/org/geysermc/geyser/network/netty/GeyserServer.java
@@ -160,10 +160,11 @@ public final class GeyserServer {
     private void modifyHandlers(ChannelFuture future) {
         future.addListener((ChannelFutureListener) f -> {
             if (!f.isSuccess()) {
+                GeyserImpl.getInstance().getLogger().warning("Not modifying handlers due to exception: " + f.cause());
                 return;
             }
 
-            Channel channel = future.channel();
+            Channel channel = f.channel();
             // Add our ping handler
             channel.pipeline()
                 .addFirst(RakConnectionRequestHandler.NAME, new RakConnectionRequestHandler(this))


### PR DESCRIPTION
This should resolve rare issues such as:

```
[14:02:35 ERROR]: Couldn't pass ListenerBoundEvent to geyser 2.9.4-b1077 (git-master-94adadf)
java.util.NoSuchElementException: rak-offline-handler
        at io.netty.channel.DefaultChannelPipeline.getContextOrDie(DefaultChannelPipeline.java:1094) ~[velocity.jar:3.5.0-SNAPSHOT (git-c2fd3c07-b576)]
        at io.netty.channel.DefaultChannelPipeline.internalAdd(DefaultChannelPipeline.java:182) ~[velocity.jar:3.5.0-SNAPSHOT (git-c2fd3c07-b576)]
        at io.netty.channel.DefaultChannelPipeline.addAfter(DefaultChannelPipeline.java:272) ~[velocity.jar:3.5.0-SNAPSHOT (git-c2fd3c07-b576)]
        at io.netty.channel.DefaultChannelPipeline.addAfter(DefaultChannelPipeline.java:266) ~[velocity.jar:3.5.0-SNAPSHOT (git-c2fd3c07-b576)]
        at org.geysermc.geyser.network.netty.GeyserServer.modifyHandlers(GeyserServer.java:164) ~[?:?]
        at org.geysermc.geyser.network.netty.GeyserServer.bind(GeyserServer.java:152) ~[?:?]
        at org.geysermc.geyser.GeyserImpl.startInstance(GeyserImpl.java:471) ~[?:?]
        at org.geysermc.geyser.GeyserImpl.initialize(GeyserImpl.java:281) ~[?:?]
        at org.geysermc.geyser.GeyserImpl.start(GeyserImpl.java:897) ~[?:?]
        at org.geysermc.geyser.platform.velocity.GeyserVelocityPlugin.onGeyserEnable(GeyserVelocityPlugin.java:148) ~[?:?]
        at org.geysermc.geyser.platform.velocity.GeyserVelocityPlugin.onProxyBound(GeyserVelocityPlugin.java:220) ~[?:?]
        at org.geysermc.geyser.platform.velocity.Lmbda$26.execute(Unknown Source) ~[?:?]
        at com.velocitypowered.proxy.event.UntargetedEventHandler$VoidHandler.lambda$buildHandler$0(UntargetedEventHandler.java:56) ~[velocity.jar:3.5.0-SNAPSHOT (git-c2fd3c07-b576)]
        at com.velocitypowered.proxy.event.VelocityEventManager.fire(VelocityEventManager.java:553) ~[velocity.jar:3.5.0-SNAPSHOT (git-c2fd3c07-b576)]
        at com.velocitypowered.proxy.event.VelocityEventManager.lambda$fire$5(VelocityEventManager.java:542) ~[velocity.jar:3.5.0-SNAPSHOT (git-c2fd3c07-b576)]
        at java.base/java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1144) ~[?:?]
        at java.base/java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:642) ~[?:?]
        at java.base/java.lang.Thread.run(Thread.java:1583) [?:?]
        ```