### PR TITLE
Fix: Shelf block entity items rendered in wrong slot for Bedrock clients

### DIFF
--- a/core/src/main/java/org/geysermc/geyser/translator/item/BedrockItemBuilder.java
+++ b/core/src/main/java/org/geysermc/geyser/translator/item/BedrockItemBuilder.java
@@ -41,6 +41,9 @@ import java.util.OptionalInt;
  * An intermediary class made to allow easy access to work-in-progress NBT, such as lore and display.
  */
 public final class BedrockItemBuilder {
+
+    public static final NbtMap EMPTY_ITEM = BedrockItemBuilder.createItemNbt("", 0, 0).build();
+
     // All Bedrock-style
     @Nullable
     private String customName;

--- a/core/src/main/java/org/geysermc/geyser/translator/level/block/entity/ShelfBlockEntityTranslator.java
+++ b/core/src/main/java/org/geysermc/geyser/translator/level/block/entity/ShelfBlockEntityTranslator.java
@@ -41,7 +41,6 @@ import java.util.List;
 public class ShelfBlockEntityTranslator extends BlockEntityTranslator {
 
     private static final int SLOT_COUNT = 3;
-    private static final NbtMap EMPTY_ITEM = BedrockItemBuilder.createItemNbt("", 0, 0).build();
 
     @Override
     public void translateTag(GeyserSession session, NbtMapBuilder bedrockNbt, NbtMap javaNbt, BlockState blockState) {
@@ -49,8 +48,9 @@ public class ShelfBlockEntityTranslator extends BlockEntityTranslator {
 
         // Bedrock determines shelf item position by list index, so we must produce
         // a dense list with empty items for unoccupied slots.
+        // Verified with BDS 1.26.0.2
         NbtMap[] items = new NbtMap[SLOT_COUNT];
-        Arrays.fill(items, EMPTY_ITEM);
+        Arrays.fill(items, BedrockItemBuilder.EMPTY_ITEM);
 
         List<NbtMap> javaItems = javaNbt.getList("Items", NbtType.COMPOUND);
         for (NbtMap stack : javaItems) {


### PR DESCRIPTION
Bedrock determines shelf item position by list index, not by a `Slot` tag. The previous implementation streamed Java's sparse `Items` list (which only contains occupied slots), so items would shift left into the wrong visual position. For example, an item in slot 1 (middle) would appear in slot 0 (left) on Bedrock.

This fix produces a dense 3-element list with empty item entries for unoccupied slots, so each item lands at the correct list index matching its Java `Slot` value.

**Before:** `[{item}]` → Bedrock renders in slot 0 (wrong)
**After:** `[{empty}, {item}, {empty}]` → Bedrock renders in slot 1 (correct)

Tested on a Velocity + Paper server with both Java and Bedrock clients connected.