### PR TITLE
Config v8: Hardcore mode and Integrated Pack config section

### DIFF
--- a/bootstrap/mod/src/main/java/org/geysermc/geyser/platform/mod/GeyserModBootstrap.java
+++ b/bootstrap/mod/src/main/java/org/geysermc/geyser/platform/mod/GeyserModBootstrap.java
@@ -221,6 +221,11 @@ public abstract class GeyserModBootstrap implements GeyserBootstrap {
         return floodgateKeyPath;
     }
 
+    @Override
+    public boolean isServerControlledHardcore() {
+        return true;
+    }
+
     @Nullable
     @Override
     public InputStream getResourceOrNull(String resource) {

--- a/bootstrap/spigot/src/main/java/org/geysermc/geyser/platform/spigot/GeyserSpigotPlugin.java
+++ b/bootstrap/spigot/src/main/java/org/geysermc/geyser/platform/spigot/GeyserSpigotPlugin.java
@@ -472,6 +472,11 @@ public class GeyserSpigotPlugin extends JavaPlugin implements GeyserBootstrap {
     }
 
     @Override
+    public boolean isServerControlledHardcore() {
+        return true;
+    }
+
+    @Override
     public MetricsPlatform createMetricsPlatform() {
         return new SpigotMetrics(this);
     }

--- a/core/src/main/java/org/geysermc/geyser/Constants.java
+++ b/core/src/main/java/org/geysermc/geyser/Constants.java
@@ -42,7 +42,7 @@ public final class Constants {
 
     public static final String MINECRAFT_SKIN_SERVER_URL = "https://textures.minecraft.net/texture/";
 
-    public static final int CONFIG_VERSION = 7;
+    public static final int CONFIG_VERSION = 8;
 
     public static final int BSTATS_ID = 5273;
 

--- a/core/src/main/java/org/geysermc/geyser/GeyserBootstrap.java
+++ b/core/src/main/java/org/geysermc/geyser/GeyserBootstrap.java
@@ -212,6 +212,14 @@ public interface GeyserBootstrap {
      */
     Path getFloodgateKeyPath();
 
+    /**
+     * Returns whether or not the hardcore value should be taken from the server, or the Geyser config.
+     * @return {@code true} when it should pull from the server, {@code false} if it should pull from the config.
+     */
+    default boolean isServerControlledHardcore() {
+        return false;
+    }
+
     @Nullable
     default MetricsPlatform createMetricsPlatform() {
         return new ProvidedMetricsPlatform();

--- a/core/src/main/java/org/geysermc/geyser/configuration/ConfigMigrations.java
+++ b/core/src/main/java/org/geysermc/geyser/configuration/ConfigMigrations.java
@@ -187,6 +187,9 @@ public class ConfigMigrations {
             .addVersion(7, ConfigurationTransformation.builder()
                 .addAction(path("gameplay", "show-cooldown"), rename(new Object[] { "gameplay", "cooldown-type" }))
                 .build())
+            .addVersion(8, ConfigurationTransformation.builder()
+                .addAction(path("gameplay", "enable-integrated-pack"), renameAndMove("gameplay", "integrated-pack", "enabled"))
+                .build())
         .build();
 
     static TransformAction renameAndMove(String... newPath) {

--- a/core/src/main/java/org/geysermc/geyser/configuration/GeyserConfig.java
+++ b/core/src/main/java/org/geysermc/geyser/configuration/GeyserConfig.java
@@ -250,6 +250,21 @@ public interface GeyserConfig {
     }
 
     @ConfigSerializable
+    interface IntegratedPackConfig {
+        @Comment("""
+            Whether to automatically serve a resource pack that is required for some Geyser features to all connecting Bedrock players.
+            If enabled, force-resource-packs will be enabled.""")
+        @DefaultBoolean(true)
+        boolean enabled();
+
+        @Comment("""
+            Whether or not to show non-vanilla inventories on bedrock, for example, a 2 row chest. This option is ignored when the IntegratedPack is disabled.
+            """)
+        @DefaultBoolean(true)
+        boolean nonVanillaInventories();
+    }
+
+    @ConfigSerializable
     interface GameplayConfig {
 
         @Comment("The server name that will be sent to Minecraft: Bedrock Edition clients. This is visible in both the pause menu and the settings menu.")
@@ -293,6 +308,13 @@ public interface GeyserConfig {
         boolean emotesEnabled();
 
         @Comment("""
+            Whether to show the world as in hardcore mode to Bedrock Edition players.
+            """)
+        @DefaultBoolean(false)
+        @ExcludePlatform(platforms = {"Spigot", "Fabric", "NeoForge"})
+        boolean hardcoreMode();
+
+        @Comment("""
             Whether to remove legacy text formatting codes sent by Bedrock players.
             Unlike on Java Edition, typing section signs for legacy color codes is possible on Bedrock Edition.
             See https://minecraft.wiki/w/Formatting_codes for further information.
@@ -325,10 +347,9 @@ public interface GeyserConfig {
         boolean forceResourcePacks();
 
         @Comment("""
-            Whether to automatically serve a resource pack that is required for some Geyser features to all connecting Bedrock players.
-            If enabled, force-resource-packs will be enabled.""")
-        @DefaultBoolean(true)
-        boolean enableIntegratedPack();
+            Options related to the GeyserIntegratedPack.
+            """)
+        IntegratedPackConfig integratedPack();
 
         @Comment("""
             Whether to forward player ping to the server. While enabling this will allow Bedrock players to have more accurate

--- a/core/src/main/java/org/geysermc/geyser/inventory/Container.java
+++ b/core/src/main/java/org/geysermc/geyser/inventory/Container.java
@@ -93,7 +93,7 @@ public class Container extends Inventory {
 
     @Override
     protected String getPrefixedTitle(GeyserSession session, String title) {
-        if (session.integratedPackActive()) {
+        if (session.integratedPackActive() && session.getGeyser().config().gameplay().integratedPack().nonVanillaInventories()) {
             return getIntegratedPackTitlePrefix(this.containerType) + title;
         }
         return title;

--- a/core/src/main/java/org/geysermc/geyser/session/GeyserSession.java
+++ b/core/src/main/java/org/geysermc/geyser/session/GeyserSession.java
@@ -434,6 +434,9 @@ public class GeyserSession implements GeyserConnection, GeyserCommandSource {
 
     private GameMode gameMode = GameMode.SURVIVAL;
 
+    @Setter
+    private boolean hardcore = false;
+
     /**
      * Keeps track of the world name for respawning.
      */
@@ -1795,6 +1798,7 @@ public class GeyserSession implements GeyserConnection, GeyserCommandSource {
         startGamePacket.setUniqueEntityId(playerEntity.geyserId());
         startGamePacket.setRuntimeEntityId(playerEntity.geyserId());
         startGamePacket.setPlayerGameType(EntityUtils.toBedrockGamemode(gameMode));
+        startGamePacket.setHardcore(hardcore);
         startGamePacket.setPlayerPosition(Vector3f.from(0, 69, 0));
         startGamePacket.setRotation(Vector2f.from(1, 1));
 

--- a/core/src/main/java/org/geysermc/geyser/translator/protocol/java/JavaLoginTranslator.java
+++ b/core/src/main/java/org/geysermc/geyser/translator/protocol/java/JavaLoginTranslator.java
@@ -27,6 +27,7 @@ package org.geysermc.geyser.translator.protocol.java;
 
 import net.kyori.adventure.key.Key;
 import org.cloudburstmc.protocol.bedrock.data.GameRuleData;
+import org.cloudburstmc.protocol.bedrock.packet.DeathInfoPacket;
 import org.cloudburstmc.protocol.bedrock.packet.GameRulesChangedPacket;
 import org.cloudburstmc.protocol.bedrock.packet.SetPlayerGameTypePacket;
 import org.geysermc.erosion.Constants;
@@ -92,12 +93,24 @@ public class JavaLoginTranslator extends PacketTranslator<ClientboundLoginPacket
         session.setWorldName(spawnInfo.getWorldName());
         session.setLevels(Arrays.stream(packet.getWorldNames()).map(Key::asString).toArray(String[]::new));
         session.setGameMode(spawnInfo.getGameMode());
+        if (session.getGeyser().getBootstrap().isServerControlledHardcore()) {
+            session.setHardcore(packet.isHardcore());
+        } else {
+            session.setHardcore(session.getGeyser().config().gameplay().hardcoreMode());
+        }
 
         boolean needsSpawnPacket = !session.isSentSpawnPacket();
         if (needsSpawnPacket) {
             // The player has yet to spawn so let's do that using some of the information in this Java packet
             DimensionUtils.setBedrockDimension(session, newDimension.bedrockId());
             session.connect();
+
+            // This is to ensure that you don't get stuck without a respawn screen in hardcore, has no effect when hardcore mode is off
+            if (!entity.isAlive()) {
+                DeathInfoPacket deathInfoPacket = new DeathInfoPacket();
+                deathInfoPacket.setCauseAttackName("");
+                session.sendUpstreamPacket(deathInfoPacket);
+            }
 
             // It is now safe to send these packets
             session.getUpstream().sendPostStartGamePackets();

--- a/core/src/main/java/org/geysermc/geyser/util/GeyserIntegratedPackUtil.java
+++ b/core/src/main/java/org/geysermc/geyser/util/GeyserIntegratedPackUtil.java
@@ -53,10 +53,10 @@ public interface GeyserIntegratedPackUtil {
     UUID OPTIONAL_PACK_UUID = UUID.fromString("e5f5c938-a701-11eb-b2a3-047d7bb283ba");
     UUID INTEGRATED_PACK_UUID = UUID.fromString("2254393d-8430-45b0-838a-bd397828c765");
     AtomicReference<ResourcePackManifest.Version> INTEGRATED_PACK_VERSION = new AtomicReference<>();
-    AtomicBoolean PACK_ENABLED = new AtomicBoolean(GeyserImpl.getInstance().config().gameplay().enableIntegratedPack());
+    AtomicBoolean PACK_ENABLED = new AtomicBoolean(GeyserImpl.getInstance().config().gameplay().integratedPack().enabled());
 
     default void registerGeyserPack(GeyserDefineResourcePacksEventImpl event) {
-        if (!GeyserImpl.getInstance().config().gameplay().enableIntegratedPack()) {
+        if (!GeyserImpl.getInstance().config().gameplay().integratedPack().enabled()) {
             return;
         }
 
@@ -152,6 +152,6 @@ public interface GeyserIntegratedPackUtil {
     boolean integratedPackRegistered();
 
     default boolean isIntegratedPackActive() {
-        return GeyserImpl.getInstance().config().gameplay().enableIntegratedPack() && integratedPackRegistered();
+        return GeyserImpl.getInstance().config().gameplay().integratedPack().enabled() && integratedPackRegistered();
     }
 }


### PR DESCRIPTION
Adds:
- `gameplay.hardcore-mode` to every platform besides Spigot, Fabric and NeoForge, those platforms will now automatically set hardcore mode within Geyser.
- `gameplay.integrated-pack.non-vanilla-inventories` which allows users to disable inventory changes made by the integrated pack in case they may conflict with their own pack, this means the rest of the integrated pack can remain enabled.

Moves:
- `gameplay.enable-integrated-pack` to `gameplay.integrated-pack.enabled` due to the addition of the integrated pack section in gameplay