### PR TITLE
Switch to JSpecify for nullability annotations in API module

### DIFF
--- a/api/build.gradle.kts
+++ b/api/build.gradle.kts
@@ -9,6 +9,7 @@ dependencies {
     api(libs.base.api)
     api(libs.math)
     api(libs.jetbrains.annotations)
+    api(libs.jspecify)
 }
 
 version = property("version")!!

--- a/api/build.gradle.kts
+++ b/api/build.gradle.kts
@@ -9,7 +9,6 @@ dependencies {
     api(libs.base.api)
     api(libs.math)
     api(libs.jetbrains.annotations)
-    api(libs.jspecify)
 }
 
 version = property("version")!!

--- a/api/src/main/java/org/geysermc/geyser/api/GeyserApi.java
+++ b/api/src/main/java/org/geysermc/geyser/api/GeyserApi.java
@@ -25,8 +25,6 @@
 
 package org.geysermc.geyser.api;
 
-import org.checkerframework.checker.nullness.qual.NonNull;
-import org.checkerframework.checker.nullness.qual.Nullable;
 import org.geysermc.api.Geyser;
 import org.geysermc.api.GeyserApiBase;
 import org.geysermc.api.util.ApiVersion;
@@ -40,6 +38,7 @@ import org.geysermc.geyser.api.network.RemoteServer;
 import org.geysermc.geyser.api.util.MinecraftVersion;
 import org.geysermc.geyser.api.util.PlatformType;
 import org.jetbrains.annotations.ApiStatus;
+import org.jspecify.annotations.Nullable;
 
 import java.nio.file.Path;
 import java.util.List;
@@ -54,18 +53,17 @@ public interface GeyserApi extends GeyserApiBase {
      * {@inheritDoc}
      */
     @Override
-    @Nullable GeyserConnection connectionByUuid(@NonNull UUID uuid);
+    @Nullable GeyserConnection connectionByUuid(UUID uuid);
 
     /**
      * {@inheritDoc}
      */
     @Override
-    @Nullable GeyserConnection connectionByXuid(@NonNull String xuid);
+    @Nullable GeyserConnection connectionByXuid(String xuid);
 
     /**
      * {@inheritDoc}
      */
-    @NonNull
     List<? extends GeyserConnection> onlineConnections();
 
     /**
@@ -73,7 +71,6 @@ public interface GeyserApi extends GeyserApiBase {
      *
      * @return the extension manager
      */
-    @NonNull
     ExtensionManager extensionManager();
 
     /**
@@ -85,8 +82,7 @@ public interface GeyserApi extends GeyserApiBase {
      * @throws IllegalArgumentException if there is no provider for the specified API class
      * @return the builder instance
      */
-    @NonNull
-    <R extends T, T> R provider(@NonNull Class<T> apiClass, @Nullable Object... args);
+    <R extends T, T> R provider(Class<T> apiClass, @Nullable Object... args);
 
     /**
      * Gets the {@link EventBus} for handling
@@ -94,7 +90,6 @@ public interface GeyserApi extends GeyserApiBase {
      *
      * @return the event bus
      */
-    @NonNull
     EventBus<EventRegistrar> eventBus();
 
     /**
@@ -103,7 +98,6 @@ public interface GeyserApi extends GeyserApiBase {
      *
      * @return the default remote server used within Geyser
      */
-    @NonNull
     RemoteServer defaultRemoteServer();
 
     /**
@@ -112,7 +106,6 @@ public interface GeyserApi extends GeyserApiBase {
      *
      * @return the listener used for Bedrock client connectins
      */
-    @NonNull
     BedrockListener bedrockListener();
 
     /**
@@ -120,7 +113,6 @@ public interface GeyserApi extends GeyserApiBase {
      *
      * @return the path to the Geyser config directory
      */
-    @NonNull
     Path configDirectory();
 
     /**
@@ -128,7 +120,6 @@ public interface GeyserApi extends GeyserApiBase {
      *
      * @return the path to the Geyser packs directory
      */
-    @NonNull
     Path packDirectory();
 
     /**
@@ -136,7 +127,6 @@ public interface GeyserApi extends GeyserApiBase {
      *
      * @return type of platform
      */
-    @NonNull
     PlatformType platformType();
 
     /**
@@ -144,7 +134,6 @@ public interface GeyserApi extends GeyserApiBase {
      *
      * @return the supported version of Java Minecraft
      */
-    @NonNull
     MinecraftVersion supportedJavaVersion();
 
     /**
@@ -152,7 +141,6 @@ public interface GeyserApi extends GeyserApiBase {
      *
      * @return the list of supported Bedrock Minecraft versions
      */
-    @NonNull
     List<MinecraftVersion> supportedBedrockVersions();
 
     /**
@@ -160,7 +148,6 @@ public interface GeyserApi extends GeyserApiBase {
      *
      * @return the console command source
      */
-    @NonNull
     CommandSource consoleCommandSource();
 
     /**
@@ -168,7 +155,6 @@ public interface GeyserApi extends GeyserApiBase {
      *
      * @return the current geyser api instance
      */
-    @NonNull
     static GeyserApi api() {
         return Geyser.api(GeyserApi.class);
     }

--- a/api/src/main/java/org/geysermc/geyser/api/GeyserApi.java
+++ b/api/src/main/java/org/geysermc/geyser/api/GeyserApi.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019-2022 GeyserMC. http://geysermc.org
+ * Copyright (c) 2019-2026 GeyserMC. http://geysermc.org
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/api/src/main/java/org/geysermc/geyser/api/bedrock/camera/CameraData.java
+++ b/api/src/main/java/org/geysermc/geyser/api/bedrock/camera/CameraData.java
@@ -25,9 +25,8 @@
 
 package org.geysermc.geyser.api.bedrock.camera;
 
-import org.checkerframework.checker.nullness.qual.NonNull;
-import org.checkerframework.checker.nullness.qual.Nullable;
 import org.geysermc.geyser.api.connection.GeyserConnection;
+import org.jspecify.annotations.Nullable;
 
 import java.util.Set;
 import java.util.UUID;
@@ -46,7 +45,7 @@ public interface CameraData {
      *
      * @param fade the camera fade instruction to send
      */
-    void sendCameraFade(@NonNull CameraFade fade);
+    void sendCameraFade(CameraFade fade);
 
     /**
      * Sends a camera position instruction to the client.
@@ -58,7 +57,7 @@ public interface CameraData {
      *
      * @param position the camera position instruction to send
      */
-    void sendCameraPosition(@NonNull CameraPosition position);
+    void sendCameraPosition(CameraPosition position);
 
     /**
      * Stops all sent camera instructions (fades, movements, and perspective locks).
@@ -76,7 +75,7 @@ public interface CameraData {
      *
      * @param perspective the {@link CameraPerspective} to force
      */
-    void forceCameraPerspective(@NonNull CameraPerspective perspective);
+    void forceCameraPerspective(CameraPerspective perspective);
 
     /**
      * Gets the client's current {@link CameraPerspective}, if one is currently forced.
@@ -99,7 +98,7 @@ public interface CameraData {
      * @param duration the time in seconds that the shake will occur for
      * @param type the type of shake
      */
-    void shakeCamera(float intensity, float duration, @NonNull CameraShake type);
+    void shakeCamera(float intensity, float duration, CameraShake type);
 
     /**
      * Stops all camera shakes of any type.
@@ -125,7 +124,6 @@ public interface CameraData {
     /**
      * Returns an immutable copy of all fog affects currently applied to this client.
      */
-    @NonNull
     Set<String> fogEffects();
 
     /**
@@ -137,7 +135,7 @@ public interface CameraData {
      * @param owner the owner of the lock, represented with a UUID
      * @return if the camera is locked after this method call
      */
-    boolean lockCamera(boolean lock, @NonNull UUID owner);
+    boolean lockCamera(boolean lock, UUID owner);
 
     /**
      * Returns whether the client's camera is locked.
@@ -151,7 +149,7 @@ public interface CameraData {
      *
      * @param element the {@link GuiElement} to hide
      */
-    void hideElement(@NonNull GuiElement... element);
+    void hideElement(GuiElement... element);
 
     /**
      * Resets a {@link GuiElement} on the client's side.
@@ -162,19 +160,19 @@ public interface CameraData {
      *
      * @param element the {@link GuiElement} to reset
      */
-    void resetElement(@NonNull GuiElement @Nullable... element);
+    void resetElement(GuiElement @Nullable... element);
 
     /**
      * Determines whether a {@link GuiElement} is currently hidden.
      *
      * @param element the {@link GuiElement} to check
      */
-    boolean isHudElementHidden(@NonNull GuiElement element);
+    boolean isHudElementHidden(GuiElement element);
 
     /**
      * Returns the currently hidden {@link GuiElement}s.
      *
      * @return an unmodifiable view of all currently hidden {@link GuiElement}s
      */
-    @NonNull Set<GuiElement> hiddenElements();
+    Set<GuiElement> hiddenElements();
 }

--- a/api/src/main/java/org/geysermc/geyser/api/bedrock/camera/CameraData.java
+++ b/api/src/main/java/org/geysermc/geyser/api/bedrock/camera/CameraData.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019-2023 GeyserMC. http://geysermc.org
+ * Copyright (c) 2019-2026 GeyserMC. http://geysermc.org
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/api/src/main/java/org/geysermc/geyser/api/bedrock/camera/CameraFade.java
+++ b/api/src/main/java/org/geysermc/geyser/api/bedrock/camera/CameraFade.java
@@ -25,7 +25,6 @@
 
 package org.geysermc.geyser.api.bedrock.camera;
 
-import org.checkerframework.checker.nullness.qual.NonNull;
 import org.checkerframework.common.value.qual.IntRange;
 import org.geysermc.geyser.api.GeyserApi;
 
@@ -44,7 +43,7 @@ public interface CameraFade {
      *
      * @return the color of the fade
      */
-    @NonNull Color color();
+    Color color();
 
     /**
      * Gets the seconds it takes to fade in.
@@ -81,7 +80,7 @@ public interface CameraFade {
 
     interface Builder {
 
-        Builder color(@NonNull Color color);
+        Builder color(Color color);
 
         Builder fadeInSeconds(@IntRange(from = 0, to = 10) float fadeInSeconds);
 

--- a/api/src/main/java/org/geysermc/geyser/api/bedrock/camera/CameraFade.java
+++ b/api/src/main/java/org/geysermc/geyser/api/bedrock/camera/CameraFade.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019-2023 GeyserMC. http://geysermc.org
+ * Copyright (c) 2019-2026 GeyserMC. http://geysermc.org
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/api/src/main/java/org/geysermc/geyser/api/bedrock/camera/CameraPosition.java
+++ b/api/src/main/java/org/geysermc/geyser/api/bedrock/camera/CameraPosition.java
@@ -25,11 +25,10 @@
 
 package org.geysermc.geyser.api.bedrock.camera;
 
-import org.checkerframework.checker.nullness.qual.NonNull;
-import org.checkerframework.checker.nullness.qual.Nullable;
 import org.checkerframework.common.value.qual.IntRange;
 import org.cloudburstmc.math.vector.Vector3f;
 import org.geysermc.geyser.api.GeyserApi;
+import org.jspecify.annotations.Nullable;
 
 /**
  * This interface represents a camera position instruction. Can be built with the {@link #builder()}.
@@ -47,7 +46,7 @@ public interface CameraPosition {
      *
      * @return camera position vector
      */
-    @NonNull Vector3f position();
+    Vector3f position();
 
     /**
      * Gets the {@link CameraEaseType} of the camera.
@@ -137,7 +136,7 @@ public interface CameraPosition {
 
         Builder easeSeconds(float easeSeconds);
 
-        Builder position(@NonNull Vector3f position);
+        Builder position(Vector3f position);
 
         Builder rotationX(@IntRange(from = -90, to = 90) int rotationX);
 

--- a/api/src/main/java/org/geysermc/geyser/api/bedrock/camera/CameraPosition.java
+++ b/api/src/main/java/org/geysermc/geyser/api/bedrock/camera/CameraPosition.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019-2023 GeyserMC. http://geysermc.org
+ * Copyright (c) 2019-2026 GeyserMC. http://geysermc.org
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/api/src/main/java/org/geysermc/geyser/api/bedrock/camera/package-info.java
+++ b/api/src/main/java/org/geysermc/geyser/api/bedrock/camera/package-info.java
@@ -1,0 +1,29 @@
+/*
+ * Copyright (c) 2026 GeyserMC. http://geysermc.org
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ *
+ * @author GeyserMC
+ * @link https://github.com/GeyserMC/Geyser
+ */
+
+@NullMarked
+package org.geysermc.geyser.api.bedrock.camera;
+
+import org.jspecify.annotations.NullMarked;

--- a/api/src/main/java/org/geysermc/geyser/api/block/custom/CustomBlockData.java
+++ b/api/src/main/java/org/geysermc/geyser/api/block/custom/CustomBlockData.java
@@ -25,12 +25,11 @@
 
 package org.geysermc.geyser.api.block.custom;
 
-import org.checkerframework.checker.nullness.qual.NonNull;
-import org.checkerframework.checker.nullness.qual.Nullable;
 import org.geysermc.geyser.api.GeyserApi;
 import org.geysermc.geyser.api.block.custom.component.CustomBlockComponents;
 import org.geysermc.geyser.api.block.custom.property.CustomBlockProperty;
 import org.geysermc.geyser.api.util.CreativeCategory;
+import org.jspecify.annotations.Nullable;
 
 import java.util.List;
 import java.util.Map;
@@ -44,14 +43,14 @@ public interface CustomBlockData {
      *
      * @return The name of the custom block.
      */
-    @NonNull String name();
+    String name();
 
     /**
      * Gets the identifier of the custom block
      *
      * @return The identifier of the custom block.
      */
-    @NonNull String identifier();
+    String identifier();
 
     /**
      * Gets if the custom block is included in the creative inventory
@@ -87,28 +86,28 @@ public interface CustomBlockData {
      *
      * @return The custom block's map of block property names to CustomBlockProperty objects.
      */
-    @NonNull Map<String, CustomBlockProperty<?>> properties();
+    Map<String, CustomBlockProperty<?>> properties();
 
     /**
      * Gets the list of the custom block's permutations
      *
      * @return The permutations of the custom block.
      */
-    @NonNull List<CustomBlockPermutation> permutations();
+    List<CustomBlockPermutation> permutations();
 
     /**
      * Gets the custom block's default block state
      *
      * @return The default block state of the custom block.
      */
-    @NonNull CustomBlockState defaultBlockState();
+    CustomBlockState defaultBlockState();
 
     /**
      * Gets a builder for a custom block state
      *
      * @return The builder for a custom block state.
      */
-    CustomBlockState.@NonNull Builder blockStateBuilder();
+    CustomBlockState.Builder blockStateBuilder();
 
     /**
      * Create a Builder for CustomBlockData
@@ -120,7 +119,7 @@ public interface CustomBlockData {
     }
 
     interface Builder {
-        Builder name(@NonNull String name);
+        Builder name(String name);
 
         Builder includedInCreativeInventory(boolean includedInCreativeInventory);
 
@@ -128,15 +127,15 @@ public interface CustomBlockData {
 
         Builder creativeGroup(@Nullable String creativeGroup);
 
-        Builder components(@NonNull CustomBlockComponents components);
+        Builder components(CustomBlockComponents components);
 
-        Builder booleanProperty(@NonNull String propertyName);
+        Builder booleanProperty(String propertyName);
 
-        Builder intProperty(@NonNull String propertyName, List<Integer> values);
+        Builder intProperty(String propertyName, List<Integer> values);
 
-        Builder stringProperty(@NonNull String propertyName, List<String> values);
+        Builder stringProperty(String propertyName, List<String> values);
 
-        Builder permutations(@NonNull List<CustomBlockPermutation> permutations);
+        Builder permutations(List<CustomBlockPermutation> permutations);
 
         CustomBlockData build();
     }

--- a/api/src/main/java/org/geysermc/geyser/api/block/custom/CustomBlockData.java
+++ b/api/src/main/java/org/geysermc/geyser/api/block/custom/CustomBlockData.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019-2022 GeyserMC. http://geysermc.org
+ * Copyright (c) 2019-2026 GeyserMC. http://geysermc.org
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/api/src/main/java/org/geysermc/geyser/api/block/custom/CustomBlockPermutation.java
+++ b/api/src/main/java/org/geysermc/geyser/api/block/custom/CustomBlockPermutation.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019-2022 GeyserMC. http://geysermc.org
+ * Copyright (c) 2019-2026 GeyserMC. http://geysermc.org
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/api/src/main/java/org/geysermc/geyser/api/block/custom/CustomBlockPermutation.java
+++ b/api/src/main/java/org/geysermc/geyser/api/block/custom/CustomBlockPermutation.java
@@ -25,7 +25,6 @@
 
 package org.geysermc.geyser.api.block.custom;
 
-import org.checkerframework.checker.nullness.qual.NonNull;
 import org.geysermc.geyser.api.block.custom.component.CustomBlockComponents;
 
 /**
@@ -35,5 +34,5 @@ import org.geysermc.geyser.api.block.custom.component.CustomBlockComponents;
  * @param components The components of the block
  * @param condition The Molang query that should return true or false
  */
-public record CustomBlockPermutation(@NonNull CustomBlockComponents components, @NonNull String condition) {
+public record CustomBlockPermutation(CustomBlockComponents components, String condition) {
 }

--- a/api/src/main/java/org/geysermc/geyser/api/block/custom/CustomBlockState.java
+++ b/api/src/main/java/org/geysermc/geyser/api/block/custom/CustomBlockState.java
@@ -25,7 +25,6 @@
 
 package org.geysermc.geyser.api.block.custom;
 
-
 import java.util.Map;
 
 /**

--- a/api/src/main/java/org/geysermc/geyser/api/block/custom/CustomBlockState.java
+++ b/api/src/main/java/org/geysermc/geyser/api/block/custom/CustomBlockState.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019-2022 GeyserMC. http://geysermc.org
+ * Copyright (c) 2019-2026 GeyserMC. http://geysermc.org
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/api/src/main/java/org/geysermc/geyser/api/block/custom/CustomBlockState.java
+++ b/api/src/main/java/org/geysermc/geyser/api/block/custom/CustomBlockState.java
@@ -25,7 +25,6 @@
 
 package org.geysermc.geyser.api.block.custom;
 
-import org.checkerframework.checker.nullness.qual.NonNull;
 
 import java.util.Map;
 
@@ -39,14 +38,14 @@ public interface CustomBlockState {
      *
      * @return The custom block data for the state.
      */
-    @NonNull CustomBlockData block();
+    CustomBlockData block();
 
     /**
      * Gets the name of the state
      *
      * @return The name of the state.
      */
-    @NonNull String name();
+    String name();
 
     /**
      * Gets the given property for the state
@@ -54,21 +53,21 @@ public interface CustomBlockState {
      * @param propertyName the property name
      * @return the boolean, int, or string property.
      */
-    @NonNull <T> T property(@NonNull String propertyName);
+    <T> T property(String propertyName);
 
     /**
      * Gets a map of the properties for the state
      *
      * @return The properties for the state.
      */
-    @NonNull Map<String, Object> properties();
+    Map<String, Object> properties();
 
     interface Builder {
-        Builder booleanProperty(@NonNull String propertyName, boolean value);
+        Builder booleanProperty(String propertyName, boolean value);
 
-        Builder intProperty(@NonNull String propertyName, int value);
+        Builder intProperty(String propertyName, int value);
 
-        Builder stringProperty(@NonNull String propertyName, @NonNull String value);
+        Builder stringProperty(String propertyName, String value);
 
         CustomBlockState build();
     }

--- a/api/src/main/java/org/geysermc/geyser/api/block/custom/NonVanillaCustomBlockData.java
+++ b/api/src/main/java/org/geysermc/geyser/api/block/custom/NonVanillaCustomBlockData.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019-2023 GeyserMC. http://geysermc.org
+ * Copyright (c) 2019-2026 GeyserMC. http://geysermc.org
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/api/src/main/java/org/geysermc/geyser/api/block/custom/NonVanillaCustomBlockData.java
+++ b/api/src/main/java/org/geysermc/geyser/api/block/custom/NonVanillaCustomBlockData.java
@@ -25,11 +25,10 @@
 
 package org.geysermc.geyser.api.block.custom;
 
-import org.checkerframework.checker.nullness.qual.NonNull;
-import org.checkerframework.checker.nullness.qual.Nullable;
 import org.geysermc.geyser.api.GeyserApi;
 import org.geysermc.geyser.api.block.custom.component.CustomBlockComponents;
 import org.geysermc.geyser.api.util.CreativeCategory;
+import org.jspecify.annotations.Nullable;
 
 import java.util.List;
 
@@ -42,7 +41,7 @@ public interface NonVanillaCustomBlockData extends CustomBlockData {
      *
      * @return The namespace of the custom block.
      */
-    @NonNull String namespace();
+    String namespace();
 
 
     /**
@@ -56,10 +55,10 @@ public interface NonVanillaCustomBlockData extends CustomBlockData {
 
     interface Builder extends CustomBlockData.Builder {
 
-        Builder namespace(@NonNull String namespace);
+        Builder namespace(String namespace);
 
         @Override
-        Builder name(@NonNull String name);
+        Builder name(String name);
 
         @Override
         Builder includedInCreativeInventory(boolean includedInCreativeInventory);
@@ -71,19 +70,19 @@ public interface NonVanillaCustomBlockData extends CustomBlockData {
         Builder creativeGroup(@Nullable String creativeGroup);
 
         @Override
-        Builder components(@NonNull CustomBlockComponents components);
+        Builder components(CustomBlockComponents components);
 
         @Override
-        Builder booleanProperty(@NonNull String propertyName);
+        Builder booleanProperty(String propertyName);
 
         @Override
-        Builder intProperty(@NonNull String propertyName, List<Integer> values);
+        Builder intProperty(String propertyName, List<Integer> values);
 
         @Override
-        Builder stringProperty(@NonNull String propertyName, List<String> values);
+        Builder stringProperty(String propertyName, List<String> values);
 
         @Override
-        Builder permutations(@NonNull List<CustomBlockPermutation> permutations);
+        Builder permutations(List<CustomBlockPermutation> permutations);
 
         @Override
         NonVanillaCustomBlockData build();

--- a/api/src/main/java/org/geysermc/geyser/api/block/custom/component/CustomBlockComponents.java
+++ b/api/src/main/java/org/geysermc/geyser/api/block/custom/component/CustomBlockComponents.java
@@ -25,10 +25,9 @@
 
 package org.geysermc.geyser.api.block.custom.component;
 
-import org.checkerframework.checker.nullness.qual.NonNull;
-import org.checkerframework.checker.nullness.qual.Nullable;
 import org.checkerframework.common.returnsreceiver.qual.This;
 import org.geysermc.geyser.api.GeyserApi;
+import org.jspecify.annotations.Nullable;
 
 import java.util.Collection;
 import java.util.List;
@@ -69,7 +68,7 @@ public interface CustomBlockComponents {
      * @return the collision boxes
      * @since 2.9.5
      */
-    @NonNull Set<BoxComponent> collisionBoxes();
+    Set<BoxComponent> collisionBoxes();
 
     /**
      * Gets the display name component.
@@ -96,7 +95,7 @@ public interface CustomBlockComponents {
      * @return the material instances
      * @since 2.2.0
      */
-    @NonNull Map<String, MaterialInstance> materialInstances();
+    Map<String, MaterialInstance> materialInstances();
 
     /**
      * Gets the placement filter component
@@ -179,7 +178,7 @@ public interface CustomBlockComponents {
      * @return the set of tags
      * @since 2.2.0
      */
-    @NonNull Set<String> tags();
+    Set<String> tags();
 
     /**
      * Create a Builder for CustomBlockComponents
@@ -263,7 +262,7 @@ public interface CustomBlockComponents {
          * @return this builder
          * @since 2.2.0
          */
-        @This Builder materialInstance(@NonNull String name, @NonNull MaterialInstance materialInstance);
+        @This Builder materialInstance(String name, MaterialInstance materialInstance);
 
         /**
          * Sets the placement filter of the block.

--- a/api/src/main/java/org/geysermc/geyser/api/block/custom/component/CustomBlockComponents.java
+++ b/api/src/main/java/org/geysermc/geyser/api/block/custom/component/CustomBlockComponents.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019-2022 GeyserMC. http://geysermc.org
+ * Copyright (c) 2019-2026 GeyserMC. http://geysermc.org
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/api/src/main/java/org/geysermc/geyser/api/block/custom/component/CustomBlockComponents.java
+++ b/api/src/main/java/org/geysermc/geyser/api/block/custom/component/CustomBlockComponents.java
@@ -221,7 +221,7 @@ public interface CustomBlockComponents {
          * @return this builder
          * @since 2.9.5
          */
-        @This Builder collisionBoxes(@Nullable BoxComponent... collisionBoxes);
+        @This Builder collisionBoxes(@Nullable BoxComponent @Nullable ... collisionBoxes);
 
         /**
          * Convenience method to set collision boxes for the block. Can be null to disable collisions.

--- a/api/src/main/java/org/geysermc/geyser/api/block/custom/component/GeometryComponent.java
+++ b/api/src/main/java/org/geysermc/geyser/api/block/custom/component/GeometryComponent.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019-2023 GeyserMC. http://geysermc.org
+ * Copyright (c) 2019-2026 GeyserMC. http://geysermc.org
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/api/src/main/java/org/geysermc/geyser/api/block/custom/component/GeometryComponent.java
+++ b/api/src/main/java/org/geysermc/geyser/api/block/custom/component/GeometryComponent.java
@@ -25,9 +25,8 @@
 
 package org.geysermc.geyser.api.block.custom.component;
 
-import org.checkerframework.checker.nullness.qual.NonNull;
-import org.checkerframework.checker.nullness.qual.Nullable;
 import org.geysermc.geyser.api.GeyserApi;
+import org.jspecify.annotations.Nullable;
 
 import java.util.Map;
 
@@ -41,7 +40,7 @@ public interface GeometryComponent {
      *
      * @return The identifier of the geometry.
      */
-    @NonNull String identifier();
+    String identifier();
 
     /**
      * Gets the bone visibility of the geometry
@@ -60,7 +59,7 @@ public interface GeometryComponent {
     }
 
     interface Builder {
-        Builder identifier(@NonNull String identifier);
+        Builder identifier(String identifier);
 
         Builder boneVisibility(@Nullable Map<String, String> boneVisibility);
 

--- a/api/src/main/java/org/geysermc/geyser/api/block/custom/component/MaterialInstance.java
+++ b/api/src/main/java/org/geysermc/geyser/api/block/custom/component/MaterialInstance.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019-2025 GeyserMC. http://geysermc.org
+ * Copyright (c) 2019-2026 GeyserMC. http://geysermc.org
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/api/src/main/java/org/geysermc/geyser/api/block/custom/component/MaterialInstance.java
+++ b/api/src/main/java/org/geysermc/geyser/api/block/custom/component/MaterialInstance.java
@@ -25,8 +25,8 @@
 
 package org.geysermc.geyser.api.block.custom.component;
 
-import org.checkerframework.checker.nullness.qual.Nullable;
 import org.geysermc.geyser.api.GeyserApi;
+import org.jspecify.annotations.Nullable;
 
 /**
  * This class is used to store data for a material instance.

--- a/api/src/main/java/org/geysermc/geyser/api/block/custom/component/PlacementConditions.java
+++ b/api/src/main/java/org/geysermc/geyser/api/block/custom/component/PlacementConditions.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019-2022 GeyserMC. http://geysermc.org
+ * Copyright (c) 2019-2026 GeyserMC. http://geysermc.org
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -21,7 +21,7 @@
  *
  * @author GeyserMC
  * @link https://github.com/GeyserMC/Geyser
-*/
+ */
 
 package org.geysermc.geyser.api.block.custom.component;
 

--- a/api/src/main/java/org/geysermc/geyser/api/block/custom/component/PlacementConditions.java
+++ b/api/src/main/java/org/geysermc/geyser/api/block/custom/component/PlacementConditions.java
@@ -25,7 +25,6 @@
 
 package org.geysermc.geyser.api.block.custom.component;
 
-import org.checkerframework.checker.nullness.qual.NonNull;
 
 import java.util.LinkedHashMap;
 import java.util.Set;
@@ -36,7 +35,7 @@ import java.util.Set;
  * @param allowedFaces The faces that the block can be placed on
  * @param blockFilters The block filters that control what blocks the block can be placed on
  */
-public record PlacementConditions(@NonNull Set<Face> allowedFaces, @NonNull LinkedHashMap<String, BlockFilterType> blockFilters) {
+public record PlacementConditions(Set<Face> allowedFaces, LinkedHashMap<String, BlockFilterType> blockFilters) {
     public enum Face {
         DOWN,
         UP,

--- a/api/src/main/java/org/geysermc/geyser/api/block/custom/component/PlacementConditions.java
+++ b/api/src/main/java/org/geysermc/geyser/api/block/custom/component/PlacementConditions.java
@@ -25,7 +25,6 @@
 
 package org.geysermc.geyser.api.block.custom.component;
 
-
 import java.util.LinkedHashMap;
 import java.util.Set;
 

--- a/api/src/main/java/org/geysermc/geyser/api/block/custom/component/package-info.java
+++ b/api/src/main/java/org/geysermc/geyser/api/block/custom/component/package-info.java
@@ -1,0 +1,29 @@
+/*
+ * Copyright (c) 2026 GeyserMC. http://geysermc.org
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ *
+ * @author GeyserMC
+ * @link https://github.com/GeyserMC/Geyser
+ */
+
+@NullMarked
+package org.geysermc.geyser.api.block.custom.component;
+
+import org.jspecify.annotations.NullMarked;

--- a/api/src/main/java/org/geysermc/geyser/api/block/custom/nonvanilla/JavaBlockState.java
+++ b/api/src/main/java/org/geysermc/geyser/api/block/custom/nonvanilla/JavaBlockState.java
@@ -1,3 +1,28 @@
+/*
+ * Copyright (c) 2023-2026 GeyserMC. http://geysermc.org
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ *
+ * @author GeyserMC
+ * @link https://github.com/GeyserMC/Geyser
+ */
+
 package org.geysermc.geyser.api.block.custom.nonvanilla;
 
 import org.checkerframework.checker.index.qual.NonNegative;

--- a/api/src/main/java/org/geysermc/geyser/api/block/custom/nonvanilla/JavaBlockState.java
+++ b/api/src/main/java/org/geysermc/geyser/api/block/custom/nonvanilla/JavaBlockState.java
@@ -1,9 +1,8 @@
 package org.geysermc.geyser.api.block.custom.nonvanilla;
 
 import org.checkerframework.checker.index.qual.NonNegative;
-import org.checkerframework.checker.nullness.qual.NonNull;
-import org.checkerframework.checker.nullness.qual.Nullable;
 import org.geysermc.geyser.api.GeyserApi;
+import org.jspecify.annotations.Nullable;
 
 public interface JavaBlockState {
     /**
@@ -11,7 +10,7 @@ public interface JavaBlockState {
      * 
      * @return the identifier of the block state
      */
-    @NonNull String identifier();
+    String identifier();
 
     /**
      * Gets the Java ID of the block state
@@ -46,7 +45,7 @@ public interface JavaBlockState {
      * 
      * @return the collision of the block state
      */
-    @NonNull JavaBoundingBox[] collision();
+    JavaBoundingBox[] collision();
 
     /**
      * Gets whether the block state can be broken with hand
@@ -57,7 +56,7 @@ public interface JavaBlockState {
 
     /**
      * Gets the pick item of the block state
-     * 
+     *
      * @return the pick item of the block state
      * @deprecated the pick item is sent by the Java server
      */
@@ -91,7 +90,7 @@ public interface JavaBlockState {
     }
 
     interface Builder {
-        Builder identifier(@NonNull String identifier);
+        Builder identifier(String identifier);
 
         Builder javaId(@NonNegative int javaId);
 
@@ -101,7 +100,7 @@ public interface JavaBlockState {
 
         Builder waterlogged(boolean waterlogged);
 
-        Builder collision(@NonNull JavaBoundingBox[] collision);
+        Builder collision(JavaBoundingBox[] collision);
 
         Builder canBreakWithHand(boolean canBreakWithHand);
 

--- a/api/src/main/java/org/geysermc/geyser/api/block/custom/nonvanilla/package-info.java
+++ b/api/src/main/java/org/geysermc/geyser/api/block/custom/nonvanilla/package-info.java
@@ -1,0 +1,29 @@
+/*
+ * Copyright (c) 2026 GeyserMC. http://geysermc.org
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ *
+ * @author GeyserMC
+ * @link https://github.com/GeyserMC/Geyser
+ */
+
+@NullMarked
+package org.geysermc.geyser.api.block.custom.nonvanilla;
+
+import org.jspecify.annotations.NullMarked;

--- a/api/src/main/java/org/geysermc/geyser/api/block/custom/package-info.java
+++ b/api/src/main/java/org/geysermc/geyser/api/block/custom/package-info.java
@@ -1,0 +1,29 @@
+/*
+ * Copyright (c) 2026 GeyserMC. http://geysermc.org
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ *
+ * @author GeyserMC
+ * @link https://github.com/GeyserMC/Geyser
+ */
+
+@NullMarked
+package org.geysermc.geyser.api.block.custom;
+
+import org.jspecify.annotations.NullMarked;

--- a/api/src/main/java/org/geysermc/geyser/api/block/custom/property/CustomBlockProperty.java
+++ b/api/src/main/java/org/geysermc/geyser/api/block/custom/property/CustomBlockProperty.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019-2022 GeyserMC. http://geysermc.org
+ * Copyright (c) 2019-2026 GeyserMC. http://geysermc.org
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/api/src/main/java/org/geysermc/geyser/api/block/custom/property/CustomBlockProperty.java
+++ b/api/src/main/java/org/geysermc/geyser/api/block/custom/property/CustomBlockProperty.java
@@ -25,7 +25,6 @@
 
 package org.geysermc.geyser.api.block.custom.property;
 
-import org.checkerframework.checker.nullness.qual.NonNull;
 
 import java.util.List;
 
@@ -38,19 +37,19 @@ public interface CustomBlockProperty<T> {
      *
      * @return The name of the property.
      */
-    @NonNull String name();
+    String name();
 
     /**
      * Gets the values of the property
      *
      * @return The values of the property.
      */
-    @NonNull List<T> values();
+    List<T> values();
 
     /**
      * Gets the type of the property
      *
      * @return The type of the property.
      */
-    @NonNull PropertyType type();
+    PropertyType type();
 }

--- a/api/src/main/java/org/geysermc/geyser/api/block/custom/property/CustomBlockProperty.java
+++ b/api/src/main/java/org/geysermc/geyser/api/block/custom/property/CustomBlockProperty.java
@@ -25,7 +25,6 @@
 
 package org.geysermc.geyser.api.block.custom.property;
 
-
 import java.util.List;
 
 /**

--- a/api/src/main/java/org/geysermc/geyser/api/block/custom/property/PropertyType.java
+++ b/api/src/main/java/org/geysermc/geyser/api/block/custom/property/PropertyType.java
@@ -25,7 +25,6 @@
 
 package org.geysermc.geyser.api.block.custom.property;
 
-import org.checkerframework.checker.nullness.qual.NonNull;
 
 /**
  * This class is used to define a custom block property's type.
@@ -40,7 +39,7 @@ public class PropertyType {
      *
      * @return The property type for a boolean.
      */
-    @NonNull public static PropertyType booleanProp() {
+    public static PropertyType booleanProp() {
         return BOOLEAN;
     }
 
@@ -49,7 +48,7 @@ public class PropertyType {
      *
      * @return The property type for an integer.
      */
-    @NonNull public static PropertyType integerProp() {
+    public static PropertyType integerProp() {
         return INTEGER;
     }
 
@@ -58,7 +57,7 @@ public class PropertyType {
      *
      * @return The property type for a string.
      */
-    @NonNull public static PropertyType stringProp() {
+    public static PropertyType stringProp() {
         return STRING;
     }
 
@@ -69,7 +68,7 @@ public class PropertyType {
      *
      * @return The class of the property type.
      */
-    @NonNull public Class<?> typeClass() {
+    public Class<?> typeClass() {
         return typeClass;
     }
 

--- a/api/src/main/java/org/geysermc/geyser/api/block/custom/property/PropertyType.java
+++ b/api/src/main/java/org/geysermc/geyser/api/block/custom/property/PropertyType.java
@@ -25,7 +25,6 @@
 
 package org.geysermc.geyser.api.block.custom.property;
 
-
 /**
  * This class is used to define a custom block property's type.
  */

--- a/api/src/main/java/org/geysermc/geyser/api/block/custom/property/PropertyType.java
+++ b/api/src/main/java/org/geysermc/geyser/api/block/custom/property/PropertyType.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019-2022 GeyserMC. http://geysermc.org
+ * Copyright (c) 2019-2026 GeyserMC. http://geysermc.org
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/api/src/main/java/org/geysermc/geyser/api/block/custom/property/package-info.java
+++ b/api/src/main/java/org/geysermc/geyser/api/block/custom/property/package-info.java
@@ -1,0 +1,29 @@
+/*
+ * Copyright (c) 2026 GeyserMC. http://geysermc.org
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ *
+ * @author GeyserMC
+ * @link https://github.com/GeyserMC/Geyser
+ */
+
+@NullMarked
+package org.geysermc.geyser.api.block.custom.property;
+
+import org.jspecify.annotations.NullMarked;

--- a/api/src/main/java/org/geysermc/geyser/api/command/Command.java
+++ b/api/src/main/java/org/geysermc/geyser/api/command/Command.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019-2022 GeyserMC. http://geysermc.org
+ * Copyright (c) 2019-2026 GeyserMC. http://geysermc.org
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/api/src/main/java/org/geysermc/geyser/api/command/Command.java
+++ b/api/src/main/java/org/geysermc/geyser/api/command/Command.java
@@ -25,7 +25,6 @@
 
 package org.geysermc.geyser.api.command;
 
-import org.checkerframework.checker.nullness.qual.NonNull;
 import org.geysermc.geyser.api.GeyserApi;
 import org.geysermc.geyser.api.connection.GeyserConnection;
 import org.geysermc.geyser.api.event.lifecycle.GeyserRegisterPermissionsEvent;
@@ -45,7 +44,6 @@ public interface Command {
      *
      * @return the command name
      */
-    @NonNull
     String name();
 
     /**
@@ -53,7 +51,6 @@ public interface Command {
      *
      * @return the command description
      */
-    @NonNull
     String description();
 
     /**
@@ -62,7 +59,6 @@ public interface Command {
      *
      * @return the permission node for this command if defined, otherwise an empty string
      */
-    @NonNull
     String permission();
 
     /**
@@ -70,7 +66,6 @@ public interface Command {
      *
      * @return the aliases for this command as an unmodifiable list
      */
-    @NonNull
     List<String> aliases();
 
     /**
@@ -107,7 +102,6 @@ public interface Command {
      * @deprecated this method will always return an empty immutable list
      */
     @Deprecated(forRemoval = true)
-    @NonNull
     default List<String> subCommands() {
         return Collections.emptyList();
     }
@@ -119,7 +113,7 @@ public interface Command {
      * @param <T> the source type
      * @return a new command builder used to construct commands
      */
-    static <T extends CommandSource> Command.Builder<T> builder(@NonNull Extension extension) {
+    static <T extends CommandSource> Command.Builder<T> builder(Extension extension) {
         return GeyserApi.api().provider(Builder.class, extension);
     }
 
@@ -136,7 +130,7 @@ public interface Command {
          * @param sourceType the source type
          * @return this builder
          */
-        Builder<T> source(@NonNull Class<? extends T> sourceType);
+        Builder<T> source(Class<? extends T> sourceType);
 
         /**
          * Sets the command name.
@@ -144,7 +138,7 @@ public interface Command {
          * @param name the command name
          * @return this builder
          */
-        Builder<T> name(@NonNull String name);
+        Builder<T> name(String name);
 
         /**
          * Sets the command description.
@@ -152,7 +146,7 @@ public interface Command {
          * @param description the command description
          * @return this builder
          */
-        Builder<T> description(@NonNull String description);
+        Builder<T> description(String description);
 
         /**
          * Sets the permission node required to run this command. <br>
@@ -162,7 +156,7 @@ public interface Command {
          * @param permission the permission node
          * @return this builder
          */
-        Builder<T> permission(@NonNull String permission);
+        Builder<T> permission(String permission);
 
         /**
          * Sets the permission node and its default value. The usage of the default value is platform dependant
@@ -177,7 +171,7 @@ public interface Command {
          * @deprecated this method is experimental and may be removed in the future
          */
         @Deprecated
-        Builder<T> permission(@NonNull String permission, @NonNull TriState defaultValue);
+        Builder<T> permission(String permission, TriState defaultValue);
 
         /**
          * Sets the aliases.
@@ -185,7 +179,7 @@ public interface Command {
          * @param aliases the aliases
          * @return this builder
          */
-        Builder<T> aliases(@NonNull List<String> aliases);
+        Builder<T> aliases(List<String> aliases);
 
         /**
          * Sets if this command is designed to be used only by server operators.
@@ -231,7 +225,7 @@ public interface Command {
          * @deprecated this method has no effect
          */
         @Deprecated(forRemoval = true)
-        default Builder<T> subCommands(@NonNull List<String> subCommands) {
+        default Builder<T> subCommands(List<String> subCommands) {
             return this;
         }
 
@@ -241,14 +235,13 @@ public interface Command {
          * @param executor the command executor
          * @return this builder
          */
-        Builder<T> executor(@NonNull CommandExecutor<T> executor);
+        Builder<T> executor(CommandExecutor<T> executor);
 
         /**
          * Builds the command.
          *
          * @return a new command from this builder
          */
-        @NonNull
         Command build();
     }
 }

--- a/api/src/main/java/org/geysermc/geyser/api/command/CommandExecutor.java
+++ b/api/src/main/java/org/geysermc/geyser/api/command/CommandExecutor.java
@@ -25,7 +25,6 @@
 
 package org.geysermc.geyser.api.command;
 
-import org.checkerframework.checker.nullness.qual.NonNull;
 
 /**
  * Handles executing a command.
@@ -41,5 +40,5 @@ public interface CommandExecutor<T extends CommandSource> {
      * @param command the command
      * @param args the arguments
      */
-    void execute(@NonNull T source, @NonNull Command command, @NonNull String[] args);
+    void execute(T source, Command command, String[] args);
 }

--- a/api/src/main/java/org/geysermc/geyser/api/command/CommandExecutor.java
+++ b/api/src/main/java/org/geysermc/geyser/api/command/CommandExecutor.java
@@ -25,7 +25,6 @@
 
 package org.geysermc.geyser.api.command;
 
-
 /**
  * Handles executing a command.
  *

--- a/api/src/main/java/org/geysermc/geyser/api/command/CommandExecutor.java
+++ b/api/src/main/java/org/geysermc/geyser/api/command/CommandExecutor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019-2022 GeyserMC. http://geysermc.org
+ * Copyright (c) 2019-2026 GeyserMC. http://geysermc.org
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/api/src/main/java/org/geysermc/geyser/api/command/CommandSource.java
+++ b/api/src/main/java/org/geysermc/geyser/api/command/CommandSource.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019-2022 GeyserMC. http://geysermc.org
+ * Copyright (c) 2019-2026 GeyserMC. http://geysermc.org
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/api/src/main/java/org/geysermc/geyser/api/command/CommandSource.java
+++ b/api/src/main/java/org/geysermc/geyser/api/command/CommandSource.java
@@ -25,9 +25,8 @@
 
 package org.geysermc.geyser.api.command;
 
-import org.checkerframework.checker.nullness.qual.NonNull;
-import org.checkerframework.checker.nullness.qual.Nullable;
 import org.geysermc.geyser.api.connection.GeyserConnection;
+import org.jspecify.annotations.Nullable;
 
 import java.util.UUID;
 
@@ -48,7 +47,7 @@ public interface CommandSource {
      *
      * @param message the message to send
      */
-    void sendMessage(@NonNull String message);
+    void sendMessage(String message);
 
     /**
      * Sends the given messages to the command source

--- a/api/src/main/java/org/geysermc/geyser/api/command/package-info.java
+++ b/api/src/main/java/org/geysermc/geyser/api/command/package-info.java
@@ -1,0 +1,29 @@
+/*
+ * Copyright (c) 2026 GeyserMC. http://geysermc.org
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ *
+ * @author GeyserMC
+ * @link https://github.com/GeyserMC/Geyser
+ */
+
+@NullMarked
+package org.geysermc.geyser.api.command;
+
+import org.jspecify.annotations.NullMarked;

--- a/api/src/main/java/org/geysermc/geyser/api/connection/GeyserConnection.java
+++ b/api/src/main/java/org/geysermc/geyser/api/connection/GeyserConnection.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019-2022 GeyserMC. http://geysermc.org
+ * Copyright (c) 2019-2026 GeyserMC. http://geysermc.org
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/api/src/main/java/org/geysermc/geyser/api/connection/GeyserConnection.java
+++ b/api/src/main/java/org/geysermc/geyser/api/connection/GeyserConnection.java
@@ -27,8 +27,6 @@ package org.geysermc.geyser.api.connection;
 
 import org.checkerframework.checker.index.qual.NonNegative;
 import org.checkerframework.checker.index.qual.Positive;
-import org.checkerframework.checker.nullness.qual.NonNull;
-import org.checkerframework.checker.nullness.qual.Nullable;
 import org.geysermc.api.connection.Connection;
 import org.geysermc.geyser.api.bedrock.camera.CameraData;
 import org.geysermc.geyser.api.bedrock.camera.CameraShake;
@@ -37,6 +35,7 @@ import org.geysermc.geyser.api.entity.EntityData;
 import org.geysermc.geyser.api.entity.type.GeyserEntity;
 import org.geysermc.geyser.api.entity.type.player.GeyserPlayerEntity;
 import org.geysermc.geyser.api.skin.SkinData;
+import org.jspecify.annotations.Nullable;
 
 import java.util.NoSuchElementException;
 import java.util.Set;
@@ -54,7 +53,7 @@ public interface GeyserConnection extends Connection, CommandSource {
      *
      * @return the CameraData for this connection.
      */
-    @NonNull CameraData camera();
+    CameraData camera();
 
     /**
      * Exposes the {@link EntityData} for this connection.
@@ -62,7 +61,7 @@ public interface GeyserConnection extends Connection, CommandSource {
      *
      * @return the EntityData for this connection.
      */
-    @NonNull EntityData entities();
+    EntityData entities();
 
     /**
      * Returns the current ping of the connection.
@@ -135,7 +134,6 @@ public interface GeyserConnection extends Connection, CommandSource {
      * @return the ip address or hostname string the player used to join 
      * @since 2.8.3
      */
-    @NonNull
     String joinAddress();
 
     /**
@@ -164,7 +162,7 @@ public interface GeyserConnection extends Connection, CommandSource {
      * @param skinData the skin data to apply
      * @since 2.8.3
      */
-    void sendSkin(@NonNull UUID player, @NonNull SkinData skinData);
+    void sendSkin(UUID player, SkinData skinData);
 
     /**
      * @param javaId the Java entity ID to look up.
@@ -172,7 +170,6 @@ public interface GeyserConnection extends Connection, CommandSource {
      * @deprecated Use {@link EntityData#entityByJavaId(int)} instead
      */
     @Deprecated
-    @NonNull
     CompletableFuture<@Nullable GeyserEntity> entityByJavaId(@NonNegative int javaId);
 
     /**
@@ -181,7 +178,7 @@ public interface GeyserConnection extends Connection, CommandSource {
      * @param emoter the player entity emoting.
      * @param emoteId the emote ID to send to this client.
      */
-    void showEmote(@NonNull GeyserPlayerEntity emoter, @NonNull String emoteId);
+    void showEmote(GeyserPlayerEntity emoter, String emoteId);
 
     /**
      * Shakes the client's camera.
@@ -198,7 +195,7 @@ public interface GeyserConnection extends Connection, CommandSource {
      * @deprecated Use {@link CameraData#shakeCamera(float, float, CameraShake)} instead.
      */
     @Deprecated
-    void shakeCamera(float intensity, float duration, @NonNull CameraShake type);
+    void shakeCamera(float intensity, float duration, CameraShake type);
 
     /**
      * Stops all camera shake of any type.
@@ -234,7 +231,6 @@ public interface GeyserConnection extends Connection, CommandSource {
      * @deprecated Use {@link CameraData#fogEffects()} instead.
      */
     @Deprecated
-    @NonNull
     Set<String> fogEffects();
 
     /**
@@ -243,7 +239,7 @@ public interface GeyserConnection extends Connection, CommandSource {
      * @return the {@link GeyserPlayerEntity} for this connection
      * @since 2.9.3
      */
-    @NonNull GeyserPlayerEntity playerEntity();
+    GeyserPlayerEntity playerEntity();
 
     /**
      * Requests an offhand swap from the Java server.
@@ -258,5 +254,5 @@ public interface GeyserConnection extends Connection, CommandSource {
      *
      * @since 2.9.4
      */
-    @NonNull String playFabId();
+    String playFabId();
 }

--- a/api/src/main/java/org/geysermc/geyser/api/connection/package-info.java
+++ b/api/src/main/java/org/geysermc/geyser/api/connection/package-info.java
@@ -1,0 +1,29 @@
+/*
+ * Copyright (c) 2026 GeyserMC. http://geysermc.org
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ *
+ * @author GeyserMC
+ * @link https://github.com/GeyserMC/Geyser
+ */
+
+@NullMarked
+package org.geysermc.geyser.api.connection;
+
+import org.jspecify.annotations.NullMarked;

--- a/api/src/main/java/org/geysermc/geyser/api/entity/EntityData.java
+++ b/api/src/main/java/org/geysermc/geyser/api/entity/EntityData.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019-2023 GeyserMC. http://geysermc.org
+ * Copyright (c) 2019-2026 GeyserMC. http://geysermc.org
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/api/src/main/java/org/geysermc/geyser/api/entity/EntityData.java
+++ b/api/src/main/java/org/geysermc/geyser/api/entity/EntityData.java
@@ -26,11 +26,10 @@
 package org.geysermc.geyser.api.entity;
 
 import org.checkerframework.checker.index.qual.NonNegative;
-import org.checkerframework.checker.nullness.qual.NonNull;
-import org.checkerframework.checker.nullness.qual.Nullable;
 import org.geysermc.geyser.api.connection.GeyserConnection;
 import org.geysermc.geyser.api.entity.type.GeyserEntity;
 import org.geysermc.geyser.api.entity.type.player.GeyserPlayerEntity;
+import org.jspecify.annotations.Nullable;
 
 import java.util.UUID;
 import java.util.concurrent.CompletableFuture;
@@ -47,7 +46,7 @@ public interface EntityData {
      * @param javaId the Java entity ID to look up
      * @return a {@link GeyserEntity} if present in this connection's entity tracker
      */
-    @NonNull CompletableFuture<@Nullable GeyserEntity> entityByJavaId(@NonNegative int javaId);
+    CompletableFuture<@Nullable GeyserEntity> entityByJavaId(@NonNegative int javaId);
 
     /**
      * (Un)locks the client's movement inputs, so that they cannot move.
@@ -58,7 +57,7 @@ public interface EntityData {
      * @param owner the owner of the lock
      * @return if the movement is locked after this method call
      */
-    boolean lockMovement(boolean lock, @NonNull UUID owner);
+    boolean lockMovement(boolean lock, UUID owner);
 
     /**
      * Returns whether the client's movement is currently locked.
@@ -77,11 +76,11 @@ public interface EntityData {
      * @deprecated Use {@link GeyserConnection#showEmote(GeyserPlayerEntity, String)} instead.
      */
     @Deprecated(since = "2.9.3")
-    void showEmote(@NonNull GeyserPlayerEntity emoter, @NonNull String emoteId);
+    void showEmote(GeyserPlayerEntity emoter, String emoteId);
 
     /**
      * @deprecated Use {@link GeyserConnection#playerEntity} instead.
      */
     @Deprecated(since = "2.9.3")
-    @NonNull GeyserPlayerEntity playerEntity();
+    GeyserPlayerEntity playerEntity();
 }

--- a/api/src/main/java/org/geysermc/geyser/api/entity/package-info.java
+++ b/api/src/main/java/org/geysermc/geyser/api/entity/package-info.java
@@ -1,0 +1,29 @@
+/*
+ * Copyright (c) 2026 GeyserMC. http://geysermc.org
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ *
+ * @author GeyserMC
+ * @link https://github.com/GeyserMC/Geyser
+ */
+
+@NullMarked
+package org.geysermc.geyser.api.entity;
+
+import org.jspecify.annotations.NullMarked;

--- a/api/src/main/java/org/geysermc/geyser/api/entity/property/BatchPropertyUpdater.java
+++ b/api/src/main/java/org/geysermc/geyser/api/entity/property/BatchPropertyUpdater.java
@@ -25,9 +25,8 @@
 
 package org.geysermc.geyser.api.entity.property;
 
-import org.checkerframework.checker.nullness.qual.NonNull;
-import org.checkerframework.checker.nullness.qual.Nullable;
 import org.geysermc.geyser.api.event.lifecycle.GeyserDefineEntityPropertiesEvent;
+import org.jspecify.annotations.Nullable;
 
 /**
  * Collects property changes to be applied as a single, batched update to an entity.
@@ -65,5 +64,5 @@ public interface BatchPropertyUpdater {
      *
      * @since 2.9.0
      */
-    <T> void update(@NonNull GeyserEntityProperty<T> property, @Nullable T value);
+    <T> void update(GeyserEntityProperty<T> property, @Nullable T value);
 }

--- a/api/src/main/java/org/geysermc/geyser/api/entity/property/BatchPropertyUpdater.java
+++ b/api/src/main/java/org/geysermc/geyser/api/entity/property/BatchPropertyUpdater.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2025 GeyserMC. http://geysermc.org
+ * Copyright (c) 2025-2026 GeyserMC. http://geysermc.org
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/api/src/main/java/org/geysermc/geyser/api/entity/property/GeyserEntityProperty.java
+++ b/api/src/main/java/org/geysermc/geyser/api/entity/property/GeyserEntityProperty.java
@@ -25,7 +25,6 @@
 
 package org.geysermc.geyser.api.entity.property;
 
-import org.checkerframework.checker.nullness.qual.NonNull;
 import org.geysermc.geyser.api.util.Identifier;
 
 /**
@@ -50,7 +49,6 @@ public interface GeyserEntityProperty<T> {
      * @return the property identifier
      * @since 2.9.0
      */
-    @NonNull
     Identifier identifier();
 
     /**
@@ -60,6 +58,5 @@ public interface GeyserEntityProperty<T> {
      * @return the default value of this property
      * @since 2.9.0
      */
-    @NonNull
     T defaultValue();
 }

--- a/api/src/main/java/org/geysermc/geyser/api/entity/property/GeyserEntityProperty.java
+++ b/api/src/main/java/org/geysermc/geyser/api/entity/property/GeyserEntityProperty.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2025 GeyserMC. http://geysermc.org
+ * Copyright (c) 2025-2026 GeyserMC. http://geysermc.org
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/api/src/main/java/org/geysermc/geyser/api/entity/property/package-info.java
+++ b/api/src/main/java/org/geysermc/geyser/api/entity/property/package-info.java
@@ -1,0 +1,29 @@
+/*
+ * Copyright (c) 2026 GeyserMC. http://geysermc.org
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ *
+ * @author GeyserMC
+ * @link https://github.com/GeyserMC/Geyser
+ */
+
+@NullMarked
+package org.geysermc.geyser.api.entity.property;
+
+import org.jspecify.annotations.NullMarked;

--- a/api/src/main/java/org/geysermc/geyser/api/entity/property/type/package-info.java
+++ b/api/src/main/java/org/geysermc/geyser/api/entity/property/type/package-info.java
@@ -1,0 +1,29 @@
+/*
+ * Copyright (c) 2026 GeyserMC. http://geysermc.org
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ *
+ * @author GeyserMC
+ * @link https://github.com/GeyserMC/Geyser
+ */
+
+@NullMarked
+package org.geysermc.geyser.api.entity.property.type;
+
+import org.jspecify.annotations.NullMarked;

--- a/api/src/main/java/org/geysermc/geyser/api/entity/type/GeyserEntity.java
+++ b/api/src/main/java/org/geysermc/geyser/api/entity/type/GeyserEntity.java
@@ -26,12 +26,11 @@
 package org.geysermc.geyser.api.entity.type;
 
 import org.checkerframework.checker.index.qual.NonNegative;
-import org.checkerframework.checker.nullness.qual.NonNull;
-import org.checkerframework.checker.nullness.qual.Nullable;
 import org.geysermc.geyser.api.connection.GeyserConnection;
 import org.geysermc.geyser.api.entity.property.BatchPropertyUpdater;
 import org.geysermc.geyser.api.entity.property.GeyserEntityProperty;
 import org.geysermc.geyser.api.event.lifecycle.GeyserDefineEntityPropertiesEvent;
+import org.jspecify.annotations.Nullable;
 
 import java.util.function.Consumer;
 
@@ -55,7 +54,7 @@ public interface GeyserEntity {
      * @param <T> the type of the value
      * @since 2.9.0
      */
-    default <T> void updateProperty(@NonNull GeyserEntityProperty<T> property, @Nullable T value) {
+    default <T> void updateProperty(GeyserEntityProperty<T> property, @Nullable T value) {
         this.updatePropertiesBatched(consumer -> consumer.update(property, value));
     }
 

--- a/api/src/main/java/org/geysermc/geyser/api/entity/type/GeyserEntity.java
+++ b/api/src/main/java/org/geysermc/geyser/api/entity/type/GeyserEntity.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019-2023 GeyserMC. http://geysermc.org
+ * Copyright (c) 2019-2026 GeyserMC. http://geysermc.org
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/api/src/main/java/org/geysermc/geyser/api/entity/type/package-info.java
+++ b/api/src/main/java/org/geysermc/geyser/api/entity/type/package-info.java
@@ -1,0 +1,29 @@
+/*
+ * Copyright (c) 2026 GeyserMC. http://geysermc.org
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ *
+ * @author GeyserMC
+ * @link https://github.com/GeyserMC/Geyser
+ */
+
+@NullMarked
+package org.geysermc.geyser.api.entity.type;
+
+import org.jspecify.annotations.NullMarked;

--- a/api/src/main/java/org/geysermc/geyser/api/entity/type/player/package-info.java
+++ b/api/src/main/java/org/geysermc/geyser/api/entity/type/player/package-info.java
@@ -1,0 +1,29 @@
+/*
+ * Copyright (c) 2026 GeyserMC. http://geysermc.org
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ *
+ * @author GeyserMC
+ * @link https://github.com/GeyserMC/Geyser
+ */
+
+@NullMarked
+package org.geysermc.geyser.api.entity.type.player;
+
+import org.jspecify.annotations.NullMarked;

--- a/api/src/main/java/org/geysermc/geyser/api/event/EventBus.java
+++ b/api/src/main/java/org/geysermc/geyser/api/event/EventBus.java
@@ -25,7 +25,6 @@
 
 package org.geysermc.geyser.api.event;
 
-import org.checkerframework.checker.nullness.qual.NonNull;
 import org.geysermc.event.Event;
 import org.geysermc.event.bus.OwnedEventBus;
 
@@ -37,6 +36,5 @@ import java.util.Set;
  */
 public interface EventBus<R extends EventRegistrar> extends OwnedEventBus<R, Event, EventSubscriber<R, ? extends Event>> {
     @Override
-    @NonNull
-    <T extends Event> Set<? extends EventSubscriber<R, T>> subscribers(@NonNull Class<T> eventClass);
+    <T extends Event> Set<? extends EventSubscriber<R, T>> subscribers(Class<T> eventClass);
 }

--- a/api/src/main/java/org/geysermc/geyser/api/event/EventBus.java
+++ b/api/src/main/java/org/geysermc/geyser/api/event/EventBus.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019-2022 GeyserMC. http://geysermc.org
+ * Copyright (c) 2019-2026 GeyserMC. http://geysermc.org
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/api/src/main/java/org/geysermc/geyser/api/event/EventRegistrar.java
+++ b/api/src/main/java/org/geysermc/geyser/api/event/EventRegistrar.java
@@ -25,7 +25,6 @@
 
 package org.geysermc.geyser.api.event;
 
-import org.checkerframework.checker.nullness.qual.NonNull;
 import org.geysermc.geyser.api.GeyserApi;
 
 /**
@@ -40,8 +39,7 @@ public interface EventRegistrar {
      * @param object the object to wrap around
      * @return an event registrar instance
      */
-    @NonNull
-    static EventRegistrar of(@NonNull Object object) {
+    static EventRegistrar of(Object object) {
         return GeyserApi.api().provider(EventRegistrar.class, object);
     }
 }

--- a/api/src/main/java/org/geysermc/geyser/api/event/EventRegistrar.java
+++ b/api/src/main/java/org/geysermc/geyser/api/event/EventRegistrar.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019-2022 GeyserMC. http://geysermc.org
+ * Copyright (c) 2019-2026 GeyserMC. http://geysermc.org
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/api/src/main/java/org/geysermc/geyser/api/event/ExtensionEventBus.java
+++ b/api/src/main/java/org/geysermc/geyser/api/event/ExtensionEventBus.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019-2022 GeyserMC. http://geysermc.org
+ * Copyright (c) 2019-2026 GeyserMC. http://geysermc.org
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/api/src/main/java/org/geysermc/geyser/api/event/ExtensionEventBus.java
+++ b/api/src/main/java/org/geysermc/geyser/api/event/ExtensionEventBus.java
@@ -25,7 +25,6 @@
 
 package org.geysermc.geyser.api.event;
 
-import org.checkerframework.checker.nullness.qual.NonNull;
 import org.geysermc.event.Event;
 import org.geysermc.geyser.api.extension.Extension;
 
@@ -37,5 +36,5 @@ import java.util.Set;
  */
 public interface ExtensionEventBus extends org.geysermc.event.bus.EventBus<Event, EventSubscriber<Extension, ? extends Event>> {
     @Override
-    @NonNull <T extends Event> Set<? extends EventSubscriber<EventRegistrar, T>> subscribers(@NonNull Class<T> eventClass);
+    <T extends Event> Set<? extends EventSubscriber<EventRegistrar, T>> subscribers(Class<T> eventClass);
 }

--- a/api/src/main/java/org/geysermc/geyser/api/event/bedrock/ClientEmoteEvent.java
+++ b/api/src/main/java/org/geysermc/geyser/api/event/bedrock/ClientEmoteEvent.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019-2022 GeyserMC. http://geysermc.org
+ * Copyright (c) 2019-2026 GeyserMC. http://geysermc.org
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/api/src/main/java/org/geysermc/geyser/api/event/bedrock/ClientEmoteEvent.java
+++ b/api/src/main/java/org/geysermc/geyser/api/event/bedrock/ClientEmoteEvent.java
@@ -25,7 +25,6 @@
 
 package org.geysermc.geyser.api.event.bedrock;
 
-import org.checkerframework.checker.nullness.qual.NonNull;
 import org.geysermc.event.Cancellable;
 import org.geysermc.geyser.api.connection.GeyserConnection;
 import org.geysermc.geyser.api.event.connection.ConnectionEvent;
@@ -37,7 +36,7 @@ public final class ClientEmoteEvent extends ConnectionEvent implements Cancellab
     private final String emoteId;
     private boolean cancelled;
 
-    public ClientEmoteEvent(@NonNull GeyserConnection connection, @NonNull String emoteId) {
+    public ClientEmoteEvent(GeyserConnection connection, String emoteId) {
         super(connection);
         this.emoteId = emoteId;
     }
@@ -45,7 +44,6 @@ public final class ClientEmoteEvent extends ConnectionEvent implements Cancellab
     /**
      * @return the emote ID that the Bedrock player is attempting to perform.
      */
-    @NonNull
     public String emoteId() {
         return emoteId;
     }

--- a/api/src/main/java/org/geysermc/geyser/api/event/bedrock/SessionAcceptCodeOfConductEvent.java
+++ b/api/src/main/java/org/geysermc/geyser/api/event/bedrock/SessionAcceptCodeOfConductEvent.java
@@ -25,7 +25,6 @@
 
 package org.geysermc.geyser.api.event.bedrock;
 
-import org.checkerframework.checker.nullness.qual.NonNull;
 import org.geysermc.geyser.api.connection.GeyserConnection;
 import org.geysermc.geyser.api.event.connection.ConnectionEvent;
 import org.geysermc.geyser.api.event.java.ServerCodeOfConductEvent;
@@ -44,7 +43,7 @@ public class SessionAcceptCodeOfConductEvent extends ConnectionEvent {
     private final String codeOfConduct;
     private boolean skipSaving = false;
 
-    public SessionAcceptCodeOfConductEvent(@NonNull GeyserConnection connection, String codeOfConduct) {
+    public SessionAcceptCodeOfConductEvent(GeyserConnection connection, String codeOfConduct) {
         super(connection);
         this.codeOfConduct = codeOfConduct;
     }

--- a/api/src/main/java/org/geysermc/geyser/api/event/bedrock/SessionAcceptCodeOfConductEvent.java
+++ b/api/src/main/java/org/geysermc/geyser/api/event/bedrock/SessionAcceptCodeOfConductEvent.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2025 GeyserMC. http://geysermc.org
+ * Copyright (c) 2025-2026 GeyserMC. http://geysermc.org
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/api/src/main/java/org/geysermc/geyser/api/event/bedrock/SessionDisconnectEvent.java
+++ b/api/src/main/java/org/geysermc/geyser/api/event/bedrock/SessionDisconnectEvent.java
@@ -25,7 +25,6 @@
 
 package org.geysermc.geyser.api.event.bedrock;
 
-import org.checkerframework.checker.nullness.qual.NonNull;
 import org.geysermc.geyser.api.connection.GeyserConnection;
 import org.geysermc.geyser.api.event.connection.ConnectionEvent;
 
@@ -35,7 +34,7 @@ import org.geysermc.geyser.api.event.connection.ConnectionEvent;
 public class SessionDisconnectEvent extends ConnectionEvent {
     private String disconnectReason;
 
-    public SessionDisconnectEvent(@NonNull GeyserConnection connection, @NonNull String reason) {
+    public SessionDisconnectEvent(GeyserConnection connection, String reason) {
         super(connection);
         this.disconnectReason = reason;
     }
@@ -45,7 +44,7 @@ public class SessionDisconnectEvent extends ConnectionEvent {
      *
      * @return the reason for the disconnect
      */
-    public @NonNull String disconnectReason() {
+    public String disconnectReason() {
         return disconnectReason;
     }
 
@@ -54,7 +53,7 @@ public class SessionDisconnectEvent extends ConnectionEvent {
      *
      * @param disconnectReason the reason for the disconnect
      */
-    public void disconnectReason(@NonNull String disconnectReason) {
+    public void disconnectReason(String disconnectReason) {
         this.disconnectReason = disconnectReason;
     }
 }

--- a/api/src/main/java/org/geysermc/geyser/api/event/bedrock/SessionDisconnectEvent.java
+++ b/api/src/main/java/org/geysermc/geyser/api/event/bedrock/SessionDisconnectEvent.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019-2023 GeyserMC. http://geysermc.org
+ * Copyright (c) 2019-2026 GeyserMC. http://geysermc.org
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/api/src/main/java/org/geysermc/geyser/api/event/bedrock/SessionInitializeEvent.java
+++ b/api/src/main/java/org/geysermc/geyser/api/event/bedrock/SessionInitializeEvent.java
@@ -25,7 +25,6 @@
 
 package org.geysermc.geyser.api.event.bedrock;
 
-import org.checkerframework.checker.nullness.qual.NonNull;
 import org.geysermc.geyser.api.connection.GeyserConnection;
 import org.geysermc.geyser.api.event.connection.ConnectionEvent;
 
@@ -33,7 +32,7 @@ import org.geysermc.geyser.api.event.connection.ConnectionEvent;
  * Called when Geyser initialises a session for a new bedrock client.
  */
 public final class SessionInitializeEvent extends ConnectionEvent {
-    public SessionInitializeEvent(@NonNull GeyserConnection connection) {
+    public SessionInitializeEvent(GeyserConnection connection) {
         super(connection);
     }
 }

--- a/api/src/main/java/org/geysermc/geyser/api/event/bedrock/SessionInitializeEvent.java
+++ b/api/src/main/java/org/geysermc/geyser/api/event/bedrock/SessionInitializeEvent.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019-2022 GeyserMC. http://geysermc.org
+ * Copyright (c) 2019-2026 GeyserMC. http://geysermc.org
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/api/src/main/java/org/geysermc/geyser/api/event/bedrock/SessionJoinEvent.java
+++ b/api/src/main/java/org/geysermc/geyser/api/event/bedrock/SessionJoinEvent.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019-2023 GeyserMC. http://geysermc.org
+ * Copyright (c) 2019-2026 GeyserMC. http://geysermc.org
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/api/src/main/java/org/geysermc/geyser/api/event/bedrock/SessionJoinEvent.java
+++ b/api/src/main/java/org/geysermc/geyser/api/event/bedrock/SessionJoinEvent.java
@@ -25,7 +25,6 @@
 
 package org.geysermc.geyser.api.event.bedrock;
 
-import org.checkerframework.checker.nullness.qual.NonNull;
 import org.geysermc.geyser.api.connection.GeyserConnection;
 import org.geysermc.geyser.api.event.connection.ConnectionEvent;
 
@@ -34,7 +33,7 @@ import org.geysermc.geyser.api.event.connection.ConnectionEvent;
  * @since 2.1.1
  */
 public final class SessionJoinEvent extends ConnectionEvent {
-    public SessionJoinEvent(@NonNull GeyserConnection connection) {
+    public SessionJoinEvent(GeyserConnection connection) {
         super(connection);
     }
 }

--- a/api/src/main/java/org/geysermc/geyser/api/event/bedrock/SessionLoadResourcePacksEvent.java
+++ b/api/src/main/java/org/geysermc/geyser/api/event/bedrock/SessionLoadResourcePacksEvent.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019-2023 GeyserMC. http://geysermc.org
+ * Copyright (c) 2019-2026 GeyserMC. http://geysermc.org
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/api/src/main/java/org/geysermc/geyser/api/event/bedrock/SessionLoadResourcePacksEvent.java
+++ b/api/src/main/java/org/geysermc/geyser/api/event/bedrock/SessionLoadResourcePacksEvent.java
@@ -25,13 +25,12 @@
 
 package org.geysermc.geyser.api.event.bedrock;
 
-import org.checkerframework.checker.nullness.qual.NonNull;
-import org.checkerframework.checker.nullness.qual.Nullable;
 import org.geysermc.geyser.api.connection.GeyserConnection;
 import org.geysermc.geyser.api.event.connection.ConnectionEvent;
 import org.geysermc.geyser.api.pack.ResourcePack;
 import org.geysermc.geyser.api.pack.exception.ResourcePackException;
 import org.geysermc.geyser.api.pack.option.ResourcePackOption;
+import org.jspecify.annotations.Nullable;
 
 import java.util.Collection;
 import java.util.List;
@@ -42,7 +41,7 @@ import java.util.UUID;
  * @since 2.1.1
  */
 public abstract class SessionLoadResourcePacksEvent extends ConnectionEvent {
-    public SessionLoadResourcePacksEvent(@NonNull GeyserConnection connection) {
+    public SessionLoadResourcePacksEvent(GeyserConnection connection) {
         super(connection);
     }
 
@@ -54,13 +53,13 @@ public abstract class SessionLoadResourcePacksEvent extends ConnectionEvent {
      * @return an unmodifiable list of {@link ResourcePack}'s
      * @since 2.1.1
      */
-    public abstract @NonNull List<ResourcePack> resourcePacks();
+    public abstract List<ResourcePack> resourcePacks();
 
     /**
      * @deprecated Use {{@link #register(ResourcePack, ResourcePackOption[])}} instead
      */
     @Deprecated
-    public abstract boolean register(@NonNull ResourcePack pack);
+    public abstract boolean register(ResourcePack pack);
 
     /**
      * Registers a {@link ResourcePack} to be sent to the client, optionally alongside
@@ -71,7 +70,7 @@ public abstract class SessionLoadResourcePacksEvent extends ConnectionEvent {
      * @throws ResourcePackException if an issue occurred during pack registration
      * @since 2.6.2
      */
-    public abstract void register(@NonNull ResourcePack pack, @Nullable ResourcePackOption<?>... options);
+    public abstract void register(ResourcePack pack, @Nullable ResourcePackOption<?>... options);
 
     /**
      * Sets {@link ResourcePackOption}'s for a {@link ResourcePack}.
@@ -83,7 +82,7 @@ public abstract class SessionLoadResourcePacksEvent extends ConnectionEvent {
      * @throws ResourcePackException if an issue occurred during {@link ResourcePackOption} registration
      * @since 2.6.2
      */
-    public abstract void registerOptions(@NonNull UUID uuid, @NonNull ResourcePackOption<?>... options);
+    public abstract void registerOptions(UUID uuid, ResourcePackOption<?>... options);
 
     /**
      * Returns a collection of {@link ResourcePackOption}'s for a registered {@link ResourcePack}.
@@ -94,7 +93,7 @@ public abstract class SessionLoadResourcePacksEvent extends ConnectionEvent {
      * @throws ResourcePackException if the pack was not registered
      * @since 2.6.2
      */
-    public abstract Collection<ResourcePackOption<?>> options(@NonNull UUID uuid);
+    public abstract Collection<ResourcePackOption<?>> options(UUID uuid);
 
     /**
      * Returns the current {@link ResourcePackOption}, or null, for a given {@link ResourcePackOption.Type}.
@@ -104,7 +103,7 @@ public abstract class SessionLoadResourcePacksEvent extends ConnectionEvent {
      * @throws ResourcePackException if the queried option is invalid or not present on the resource pack
      * @since 2.6.2
      */
-    public abstract @Nullable ResourcePackOption<?> option(@NonNull UUID uuid, ResourcePackOption.@NonNull Type type);
+    public abstract @Nullable ResourcePackOption<?> option(UUID uuid, ResourcePackOption.Type type);
 
     /**
      * Unregisters a {@link ResourcePack} from the list of packs sent to this {@link GeyserConnection}.
@@ -112,7 +111,7 @@ public abstract class SessionLoadResourcePacksEvent extends ConnectionEvent {
      * @param uuid the UUID of the {@link ResourcePack} to be removed
      * @since 2.1.1
      */
-    public abstract boolean unregister(@NonNull UUID uuid);
+    public abstract boolean unregister(UUID uuid);
 
     /**
      * Whether to forcefully disable vibrant visuals for joining clients.

--- a/api/src/main/java/org/geysermc/geyser/api/event/bedrock/SessionLoginEvent.java
+++ b/api/src/main/java/org/geysermc/geyser/api/event/bedrock/SessionLoginEvent.java
@@ -25,13 +25,12 @@
 
 package org.geysermc.geyser.api.event.bedrock;
 
-import org.checkerframework.checker.nullness.qual.NonNull;
-import org.checkerframework.checker.nullness.qual.Nullable;
 import org.geysermc.event.Cancellable;
 import org.geysermc.geyser.api.connection.GeyserConnection;
 import org.geysermc.geyser.api.event.connection.ConnectionEvent;
 import org.geysermc.geyser.api.network.RemoteServer;
 import org.geysermc.geyser.api.util.PlatformType;
+import org.jspecify.annotations.Nullable;
 
 import java.util.Map;
 import java.util.Objects;
@@ -47,9 +46,9 @@ public final class SessionLoginEvent extends ConnectionEvent implements Cancella
     private Map<String, byte[]> cookies;
     private boolean transferring;
 
-    public SessionLoginEvent(@NonNull GeyserConnection connection,
-                             @NonNull RemoteServer remoteServer,
-                             @NonNull Map<String, byte[]> cookies) {
+    public SessionLoginEvent(GeyserConnection connection,
+                             RemoteServer remoteServer,
+                             Map<String, byte[]> cookies) {
         super(connection);
         this.remoteServer = remoteServer;
         this.cookies = cookies;
@@ -85,7 +84,7 @@ public final class SessionLoginEvent extends ConnectionEvent implements Cancella
      * @param cancelled If the login event should be cancelled.
      * @param disconnectReason The reason for the cancellation.
      */
-    public void setCancelled(boolean cancelled, @NonNull String disconnectReason) {
+    public void setCancelled(boolean cancelled, String disconnectReason) {
         this.cancelled = cancelled;
         this.disconnectReason = disconnectReason;
     }
@@ -104,7 +103,7 @@ public final class SessionLoginEvent extends ConnectionEvent implements Cancella
      *
      * @return the {@link RemoteServer} the session will attempt to connect to.
      */
-    public @NonNull RemoteServer remoteServer() {
+    public RemoteServer remoteServer() {
         return this.remoteServer;
     }
 
@@ -115,7 +114,7 @@ public final class SessionLoginEvent extends ConnectionEvent implements Cancella
      *
      * @param remoteServer Sets the {@link RemoteServer} to connect to.
      */
-    public void remoteServer(@NonNull RemoteServer remoteServer) {
+    public void remoteServer(RemoteServer remoteServer) {
         this.remoteServer = remoteServer;
     }
 
@@ -123,7 +122,7 @@ public final class SessionLoginEvent extends ConnectionEvent implements Cancella
      * Sets a map of cookies from a possible previous session. The Java server can send and request these
      * to store information on the client across server transfers.
      */
-    public void cookies(@NonNull Map<String, byte[]> cookies) {
+    public void cookies(Map<String, byte[]> cookies) {
         Objects.requireNonNull(cookies);
         this.cookies = cookies;
     }
@@ -132,7 +131,7 @@ public final class SessionLoginEvent extends ConnectionEvent implements Cancella
      * Gets a map of the sessions cookies, if set.
      * @return the connections cookies
      */
-    public @NonNull Map<String, byte[]> cookies() {
+    public Map<String, byte[]> cookies() {
         return cookies;
     }
 

--- a/api/src/main/java/org/geysermc/geyser/api/event/bedrock/SessionLoginEvent.java
+++ b/api/src/main/java/org/geysermc/geyser/api/event/bedrock/SessionLoginEvent.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019-2023 GeyserMC. http://geysermc.org
+ * Copyright (c) 2019-2026 GeyserMC. http://geysermc.org
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/api/src/main/java/org/geysermc/geyser/api/event/bedrock/SessionLoginEvent.java
+++ b/api/src/main/java/org/geysermc/geyser/api/event/bedrock/SessionLoginEvent.java
@@ -42,7 +42,7 @@ import java.util.Objects;
 public final class SessionLoginEvent extends ConnectionEvent implements Cancellable {
     private RemoteServer remoteServer;
     private boolean cancelled;
-    private String disconnectReason;
+    private @Nullable String disconnectReason;
     private Map<String, byte[]> cookies;
     private boolean transferring;
 

--- a/api/src/main/java/org/geysermc/geyser/api/event/bedrock/SessionSkinApplyEvent.java
+++ b/api/src/main/java/org/geysermc/geyser/api/event/bedrock/SessionSkinApplyEvent.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019-2024 GeyserMC. http://geysermc.org
+ * Copyright (c) 2019-2026 GeyserMC. http://geysermc.org
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/api/src/main/java/org/geysermc/geyser/api/event/bedrock/SessionSkinApplyEvent.java
+++ b/api/src/main/java/org/geysermc/geyser/api/event/bedrock/SessionSkinApplyEvent.java
@@ -25,7 +25,6 @@
 
 package org.geysermc.geyser.api.event.bedrock;
 
-import org.checkerframework.checker.nullness.qual.NonNull;
 import org.geysermc.geyser.api.connection.GeyserConnection;
 import org.geysermc.geyser.api.event.connection.ConnectionEvent;
 import org.geysermc.geyser.api.skin.Cape;
@@ -48,7 +47,7 @@ public abstract class SessionSkinApplyEvent extends ConnectionEvent {
     private final boolean bedrock;
     private final SkinData originalSkinData;
 
-    public SessionSkinApplyEvent(@NonNull GeyserConnection connection, String username, UUID uuid, boolean slim, boolean bedrock, SkinData skinData) {
+    public SessionSkinApplyEvent(GeyserConnection connection, String username, UUID uuid, boolean slim, boolean bedrock, SkinData skinData) {
         super(connection);
         this.username = username;
         this.uuid = uuid;
@@ -62,7 +61,7 @@ public abstract class SessionSkinApplyEvent extends ConnectionEvent {
      *
      * @return the username of the player
      */
-    public @NonNull String username() {
+    public String username() {
         return username;
     }
 
@@ -71,7 +70,7 @@ public abstract class SessionSkinApplyEvent extends ConnectionEvent {
      *
      * @return the UUID of the player
      */
-    public @NonNull UUID uuid() {
+    public UUID uuid() {
         return uuid;
     }
 
@@ -98,7 +97,7 @@ public abstract class SessionSkinApplyEvent extends ConnectionEvent {
      *
      * @return the original skin data of the player
      */
-    public @NonNull SkinData originalSkin() {
+    public SkinData originalSkin() {
         return originalSkinData;
     }
 
@@ -107,28 +106,28 @@ public abstract class SessionSkinApplyEvent extends ConnectionEvent {
      *
      * @return the current skin data of the player
      */
-    public abstract @NonNull SkinData skinData();
+    public abstract SkinData skinData();
 
     /**
      * Change the skin of the player.
      *
      * @param newSkin the new skin
      */
-    public abstract void skin(@NonNull Skin newSkin);
+    public abstract void skin(Skin newSkin);
 
     /**
      * Change the cape of the player.
      *
      * @param newCape the new cape
      */
-    public abstract void cape(@NonNull Cape newCape);
+    public abstract void cape(Cape newCape);
 
     /**
      * Change the geometry of the player.
      *
      * @param newGeometry the new geometry
      */
-    public abstract void geometry(@NonNull SkinGeometry newGeometry);
+    public abstract void geometry(SkinGeometry newGeometry);
 
     /**
      * Change the geometry of the player.
@@ -138,7 +137,7 @@ public abstract class SessionSkinApplyEvent extends ConnectionEvent {
      * @param geometryName the name of the geometry
      * @param geometryData the data of the geometry
      */
-    public void geometry(@NonNull String geometryName, @NonNull String geometryData) {
+    public void geometry(String geometryName, String geometryData) {
         geometry(new SkinGeometry("{\"geometry\" :{\"default\" :\"" + geometryName + "\"}}", geometryData));
     }
 }

--- a/api/src/main/java/org/geysermc/geyser/api/event/bedrock/package-info.java
+++ b/api/src/main/java/org/geysermc/geyser/api/event/bedrock/package-info.java
@@ -1,0 +1,29 @@
+/*
+ * Copyright (c) 2026 GeyserMC. http://geysermc.org
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ *
+ * @author GeyserMC
+ * @link https://github.com/GeyserMC/Geyser
+ */
+
+@NullMarked
+package org.geysermc.geyser.api.event.bedrock;
+
+import org.jspecify.annotations.NullMarked;

--- a/api/src/main/java/org/geysermc/geyser/api/event/connection/ConnectionEvent.java
+++ b/api/src/main/java/org/geysermc/geyser/api/event/connection/ConnectionEvent.java
@@ -25,7 +25,6 @@
 
 package org.geysermc.geyser.api.event.connection;
 
-import org.checkerframework.checker.nullness.qual.NonNull;
 import org.geysermc.event.Event;
 import org.geysermc.geyser.api.connection.GeyserConnection;
 
@@ -35,7 +34,7 @@ import org.geysermc.geyser.api.connection.GeyserConnection;
 public abstract class ConnectionEvent implements Event {
     private final GeyserConnection connection;
 
-    public ConnectionEvent(@NonNull GeyserConnection connection) {
+    public ConnectionEvent(GeyserConnection connection) {
         this.connection = connection;
     }
 
@@ -44,7 +43,6 @@ public abstract class ConnectionEvent implements Event {
      *
      * @return the connection
      */
-    @NonNull
     public GeyserConnection connection() {
         return this.connection;
     }

--- a/api/src/main/java/org/geysermc/geyser/api/event/connection/ConnectionEvent.java
+++ b/api/src/main/java/org/geysermc/geyser/api/event/connection/ConnectionEvent.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019-2022 GeyserMC. http://geysermc.org
+ * Copyright (c) 2019-2026 GeyserMC. http://geysermc.org
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/api/src/main/java/org/geysermc/geyser/api/event/connection/ConnectionRequestEvent.java
+++ b/api/src/main/java/org/geysermc/geyser/api/event/connection/ConnectionRequestEvent.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019-2024 GeyserMC. http://geysermc.org
+ * Copyright (c) 2019-2026 GeyserMC. http://geysermc.org
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/api/src/main/java/org/geysermc/geyser/api/event/connection/ConnectionRequestEvent.java
+++ b/api/src/main/java/org/geysermc/geyser/api/event/connection/ConnectionRequestEvent.java
@@ -38,7 +38,7 @@ public final class ConnectionRequestEvent implements Event, Cancellable {
 
     private boolean cancelled;
     private final InetSocketAddress ip;
-    private final InetSocketAddress proxyIp;
+    private final @Nullable InetSocketAddress proxyIp;
 
     public ConnectionRequestEvent(InetSocketAddress ip, @Nullable InetSocketAddress proxyIp) {
         this.ip = ip;

--- a/api/src/main/java/org/geysermc/geyser/api/event/connection/ConnectionRequestEvent.java
+++ b/api/src/main/java/org/geysermc/geyser/api/event/connection/ConnectionRequestEvent.java
@@ -25,10 +25,9 @@
 
 package org.geysermc.geyser.api.event.connection;
 
-import org.checkerframework.checker.nullness.qual.NonNull;
-import org.checkerframework.checker.nullness.qual.Nullable;
 import org.geysermc.event.Cancellable;
 import org.geysermc.event.Event;
+import org.jspecify.annotations.Nullable;
 
 import java.net.InetSocketAddress;
 
@@ -41,7 +40,7 @@ public final class ConnectionRequestEvent implements Event, Cancellable {
     private final InetSocketAddress ip;
     private final InetSocketAddress proxyIp;
 
-    public ConnectionRequestEvent(@NonNull InetSocketAddress ip, @Nullable InetSocketAddress proxyIp) {
+    public ConnectionRequestEvent(InetSocketAddress ip, @Nullable InetSocketAddress proxyIp) {
         this.ip = ip;
         this.proxyIp = proxyIp;
     }
@@ -52,7 +51,7 @@ public final class ConnectionRequestEvent implements Event, Cancellable {
      * @return the IP address of the client attempting to connect
      * @deprecated Use {@link #inetSocketAddress()} instead
      */
-    @NonNull @Deprecated(forRemoval = true)
+    @Deprecated(forRemoval = true)
     public InetSocketAddress getInetSocketAddress() {
         return ip;
     }
@@ -63,8 +62,8 @@ public final class ConnectionRequestEvent implements Event, Cancellable {
      * @return the IP address of the proxy handling the connection
      * @deprecated Use {@link #proxyIp()} instead
      */
-    @Nullable @Deprecated(forRemoval = true)
-    public InetSocketAddress getProxyIp() {
+    @Deprecated(forRemoval = true)
+    public @Nullable InetSocketAddress getProxyIp() {
         return proxyIp;
     }
 
@@ -73,7 +72,6 @@ public final class ConnectionRequestEvent implements Event, Cancellable {
      *
      * @return the IP address of the client attempting to connect
      */
-    @NonNull
     public InetSocketAddress inetSocketAddress() {
         return ip;
     }
@@ -83,8 +81,7 @@ public final class ConnectionRequestEvent implements Event, Cancellable {
      *
      * @return the IP address of the proxy handling the connection
      */
-    @Nullable
-    public InetSocketAddress proxyIp() {
+    public @Nullable InetSocketAddress proxyIp() {
         return proxyIp;
     }
 

--- a/api/src/main/java/org/geysermc/geyser/api/event/connection/GeyserBedrockPingEvent.java
+++ b/api/src/main/java/org/geysermc/geyser/api/event/connection/GeyserBedrockPingEvent.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019-2023 GeyserMC. http://geysermc.org
+ * Copyright (c) 2019-2026 GeyserMC. http://geysermc.org
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/api/src/main/java/org/geysermc/geyser/api/event/connection/GeyserBedrockPingEvent.java
+++ b/api/src/main/java/org/geysermc/geyser/api/event/connection/GeyserBedrockPingEvent.java
@@ -26,9 +26,8 @@
 package org.geysermc.geyser.api.event.connection;
 
 import org.checkerframework.checker.index.qual.NonNegative;
-import org.checkerframework.checker.nullness.qual.NonNull;
-import org.checkerframework.checker.nullness.qual.Nullable;
 import org.geysermc.event.Event;
+import org.jspecify.annotations.Nullable;
 
 import java.net.InetSocketAddress;
 
@@ -45,7 +44,7 @@ public interface GeyserBedrockPingEvent extends Event {
      *
      * @param primary the string to set as the primary motd
      */
-    void primaryMotd(@NonNull String primary);
+    void primaryMotd(String primary);
 
     /**
      * Sets the given string as the secondary motd, the given string cannot be null.
@@ -53,7 +52,7 @@ public interface GeyserBedrockPingEvent extends Event {
      *
      * @param secondary the string to set as the secondary motd
      */
-    void secondaryMotd(@NonNull String secondary);
+    void secondaryMotd(String secondary);
 
     /**
      * Sets how many players are currently online, the given number cannot be below 0.
@@ -74,16 +73,14 @@ public interface GeyserBedrockPingEvent extends Event {
      *
      * @return the primary motd string
      */
-    @Nullable
-    String primaryMotd();
+    @Nullable String primaryMotd();
 
     /**
      * Gets the secondary motd.
      *
      * @return the secondary motd string
      */
-    @Nullable
-    String secondaryMotd();
+    @Nullable String secondaryMotd();
 
     /**
      * Gets the current number of players.
@@ -105,6 +102,5 @@ public interface GeyserBedrockPingEvent extends Event {
      *
      * @return a {@link InetSocketAddress}
      */
-    @NonNull
     InetSocketAddress address();
 }

--- a/api/src/main/java/org/geysermc/geyser/api/event/connection/package-info.java
+++ b/api/src/main/java/org/geysermc/geyser/api/event/connection/package-info.java
@@ -1,0 +1,29 @@
+/*
+ * Copyright (c) 2026 GeyserMC. http://geysermc.org
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ *
+ * @author GeyserMC
+ * @link https://github.com/GeyserMC/Geyser
+ */
+
+@NullMarked
+package org.geysermc.geyser.api.event.connection;
+
+import org.jspecify.annotations.NullMarked;

--- a/api/src/main/java/org/geysermc/geyser/api/event/downstream/ServerDefineCommandsEvent.java
+++ b/api/src/main/java/org/geysermc/geyser/api/event/downstream/ServerDefineCommandsEvent.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019-2022 GeyserMC. http://geysermc.org
+ * Copyright (c) 2019-2026 GeyserMC. http://geysermc.org
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/api/src/main/java/org/geysermc/geyser/api/event/downstream/ServerDefineCommandsEvent.java
+++ b/api/src/main/java/org/geysermc/geyser/api/event/downstream/ServerDefineCommandsEvent.java
@@ -25,7 +25,6 @@
 
 package org.geysermc.geyser.api.event.downstream;
 
-import org.checkerframework.checker.nullness.qual.NonNull;
 import org.geysermc.event.Cancellable;
 import org.geysermc.geyser.api.connection.GeyserConnection;
 import org.geysermc.geyser.api.event.connection.ConnectionEvent;
@@ -41,7 +40,7 @@ public class ServerDefineCommandsEvent extends ConnectionEvent implements Cancel
     private final Set<? extends CommandInfo> commands;
     private boolean cancelled;
 
-    public ServerDefineCommandsEvent(@NonNull GeyserConnection connection, @NonNull Set<? extends CommandInfo> commands) {
+    public ServerDefineCommandsEvent(GeyserConnection connection, Set<? extends CommandInfo> commands) {
         super(connection);
         this.commands = commands;
     }
@@ -52,7 +51,6 @@ public class ServerDefineCommandsEvent extends ConnectionEvent implements Cancel
      *
      * @return a collection of the commands sent over
      */
-    @NonNull
     public Set<? extends CommandInfo> commands() {
         return this.commands;
     }

--- a/api/src/main/java/org/geysermc/geyser/api/event/downstream/package-info.java
+++ b/api/src/main/java/org/geysermc/geyser/api/event/downstream/package-info.java
@@ -1,0 +1,29 @@
+/*
+ * Copyright (c) 2026 GeyserMC. http://geysermc.org
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ *
+ * @author GeyserMC
+ * @link https://github.com/GeyserMC/Geyser
+ */
+
+@NullMarked
+package org.geysermc.geyser.api.event.downstream;
+
+import org.jspecify.annotations.NullMarked;

--- a/api/src/main/java/org/geysermc/geyser/api/event/java/ServerCodeOfConductEvent.java
+++ b/api/src/main/java/org/geysermc/geyser/api/event/java/ServerCodeOfConductEvent.java
@@ -25,7 +25,6 @@
 
 package org.geysermc.geyser.api.event.java;
 
-import org.checkerframework.checker.nullness.qual.NonNull;
 import org.geysermc.geyser.api.connection.GeyserConnection;
 import org.geysermc.geyser.api.event.bedrock.SessionAcceptCodeOfConductEvent;
 import org.geysermc.geyser.api.event.connection.ConnectionEvent;
@@ -45,7 +44,7 @@ public final class ServerCodeOfConductEvent extends ConnectionEvent {
     private final String codeOfConduct;
     private boolean hasAccepted = false;
     
-    public ServerCodeOfConductEvent(@NonNull GeyserConnection connection, String codeOfConduct) {
+    public ServerCodeOfConductEvent(GeyserConnection connection, String codeOfConduct) {
         super(connection);
         this.codeOfConduct = codeOfConduct;
     }

--- a/api/src/main/java/org/geysermc/geyser/api/event/java/ServerCodeOfConductEvent.java
+++ b/api/src/main/java/org/geysermc/geyser/api/event/java/ServerCodeOfConductEvent.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2025 GeyserMC. http://geysermc.org
+ * Copyright (c) 2025-2026 GeyserMC. http://geysermc.org
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/api/src/main/java/org/geysermc/geyser/api/event/java/ServerDefineCommandsEvent.java
+++ b/api/src/main/java/org/geysermc/geyser/api/event/java/ServerDefineCommandsEvent.java
@@ -25,7 +25,6 @@
 
 package org.geysermc.geyser.api.event.java;
 
-import org.checkerframework.checker.nullness.qual.NonNull;
 import org.geysermc.event.Cancellable;
 import org.geysermc.geyser.api.connection.GeyserConnection;
 import org.geysermc.geyser.api.event.connection.ConnectionEvent;
@@ -41,7 +40,7 @@ public final class ServerDefineCommandsEvent extends ConnectionEvent implements 
     private final Set<? extends CommandInfo> commands;
     private boolean cancelled;
 
-    public ServerDefineCommandsEvent(@NonNull GeyserConnection connection, @NonNull Set<? extends CommandInfo> commands) {
+    public ServerDefineCommandsEvent(GeyserConnection connection, Set<? extends CommandInfo> commands) {
         super(connection);
         this.commands = commands;
     }
@@ -52,7 +51,6 @@ public final class ServerDefineCommandsEvent extends ConnectionEvent implements 
      *
      * @return a collection of the commands sent over
      */
-    @NonNull
     public Set<? extends CommandInfo> commands() {
         return this.commands;
     }

--- a/api/src/main/java/org/geysermc/geyser/api/event/java/ServerDefineCommandsEvent.java
+++ b/api/src/main/java/org/geysermc/geyser/api/event/java/ServerDefineCommandsEvent.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019-2023 GeyserMC. http://geysermc.org
+ * Copyright (c) 2019-2026 GeyserMC. http://geysermc.org
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/api/src/main/java/org/geysermc/geyser/api/event/java/ServerTransferEvent.java
+++ b/api/src/main/java/org/geysermc/geyser/api/event/java/ServerTransferEvent.java
@@ -40,7 +40,7 @@ public final class ServerTransferEvent extends ConnectionEvent {
 
     private final String host;
     private final int port;
-    private String bedrockHost;
+    private @Nullable String bedrockHost;
     private int bedrockPort;
     private final Map<String, byte[]> cookies;
 
@@ -95,7 +95,7 @@ public final class ServerTransferEvent extends ConnectionEvent {
     /**
      * Sets the host for the Bedrock player to be transferred to
      */
-    public void bedrockHost(String host) {
+    public void bedrockHost(@Nullable String host) {
         if (host == null || host.isBlank()) {
             throw new IllegalArgumentException("Server address cannot be null or blank");
         }

--- a/api/src/main/java/org/geysermc/geyser/api/event/java/ServerTransferEvent.java
+++ b/api/src/main/java/org/geysermc/geyser/api/event/java/ServerTransferEvent.java
@@ -25,11 +25,10 @@
 
 package org.geysermc.geyser.api.event.java;
 
-import org.checkerframework.checker.nullness.qual.NonNull;
-import org.checkerframework.checker.nullness.qual.Nullable;
 import org.checkerframework.common.value.qual.IntRange;
 import org.geysermc.geyser.api.connection.GeyserConnection;
 import org.geysermc.geyser.api.event.connection.ConnectionEvent;
+import org.jspecify.annotations.Nullable;
 
 import java.util.Map;
 
@@ -45,8 +44,8 @@ public final class ServerTransferEvent extends ConnectionEvent {
     private int bedrockPort;
     private final Map<String, byte[]> cookies;
 
-    public ServerTransferEvent(@NonNull GeyserConnection connection,
-                               @NonNull String host, int port, @NonNull Map<String, byte[]> cookies) {
+    public ServerTransferEvent(GeyserConnection connection,
+                               String host, int port, Map<String, byte[]> cookies) {
         super(connection);
         this.host = host;
         this.port = port;
@@ -60,7 +59,7 @@ public final class ServerTransferEvent extends ConnectionEvent {
      *
      * @return the host
      */
-    public @NonNull String host() {
+    public String host() {
         return this.host;
     }
 
@@ -96,7 +95,7 @@ public final class ServerTransferEvent extends ConnectionEvent {
     /**
      * Sets the host for the Bedrock player to be transferred to
      */
-    public void bedrockHost(@NonNull String host) {
+    public void bedrockHost(String host) {
         if (host == null || host.isBlank()) {
             throw new IllegalArgumentException("Server address cannot be null or blank");
         }
@@ -118,7 +117,7 @@ public final class ServerTransferEvent extends ConnectionEvent {
      *
      * @return the connections cookies
      */
-    public @NonNull Map<String, byte[]> cookies() {
+    public Map<String, byte[]> cookies() {
         return cookies;
     }
 

--- a/api/src/main/java/org/geysermc/geyser/api/event/java/ServerTransferEvent.java
+++ b/api/src/main/java/org/geysermc/geyser/api/event/java/ServerTransferEvent.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019-2024 GeyserMC. http://geysermc.org
+ * Copyright (c) 2019-2026 GeyserMC. http://geysermc.org
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/api/src/main/java/org/geysermc/geyser/api/event/java/package-info.java
+++ b/api/src/main/java/org/geysermc/geyser/api/event/java/package-info.java
@@ -1,0 +1,29 @@
+/*
+ * Copyright (c) 2026 GeyserMC. http://geysermc.org
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ *
+ * @author GeyserMC
+ * @link https://github.com/GeyserMC/Geyser
+ */
+
+@NullMarked
+package org.geysermc.geyser.api.event.java;
+
+import org.jspecify.annotations.NullMarked;

--- a/api/src/main/java/org/geysermc/geyser/api/event/lifecycle/GeyserDefineCommandsEvent.java
+++ b/api/src/main/java/org/geysermc/geyser/api/event/lifecycle/GeyserDefineCommandsEvent.java
@@ -25,7 +25,6 @@
 
 package org.geysermc.geyser.api.event.lifecycle;
 
-import org.checkerframework.checker.nullness.qual.NonNull;
 import org.geysermc.event.Event;
 import org.geysermc.geyser.api.command.Command;
 
@@ -45,13 +44,12 @@ public interface GeyserDefineCommandsEvent extends Event {
      *
      * @param command the command to register
      */
-    void register(@NonNull Command command);
+    void register(Command command);
 
     /**
      * Gets all the registered built-in {@link Command}s.
      *
      * @return all the registered built-in commands as an unmodifiable map
      */
-    @NonNull
     Map<String, Command> commands();
 }

--- a/api/src/main/java/org/geysermc/geyser/api/event/lifecycle/GeyserDefineCommandsEvent.java
+++ b/api/src/main/java/org/geysermc/geyser/api/event/lifecycle/GeyserDefineCommandsEvent.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019-2022 GeyserMC. http://geysermc.org
+ * Copyright (c) 2019-2026 GeyserMC. http://geysermc.org
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/api/src/main/java/org/geysermc/geyser/api/event/lifecycle/GeyserDefineCustomBlocksEvent.java
+++ b/api/src/main/java/org/geysermc/geyser/api/event/lifecycle/GeyserDefineCustomBlocksEvent.java
@@ -25,7 +25,6 @@
 
 package org.geysermc.geyser.api.event.lifecycle;
 
-import org.checkerframework.checker.nullness.qual.NonNull;
 import org.geysermc.geyser.api.block.custom.CustomBlockData;
 import org.geysermc.geyser.api.block.custom.CustomBlockState;
 import org.geysermc.geyser.api.block.custom.nonvanilla.JavaBlockState;
@@ -42,7 +41,7 @@ public abstract class GeyserDefineCustomBlocksEvent implements Event {
      *
      * @param customBlockData the custom block to register
      */
-    public abstract void register(@NonNull CustomBlockData customBlockData);
+    public abstract void register(CustomBlockData customBlockData);
 
     /**
      * Registers the given {@link CustomBlockState} as an override for the
@@ -53,7 +52,7 @@ public abstract class GeyserDefineCustomBlocksEvent implements Event {
      * @param javaIdentifier the java state identifier to override
      * @param customBlockState the custom block state with which to override java state identifier
      */
-    public abstract void registerOverride(@NonNull String javaIdentifier, @NonNull CustomBlockState customBlockState);
+    public abstract void registerOverride(String javaIdentifier, CustomBlockState customBlockState);
 
     /**
      * Registers the given {@link CustomBlockData} as an override for the
@@ -62,7 +61,7 @@ public abstract class GeyserDefineCustomBlocksEvent implements Event {
      * @param javaIdentifier the java item identifier to override
      * @param customBlockData the custom block data with which to override java item identifier
      */
-    public abstract void registerItemOverride(@NonNull String javaIdentifier, @NonNull CustomBlockData customBlockData);
+    public abstract void registerItemOverride(String javaIdentifier, CustomBlockData customBlockData);
 
     /**
      * Registers the given {@link CustomBlockState} as an override for the
@@ -71,5 +70,5 @@ public abstract class GeyserDefineCustomBlocksEvent implements Event {
      * @param javaBlockState the java block state for the non-vanilla block
      * @param customBlockState the custom block state with which to override java state identifier
      */
-    public abstract void registerOverride(@NonNull JavaBlockState javaBlockState, @NonNull CustomBlockState customBlockState);
+    public abstract void registerOverride(JavaBlockState javaBlockState, CustomBlockState customBlockState);
 }

--- a/api/src/main/java/org/geysermc/geyser/api/event/lifecycle/GeyserDefineCustomBlocksEvent.java
+++ b/api/src/main/java/org/geysermc/geyser/api/event/lifecycle/GeyserDefineCustomBlocksEvent.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019-2022 GeyserMC. http://geysermc.org
+ * Copyright (c) 2019-2026 GeyserMC. http://geysermc.org
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/api/src/main/java/org/geysermc/geyser/api/event/lifecycle/GeyserDefineCustomItemsEvent.java
+++ b/api/src/main/java/org/geysermc/geyser/api/event/lifecycle/GeyserDefineCustomItemsEvent.java
@@ -25,7 +25,6 @@
 
 package org.geysermc.geyser.api.event.lifecycle;
 
-import org.checkerframework.checker.nullness.qual.NonNull;
 import org.geysermc.event.Event;
 import org.geysermc.geyser.api.item.custom.v2.CustomItemDefinitionRegisterException;
 import org.geysermc.geyser.api.item.custom.CustomItemData;
@@ -55,7 +54,6 @@ public interface GeyserDefineCustomItemsEvent extends Event {
      * @deprecated replaced by {@link GeyserDefineCustomItemsEvent#customItemDefinitions()}
      */
     @Deprecated
-    @NonNull
     Map<String, Collection<CustomItemData>> getExistingCustomItems();
 
     /**
@@ -63,7 +61,6 @@ public interface GeyserDefineCustomItemsEvent extends Event {
      * indexed by the {@link Identifier} of the Java item which the item is based on.
      * @since 2.9.3
      */
-    @NonNull
     Map<Identifier, Collection<CustomItemDefinition>> customItemDefinitions();
 
     /**
@@ -74,7 +71,6 @@ public interface GeyserDefineCustomItemsEvent extends Event {
      * @deprecated replaced by {@link GeyserDefineCustomItemsEvent#nonVanillaCustomItemDefinitions()}
      */
     @Deprecated
-    @NonNull
     List<NonVanillaCustomItemData> getExistingNonVanillaCustomItems();
 
     /**
@@ -83,7 +79,6 @@ public interface GeyserDefineCustomItemsEvent extends Event {
      * <p>This multimap will, at the moment, always have one entry per key.</p>
      * @since 2.9.3
      */
-    @NonNull
     Map<Identifier, Collection<NonVanillaCustomItemDefinition>> nonVanillaCustomItemDefinitions();
 
     /**
@@ -96,7 +91,7 @@ public interface GeyserDefineCustomItemsEvent extends Event {
      * @deprecated use {@link GeyserDefineCustomItemsEvent#register(Identifier, CustomItemDefinition)}
      */
     @Deprecated
-    boolean register(@NonNull String identifier, @NonNull CustomItemData customItemData);
+    boolean register(String identifier, CustomItemData customItemData);
 
     /**
      * Registers a Bedrock custom item definition based on a Java item. This is used to register items with custom textures and properties
@@ -107,7 +102,7 @@ public interface GeyserDefineCustomItemsEvent extends Event {
      * @throws CustomItemDefinitionRegisterException when an error occurred while registering the item
      * @since 2.9.3
      */
-    void register(@NonNull Identifier identifier, @NonNull CustomItemDefinition customItemDefinition);
+    void register(Identifier identifier, CustomItemDefinition customItemDefinition);
 
     /**
      * Registers a custom item with no base item. This is used for mods.
@@ -118,7 +113,7 @@ public interface GeyserDefineCustomItemsEvent extends Event {
      * @deprecated use {@link GeyserDefineCustomItemsEvent#register(NonVanillaCustomItemDefinition)}
      */
     @Deprecated
-    boolean register(@NonNull NonVanillaCustomItemData customItemData);
+    boolean register(NonVanillaCustomItemData customItemData);
 
     /**
      * Registers a custom item with no base Java edition item. This is used for non-vanilla items added by mods.
@@ -127,5 +122,5 @@ public interface GeyserDefineCustomItemsEvent extends Event {
      * @throws CustomItemDefinitionRegisterException when an error occurred while registering the item
      * @since 2.9.3
      */
-    void register(@NonNull NonVanillaCustomItemDefinition customItemDefinition);
+    void register(NonVanillaCustomItemDefinition customItemDefinition);
 }

--- a/api/src/main/java/org/geysermc/geyser/api/event/lifecycle/GeyserDefineCustomItemsEvent.java
+++ b/api/src/main/java/org/geysermc/geyser/api/event/lifecycle/GeyserDefineCustomItemsEvent.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019-2022 GeyserMC. http://geysermc.org
+ * Copyright (c) 2019-2026 GeyserMC. http://geysermc.org
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/api/src/main/java/org/geysermc/geyser/api/event/lifecycle/GeyserDefineCustomSkullsEvent.java
+++ b/api/src/main/java/org/geysermc/geyser/api/event/lifecycle/GeyserDefineCustomSkullsEvent.java
@@ -1,6 +1,5 @@
 package org.geysermc.geyser.api.event.lifecycle;
 
-import org.checkerframework.checker.nullness.qual.NonNull;
 import org.geysermc.event.Event;
 
 /**
@@ -24,5 +23,5 @@ public abstract class GeyserDefineCustomSkullsEvent implements Event {
      * @param texture the username, UUID, base64 encoded profile, or skin hash
      * @param type the type of texture provided
      */
-    public abstract void register(@NonNull String texture, @NonNull SkullTextureType type);
+    public abstract void register(String texture, SkullTextureType type);
 }

--- a/api/src/main/java/org/geysermc/geyser/api/event/lifecycle/GeyserDefineCustomSkullsEvent.java
+++ b/api/src/main/java/org/geysermc/geyser/api/event/lifecycle/GeyserDefineCustomSkullsEvent.java
@@ -1,3 +1,28 @@
+/*
+ * Copyright (c) 2023-2026 GeyserMC. http://geysermc.org
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ *
+ * @author GeyserMC
+ * @link https://github.com/GeyserMC/Geyser
+ */
+
 package org.geysermc.geyser.api.event.lifecycle;
 
 import org.geysermc.event.Event;

--- a/api/src/main/java/org/geysermc/geyser/api/event/lifecycle/GeyserDefineEntityPropertiesEvent.java
+++ b/api/src/main/java/org/geysermc/geyser/api/event/lifecycle/GeyserDefineEntityPropertiesEvent.java
@@ -25,8 +25,6 @@
 
 package org.geysermc.geyser.api.event.lifecycle;
 
-import org.checkerframework.checker.nullness.qual.NonNull;
-import org.checkerframework.checker.nullness.qual.Nullable;
 import org.geysermc.event.Event;
 import org.geysermc.geyser.api.entity.EntityData;
 import org.geysermc.geyser.api.entity.property.GeyserEntityProperty;
@@ -37,6 +35,7 @@ import org.geysermc.geyser.api.entity.property.type.GeyserIntEntityProperty;
 import org.geysermc.geyser.api.entity.property.type.GeyserStringEnumProperty;
 import org.geysermc.geyser.api.entity.type.GeyserEntity;
 import org.geysermc.geyser.api.util.Identifier;
+import org.jspecify.annotations.Nullable;
 
 import java.util.Collection;
 import java.util.List;
@@ -89,7 +88,7 @@ public interface GeyserDefineEntityPropertiesEvent extends Event {
      * 
      * @since 2.9.0
      */
-    Collection<GeyserEntityProperty<?>> properties(@NonNull Identifier entityType);
+    Collection<GeyserEntityProperty<?>> properties(Identifier entityType);
 
     /**
      * Registers a {@code float}-backed entity property.
@@ -103,7 +102,7 @@ public interface GeyserDefineEntityPropertiesEvent extends Event {
      * 
      * @since 2.9.0
      */
-    GeyserFloatEntityProperty registerFloatProperty(@NonNull Identifier entityType, @NonNull Identifier propertyIdentifier, float min, float max, @Nullable Float defaultValue);
+    GeyserFloatEntityProperty registerFloatProperty(Identifier entityType, Identifier propertyIdentifier, float min, float max, @Nullable Float defaultValue);
 
     /**
      * Registers a {@code float}-backed entity property with a default value set to the minimum value.
@@ -117,7 +116,7 @@ public interface GeyserDefineEntityPropertiesEvent extends Event {
      * 
      * @since 2.9.0
      */
-    default GeyserFloatEntityProperty registerFloatProperty(@NonNull Identifier entityType, @NonNull Identifier propertyIdentifier, float min, float max) {
+    default GeyserFloatEntityProperty registerFloatProperty(Identifier entityType, Identifier propertyIdentifier, float min, float max) {
         return registerFloatProperty(entityType, propertyIdentifier, min, max, null);
     }
 
@@ -133,7 +132,7 @@ public interface GeyserDefineEntityPropertiesEvent extends Event {
      * 
      * @since 2.9.0
      */
-    GeyserIntEntityProperty registerIntegerProperty(@NonNull Identifier entityType, @NonNull Identifier propertyIdentifier, int min, int max, @Nullable Integer defaultValue);
+    GeyserIntEntityProperty registerIntegerProperty(Identifier entityType, Identifier propertyIdentifier, int min, int max, @Nullable Integer defaultValue);
 
     /**
      * Registers an {@code int}-backed entity property with a default value set to the minimum value.
@@ -146,7 +145,7 @@ public interface GeyserDefineEntityPropertiesEvent extends Event {
      * 
      * @since 2.9.0
      */
-    default GeyserIntEntityProperty registerIntegerProperty(@NonNull Identifier entityType, @NonNull Identifier propertyIdentifier, int min, int max) {
+    default GeyserIntEntityProperty registerIntegerProperty(Identifier entityType, Identifier propertyIdentifier, int min, int max) {
         return registerIntegerProperty(entityType, propertyIdentifier, min, max, null);
     }
 
@@ -160,7 +159,7 @@ public interface GeyserDefineEntityPropertiesEvent extends Event {
      * 
      * @since 2.9.0
      */
-    GeyserBooleanEntityProperty registerBooleanProperty(@NonNull Identifier entityType, @NonNull Identifier propertyIdentifier, boolean defaultValue);
+    GeyserBooleanEntityProperty registerBooleanProperty(Identifier entityType, Identifier propertyIdentifier, boolean defaultValue);
 
     /**
      * Registers a {@code boolean}-backed entity property with a default of {@code false}.
@@ -171,7 +170,7 @@ public interface GeyserDefineEntityPropertiesEvent extends Event {
      * @return the created boolean property
      * @since 2.9.0
      */
-    default GeyserBooleanEntityProperty registerBooleanProperty(@NonNull Identifier entityType, @NonNull Identifier propertyIdentifier) {
+    default GeyserBooleanEntityProperty registerBooleanProperty(Identifier entityType, Identifier propertyIdentifier) {
         return registerBooleanProperty(entityType, propertyIdentifier, false);
     }
 
@@ -191,7 +190,7 @@ public interface GeyserDefineEntityPropertiesEvent extends Event {
      * 
      * @since 2.9.0
      */
-    <E extends Enum<E>> GeyserEnumEntityProperty<E> registerEnumProperty(@NonNull Identifier entityType, @NonNull Identifier propertyIdentifier, @NonNull Class<E> enumClass, @Nullable E defaultValue);
+    <E extends Enum<E>> GeyserEnumEntityProperty<E> registerEnumProperty(Identifier entityType, Identifier propertyIdentifier, Class<E> enumClass, @Nullable E defaultValue);
 
     /**
      * Registers a typed {@linkplain Enum enum}-backed entity property with the first value set as the default.
@@ -205,7 +204,7 @@ public interface GeyserDefineEntityPropertiesEvent extends Event {
      * 
      * @since 2.9.0
      */
-    default <E extends Enum<E>> GeyserEnumEntityProperty<E> registerEnumProperty(@NonNull Identifier entityType, @NonNull Identifier propertyIdentifier, @NonNull Class<E> enumClass) {
+    default <E extends Enum<E>> GeyserEnumEntityProperty<E> registerEnumProperty(Identifier entityType, Identifier propertyIdentifier, Class<E> enumClass) {
         return registerEnumProperty(entityType, propertyIdentifier, enumClass, null);
     }
 
@@ -223,7 +222,7 @@ public interface GeyserDefineEntityPropertiesEvent extends Event {
      * 
      * @since 2.9.0
      */
-    GeyserStringEnumProperty registerEnumProperty(@NonNull Identifier entityType, @NonNull Identifier propertyIdentifier, @NonNull List<String> values, @Nullable String defaultValue);
+    GeyserStringEnumProperty registerEnumProperty(Identifier entityType, Identifier propertyIdentifier, List<String> values, @Nullable String defaultValue);
 
     /**
      * Registers a string-backed "enum-like" entity property with the first value as the default.
@@ -236,7 +235,7 @@ public interface GeyserDefineEntityPropertiesEvent extends Event {
      * 
      * @since 2.9.0
      */
-    default GeyserStringEnumProperty registerEnumProperty(@NonNull Identifier entityType, @NonNull Identifier propertyIdentifier, @NonNull List<String> values) {
+    default GeyserStringEnumProperty registerEnumProperty(Identifier entityType, Identifier propertyIdentifier, List<String> values) {
         return registerEnumProperty(entityType, propertyIdentifier, values, null);
     }
 }

--- a/api/src/main/java/org/geysermc/geyser/api/event/lifecycle/GeyserDefineEntityPropertiesEvent.java
+++ b/api/src/main/java/org/geysermc/geyser/api/event/lifecycle/GeyserDefineEntityPropertiesEvent.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2025 GeyserMC. http://geysermc.org
+ * Copyright (c) 2025-2026 GeyserMC. http://geysermc.org
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/api/src/main/java/org/geysermc/geyser/api/event/lifecycle/GeyserDefineResourcePacksEvent.java
+++ b/api/src/main/java/org/geysermc/geyser/api/event/lifecycle/GeyserDefineResourcePacksEvent.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019-2025 GeyserMC. http://geysermc.org
+ * Copyright (c) 2019-2026 GeyserMC. http://geysermc.org
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/api/src/main/java/org/geysermc/geyser/api/event/lifecycle/GeyserDefineResourcePacksEvent.java
+++ b/api/src/main/java/org/geysermc/geyser/api/event/lifecycle/GeyserDefineResourcePacksEvent.java
@@ -25,12 +25,11 @@
 
 package org.geysermc.geyser.api.event.lifecycle;
 
-import org.checkerframework.checker.nullness.qual.NonNull;
-import org.checkerframework.checker.nullness.qual.Nullable;
 import org.geysermc.event.Event;
 import org.geysermc.geyser.api.pack.ResourcePack;
 import org.geysermc.geyser.api.pack.exception.ResourcePackException;
 import org.geysermc.geyser.api.pack.option.ResourcePackOption;
+import org.jspecify.annotations.Nullable;
 
 import java.util.Collection;
 import java.util.List;
@@ -50,7 +49,7 @@ public abstract class GeyserDefineResourcePacksEvent implements Event {
      * @return an unmodifiable list of {@link ResourcePack}'s
      * @since 2.6.2
      */
-    public abstract @NonNull List<ResourcePack> resourcePacks();
+    public abstract List<ResourcePack> resourcePacks();
 
     /**
      * Registers a {@link ResourcePack} to be sent to the client, optionally alongside
@@ -61,7 +60,7 @@ public abstract class GeyserDefineResourcePacksEvent implements Event {
      * @throws ResourcePackException if an issue occurred during pack registration
      * @since 2.6.2
      */
-    public abstract void register(@NonNull ResourcePack pack, @Nullable ResourcePackOption<?>... options);
+    public abstract void register(ResourcePack pack, @Nullable ResourcePackOption<?>... options);
 
     /**
      * Sets {@link ResourcePackOption}'s for a {@link ResourcePack}.
@@ -71,7 +70,7 @@ public abstract class GeyserDefineResourcePacksEvent implements Event {
      * @throws ResourcePackException if an issue occurred during {@link ResourcePackOption} registration
      * @since 2.6.2
      */
-    public abstract void registerOptions(@NonNull UUID uuid, @NonNull ResourcePackOption<?>... options);
+    public abstract void registerOptions(UUID uuid, ResourcePackOption<?>... options);
 
     /**
      * Returns a collection of {@link ResourcePackOption}'s for a registered {@link ResourcePack}.
@@ -82,7 +81,7 @@ public abstract class GeyserDefineResourcePacksEvent implements Event {
      * @throws ResourcePackException if the pack was not registered
      * @since 2.6.2
      */
-    public abstract Collection<ResourcePackOption<?>> options(@NonNull UUID uuid);
+    public abstract Collection<ResourcePackOption<?>> options(UUID uuid);
 
     /**
      * Returns the current option, or null, for a given {@link ResourcePackOption.Type}.
@@ -92,7 +91,7 @@ public abstract class GeyserDefineResourcePacksEvent implements Event {
      * @throws ResourcePackException if the queried option is invalid or not present on the resource pack
      * @since 2.6.2
      */
-    public abstract @Nullable ResourcePackOption<?> option(@NonNull UUID uuid, ResourcePackOption.@NonNull Type type);
+    public abstract @Nullable ResourcePackOption<?> option(UUID uuid, ResourcePackOption.Type type);
 
     /**
      * Unregisters a {@link ResourcePack} from the list of packs sent to connecting Bedrock clients.
@@ -100,5 +99,5 @@ public abstract class GeyserDefineResourcePacksEvent implements Event {
      * @param uuid the UUID of the {@link ResourcePack} to be removed
      * @since 2.6.2
      */
-    public abstract void unregister(@NonNull UUID uuid);
+    public abstract void unregister(UUID uuid);
 }

--- a/api/src/main/java/org/geysermc/geyser/api/event/lifecycle/GeyserLoadResourcePacksEvent.java
+++ b/api/src/main/java/org/geysermc/geyser/api/event/lifecycle/GeyserLoadResourcePacksEvent.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019-2022 GeyserMC. http://geysermc.org
+ * Copyright (c) 2019-2026 GeyserMC. http://geysermc.org
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/api/src/main/java/org/geysermc/geyser/api/event/lifecycle/GeyserLoadResourcePacksEvent.java
+++ b/api/src/main/java/org/geysermc/geyser/api/event/lifecycle/GeyserLoadResourcePacksEvent.java
@@ -25,7 +25,6 @@
 
 package org.geysermc.geyser.api.event.lifecycle;
 
-import org.checkerframework.checker.nullness.qual.NonNull;
 import org.geysermc.event.Event;
 
 import java.nio.file.Path;
@@ -35,5 +34,5 @@ import java.util.List;
  * @deprecated Use the {@link GeyserDefineResourcePacksEvent} instead.
  */
 @Deprecated
-public record GeyserLoadResourcePacksEvent(@NonNull List<Path> resourcePacks) implements Event {
+public record GeyserLoadResourcePacksEvent(List<Path> resourcePacks) implements Event {
 }

--- a/api/src/main/java/org/geysermc/geyser/api/event/lifecycle/GeyserPostInitializeEvent.java
+++ b/api/src/main/java/org/geysermc/geyser/api/event/lifecycle/GeyserPostInitializeEvent.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019-2022 GeyserMC. http://geysermc.org
+ * Copyright (c) 2019-2026 GeyserMC. http://geysermc.org
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/api/src/main/java/org/geysermc/geyser/api/event/lifecycle/GeyserPostInitializeEvent.java
+++ b/api/src/main/java/org/geysermc/geyser/api/event/lifecycle/GeyserPostInitializeEvent.java
@@ -25,7 +25,6 @@
 
 package org.geysermc.geyser.api.event.lifecycle;
 
-import org.checkerframework.checker.nullness.qual.NonNull;
 import org.geysermc.event.Event;
 import org.geysermc.geyser.api.event.EventBus;
 import org.geysermc.geyser.api.event.EventRegistrar;
@@ -37,5 +36,5 @@ import org.geysermc.geyser.api.extension.ExtensionManager;
  * @param extensionManager the extension manager
  * @param eventBus the event bus
  */
-public record GeyserPostInitializeEvent(@NonNull ExtensionManager extensionManager, @NonNull EventBus<EventRegistrar> eventBus) implements Event {
+public record GeyserPostInitializeEvent(ExtensionManager extensionManager, EventBus<EventRegistrar> eventBus) implements Event {
 }

--- a/api/src/main/java/org/geysermc/geyser/api/event/lifecycle/GeyserPostReloadEvent.java
+++ b/api/src/main/java/org/geysermc/geyser/api/event/lifecycle/GeyserPostReloadEvent.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019-2024 GeyserMC. http://geysermc.org
+ * Copyright (c) 2019-2026 GeyserMC. http://geysermc.org
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/api/src/main/java/org/geysermc/geyser/api/event/lifecycle/GeyserPostReloadEvent.java
+++ b/api/src/main/java/org/geysermc/geyser/api/event/lifecycle/GeyserPostReloadEvent.java
@@ -25,7 +25,6 @@
 
 package org.geysermc.geyser.api.event.lifecycle;
 
-import org.checkerframework.checker.nullness.qual.NonNull;
 import org.geysermc.event.Event;
 import org.geysermc.geyser.api.event.EventBus;
 import org.geysermc.geyser.api.event.EventRegistrar;
@@ -38,5 +37,5 @@ import org.geysermc.geyser.api.extension.ExtensionManager;
  * @param extensionManager the extension manager
  * @param eventBus the event bus
  */
-public record GeyserPostReloadEvent(@NonNull ExtensionManager extensionManager, @NonNull EventBus<EventRegistrar> eventBus) implements Event {
+public record GeyserPostReloadEvent(ExtensionManager extensionManager, EventBus<EventRegistrar> eventBus) implements Event {
 }

--- a/api/src/main/java/org/geysermc/geyser/api/event/lifecycle/GeyserPreInitializeEvent.java
+++ b/api/src/main/java/org/geysermc/geyser/api/event/lifecycle/GeyserPreInitializeEvent.java
@@ -25,7 +25,6 @@
 
 package org.geysermc.geyser.api.event.lifecycle;
 
-import org.checkerframework.checker.nullness.qual.NonNull;
 import org.geysermc.event.Event;
 import org.geysermc.geyser.api.event.EventBus;
 import org.geysermc.geyser.api.event.EventRegistrar;
@@ -37,5 +36,5 @@ import org.geysermc.geyser.api.extension.ExtensionManager;
  * @param extensionManager the extension manager
  * @param eventBus the event bus
  */
-public record GeyserPreInitializeEvent(@NonNull ExtensionManager extensionManager, @NonNull EventBus<EventRegistrar> eventBus) implements Event {
+public record GeyserPreInitializeEvent(ExtensionManager extensionManager, EventBus<EventRegistrar> eventBus) implements Event {
 }

--- a/api/src/main/java/org/geysermc/geyser/api/event/lifecycle/GeyserPreInitializeEvent.java
+++ b/api/src/main/java/org/geysermc/geyser/api/event/lifecycle/GeyserPreInitializeEvent.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019-2022 GeyserMC. http://geysermc.org
+ * Copyright (c) 2019-2026 GeyserMC. http://geysermc.org
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/api/src/main/java/org/geysermc/geyser/api/event/lifecycle/GeyserPreReloadEvent.java
+++ b/api/src/main/java/org/geysermc/geyser/api/event/lifecycle/GeyserPreReloadEvent.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019-2024 GeyserMC. http://geysermc.org
+ * Copyright (c) 2019-2026 GeyserMC. http://geysermc.org
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/api/src/main/java/org/geysermc/geyser/api/event/lifecycle/GeyserPreReloadEvent.java
+++ b/api/src/main/java/org/geysermc/geyser/api/event/lifecycle/GeyserPreReloadEvent.java
@@ -25,7 +25,6 @@
 
 package org.geysermc.geyser.api.event.lifecycle;
 
-import org.checkerframework.checker.nullness.qual.NonNull;
 import org.geysermc.event.Event;
 import org.geysermc.geyser.api.event.EventBus;
 import org.geysermc.geyser.api.event.EventRegistrar;
@@ -38,5 +37,5 @@ import org.geysermc.geyser.api.extension.ExtensionManager;
  * @param extensionManager the extension manager
  * @param eventBus the event bus
  */
-public record GeyserPreReloadEvent(@NonNull ExtensionManager extensionManager, @NonNull EventBus<EventRegistrar> eventBus) implements Event {
+public record GeyserPreReloadEvent(ExtensionManager extensionManager, EventBus<EventRegistrar> eventBus) implements Event {
 }

--- a/api/src/main/java/org/geysermc/geyser/api/event/lifecycle/GeyserRegisterPermissionsEvent.java
+++ b/api/src/main/java/org/geysermc/geyser/api/event/lifecycle/GeyserRegisterPermissionsEvent.java
@@ -25,7 +25,6 @@
 
 package org.geysermc.geyser.api.event.lifecycle;
 
-import org.checkerframework.checker.nullness.qual.NonNull;
 import org.geysermc.event.Event;
 import org.geysermc.geyser.api.util.TriState;
 
@@ -47,5 +46,5 @@ public interface GeyserRegisterPermissionsEvent extends Event {
      * @param permission the permission node to register
      * @param defaultValue the default value of the node
      */
-    void register(@NonNull String permission, @NonNull TriState defaultValue);
+    void register(String permission, TriState defaultValue);
 }

--- a/api/src/main/java/org/geysermc/geyser/api/event/lifecycle/GeyserRegisterPermissionsEvent.java
+++ b/api/src/main/java/org/geysermc/geyser/api/event/lifecycle/GeyserRegisterPermissionsEvent.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019-2023 GeyserMC. http://geysermc.org
+ * Copyright (c) 2019-2026 GeyserMC. http://geysermc.org
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/api/src/main/java/org/geysermc/geyser/api/event/lifecycle/GeyserShutdownEvent.java
+++ b/api/src/main/java/org/geysermc/geyser/api/event/lifecycle/GeyserShutdownEvent.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019-2022 GeyserMC. http://geysermc.org
+ * Copyright (c) 2019-2026 GeyserMC. http://geysermc.org
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/api/src/main/java/org/geysermc/geyser/api/event/lifecycle/GeyserShutdownEvent.java
+++ b/api/src/main/java/org/geysermc/geyser/api/event/lifecycle/GeyserShutdownEvent.java
@@ -25,7 +25,6 @@
 
 package org.geysermc.geyser.api.event.lifecycle;
 
-import org.checkerframework.checker.nullness.qual.NonNull;
 import org.geysermc.event.Event;
 import org.geysermc.geyser.api.event.EventBus;
 import org.geysermc.geyser.api.event.EventRegistrar;
@@ -34,5 +33,5 @@ import org.geysermc.geyser.api.extension.ExtensionManager;
 /**
  * Called when Geyser is shutting down.
  */
-public record GeyserShutdownEvent(@NonNull ExtensionManager extensionManager, @NonNull EventBus<EventRegistrar> eventBus) implements Event {
+public record GeyserShutdownEvent(ExtensionManager extensionManager, EventBus<EventRegistrar> eventBus) implements Event {
 }

--- a/api/src/main/java/org/geysermc/geyser/api/event/lifecycle/package-info.java
+++ b/api/src/main/java/org/geysermc/geyser/api/event/lifecycle/package-info.java
@@ -1,0 +1,29 @@
+/*
+ * Copyright (c) 2026 GeyserMC. http://geysermc.org
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ *
+ * @author GeyserMC
+ * @link https://github.com/GeyserMC/Geyser
+ */
+
+@NullMarked
+package org.geysermc.geyser.api.event.lifecycle;
+
+import org.jspecify.annotations.NullMarked;

--- a/api/src/main/java/org/geysermc/geyser/api/event/package-info.java
+++ b/api/src/main/java/org/geysermc/geyser/api/event/package-info.java
@@ -1,0 +1,29 @@
+/*
+ * Copyright (c) 2026 GeyserMC. http://geysermc.org
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ *
+ * @author GeyserMC
+ * @link https://github.com/GeyserMC/Geyser
+ */
+
+@NullMarked
+package org.geysermc.geyser.api.event;
+
+import org.jspecify.annotations.NullMarked;

--- a/api/src/main/java/org/geysermc/geyser/api/extension/Extension.java
+++ b/api/src/main/java/org/geysermc/geyser/api/extension/Extension.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019-2022 GeyserMC. http://geysermc.org
+ * Copyright (c) 2019-2026 GeyserMC. http://geysermc.org
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/api/src/main/java/org/geysermc/geyser/api/extension/Extension.java
+++ b/api/src/main/java/org/geysermc/geyser/api/extension/Extension.java
@@ -25,7 +25,6 @@
 
 package org.geysermc.geyser.api.extension;
 
-import org.checkerframework.checker.nullness.qual.NonNull;
 import org.geysermc.api.GeyserApiBase;
 import org.geysermc.geyser.api.GeyserApi;
 import org.geysermc.geyser.api.event.EventRegistrar;
@@ -62,7 +61,6 @@ public interface Extension extends EventRegistrar {
      *
      * @return the extension's data folder
      */
-    @NonNull
     default Path dataFolder() {
         return this.extensionLoader().dataFolder(this);
     }
@@ -72,7 +70,6 @@ public interface Extension extends EventRegistrar {
      *
      * @return the extension event bus
      */
-    @NonNull
     default ExtensionEventBus eventBus() {
         return this.extensionLoader().eventBus(this);
     }
@@ -82,7 +79,6 @@ public interface Extension extends EventRegistrar {
      *
      * @return the extension manager
      */
-    @NonNull
     default ExtensionManager extensionManager() {
         return this.geyserApi().extensionManager();
     }
@@ -92,7 +88,6 @@ public interface Extension extends EventRegistrar {
      *
      * @return the extension's name
      */
-    @NonNull
     default String name() {
         return this.description().name();
     }
@@ -102,7 +97,6 @@ public interface Extension extends EventRegistrar {
      *
      * @return the extension's description
      */
-    @NonNull
     default ExtensionDescription description() {
         return this.extensionLoader().description(this);
     }
@@ -111,7 +105,6 @@ public interface Extension extends EventRegistrar {
      * @return the root command that all of this extension's commands will stem from.
      *         By default, this is the extension's id.
      */
-    @NonNull
     default String rootCommand() {
         return this.description().id();
     }
@@ -121,7 +114,6 @@ public interface Extension extends EventRegistrar {
      *
      * @return the extension's logger
      */
-    @NonNull
     default ExtensionLogger logger() {
         return this.extensionLoader().logger(this);
     }
@@ -131,7 +123,6 @@ public interface Extension extends EventRegistrar {
      *
      * @return the extension loader
      */
-    @NonNull
     default ExtensionLoader extensionLoader() {
         return Objects.requireNonNull(this.extensionManager().extensionLoader());
     }
@@ -141,7 +132,6 @@ public interface Extension extends EventRegistrar {
      *
      * @return the geyser api instance
      */
-    @NonNull
     default GeyserApi geyserApi() {
         return GeyserApi.api();
     }

--- a/api/src/main/java/org/geysermc/geyser/api/extension/ExtensionDescription.java
+++ b/api/src/main/java/org/geysermc/geyser/api/extension/ExtensionDescription.java
@@ -25,7 +25,6 @@
 
 package org.geysermc.geyser.api.extension;
 
-import org.checkerframework.checker.nullness.qual.NonNull;
 
 import java.util.List;
 
@@ -39,7 +38,6 @@ public interface ExtensionDescription {
      *
      * @return the extension's id
      */
-    @NonNull
     String id();
 
     /**
@@ -47,7 +45,6 @@ public interface ExtensionDescription {
      *
      * @return the extension's name
      */
-    @NonNull
     String name();
 
     /**
@@ -55,7 +52,6 @@ public interface ExtensionDescription {
      *
      * @return the extension's main class
      */
-    @NonNull
     String main();
 
     /**
@@ -106,7 +102,6 @@ public interface ExtensionDescription {
      *
      * @return the extension's description
      */
-    @NonNull
     String version();
 
     /**
@@ -114,6 +109,5 @@ public interface ExtensionDescription {
      *
      * @return the extension's authors
      */
-    @NonNull
     List<String> authors();
 }

--- a/api/src/main/java/org/geysermc/geyser/api/extension/ExtensionDescription.java
+++ b/api/src/main/java/org/geysermc/geyser/api/extension/ExtensionDescription.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019-2022 GeyserMC. http://geysermc.org
+ * Copyright (c) 2019-2026 GeyserMC. http://geysermc.org
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/api/src/main/java/org/geysermc/geyser/api/extension/ExtensionLoader.java
+++ b/api/src/main/java/org/geysermc/geyser/api/extension/ExtensionLoader.java
@@ -25,7 +25,6 @@
 
 package org.geysermc.geyser.api.extension;
 
-import org.checkerframework.checker.nullness.qual.NonNull;
 import org.geysermc.geyser.api.event.ExtensionEventBus;
 
 import java.nio.file.Path;
@@ -40,7 +39,7 @@ public abstract class ExtensionLoader {
      * @param extension the extension
      * @return if the extension is enabled
      */
-    protected abstract boolean isEnabled(@NonNull Extension extension);
+    protected abstract boolean isEnabled(Extension extension);
 
     /**
      * Sets if the given {@link Extension} is enabled.
@@ -48,7 +47,7 @@ public abstract class ExtensionLoader {
      * @param extension the extension to enable
      * @param enabled if the extension should be enabled
      */
-    protected abstract void setEnabled(@NonNull Extension extension, boolean enabled);
+    protected abstract void setEnabled(Extension extension, boolean enabled);
 
     /**
      * Gets the given {@link Extension}'s data folder.
@@ -56,8 +55,7 @@ public abstract class ExtensionLoader {
      * @param extension the extension
      * @return the data folder of the given extension
      */
-    @NonNull
-    protected abstract Path dataFolder(@NonNull Extension extension);
+    protected abstract Path dataFolder(Extension extension);
 
     /**
      * Gets the given {@link Extension}'s {@link ExtensionDescription}.
@@ -65,8 +63,7 @@ public abstract class ExtensionLoader {
      * @param extension the extension
      * @return the description of the given extension
      */
-    @NonNull
-    protected abstract ExtensionDescription description(@NonNull Extension extension);
+    protected abstract ExtensionDescription description(Extension extension);
 
     /**
      * Gets the given {@link Extension}'s {@link ExtensionEventBus}.
@@ -74,8 +71,7 @@ public abstract class ExtensionLoader {
      * @param extension the extension
      * @return the extension's event bus
      */
-    @NonNull
-    protected abstract ExtensionEventBus eventBus(@NonNull Extension extension);
+    protected abstract ExtensionEventBus eventBus(Extension extension);
 
     /**
      * Gets the {@link ExtensionLogger} for the given {@link Extension}.
@@ -83,15 +79,14 @@ public abstract class ExtensionLoader {
      * @param extension the extension
      * @return the extension logger for the given extension
      */
-    @NonNull
-    protected abstract ExtensionLogger logger(@NonNull Extension extension);
+    protected abstract ExtensionLogger logger(Extension extension);
 
     /**
      * Loads all extensions.
      *
      * @param extensionManager the extension manager
      */
-    protected abstract void loadAllExtensions(@NonNull ExtensionManager extensionManager);
+    protected abstract void loadAllExtensions(ExtensionManager extensionManager);
 
     /**
      * Registers the given {@link Extension} with the given {@link ExtensionManager}.
@@ -99,7 +94,7 @@ public abstract class ExtensionLoader {
      * @param extension the extension
      * @param extensionManager the extension manager
      */
-    protected void register(@NonNull Extension extension, @NonNull ExtensionManager extensionManager) {
+    protected void register(Extension extension, ExtensionManager extensionManager) {
         extensionManager.register(extension);
     }
 }

--- a/api/src/main/java/org/geysermc/geyser/api/extension/ExtensionLoader.java
+++ b/api/src/main/java/org/geysermc/geyser/api/extension/ExtensionLoader.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019-2022 GeyserMC. http://geysermc.org
+ * Copyright (c) 2019-2026 GeyserMC. http://geysermc.org
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/api/src/main/java/org/geysermc/geyser/api/extension/ExtensionManager.java
+++ b/api/src/main/java/org/geysermc/geyser/api/extension/ExtensionManager.java
@@ -25,8 +25,8 @@
 
 package org.geysermc.geyser.api.extension;
 
-import org.checkerframework.checker.nullness.qual.NonNull;
-import org.checkerframework.checker.nullness.qual.Nullable;
+
+import org.jspecify.annotations.Nullable;
 
 import java.util.Collection;
 
@@ -41,29 +41,27 @@ public abstract class ExtensionManager {
      * @param id the ID of the extension
      * @return an extension with the given ID
      */
-    @Nullable
-    public abstract Extension extension(@NonNull String id);
+    public abstract @Nullable Extension extension(String id);
 
     /**
      * Enables the given {@link Extension}.
      *
      * @param extension the extension to enable
      */
-    public abstract void enable(@NonNull Extension extension);
+    public abstract void enable(Extension extension);
 
     /**
      * Disables the given {@link Extension}.
      *
      * @param extension the extension to disable
      */
-    public abstract void disable(@NonNull Extension extension);
+    public abstract void disable(Extension extension);
 
     /**
      * Gets all the {@link Extension}s currently loaded.
      *
      * @return all the extensions currently loaded
      */
-    @NonNull
     public abstract Collection<Extension> extensions();
 
     /**
@@ -71,20 +69,19 @@ public abstract class ExtensionManager {
      *
      * @return the extension loader
      */
-    @Nullable
-    public abstract ExtensionLoader extensionLoader();
+    public abstract @Nullable ExtensionLoader extensionLoader();
 
     /**
      * Registers an {@link Extension} with the given {@link ExtensionLoader}.
      *
      * @param extension the extension
      */
-    public abstract void register(@NonNull Extension extension);
+    public abstract void register(Extension extension);
 
     /**
      * Loads all extensions from the given {@link ExtensionLoader}.
      */
-    protected final void loadAllExtensions(@NonNull ExtensionLoader extensionLoader) {
+    protected final void loadAllExtensions(ExtensionLoader extensionLoader) {
         extensionLoader.loadAllExtensions(this);
     }
 }

--- a/api/src/main/java/org/geysermc/geyser/api/extension/ExtensionManager.java
+++ b/api/src/main/java/org/geysermc/geyser/api/extension/ExtensionManager.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019-2022 GeyserMC. http://geysermc.org
+ * Copyright (c) 2019-2026 GeyserMC. http://geysermc.org
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/api/src/main/java/org/geysermc/geyser/api/extension/ExtensionManager.java
+++ b/api/src/main/java/org/geysermc/geyser/api/extension/ExtensionManager.java
@@ -25,7 +25,6 @@
 
 package org.geysermc.geyser.api.extension;
 
-
 import org.jspecify.annotations.Nullable;
 
 import java.util.Collection;

--- a/api/src/main/java/org/geysermc/geyser/api/extension/exception/package-info.java
+++ b/api/src/main/java/org/geysermc/geyser/api/extension/exception/package-info.java
@@ -1,0 +1,29 @@
+/*
+ * Copyright (c) 2026 GeyserMC. http://geysermc.org
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ *
+ * @author GeyserMC
+ * @link https://github.com/GeyserMC/Geyser
+ */
+
+@NullMarked
+package org.geysermc.geyser.api.extension.exception;
+
+import org.jspecify.annotations.NullMarked;

--- a/api/src/main/java/org/geysermc/geyser/api/extension/package-info.java
+++ b/api/src/main/java/org/geysermc/geyser/api/extension/package-info.java
@@ -1,0 +1,29 @@
+/*
+ * Copyright (c) 2026 GeyserMC. http://geysermc.org
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ *
+ * @author GeyserMC
+ * @link https://github.com/GeyserMC/Geyser
+ */
+
+@NullMarked
+package org.geysermc.geyser.api.extension;
+
+import org.jspecify.annotations.NullMarked;

--- a/api/src/main/java/org/geysermc/geyser/api/item/custom/CustomItemData.java
+++ b/api/src/main/java/org/geysermc/geyser/api/item/custom/CustomItemData.java
@@ -25,9 +25,8 @@
 
 package org.geysermc.geyser.api.item.custom;
 
-import org.checkerframework.checker.nullness.qual.NonNull;
-import org.checkerframework.checker.nullness.qual.Nullable;
 import org.geysermc.geyser.api.GeyserApi;
+import org.jspecify.annotations.Nullable;
 
 import java.util.OptionalInt;
 import java.util.Set;
@@ -44,7 +43,7 @@ public interface CustomItemData {
      *
      * @return the item's name
      */
-    @NonNull String name();
+    String name();
 
     /**
      * Gets the custom item options of the item.
@@ -58,14 +57,14 @@ public interface CustomItemData {
      *
      * @return the item's display name
      */
-    @NonNull String displayName();
+    String displayName();
 
     /**
      * Gets the item's icon. By default, this is the item's name.
      *
      * @return the item's icon
      */
-    @NonNull String icon();
+    String icon();
 
     /**
      * Gets if the item is allowed to be put into the offhand.
@@ -86,7 +85,7 @@ public interface CustomItemData {
      *
      * @return the item's creative category
      */
-    @NonNull OptionalInt creativeCategory();
+    OptionalInt creativeCategory();
 
     /**
      * Gets the item's creative group.
@@ -119,7 +118,7 @@ public interface CustomItemData {
      *
      * @return the item's tags, if they exist
      */
-    @NonNull Set<String> tags();
+    Set<String> tags();
 
     static CustomItemData.Builder builder() {
         return GeyserApi.api().provider(CustomItemData.Builder.class);
@@ -129,13 +128,13 @@ public interface CustomItemData {
         /**
          * Will also set the display name and icon to the provided parameter, if it is currently not set.
          */
-        Builder name(@NonNull String name);
+        Builder name(String name);
 
-        Builder customItemOptions(@NonNull CustomItemOptions customItemOptions);
+        Builder customItemOptions(CustomItemOptions customItemOptions);
 
-        Builder displayName(@NonNull String displayName);
+        Builder displayName(String displayName);
 
-        Builder icon(@NonNull String icon);
+        Builder icon(String icon);
 
         Builder allowOffhand(boolean allowOffhand);
 

--- a/api/src/main/java/org/geysermc/geyser/api/item/custom/CustomItemData.java
+++ b/api/src/main/java/org/geysermc/geyser/api/item/custom/CustomItemData.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019-2022 GeyserMC. http://geysermc.org
+ * Copyright (c) 2019-2026 GeyserMC. http://geysermc.org
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/api/src/main/java/org/geysermc/geyser/api/item/custom/CustomItemOptions.java
+++ b/api/src/main/java/org/geysermc/geyser/api/item/custom/CustomItemOptions.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019-2022 GeyserMC. http://geysermc.org
+ * Copyright (c) 2019-2026 GeyserMC. http://geysermc.org
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/api/src/main/java/org/geysermc/geyser/api/item/custom/CustomItemOptions.java
+++ b/api/src/main/java/org/geysermc/geyser/api/item/custom/CustomItemOptions.java
@@ -25,7 +25,6 @@
 
 package org.geysermc.geyser.api.item.custom;
 
-import org.checkerframework.checker.nullness.qual.NonNull;
 import org.geysermc.geyser.api.GeyserApi;
 import org.geysermc.geyser.api.util.TriState;
 
@@ -43,21 +42,21 @@ public interface CustomItemOptions {
      *
      * @return if the item should be unbreakable
      */
-    @NonNull TriState unbreakable();
+    TriState unbreakable();
 
     /**
      * Gets the item's custom model data predicate.
      *
      * @return the item's custom model data
      */
-    @NonNull OptionalInt customModelData();
+    OptionalInt customModelData();
 
     /**
      * Gets the item's damage predicate.
      *
      * @return the item's damage predicate
      */
-    @NonNull OptionalInt damagePredicate();
+    OptionalInt damagePredicate();
 
     /**
      * Gets if this mapping should just translate to the default item.

--- a/api/src/main/java/org/geysermc/geyser/api/item/custom/CustomRenderOffsets.java
+++ b/api/src/main/java/org/geysermc/geyser/api/item/custom/CustomRenderOffsets.java
@@ -25,7 +25,7 @@
 
 package org.geysermc.geyser.api.item.custom;
 
-import org.checkerframework.checker.nullness.qual.Nullable;
+import org.jspecify.annotations.Nullable;
 
 /**
  * This class is used to store the render offsets of custom items.

--- a/api/src/main/java/org/geysermc/geyser/api/item/custom/CustomRenderOffsets.java
+++ b/api/src/main/java/org/geysermc/geyser/api/item/custom/CustomRenderOffsets.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019-2022 GeyserMC. http://geysermc.org
+ * Copyright (c) 2019-2026 GeyserMC. http://geysermc.org
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/api/src/main/java/org/geysermc/geyser/api/item/custom/NonVanillaCustomItemData.java
+++ b/api/src/main/java/org/geysermc/geyser/api/item/custom/NonVanillaCustomItemData.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019-2024 GeyserMC. http://geysermc.org
+ * Copyright (c) 2019-2026 GeyserMC. http://geysermc.org
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/api/src/main/java/org/geysermc/geyser/api/item/custom/NonVanillaCustomItemData.java
+++ b/api/src/main/java/org/geysermc/geyser/api/item/custom/NonVanillaCustomItemData.java
@@ -26,9 +26,8 @@
 package org.geysermc.geyser.api.item.custom;
 
 import org.checkerframework.checker.index.qual.NonNegative;
-import org.checkerframework.checker.nullness.qual.NonNull;
-import org.checkerframework.checker.nullness.qual.Nullable;
 import org.geysermc.geyser.api.GeyserApi;
+import org.jspecify.annotations.Nullable;
 
 import java.util.Set;
 
@@ -44,7 +43,7 @@ public interface NonVanillaCustomItemData extends CustomItemData {
      *
      * @return The java identifier for this item.
      */
-    @NonNull String identifier();
+    String identifier();
 
     /**
      * Gets the java item id of the item.
@@ -175,9 +174,9 @@ public interface NonVanillaCustomItemData extends CustomItemData {
 
     interface Builder extends CustomItemData.Builder {
         @Override
-        Builder name(@NonNull String name);
+        Builder name(String name);
 
-        Builder identifier(@NonNull String identifier);
+        Builder identifier(String identifier);
 
         Builder javaId(@NonNegative int javaId);
 
@@ -226,13 +225,13 @@ public interface NonVanillaCustomItemData extends CustomItemData {
         Builder creativeGroup(@Nullable String creativeGroup);
 
         @Override
-        Builder customItemOptions(@NonNull CustomItemOptions customItemOptions);
+        Builder customItemOptions(CustomItemOptions customItemOptions);
 
         @Override
-        Builder displayName(@NonNull String displayName);
+        Builder displayName(String displayName);
 
         @Override
-        Builder icon(@NonNull String icon);
+        Builder icon(String icon);
 
         @Override
         Builder allowOffhand(boolean allowOffhand);

--- a/api/src/main/java/org/geysermc/geyser/api/item/custom/package-info.java
+++ b/api/src/main/java/org/geysermc/geyser/api/item/custom/package-info.java
@@ -1,0 +1,29 @@
+/*
+ * Copyright (c) 2026 GeyserMC. http://geysermc.org
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ *
+ * @author GeyserMC
+ * @link https://github.com/GeyserMC/Geyser
+ */
+
+@NullMarked
+package org.geysermc.geyser.api.item.custom;
+
+import org.jspecify.annotations.NullMarked;

--- a/api/src/main/java/org/geysermc/geyser/api/item/custom/v2/CustomItemBedrockOptions.java
+++ b/api/src/main/java/org/geysermc/geyser/api/item/custom/v2/CustomItemBedrockOptions.java
@@ -25,12 +25,11 @@
 
 package org.geysermc.geyser.api.item.custom.v2;
 
-import org.checkerframework.checker.nullness.qual.NonNull;
-import org.checkerframework.checker.nullness.qual.Nullable;
 import org.checkerframework.common.returnsreceiver.qual.This;
 import org.geysermc.geyser.api.GeyserApi;
 import org.geysermc.geyser.api.util.CreativeCategory;
 import org.geysermc.geyser.api.util.Identifier;
+import org.jspecify.annotations.Nullable;
 
 import java.util.Set;
 
@@ -47,8 +46,7 @@ public interface CustomItemBedrockOptions {
      * @see CustomItemDefinition#icon()
      * @since 2.9.3
      */
-    @Nullable
-    String icon();
+    @Nullable String icon();
 
     /**
      * If the item is allowed to be put into the offhand. Defaults to true.
@@ -83,7 +81,6 @@ public interface CustomItemBedrockOptions {
      * @return the item's creative category
      * @since 2.9.3
      */
-    @NonNull
     CreativeCategory creativeCategory();
 
     /**
@@ -94,8 +91,7 @@ public interface CustomItemBedrockOptions {
      * @return the item's creative group
      * @since 2.9.3
      */
-    @Nullable
-    String creativeGroup();
+    @Nullable String creativeGroup();
 
     /**
      * Gets the item's set of bedrock tags that can be used in Molang.
@@ -104,7 +100,6 @@ public interface CustomItemBedrockOptions {
      * @return the item's set of bedrock tags, can be empty
      * @since 2.9.3
      */
-    @NonNull
     Set<Identifier> tags();
 
     /**
@@ -176,7 +171,7 @@ public interface CustomItemBedrockOptions {
          * @since 2.9.3
          */
         @This
-        Builder creativeCategory(@NonNull CreativeCategory creativeCategory);
+        Builder creativeCategory(CreativeCategory creativeCategory);
 
         /**
          * Sets the item's creative group.
@@ -198,7 +193,7 @@ public interface CustomItemBedrockOptions {
          * @since 2.9.3
          */
         @This
-        Builder tag(@NonNull Identifier tag);
+        Builder tag(Identifier tag);
 
         /**
          * Sets the item's set of bedrock tags, for use in Molang. Pass {@code null} to clear all tags.

--- a/api/src/main/java/org/geysermc/geyser/api/item/custom/v2/CustomItemBedrockOptions.java
+++ b/api/src/main/java/org/geysermc/geyser/api/item/custom/v2/CustomItemBedrockOptions.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024 GeyserMC. http://geysermc.org
+ * Copyright (c) 2024-2026 GeyserMC. http://geysermc.org
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/api/src/main/java/org/geysermc/geyser/api/item/custom/v2/CustomItemDefinition.java
+++ b/api/src/main/java/org/geysermc/geyser/api/item/custom/v2/CustomItemDefinition.java
@@ -25,7 +25,6 @@
 
 package org.geysermc.geyser.api.item.custom.v2;
 
-import org.checkerframework.checker.nullness.qual.NonNull;
 import org.checkerframework.common.returnsreceiver.qual.This;
 import org.geysermc.geyser.api.GeyserApi;
 import org.geysermc.geyser.api.item.custom.v2.component.ItemDataComponent;
@@ -76,7 +75,7 @@ public interface CustomItemDefinition {
      * @return the Bedrock item identifier
      * @since 2.9.3
      */
-    @NonNull Identifier bedrockIdentifier();
+    Identifier bedrockIdentifier();
 
     /**
      * The display name of the item. If none is set, the display name is taken from the item's Bedrock identifier.
@@ -84,7 +83,7 @@ public interface CustomItemDefinition {
      * @return the display name shown to Bedrock clients
      * @since 2.9.3
      */
-    @NonNull String displayName();
+    String displayName();
 
     /**
      * The item model this definition is for. If the model is in the {@code minecraft} namespace, then the definition must have at least one predicate.
@@ -94,7 +93,7 @@ public interface CustomItemDefinition {
      * @return the identifier of the Java item model used to match this definition
      * @since 2.9.3
      */
-    @NonNull Identifier model();
+    Identifier model();
 
     /**
      * The icon used for this item.
@@ -108,7 +107,7 @@ public interface CustomItemDefinition {
      * @return the icon shown to Bedrock players
      * @since 2.9.3
      */
-    @NonNull String icon();
+    String icon();
 
     /**
      * The predicates that have to match for this item definition to be used. These predicates can access properties similar to the Java item model predicates.
@@ -122,14 +121,14 @@ public interface CustomItemDefinition {
      *
      * @since 2.9.3
      */
-    @NonNull List<MinecraftPredicate<? super ItemPredicateContext>> predicates();
+    List<MinecraftPredicate<? super ItemPredicateContext>> predicates();
 
     /**
      * The predicate strategy used when evaluating predicates. Determines if one of, or all of the predicates have to pass for this item definition to be used. Defaults to {@link PredicateStrategy#AND}.
      *
      * @since 2.9.3
      */
-    @NonNull PredicateStrategy predicateStrategy();
+    PredicateStrategy predicateStrategy();
 
     /**
      * @return the priority of this definition. For all definitions for a single Java item model, definitions with a higher priority will be matched first. Defaults to 0.
@@ -141,7 +140,7 @@ public interface CustomItemDefinition {
      * @return the item's Bedrock options. These describe item properties that can't be described in item components, e.g. item texture size and if the item is allowed in the off-hand.
      * @since 2.9.3
      */
-    @NonNull CustomItemBedrockOptions bedrockOptions();
+    CustomItemBedrockOptions bedrockOptions();
 
     /**
      * The item's data components. It is expected that the item <em>always</em> has these components on the server. If the components mismatch, bugs will occur.
@@ -173,7 +172,6 @@ public interface CustomItemDefinition {
      * @return the item's data component patch
      * @since 2.9.3
      */
-    @NonNull
     ItemDataComponentMap components();
 
     /**
@@ -184,7 +182,7 @@ public interface CustomItemDefinition {
      * @return a list of removed default item data components
      * @since 2.9.3
      */
-    @NonNull List<Identifier> removedComponents();
+    List<Identifier> removedComponents();
 
     /**
      * Creates a builder for the custom item definition.
@@ -196,7 +194,7 @@ public interface CustomItemDefinition {
      * @return a new builder
      * @since 2.9.3
      */
-    static Builder builder(@NonNull Identifier bedrockIdentifier, @NonNull Identifier itemModel) {
+    static Builder builder(Identifier bedrockIdentifier, Identifier itemModel) {
         return GeyserApi.api().provider(Builder.class, bedrockIdentifier, itemModel);
     }
 
@@ -215,7 +213,7 @@ public interface CustomItemDefinition {
          * @since 2.9.3
          */
         @This
-        Builder displayName(@NonNull String displayName);
+        Builder displayName(String displayName);
 
         /**
          * Sets the priority of this definition, used for definition matching.
@@ -239,7 +237,7 @@ public interface CustomItemDefinition {
          * @since 2.9.3
          */
         @This
-        Builder bedrockOptions(CustomItemBedrockOptions.@NonNull Builder options);
+        Builder bedrockOptions(CustomItemBedrockOptions.Builder options);
 
         /**
          * Adds a predicate that must match for Geyser to use this item definition.
@@ -250,7 +248,7 @@ public interface CustomItemDefinition {
          * @since 2.9.3
          */
         @This
-        Builder predicate(@NonNull MinecraftPredicate<? super ItemPredicateContext> predicate);
+        Builder predicate(MinecraftPredicate<? super ItemPredicateContext> predicate);
 
         /**
          * Sets the predicate strategy that should be used for item definition matching.
@@ -260,7 +258,7 @@ public interface CustomItemDefinition {
          * @since 2.9.3
          */
         @This
-        Builder predicateStrategy(@NonNull PredicateStrategy strategy);
+        Builder predicateStrategy(PredicateStrategy strategy);
 
         /**
          * Sets data components that determine the item behavior. These are assumed to also be
@@ -278,7 +276,7 @@ public interface CustomItemDefinition {
          * @since 2.9.3
          */
         @This
-        <T> Builder component(@NonNull ItemDataComponent<T> component, @NonNull T value);
+        <T> Builder component(ItemDataComponent<T> component, T value);
 
         /**
          * Convenience method for {@link CustomItemDefinition.Builder#component(ItemDataComponent, Object)}
@@ -292,7 +290,7 @@ public interface CustomItemDefinition {
          * @since 2.9.3
          */
         @This
-        default <T> Builder component(@NonNull ItemDataComponent<T> component, @NonNull GenericBuilder<T> builder) {
+        default <T> Builder component(ItemDataComponent<T> component, GenericBuilder<T> builder) {
             return component(component, builder.build());
         }
 
@@ -310,7 +308,7 @@ public interface CustomItemDefinition {
          * @since 2.9.3
          */
         @This
-        Builder removeComponent(@NonNull Identifier component);
+        Builder removeComponent(Identifier component);
 
         /**
          * Convenience method for {@link CustomItemDefinition.Builder#removeComponent(Identifier)}.
@@ -321,7 +319,7 @@ public interface CustomItemDefinition {
          * @since 2.9.3
          */
         @This
-        default Builder removeComponent(@NonNull ItemDataComponent<?> component) {
+        default Builder removeComponent(ItemDataComponent<?> component) {
             Objects.requireNonNull(component);
             if (!component.vanilla()) {
                 throw new IllegalArgumentException("Cannot remove non-vanilla component");

--- a/api/src/main/java/org/geysermc/geyser/api/item/custom/v2/CustomItemDefinition.java
+++ b/api/src/main/java/org/geysermc/geyser/api/item/custom/v2/CustomItemDefinition.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024 GeyserMC. http://geysermc.org
+ * Copyright (c) 2024-2026 GeyserMC. http://geysermc.org
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/api/src/main/java/org/geysermc/geyser/api/item/custom/v2/NonVanillaCustomItemDefinition.java
+++ b/api/src/main/java/org/geysermc/geyser/api/item/custom/v2/NonVanillaCustomItemDefinition.java
@@ -26,8 +26,6 @@
 package org.geysermc.geyser.api.item.custom.v2;
 
 import org.checkerframework.checker.index.qual.NonNegative;
-import org.checkerframework.checker.nullness.qual.NonNull;
-import org.checkerframework.checker.nullness.qual.Nullable;
 import org.checkerframework.common.returnsreceiver.qual.This;
 import org.geysermc.geyser.api.GeyserApi;
 import org.geysermc.geyser.api.item.custom.v2.component.geyser.GeyserItemDataComponents;
@@ -38,6 +36,7 @@ import org.geysermc.geyser.api.predicate.PredicateStrategy;
 import org.geysermc.geyser.api.predicate.context.item.ItemPredicateContext;
 import org.geysermc.geyser.api.util.Identifier;
 import org.jetbrains.annotations.ApiStatus;
+import org.jspecify.annotations.Nullable;
 
 import java.util.List;
 
@@ -60,7 +59,7 @@ public interface NonVanillaCustomItemDefinition extends CustomItemDefinition {
      * @return the item's Java identifier
      * @since 2.9.3
      */
-    @NonNull Identifier identifier();
+    Identifier identifier();
 
     /**
      * The item's Java network ID.
@@ -89,7 +88,6 @@ public interface NonVanillaCustomItemDefinition extends CustomItemDefinition {
      * @since 2.9.3
      */
     @Override
-    @NonNull
     default List<MinecraftPredicate<? super ItemPredicateContext>> predicates() {
         throw new UnsupportedOperationException("Predicates are currently not supported for use with non-vanilla custom item definitions");
     }
@@ -103,7 +101,6 @@ public interface NonVanillaCustomItemDefinition extends CustomItemDefinition {
      * @since 2.9.3
      */
     @Override
-    @NonNull
     default PredicateStrategy predicateStrategy() {
         throw new UnsupportedOperationException("Predicates are currently not supported for use with non-vanilla custom item definitions");
     }
@@ -134,7 +131,6 @@ public interface NonVanillaCustomItemDefinition extends CustomItemDefinition {
      * @since 2.9.3
      */
     @Override
-    @NonNull
     ItemDataComponentMap components();
 
     /**
@@ -147,7 +143,7 @@ public interface NonVanillaCustomItemDefinition extends CustomItemDefinition {
      * @return a new builder
      * @since 2.9.3
      */
-    static Builder builder(@NonNull Identifier javaIdentifier, int javaId) {
+    static Builder builder(Identifier javaIdentifier, int javaId) {
         return builder(javaIdentifier, javaIdentifier, javaId);
     }
 
@@ -163,7 +159,7 @@ public interface NonVanillaCustomItemDefinition extends CustomItemDefinition {
      * @return a new builder
      * @since 2.9.3
      */
-    static Builder builder(@NonNull Identifier javaIdentifier, @NonNull Identifier bedrockIdentifier, int javaId) {
+    static Builder builder(Identifier javaIdentifier, Identifier bedrockIdentifier, int javaId) {
         return GeyserApi.api().provider(Builder.class, javaIdentifier, bedrockIdentifier, javaId);
     }
 
@@ -179,7 +175,7 @@ public interface NonVanillaCustomItemDefinition extends CustomItemDefinition {
          */
         @Override
         @This
-        Builder displayName(@NonNull String displayName);
+        Builder displayName(String displayName);
 
         /**
          * {@inheritDoc}
@@ -195,7 +191,7 @@ public interface NonVanillaCustomItemDefinition extends CustomItemDefinition {
          */
         @Override
         @This
-        Builder bedrockOptions(CustomItemBedrockOptions.@NonNull Builder options);
+        Builder bedrockOptions(CustomItemBedrockOptions.Builder options);
 
         /**
          * {@inheritDoc}
@@ -203,7 +199,7 @@ public interface NonVanillaCustomItemDefinition extends CustomItemDefinition {
          */
         @Override
         @This
-        <T> Builder component(@NonNull ItemDataComponent<T> component, @NonNull T value);
+        <T> Builder component(ItemDataComponent<T> component, T value);
 
         /**
          * Sets the Java translation string of the item.

--- a/api/src/main/java/org/geysermc/geyser/api/item/custom/v2/NonVanillaCustomItemDefinition.java
+++ b/api/src/main/java/org/geysermc/geyser/api/item/custom/v2/NonVanillaCustomItemDefinition.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2025 GeyserMC. http://geysermc.org
+ * Copyright (c) 2025-2026 GeyserMC. http://geysermc.org
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/api/src/main/java/org/geysermc/geyser/api/item/custom/v2/component/ItemDataComponent.java
+++ b/api/src/main/java/org/geysermc/geyser/api/item/custom/v2/component/ItemDataComponent.java
@@ -25,7 +25,6 @@
 
 package org.geysermc.geyser.api.item.custom.v2.component;
 
-import org.checkerframework.checker.nullness.qual.NonNull;
 import org.geysermc.geyser.api.item.custom.v2.CustomItemDefinition;
 import org.geysermc.geyser.api.item.custom.v2.component.geyser.GeyserItemDataComponents;
 import org.geysermc.geyser.api.item.custom.v2.component.java.JavaItemDataComponents;
@@ -54,7 +53,6 @@ public interface ItemDataComponent<T> {
      * @return the identifier
      * @since 2.9.3
      */
-    @NonNull
     Identifier identifier();
 
     /**
@@ -63,7 +61,6 @@ public interface ItemDataComponent<T> {
      * @return the validator
      * @since 2.9.3
      */
-    @NonNull
     Predicate<T> validator();
 
     /**

--- a/api/src/main/java/org/geysermc/geyser/api/item/custom/v2/component/ItemDataComponent.java
+++ b/api/src/main/java/org/geysermc/geyser/api/item/custom/v2/component/ItemDataComponent.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2025 GeyserMC. http://geysermc.org
+ * Copyright (c) 2025-2026 GeyserMC. http://geysermc.org
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/api/src/main/java/org/geysermc/geyser/api/item/custom/v2/component/geyser/GeyserBlockPlacer.java
+++ b/api/src/main/java/org/geysermc/geyser/api/item/custom/v2/component/geyser/GeyserBlockPlacer.java
@@ -25,7 +25,6 @@
 
 package org.geysermc.geyser.api.item.custom.v2.component.geyser;
 
-import org.checkerframework.checker.nullness.qual.NonNull;
 import org.checkerframework.common.returnsreceiver.qual.This;
 import org.geysermc.geyser.api.GeyserApi;
 import org.geysermc.geyser.api.util.GenericBuilder;
@@ -47,7 +46,7 @@ public interface GeyserBlockPlacer {
      * @return the identifier of the block to place
      * @since 2.9.3
      */
-    @NonNull Identifier block();
+    Identifier block();
 
     /**
      * Whether to use the block's rendering
@@ -65,7 +64,7 @@ public interface GeyserBlockPlacer {
      * @return a new builder
      * @since 2.9.3
      */
-    static @NonNull Builder builder() {
+    static Builder builder() {
         return GeyserApi.api().provider(GeyserBlockPlacer.Builder.class);
     }
 
@@ -77,7 +76,7 @@ public interface GeyserBlockPlacer {
      * @return the block placer component
      * @since 2.9.3
      */
-    static @NonNull GeyserBlockPlacer of(@NonNull Identifier block, boolean useBlockIcon) {
+    static GeyserBlockPlacer of(Identifier block, boolean useBlockIcon) {
         return GeyserBlockPlacer.builder().block(block).useBlockIcon(useBlockIcon).build();
     }
 
@@ -98,7 +97,7 @@ public interface GeyserBlockPlacer {
          * @since 2.9.3
          */
         @This
-        Builder block(@NonNull Identifier block);
+        Builder block(Identifier block);
 
         /**
          * Whether to use the block's icon over the item icon.

--- a/api/src/main/java/org/geysermc/geyser/api/item/custom/v2/component/geyser/GeyserBlockPlacer.java
+++ b/api/src/main/java/org/geysermc/geyser/api/item/custom/v2/component/geyser/GeyserBlockPlacer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2025 GeyserMC. http://geysermc.org
+ * Copyright (c) 2025-2026 GeyserMC. http://geysermc.org
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/api/src/main/java/org/geysermc/geyser/api/item/custom/v2/component/geyser/GeyserChargeable.java
+++ b/api/src/main/java/org/geysermc/geyser/api/item/custom/v2/component/geyser/GeyserChargeable.java
@@ -26,7 +26,6 @@
 package org.geysermc.geyser.api.item.custom.v2.component.geyser;
 
 import org.checkerframework.checker.index.qual.NonNegative;
-import org.checkerframework.checker.nullness.qual.NonNull;
 import org.checkerframework.common.returnsreceiver.qual.This;
 import org.geysermc.geyser.api.GeyserApi;
 import org.geysermc.geyser.api.util.GenericBuilder;
@@ -71,7 +70,7 @@ public interface GeyserChargeable {
      * @return all valid ammunition items
      * @since 2.9.3
      */
-    List<@NonNull Identifier> ammunition();
+    List<Identifier> ammunition();
 
     /**
      * Creates a builder for the Chargeable component.
@@ -79,7 +78,7 @@ public interface GeyserChargeable {
      * @return a new builder
      * @since 2.9.3
      */
-    static @NonNull Builder builder() {
+    static Builder builder() {
         return GeyserApi.api().provider(GeyserChargeable.Builder.class);
     }
 
@@ -121,7 +120,7 @@ public interface GeyserChargeable {
          * @since 2.9.3
          */
         @This
-        Builder ammunition(@NonNull Identifier ammunition);
+        Builder ammunition(Identifier ammunition);
 
         /**
          * Creates the chargeable component.

--- a/api/src/main/java/org/geysermc/geyser/api/item/custom/v2/component/geyser/GeyserChargeable.java
+++ b/api/src/main/java/org/geysermc/geyser/api/item/custom/v2/component/geyser/GeyserChargeable.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2025 GeyserMC. http://geysermc.org
+ * Copyright (c) 2025-2026 GeyserMC. http://geysermc.org
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/api/src/main/java/org/geysermc/geyser/api/item/custom/v2/component/geyser/GeyserThrowableComponent.java
+++ b/api/src/main/java/org/geysermc/geyser/api/item/custom/v2/component/geyser/GeyserThrowableComponent.java
@@ -25,7 +25,6 @@
 
 package org.geysermc.geyser.api.item.custom.v2.component.geyser;
 
-import org.checkerframework.checker.nullness.qual.NonNull;
 import org.checkerframework.common.returnsreceiver.qual.This;
 import org.geysermc.geyser.api.GeyserApi;
 import org.geysermc.geyser.api.util.GenericBuilder;
@@ -54,7 +53,7 @@ public interface GeyserThrowableComponent {
      * @return a new builder
      * @since 2.9.3
      */
-    static @NonNull Builder builder() {
+    static Builder builder() {
         return GeyserApi.api().provider(GeyserThrowableComponent.Builder.class);
     }
 
@@ -65,7 +64,7 @@ public interface GeyserThrowableComponent {
      * @return a throwable component
      * @since 2.9.3
      */
-    static @NonNull GeyserThrowableComponent of(boolean doSwingAnimation) {
+    static GeyserThrowableComponent of(boolean doSwingAnimation) {
         return builder().doSwingAnimation(doSwingAnimation).build();
     }
 

--- a/api/src/main/java/org/geysermc/geyser/api/item/custom/v2/component/geyser/GeyserThrowableComponent.java
+++ b/api/src/main/java/org/geysermc/geyser/api/item/custom/v2/component/geyser/GeyserThrowableComponent.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2025 GeyserMC. http://geysermc.org
+ * Copyright (c) 2025-2026 GeyserMC. http://geysermc.org
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/api/src/main/java/org/geysermc/geyser/api/item/custom/v2/component/geyser/package-info.java
+++ b/api/src/main/java/org/geysermc/geyser/api/item/custom/v2/component/geyser/package-info.java
@@ -1,0 +1,29 @@
+/*
+ * Copyright (c) 2026 GeyserMC. http://geysermc.org
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ *
+ * @author GeyserMC
+ * @link https://github.com/GeyserMC/Geyser
+ */
+
+@NullMarked
+package org.geysermc.geyser.api.item.custom.v2.component.geyser;
+
+import org.jspecify.annotations.NullMarked;

--- a/api/src/main/java/org/geysermc/geyser/api/item/custom/v2/component/java/JavaAttackRange.java
+++ b/api/src/main/java/org/geysermc/geyser/api/item/custom/v2/component/java/JavaAttackRange.java
@@ -25,7 +25,6 @@
 
 package org.geysermc.geyser.api.item.custom.v2.component.java;
 
-import org.checkerframework.checker.nullness.qual.NonNull;
 import org.checkerframework.common.returnsreceiver.qual.This;
 import org.checkerframework.common.value.qual.IntRange;
 import org.geysermc.geyser.api.GeyserApi;
@@ -85,7 +84,7 @@ public interface JavaAttackRange {
      * @return a new builder
      * @since 2.9.3
      */
-    static @NonNull Builder builder() {
+    static Builder builder() {
         return GeyserApi.api().provider(Builder.class);
     }
 

--- a/api/src/main/java/org/geysermc/geyser/api/item/custom/v2/component/java/JavaAttackRange.java
+++ b/api/src/main/java/org/geysermc/geyser/api/item/custom/v2/component/java/JavaAttackRange.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2025 GeyserMC. http://geysermc.org
+ * Copyright (c) 2025-2026 GeyserMC. http://geysermc.org
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/api/src/main/java/org/geysermc/geyser/api/item/custom/v2/component/java/JavaConsumable.java
+++ b/api/src/main/java/org/geysermc/geyser/api/item/custom/v2/component/java/JavaConsumable.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2025 GeyserMC. http://geysermc.org
+ * Copyright (c) 2025-2026 GeyserMC. http://geysermc.org
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -128,7 +128,7 @@ public interface JavaConsumable {
          * Brush in 1st and 3rd person. Will look weird when not displayed handheld.
          * @since 2.9.3
          */
-        BRUSH;
+        BRUSH
     }
 
     /**

--- a/api/src/main/java/org/geysermc/geyser/api/item/custom/v2/component/java/JavaConsumable.java
+++ b/api/src/main/java/org/geysermc/geyser/api/item/custom/v2/component/java/JavaConsumable.java
@@ -26,7 +26,6 @@
 package org.geysermc.geyser.api.item.custom.v2.component.java;
 
 import org.checkerframework.checker.index.qual.Positive;
-import org.checkerframework.checker.nullness.qual.NonNull;
 import org.checkerframework.common.returnsreceiver.qual.This;
 import org.geysermc.geyser.api.GeyserApi;
 import org.geysermc.geyser.api.util.GenericBuilder;
@@ -54,7 +53,7 @@ public interface JavaConsumable {
      * @return the animation to play
      * @since 2.9.3
      */
-    @NonNull Animation animation();
+    Animation animation();
 
     /**
      * Creates a builder for the consumable component.
@@ -62,7 +61,7 @@ public interface JavaConsumable {
      * @return a new builder
      * @since 2.9.3
      */
-    static @NonNull Builder builder() {
+    static Builder builder() {
         return GeyserApi.api().provider(JavaConsumable.Builder.class);
     }
 
@@ -74,7 +73,7 @@ public interface JavaConsumable {
      * @return the consumable component
      * @since 2.9.3
      */
-    static @NonNull JavaConsumable of(float consumeSeconds, Animation animation) {
+    static JavaConsumable of(float consumeSeconds, Animation animation) {
         return JavaConsumable.builder().consumeSeconds(consumeSeconds).animation(animation).build();
     }
 
@@ -160,7 +159,7 @@ public interface JavaConsumable {
          * @since 2.9.3
          */
         @This
-        Builder animation(@NonNull Animation animation);
+        Builder animation(Animation animation);
 
         /**
          * Creates the consumable component.

--- a/api/src/main/java/org/geysermc/geyser/api/item/custom/v2/component/java/JavaEquippable.java
+++ b/api/src/main/java/org/geysermc/geyser/api/item/custom/v2/component/java/JavaEquippable.java
@@ -25,7 +25,6 @@
 
 package org.geysermc.geyser.api.item.custom.v2.component.java;
 
-import org.checkerframework.checker.nullness.qual.NonNull;
 import org.checkerframework.common.returnsreceiver.qual.This;
 import org.geysermc.geyser.api.GeyserApi;
 import org.geysermc.geyser.api.util.GenericBuilder;
@@ -43,14 +42,14 @@ public interface JavaEquippable {
      *
      * @return the equipment slot
      */
-    @NonNull EquipmentSlot slot();
+    EquipmentSlot slot();
 
     /**
      * Creates a builder for the equippable component.
      *
      * @return a new builder
      */
-    static @NonNull Builder builder() {
+    static Builder builder() {
         return GeyserApi.api().provider(JavaEquippable.Builder.class);
     }
 
@@ -60,7 +59,7 @@ public interface JavaEquippable {
      * @param slot the slot in which the item can be equipped
      * @return the Equippable component
      */
-    static @NonNull JavaEquippable of(EquipmentSlot slot) {
+    static JavaEquippable of(EquipmentSlot slot) {
         return builder().slot(slot).build();
     }
 
@@ -77,7 +76,7 @@ public interface JavaEquippable {
          * @return this builder
          */
         @This
-        Builder slot(@NonNull EquipmentSlot slot);
+        Builder slot(EquipmentSlot slot);
 
         /**
          * Creates the equippable component.

--- a/api/src/main/java/org/geysermc/geyser/api/item/custom/v2/component/java/JavaEquippable.java
+++ b/api/src/main/java/org/geysermc/geyser/api/item/custom/v2/component/java/JavaEquippable.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2025 GeyserMC. http://geysermc.org
+ * Copyright (c) 2025-2026 GeyserMC. http://geysermc.org
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/api/src/main/java/org/geysermc/geyser/api/item/custom/v2/component/java/JavaFoodProperties.java
+++ b/api/src/main/java/org/geysermc/geyser/api/item/custom/v2/component/java/JavaFoodProperties.java
@@ -26,7 +26,6 @@
 package org.geysermc.geyser.api.item.custom.v2.component.java;
 
 import org.checkerframework.checker.index.qual.NonNegative;
-import org.checkerframework.checker.nullness.qual.NonNull;
 import org.checkerframework.common.returnsreceiver.qual.This;
 import org.geysermc.geyser.api.GeyserApi;
 import org.geysermc.geyser.api.util.GenericBuilder;
@@ -71,7 +70,7 @@ public interface JavaFoodProperties {
      * @return a new builder
      * @since 2.9.3
      */
-    static @NonNull Builder builder() {
+    static Builder builder() {
         return GeyserApi.api().provider(JavaFoodProperties.Builder.class);
     }
 
@@ -84,7 +83,7 @@ public interface JavaFoodProperties {
      * @return the food properties component
      * @since 2.9.3
      */
-    static @NonNull JavaFoodProperties of(int nutrition, float saturation, boolean canAlwaysEat) {
+    static JavaFoodProperties of(int nutrition, float saturation, boolean canAlwaysEat) {
         return JavaFoodProperties.builder().nutrition(nutrition).saturation(saturation).canAlwaysEat(canAlwaysEat).build();
     }
 

--- a/api/src/main/java/org/geysermc/geyser/api/item/custom/v2/component/java/JavaFoodProperties.java
+++ b/api/src/main/java/org/geysermc/geyser/api/item/custom/v2/component/java/JavaFoodProperties.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2025 GeyserMC. http://geysermc.org
+ * Copyright (c) 2025-2026 GeyserMC. http://geysermc.org
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/api/src/main/java/org/geysermc/geyser/api/item/custom/v2/component/java/JavaKineticWeapon.java
+++ b/api/src/main/java/org/geysermc/geyser/api/item/custom/v2/component/java/JavaKineticWeapon.java
@@ -26,11 +26,10 @@
 package org.geysermc.geyser.api.item.custom.v2.component.java;
 
 import org.checkerframework.checker.index.qual.NonNegative;
-import org.checkerframework.checker.nullness.qual.NonNull;
-import org.checkerframework.checker.nullness.qual.Nullable;
 import org.checkerframework.common.returnsreceiver.qual.This;
 import org.geysermc.geyser.api.GeyserApi;
 import org.geysermc.geyser.api.util.GenericBuilder;
+import org.jspecify.annotations.Nullable;
 
 /**
  * The kinetic weapon component is used to specify a spear-like attack when the item is in use.
@@ -60,7 +59,7 @@ public interface JavaKineticWeapon {
      * @return a new builder
      * @since 2.9.3
      */
-    static @NonNull Builder builder() {
+    static Builder builder() {
         return GeyserApi.api().provider(Builder.class);
     }
 
@@ -73,7 +72,7 @@ public interface JavaKineticWeapon {
      * @return the new {@link Condition}
      * @since 2.9.3
      */
-    static @NonNull Condition condition(@NonNegative int maxDurationTicks) {
+    static Condition condition(@NonNegative int maxDurationTicks) {
         return condition(maxDurationTicks, 0.0F, 0.0F);
     }
 
@@ -90,7 +89,7 @@ public interface JavaKineticWeapon {
      * @return the new {@link Condition}
      * @since 2.9.3
      */
-    static @NonNull Condition condition(@NonNegative int maxDurationTicks, float minSpeed, float minRelativeSpeed) {
+    static Condition condition(@NonNegative int maxDurationTicks, float minSpeed, float minRelativeSpeed) {
         return Condition.builder(maxDurationTicks)
             .minSpeed(minSpeed)
             .minRelativeSpeed(minRelativeSpeed)
@@ -119,7 +118,7 @@ public interface JavaKineticWeapon {
          * @since 2.9.3
          */
         @This
-        default Builder dismountConditions(Condition.@NonNull Builder dismountConditions) {
+        default Builder dismountConditions(Condition.Builder dismountConditions) {
             return dismountConditions(dismountConditions.build());
         }
 
@@ -183,7 +182,7 @@ public interface JavaKineticWeapon {
          * @return a new builder
          * @since 2.9.3
          */
-        static @NonNull Builder builder(@NonNegative int maxDurationTicks) {
+        static Builder builder(@NonNegative int maxDurationTicks) {
             return GeyserApi.api().provider(Builder.class, maxDurationTicks);
         }
 

--- a/api/src/main/java/org/geysermc/geyser/api/item/custom/v2/component/java/JavaKineticWeapon.java
+++ b/api/src/main/java/org/geysermc/geyser/api/item/custom/v2/component/java/JavaKineticWeapon.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2025 GeyserMC. http://geysermc.org
+ * Copyright (c) 2025-2026 GeyserMC. http://geysermc.org
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/api/src/main/java/org/geysermc/geyser/api/item/custom/v2/component/java/JavaPiercingWeapon.java
+++ b/api/src/main/java/org/geysermc/geyser/api/item/custom/v2/component/java/JavaPiercingWeapon.java
@@ -25,7 +25,6 @@
 
 package org.geysermc.geyser.api.item.custom.v2.component.java;
 
-import org.checkerframework.checker.nullness.qual.NonNull;
 import org.geysermc.geyser.api.GeyserApi;
 
 /**
@@ -38,7 +37,7 @@ public interface JavaPiercingWeapon {
      * @return the piercing weapon component
      * @since 2.9.3
      */
-    static @NonNull JavaPiercingWeapon instance() {
+    static JavaPiercingWeapon instance() {
         return GeyserApi.api().provider(JavaPiercingWeapon.class);
     }
 }

--- a/api/src/main/java/org/geysermc/geyser/api/item/custom/v2/component/java/JavaPiercingWeapon.java
+++ b/api/src/main/java/org/geysermc/geyser/api/item/custom/v2/component/java/JavaPiercingWeapon.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2025 GeyserMC. http://geysermc.org
+ * Copyright (c) 2025-2026 GeyserMC. http://geysermc.org
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/api/src/main/java/org/geysermc/geyser/api/item/custom/v2/component/java/JavaRepairable.java
+++ b/api/src/main/java/org/geysermc/geyser/api/item/custom/v2/component/java/JavaRepairable.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2025 GeyserMC. http://geysermc.org
+ * Copyright (c) 2025-2026 GeyserMC. http://geysermc.org
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/api/src/main/java/org/geysermc/geyser/api/item/custom/v2/component/java/JavaRepairable.java
+++ b/api/src/main/java/org/geysermc/geyser/api/item/custom/v2/component/java/JavaRepairable.java
@@ -25,7 +25,6 @@
 
 package org.geysermc.geyser.api.item.custom.v2.component.java;
 
-import org.checkerframework.checker.nullness.qual.NonNull;
 import org.checkerframework.common.returnsreceiver.qual.This;
 import org.geysermc.geyser.api.GeyserApi;
 import org.geysermc.geyser.api.util.GenericBuilder;
@@ -44,7 +43,7 @@ public interface JavaRepairable {
      * @return the {@link Holders} of item identifiers
      * @since 2.9.3
      */
-    @NonNull Holders items();
+    Holders items();
 
     /**
      * Creates a builder for the repairable component.
@@ -52,7 +51,7 @@ public interface JavaRepairable {
      * @return a new builder
      * @since 2.9.3
      */
-    static @NonNull Builder builder() {
+    static Builder builder() {
         return GeyserApi.api().provider(JavaRepairable.Builder.class);
     }
 
@@ -64,7 +63,7 @@ public interface JavaRepairable {
      * @return the repairable component
      * @since 2.9.3
      */
-    static @NonNull JavaRepairable of(@NonNull Holders items) {
+    static JavaRepairable of(Holders items) {
         return JavaRepairable.builder().items(items).build();
     }
 
@@ -83,7 +82,7 @@ public interface JavaRepairable {
          * @since 2.9.3
          */
         @This
-        Builder items(@NonNull Holders items);
+        Builder items(Holders items);
 
         /**
          * Creates the repairable component.

--- a/api/src/main/java/org/geysermc/geyser/api/item/custom/v2/component/java/JavaSwingAnimation.java
+++ b/api/src/main/java/org/geysermc/geyser/api/item/custom/v2/component/java/JavaSwingAnimation.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2025 GeyserMC. http://geysermc.org
+ * Copyright (c) 2025-2026 GeyserMC. http://geysermc.org
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/api/src/main/java/org/geysermc/geyser/api/item/custom/v2/component/java/JavaSwingAnimation.java
+++ b/api/src/main/java/org/geysermc/geyser/api/item/custom/v2/component/java/JavaSwingAnimation.java
@@ -26,7 +26,6 @@
 package org.geysermc.geyser.api.item.custom.v2.component.java;
 
 import org.checkerframework.checker.index.qual.Positive;
-import org.checkerframework.checker.nullness.qual.NonNull;
 import org.checkerframework.common.returnsreceiver.qual.This;
 import org.geysermc.geyser.api.GeyserApi;
 import org.geysermc.geyser.api.util.GenericBuilder;
@@ -53,7 +52,7 @@ public interface JavaSwingAnimation {
      * @return a new builder
      * @since 2.9.3
      */
-    static @NonNull Builder builder() {
+    static Builder builder() {
         return GeyserApi.api().provider(Builder.class);
     }
 
@@ -64,7 +63,7 @@ public interface JavaSwingAnimation {
      * @return the new swing animation component
      * @since 2.9.3
      */
-    static @NonNull JavaSwingAnimation of(@Positive int duration) {
+    static JavaSwingAnimation of(@Positive int duration) {
         return builder()
             .duration(duration)
             .build();

--- a/api/src/main/java/org/geysermc/geyser/api/item/custom/v2/component/java/JavaTool.java
+++ b/api/src/main/java/org/geysermc/geyser/api/item/custom/v2/component/java/JavaTool.java
@@ -26,7 +26,6 @@
 package org.geysermc.geyser.api.item.custom.v2.component.java;
 
 import org.checkerframework.checker.index.qual.Positive;
-import org.checkerframework.checker.nullness.qual.NonNull;
 import org.checkerframework.common.returnsreceiver.qual.This;
 import org.geysermc.geyser.api.GeyserApi;
 import org.geysermc.geyser.api.util.GenericBuilder;
@@ -50,7 +49,7 @@ public interface JavaTool {
      * @return a list of rules this tool has
      * @since 2.9.3
      */
-    List<@NonNull Rule> rules();
+    List<Rule> rules();
 
     /**
      * The default mining speed of the tool. This speed is used when no rules match when breaking a block.
@@ -76,7 +75,7 @@ public interface JavaTool {
      * @return a new builder
      * @since 2.9.3
      */
-    static @NonNull Builder builder() {
+    static Builder builder() {
         return GeyserApi.api().provider(JavaTool.Builder.class);
     }
 
@@ -87,7 +86,7 @@ public interface JavaTool {
      * @return a tool  component
      * @since 2.9.3
      */
-    static @NonNull JavaTool of(boolean canDestroyBlocksInCreative) {
+    static JavaTool of(boolean canDestroyBlocksInCreative) {
         return builder().canDestroyBlocksInCreative(canDestroyBlocksInCreative).build();
     }
 
@@ -106,7 +105,7 @@ public interface JavaTool {
          * @since 2.9.3
          */
         @This
-        Builder rule(@NonNull Rule rule);
+        Builder rule(Rule rule);
 
         /**
          * Sets the default mining speed of this tool. Vanilla-item overrides don't need a speed set.
@@ -151,7 +150,7 @@ public interface JavaTool {
          * @return the {@link Holders} of block identifiers that this rule is for
          * @since 2.9.3
          */
-        @NonNull Holders blocks();
+        Holders blocks();
 
         /**
          * @return the speed to use when mining a block that matches this rule
@@ -165,7 +164,7 @@ public interface JavaTool {
          * @return a new builder
          * @since 2.9.3
          */
-        static @NonNull Builder builder() {
+        static Builder builder() {
             return GeyserApi.api().provider(Rule.Builder.class);
         }
 
@@ -177,7 +176,7 @@ public interface JavaTool {
          * @return a tool rule
          * @since 2.9.3
          */
-        static @NonNull Rule of(@NonNull Holders blocks, @Positive float speed) {
+        static Rule of(Holders blocks, @Positive float speed) {
             return Rule.builder().blocks(blocks).speed(speed).build();
         }
 
@@ -195,7 +194,7 @@ public interface JavaTool {
              * @since 2.9.3
              */
             @This
-            Builder blocks(@NonNull Holders blocks);
+            Builder blocks(Holders blocks);
 
             /**
              * Sets the speed to use when mining a block that matches this rule

--- a/api/src/main/java/org/geysermc/geyser/api/item/custom/v2/component/java/JavaTool.java
+++ b/api/src/main/java/org/geysermc/geyser/api/item/custom/v2/component/java/JavaTool.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2025 GeyserMC. http://geysermc.org
+ * Copyright (c) 2025-2026 GeyserMC. http://geysermc.org
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/api/src/main/java/org/geysermc/geyser/api/item/custom/v2/component/java/JavaUseCooldown.java
+++ b/api/src/main/java/org/geysermc/geyser/api/item/custom/v2/component/java/JavaUseCooldown.java
@@ -26,12 +26,11 @@
 package org.geysermc.geyser.api.item.custom.v2.component.java;
 
 import org.checkerframework.checker.index.qual.Positive;
-import org.checkerframework.checker.nullness.qual.NonNull;
-import org.checkerframework.checker.nullness.qual.Nullable;
 import org.checkerframework.common.returnsreceiver.qual.This;
 import org.geysermc.geyser.api.GeyserApi;
 import org.geysermc.geyser.api.util.GenericBuilder;
 import org.geysermc.geyser.api.util.Identifier;
+import org.jspecify.annotations.Nullable;
 
 /**
  * The use cooldown component is used to add an item use cooldown to items.
@@ -65,7 +64,7 @@ public interface JavaUseCooldown {
      * @return a new builder
      * @since 2.9.3
      */
-    static @NonNull Builder builder() {
+    static Builder builder() {
         return GeyserApi.api().provider(JavaUseCooldown.Builder.class);
     }
 

--- a/api/src/main/java/org/geysermc/geyser/api/item/custom/v2/component/java/JavaUseCooldown.java
+++ b/api/src/main/java/org/geysermc/geyser/api/item/custom/v2/component/java/JavaUseCooldown.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2025 GeyserMC. http://geysermc.org
+ * Copyright (c) 2025-2026 GeyserMC. http://geysermc.org
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/api/src/main/java/org/geysermc/geyser/api/item/custom/v2/component/java/JavaUseEffects.java
+++ b/api/src/main/java/org/geysermc/geyser/api/item/custom/v2/component/java/JavaUseEffects.java
@@ -25,7 +25,6 @@
 
 package org.geysermc.geyser.api.item.custom.v2.component.java;
 
-import org.checkerframework.checker.nullness.qual.NonNull;
 import org.checkerframework.common.returnsreceiver.qual.This;
 import org.checkerframework.common.value.qual.IntRange;
 import org.geysermc.geyser.api.GeyserApi;
@@ -53,7 +52,7 @@ public interface JavaUseEffects {
      * @return a new builder
      * @since 2.9.3
      */
-    static @NonNull Builder builder() {
+    static Builder builder() {
         return GeyserApi.api().provider(Builder.class);
     }
 
@@ -64,7 +63,7 @@ public interface JavaUseEffects {
      * @return the new use effects component
      * @since 2.9.3
      */
-    static @NonNull JavaUseEffects of(@IntRange(from = 0, to = 1) float speedMultiplier) {
+    static JavaUseEffects of(@IntRange(from = 0, to = 1) float speedMultiplier) {
         return builder()
             .speedMultiplier(speedMultiplier)
             .build();

--- a/api/src/main/java/org/geysermc/geyser/api/item/custom/v2/component/java/JavaUseEffects.java
+++ b/api/src/main/java/org/geysermc/geyser/api/item/custom/v2/component/java/JavaUseEffects.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2025 GeyserMC. http://geysermc.org
+ * Copyright (c) 2025-2026 GeyserMC. http://geysermc.org
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/api/src/main/java/org/geysermc/geyser/api/item/custom/v2/component/java/package-info.java
+++ b/api/src/main/java/org/geysermc/geyser/api/item/custom/v2/component/java/package-info.java
@@ -1,0 +1,29 @@
+/*
+ * Copyright (c) 2026 GeyserMC. http://geysermc.org
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ *
+ * @author GeyserMC
+ * @link https://github.com/GeyserMC/Geyser
+ */
+
+@NullMarked
+package org.geysermc.geyser.api.item.custom.v2.component.java;
+
+import org.jspecify.annotations.NullMarked;

--- a/api/src/main/java/org/geysermc/geyser/api/item/custom/v2/component/package-info.java
+++ b/api/src/main/java/org/geysermc/geyser/api/item/custom/v2/component/package-info.java
@@ -1,0 +1,29 @@
+/*
+ * Copyright (c) 2026 GeyserMC. http://geysermc.org
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ *
+ * @author GeyserMC
+ * @link https://github.com/GeyserMC/Geyser
+ */
+
+@NullMarked
+package org.geysermc.geyser.api.item.custom.v2.component;
+
+import org.jspecify.annotations.NullMarked;

--- a/api/src/main/java/org/geysermc/geyser/api/item/custom/v2/package-info.java
+++ b/api/src/main/java/org/geysermc/geyser/api/item/custom/v2/package-info.java
@@ -1,0 +1,29 @@
+/*
+ * Copyright (c) 2026 GeyserMC. http://geysermc.org
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ *
+ * @author GeyserMC
+ * @link https://github.com/GeyserMC/Geyser
+ */
+
+@NullMarked
+package org.geysermc.geyser.api.item.custom.v2;
+
+import org.jspecify.annotations.NullMarked;

--- a/api/src/main/java/org/geysermc/geyser/api/network/BedrockListener.java
+++ b/api/src/main/java/org/geysermc/geyser/api/network/BedrockListener.java
@@ -25,8 +25,6 @@
 
 package org.geysermc.geyser.api.network;
 
-import org.checkerframework.checker.nullness.qual.NonNull;
-
 /**
  * The listener that handles connections from Minecraft:
  * Bedrock Edition.
@@ -39,7 +37,6 @@ public interface BedrockListener {
      *
      * @return the listening address
      */
-    @NonNull
     String address();
 
     /**

--- a/api/src/main/java/org/geysermc/geyser/api/network/BedrockListener.java
+++ b/api/src/main/java/org/geysermc/geyser/api/network/BedrockListener.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019-2022 GeyserMC. http://geysermc.org
+ * Copyright (c) 2019-2026 GeyserMC. http://geysermc.org
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/api/src/main/java/org/geysermc/geyser/api/network/RemoteServer.java
+++ b/api/src/main/java/org/geysermc/geyser/api/network/RemoteServer.java
@@ -25,7 +25,6 @@
 
 package org.geysermc.geyser.api.network;
 
-
 /**
  * Represents the Java server that Geyser is connecting to.
  */

--- a/api/src/main/java/org/geysermc/geyser/api/network/RemoteServer.java
+++ b/api/src/main/java/org/geysermc/geyser/api/network/RemoteServer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019-2022 GeyserMC. http://geysermc.org
+ * Copyright (c) 2019-2026 GeyserMC. http://geysermc.org
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/api/src/main/java/org/geysermc/geyser/api/network/RemoteServer.java
+++ b/api/src/main/java/org/geysermc/geyser/api/network/RemoteServer.java
@@ -25,7 +25,6 @@
 
 package org.geysermc.geyser.api.network;
 
-import org.checkerframework.checker.nullness.qual.NonNull;
 
 /**
  * Represents the Java server that Geyser is connecting to.
@@ -65,7 +64,6 @@ public interface RemoteServer {
      *
      * @return the auth type required by the remote server
      */
-    @NonNull
     AuthType authType();
 
     /**

--- a/api/src/main/java/org/geysermc/geyser/api/network/package-info.java
+++ b/api/src/main/java/org/geysermc/geyser/api/network/package-info.java
@@ -1,0 +1,29 @@
+/*
+ * Copyright (c) 2026 GeyserMC. http://geysermc.org
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ *
+ * @author GeyserMC
+ * @link https://github.com/GeyserMC/Geyser
+ */
+
+@NullMarked
+package org.geysermc.geyser.api.network;
+
+import org.jspecify.annotations.NullMarked;

--- a/api/src/main/java/org/geysermc/geyser/api/pack/PackCodec.java
+++ b/api/src/main/java/org/geysermc/geyser/api/pack/PackCodec.java
@@ -25,7 +25,6 @@
 
 package org.geysermc.geyser.api.pack;
 
-import org.checkerframework.checker.nullness.qual.NonNull;
 import org.geysermc.geyser.api.GeyserApi;
 
 import java.io.IOException;
@@ -45,7 +44,7 @@ public abstract class PackCodec {
      * @return the hash of the resource pack
      * @since 2.1.1
      */
-    public abstract byte @NonNull [] sha256();
+    public abstract byte[] sha256();
 
     /**
      * Gets the resource pack size.
@@ -59,8 +58,7 @@ public abstract class PackCodec {
      * @deprecated use {@link #serialize()} instead.
      */
     @Deprecated
-    @NonNull
-    public SeekableByteChannel serialize(@NonNull ResourcePack resourcePack) throws IOException {
+    public SeekableByteChannel serialize(ResourcePack resourcePack) throws IOException {
         return serialize();
     };
 
@@ -70,7 +68,6 @@ public abstract class PackCodec {
      * @return the serialized resource pack
      * @since 2.6.2
      */
-    @NonNull
     public abstract SeekableByteChannel serialize() throws IOException;
 
     /**
@@ -79,7 +76,6 @@ public abstract class PackCodec {
      * @return the new resource pack
      * @since 2.1.1
      */
-    @NonNull
     protected abstract ResourcePack create();
 
     /**
@@ -88,7 +84,7 @@ public abstract class PackCodec {
      * @return the new resource pack builder
      * @since 2.6.2
      */
-    protected abstract ResourcePack.@NonNull Builder createBuilder();
+    protected abstract ResourcePack.Builder createBuilder();
 
     /**
      * Creates a new pack provider from the given path.
@@ -97,8 +93,7 @@ public abstract class PackCodec {
      * @return the new pack provider
      * @since 2.1.1
      */
-    @NonNull
-    public static PackCodec path(@NonNull Path path) {
+    public static PackCodec path(Path path) {
         return GeyserApi.api().provider(PathPackCodec.class, path);
     }
 
@@ -109,8 +104,7 @@ public abstract class PackCodec {
      * @return the new pack provider
      * @since 2.6.2
      */
-    @NonNull
-    public static PackCodec url(@NonNull String url) {
+    public static PackCodec url(String url) {
         return GeyserApi.api().provider(UrlPackCodec.class, url);
     }
 }

--- a/api/src/main/java/org/geysermc/geyser/api/pack/PackCodec.java
+++ b/api/src/main/java/org/geysermc/geyser/api/pack/PackCodec.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019-2023 GeyserMC. http://geysermc.org
+ * Copyright (c) 2019-2026 GeyserMC. http://geysermc.org
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -60,7 +60,7 @@ public abstract class PackCodec {
     @Deprecated
     public SeekableByteChannel serialize(ResourcePack resourcePack) throws IOException {
         return serialize();
-    };
+    }
 
     /**
      * Serializes the given codec into a byte buffer.

--- a/api/src/main/java/org/geysermc/geyser/api/pack/PathPackCodec.java
+++ b/api/src/main/java/org/geysermc/geyser/api/pack/PathPackCodec.java
@@ -25,7 +25,6 @@
 
 package org.geysermc.geyser.api.pack;
 
-import org.checkerframework.checker.nullness.qual.NonNull;
 
 import java.nio.file.Path;
 
@@ -42,6 +41,5 @@ public abstract class PathPackCodec extends PackCodec {
      * @return the path of the resource pack
      * @since 2.1.1
      */
-    @NonNull
     public abstract Path path();
 }

--- a/api/src/main/java/org/geysermc/geyser/api/pack/PathPackCodec.java
+++ b/api/src/main/java/org/geysermc/geyser/api/pack/PathPackCodec.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019-2023 GeyserMC. http://geysermc.org
+ * Copyright (c) 2019-2026 GeyserMC. http://geysermc.org
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/api/src/main/java/org/geysermc/geyser/api/pack/PathPackCodec.java
+++ b/api/src/main/java/org/geysermc/geyser/api/pack/PathPackCodec.java
@@ -25,7 +25,6 @@
 
 package org.geysermc.geyser.api.pack;
 
-
 import java.nio.file.Path;
 
 /**

--- a/api/src/main/java/org/geysermc/geyser/api/pack/ResourcePack.java
+++ b/api/src/main/java/org/geysermc/geyser/api/pack/ResourcePack.java
@@ -25,7 +25,6 @@
 
 package org.geysermc.geyser.api.pack;
 
-import org.checkerframework.checker.nullness.qual.NonNull;
 import org.checkerframework.common.returnsreceiver.qual.This;
 
 import java.util.UUID;
@@ -45,7 +44,6 @@ public interface ResourcePack {
      * @return the codec for this pack
      * @since 2.1.1
      */
-    @NonNull
     PackCodec codec();
 
     /**
@@ -54,7 +52,6 @@ public interface ResourcePack {
      * @return the resource pack manifest
      * @since 2.1.1
      */
-    @NonNull
     ResourcePackManifest manifest();
 
     /**
@@ -63,7 +60,6 @@ public interface ResourcePack {
      * @return the content key of the resource pack
      * @since 2.1.1
      */
-    @NonNull
     String contentKey();
 
     /**
@@ -72,7 +68,6 @@ public interface ResourcePack {
      * @return the resource pack uuid
      * @since 2.6.2
      */
-    @NonNull
     default UUID uuid() {
         return manifest().header().uuid();
     }
@@ -84,8 +79,7 @@ public interface ResourcePack {
      * @return the resource pack
      * @since 2.1.1
      */
-    @NonNull
-    static ResourcePack create(@NonNull PackCodec codec) {
+    static ResourcePack create(PackCodec codec) {
         return codec.create();
     }
 
@@ -97,7 +91,7 @@ public interface ResourcePack {
      * @return a {@link Builder} to build a resource pack
      * @since 2.6.2
      */
-    static Builder builder(@NonNull PackCodec codec) {
+    static Builder builder(PackCodec codec) {
         return codec.createBuilder();
     }
 
@@ -132,7 +126,7 @@ public interface ResourcePack {
          * @return this builder
          * @since 2.6.2
          */
-        @This Builder contentKey(@NonNull String contentKey);
+        @This Builder contentKey(String contentKey);
 
         /**
          * @return the resource pack

--- a/api/src/main/java/org/geysermc/geyser/api/pack/ResourcePack.java
+++ b/api/src/main/java/org/geysermc/geyser/api/pack/ResourcePack.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019-2023 GeyserMC. http://geysermc.org
+ * Copyright (c) 2019-2026 GeyserMC. http://geysermc.org
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/api/src/main/java/org/geysermc/geyser/api/pack/ResourcePackManifest.java
+++ b/api/src/main/java/org/geysermc/geyser/api/pack/ResourcePackManifest.java
@@ -25,11 +25,10 @@
 
 package org.geysermc.geyser.api.pack;
 
-import org.checkerframework.checker.nullness.qual.NonNull;
-import org.checkerframework.checker.nullness.qual.Nullable;
 import org.geysermc.geyser.api.event.bedrock.SessionLoadResourcePacksEvent;
 import org.geysermc.geyser.api.event.lifecycle.GeyserDefineResourcePacksEvent;
 import org.geysermc.geyser.api.pack.option.SubpackOption;
+import org.jspecify.annotations.Nullable;
 
 import java.util.Collection;
 import java.util.UUID;
@@ -60,7 +59,6 @@ public interface ResourcePackManifest {
      * @return the {@link Header}
      * @since 2.1.1
      */
-    @NonNull
     Header header();
 
     /**
@@ -69,7 +67,6 @@ public interface ResourcePackManifest {
      * @return a collection of modules
      * @since 2.1.1
      */
-    @NonNull
     Collection<? extends Module> modules();
 
     /**
@@ -78,7 +75,6 @@ public interface ResourcePackManifest {
      * @return a collection of dependencies
      * @since 2.6.2
      */
-    @NonNull
     Collection<? extends Dependency> dependencies();
 
     /**
@@ -89,7 +85,6 @@ public interface ResourcePackManifest {
      * @return a collection of subpacks
      * @since 2.6.2
      */
-    @NonNull
     Collection<? extends Subpack> subpacks();
 
     /**
@@ -100,7 +95,6 @@ public interface ResourcePackManifest {
      * @return a collection of settings
      * @since 2.6.2
      */
-    @NonNull
     Collection<? extends Setting> settings();
 
     /**
@@ -120,7 +114,6 @@ public interface ResourcePackManifest {
          * @return the UUID
          * @since 2.1.1
          */
-        @NonNull
         UUID uuid();
 
         /**
@@ -129,7 +122,6 @@ public interface ResourcePackManifest {
          * @return the version
          * @since 2.1.1
          */
-        @NonNull
         Version version();
 
         /**
@@ -138,7 +130,6 @@ public interface ResourcePackManifest {
          * @return the name
          * @since 2.1.1
          */
-        @NonNull
         String name();
 
         /**
@@ -147,7 +138,6 @@ public interface ResourcePackManifest {
          * @return the description
          * @since 2.1.1
          */
-        @NonNull
         String description();
 
         /**
@@ -156,7 +146,6 @@ public interface ResourcePackManifest {
          * @return the minimum supported Minecraft version
          * @since 2.1.1
          */
-        @NonNull
         Version minimumSupportedMinecraftVersion();
     }
 
@@ -177,7 +166,6 @@ public interface ResourcePackManifest {
          * @return the UUID
          * @since 2.1.1
          */
-        @NonNull
         UUID uuid();
 
         /**
@@ -186,7 +174,6 @@ public interface ResourcePackManifest {
          * @return the {@link Version}
          * @since 2.1.1
          */
-        @NonNull
         Version version();
 
         /**
@@ -195,7 +182,6 @@ public interface ResourcePackManifest {
          * @return the type
          * @since 2.1.1
          */
-        @NonNull
         String type();
 
         /**
@@ -204,7 +190,6 @@ public interface ResourcePackManifest {
          * @return the description
          * @since 2.1.1
          */
-        @NonNull
         String description();
     }
 
@@ -224,7 +209,6 @@ public interface ResourcePackManifest {
          * @return the uuid
          * @since 2.1.1
          */
-        @NonNull
         UUID uuid();
 
         /**
@@ -233,7 +217,6 @@ public interface ResourcePackManifest {
          * @return the {@link Version}
          * @since 2.1.1
          */
-        @NonNull
         Version version();
     }
 
@@ -250,7 +233,6 @@ public interface ResourcePackManifest {
          * @return the folder name
          * @since 2.6.2
          */
-        @NonNull
         String folderName();
 
         /**
@@ -262,7 +244,6 @@ public interface ResourcePackManifest {
          * @return the subpack name
          * @since 2.6.2
          */
-        @NonNull
         String name();
 
         /**
@@ -273,8 +254,7 @@ public interface ResourcePackManifest {
          * @return the memory tier
          * @since 2.6.2
          */
-        @Nullable
-        Float memoryTier();
+        @Nullable Float memoryTier();
     }
 
     /**
@@ -290,7 +270,6 @@ public interface ResourcePackManifest {
          * @return the type
          * @since 2.6.2
          */
-        @NonNull
         String type();
 
         /**
@@ -299,7 +278,6 @@ public interface ResourcePackManifest {
          * @return the text content
          * @since 2.6.2
          */
-        @NonNull
         String text();
     }
 
@@ -339,7 +317,7 @@ public interface ResourcePackManifest {
          * @return the version string
          * @since 2.1.1
          */
-        @NonNull String toString();
+        String toString();
     }
 }
 

--- a/api/src/main/java/org/geysermc/geyser/api/pack/ResourcePackManifest.java
+++ b/api/src/main/java/org/geysermc/geyser/api/pack/ResourcePackManifest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019-2023 GeyserMC. http://geysermc.org
+ * Copyright (c) 2019-2026 GeyserMC. http://geysermc.org
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/api/src/main/java/org/geysermc/geyser/api/pack/UrlPackCodec.java
+++ b/api/src/main/java/org/geysermc/geyser/api/pack/UrlPackCodec.java
@@ -25,7 +25,6 @@
 
 package org.geysermc.geyser.api.pack;
 
-import org.checkerframework.checker.nullness.qual.NonNull;
 
 /**
  * Represents a pack codec that creates a resource
@@ -46,6 +45,5 @@ public abstract class UrlPackCodec extends PackCodec {
      * @return the URL of the resource pack
      * @since 2.6.2
      */
-    @NonNull
     public abstract String url();
 }

--- a/api/src/main/java/org/geysermc/geyser/api/pack/UrlPackCodec.java
+++ b/api/src/main/java/org/geysermc/geyser/api/pack/UrlPackCodec.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019-2023 GeyserMC. http://geysermc.org
+ * Copyright (c) 2019-2026 GeyserMC. http://geysermc.org
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/api/src/main/java/org/geysermc/geyser/api/pack/UrlPackCodec.java
+++ b/api/src/main/java/org/geysermc/geyser/api/pack/UrlPackCodec.java
@@ -25,7 +25,6 @@
 
 package org.geysermc.geyser.api.pack;
 
-
 /**
  * Represents a pack codec that creates a resource
  * pack from a URL.

--- a/api/src/main/java/org/geysermc/geyser/api/pack/exception/package-info.java
+++ b/api/src/main/java/org/geysermc/geyser/api/pack/exception/package-info.java
@@ -1,0 +1,29 @@
+/*
+ * Copyright (c) 2026 GeyserMC. http://geysermc.org
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ *
+ * @author GeyserMC
+ * @link https://github.com/GeyserMC/Geyser
+ */
+
+@NullMarked
+package org.geysermc.geyser.api.pack.exception;
+
+import org.jspecify.annotations.NullMarked;

--- a/api/src/main/java/org/geysermc/geyser/api/pack/option/ResourcePackOption.java
+++ b/api/src/main/java/org/geysermc/geyser/api/pack/option/ResourcePackOption.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024 GeyserMC. http://geysermc.org
+ * Copyright (c) 2024-2026 GeyserMC. http://geysermc.org
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/api/src/main/java/org/geysermc/geyser/api/pack/option/ResourcePackOption.java
+++ b/api/src/main/java/org/geysermc/geyser/api/pack/option/ResourcePackOption.java
@@ -25,7 +25,6 @@
 
 package org.geysermc.geyser.api.pack.option;
 
-import org.checkerframework.checker.nullness.qual.NonNull;
 import org.geysermc.geyser.api.pack.ResourcePack;
 import org.geysermc.geyser.api.pack.exception.ResourcePackException;
 
@@ -45,13 +44,13 @@ public interface ResourcePackOption<T> {
      * @return the option type
      * @since 2.6.2
      */
-    @NonNull Type type();
+    Type type();
 
     /**
      * @return the value of the option
      * @since 2.6.2
      */
-    @NonNull T value();
+    T value();
 
     /**
      * Used to validate a specific options for a pack.
@@ -61,7 +60,7 @@ public interface ResourcePackOption<T> {
      * @throws ResourcePackException with the {@link ResourcePackException.Cause#INVALID_PACK_OPTION} cause
      * @since 2.6.2
      */
-    void validate(@NonNull ResourcePack pack);
+    void validate(ResourcePack pack);
 
     /**
      * Represents the different types of resource pack options.

--- a/api/src/main/java/org/geysermc/geyser/api/pack/option/SubpackOption.java
+++ b/api/src/main/java/org/geysermc/geyser/api/pack/option/SubpackOption.java
@@ -25,7 +25,6 @@
 
 package org.geysermc.geyser.api.pack.option;
 
-import org.checkerframework.checker.nullness.qual.NonNull;
 import org.geysermc.geyser.api.GeyserApi;
 import org.geysermc.geyser.api.pack.ResourcePackManifest;
 
@@ -43,7 +42,7 @@ public interface SubpackOption extends ResourcePackOption<String> {
      * @return a subpack option specifying that subpack
      * @since 2.6.2
      */
-    static SubpackOption subpack(ResourcePackManifest.@NonNull Subpack subpack) {
+    static SubpackOption subpack(ResourcePackManifest.Subpack subpack) {
         return named(subpack.name());
     }
 
@@ -54,7 +53,7 @@ public interface SubpackOption extends ResourcePackOption<String> {
      * @return a subpack option specifying a subpack with that name
      * @since 2.6.2
      */
-    static SubpackOption named(@NonNull String subpackName) {
+    static SubpackOption named(String subpackName) {
         return GeyserApi.api().provider(SubpackOption.class, subpackName);
     }
 

--- a/api/src/main/java/org/geysermc/geyser/api/pack/option/SubpackOption.java
+++ b/api/src/main/java/org/geysermc/geyser/api/pack/option/SubpackOption.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024 GeyserMC. http://geysermc.org
+ * Copyright (c) 2024-2026 GeyserMC. http://geysermc.org
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/api/src/main/java/org/geysermc/geyser/api/pack/option/package-info.java
+++ b/api/src/main/java/org/geysermc/geyser/api/pack/option/package-info.java
@@ -1,0 +1,29 @@
+/*
+ * Copyright (c) 2026 GeyserMC. http://geysermc.org
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ *
+ * @author GeyserMC
+ * @link https://github.com/GeyserMC/Geyser
+ */
+
+@NullMarked
+package org.geysermc.geyser.api.pack.option;
+
+import org.jspecify.annotations.NullMarked;

--- a/api/src/main/java/org/geysermc/geyser/api/pack/package-info.java
+++ b/api/src/main/java/org/geysermc/geyser/api/pack/package-info.java
@@ -1,0 +1,29 @@
+/*
+ * Copyright (c) 2026 GeyserMC. http://geysermc.org
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ *
+ * @author GeyserMC
+ * @link https://github.com/GeyserMC/Geyser
+ */
+
+@NullMarked
+package org.geysermc.geyser.api.pack;
+
+import org.jspecify.annotations.NullMarked;

--- a/api/src/main/java/org/geysermc/geyser/api/package-info.java
+++ b/api/src/main/java/org/geysermc/geyser/api/package-info.java
@@ -1,0 +1,29 @@
+/*
+ * Copyright (c) 2026 GeyserMC. http://geysermc.org
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ *
+ * @author GeyserMC
+ * @link https://github.com/GeyserMC/Geyser
+ */
+
+@NullMarked
+package org.geysermc.geyser.api;
+
+import org.jspecify.annotations.NullMarked;

--- a/api/src/main/java/org/geysermc/geyser/api/permission/PermissionChecker.java
+++ b/api/src/main/java/org/geysermc/geyser/api/permission/PermissionChecker.java
@@ -25,7 +25,6 @@
 
 package org.geysermc.geyser.api.permission;
 
-import org.checkerframework.checker.nullness.qual.NonNull;
 import org.geysermc.geyser.api.command.CommandSource;
 import org.geysermc.geyser.api.util.TriState;
 
@@ -44,6 +43,5 @@ public interface PermissionChecker {
      *         node itself was not found, and the source does not have such permission.
      *         {@link TriState#TRUE} and {@link TriState#FALSE} represent explicitly set values.
      */
-    @NonNull
-    TriState hasPermission(@NonNull CommandSource source, @NonNull String permission);
+    TriState hasPermission(CommandSource source, String permission);
 }

--- a/api/src/main/java/org/geysermc/geyser/api/permission/PermissionChecker.java
+++ b/api/src/main/java/org/geysermc/geyser/api/permission/PermissionChecker.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019-2023 GeyserMC. http://geysermc.org
+ * Copyright (c) 2019-2026 GeyserMC. http://geysermc.org
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/api/src/main/java/org/geysermc/geyser/api/permission/package-info.java
+++ b/api/src/main/java/org/geysermc/geyser/api/permission/package-info.java
@@ -1,0 +1,29 @@
+/*
+ * Copyright (c) 2026 GeyserMC. http://geysermc.org
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ *
+ * @author GeyserMC
+ * @link https://github.com/GeyserMC/Geyser
+ */
+
+@NullMarked
+package org.geysermc.geyser.api.permission;
+
+import org.jspecify.annotations.NullMarked;

--- a/api/src/main/java/org/geysermc/geyser/api/predicate/DimensionPredicate.java
+++ b/api/src/main/java/org/geysermc/geyser/api/predicate/DimensionPredicate.java
@@ -25,7 +25,6 @@
 
 package org.geysermc.geyser.api.predicate;
 
-import org.checkerframework.checker.nullness.qual.NonNull;
 import org.geysermc.geyser.api.predicate.context.MinecraftPredicateContext;
 import org.geysermc.geyser.api.util.GeyserProvided;
 import org.geysermc.geyser.api.util.Identifier;
@@ -50,7 +49,7 @@ public interface DimensionPredicate extends MinecraftPredicate<MinecraftPredicat
      * @return the dimension to test for
      * @since 2.9.3
      */
-    @NonNull Identifier dimension();
+    Identifier dimension();
 
     /**
      * @return whether this predicate is negated

--- a/api/src/main/java/org/geysermc/geyser/api/predicate/DimensionPredicate.java
+++ b/api/src/main/java/org/geysermc/geyser/api/predicate/DimensionPredicate.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2025 GeyserMC. http://geysermc.org
+ * Copyright (c) 2025-2026 GeyserMC. http://geysermc.org
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/api/src/main/java/org/geysermc/geyser/api/predicate/MatchPredicate.java
+++ b/api/src/main/java/org/geysermc/geyser/api/predicate/MatchPredicate.java
@@ -25,7 +25,6 @@
 
 package org.geysermc.geyser.api.predicate;
 
-import org.checkerframework.checker.nullness.qual.NonNull;
 import org.geysermc.geyser.api.GeyserApi;
 import org.geysermc.geyser.api.predicate.context.MinecraftPredicateContext;
 import org.geysermc.geyser.api.util.Identifier;
@@ -45,7 +44,7 @@ public interface MatchPredicate {
      * @see DimensionPredicate
      * @since 2.9.3
      */
-    static MinecraftPredicate<MinecraftPredicateContext> dimension(@NonNull Identifier dimension) {
+    static MinecraftPredicate<MinecraftPredicateContext> dimension(Identifier dimension) {
         return GeyserApi.api().provider(DimensionPredicate.class, dimension, false);
     }
 }

--- a/api/src/main/java/org/geysermc/geyser/api/predicate/MatchPredicate.java
+++ b/api/src/main/java/org/geysermc/geyser/api/predicate/MatchPredicate.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2025 GeyserMC. http://geysermc.org
+ * Copyright (c) 2025-2026 GeyserMC. http://geysermc.org
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/api/src/main/java/org/geysermc/geyser/api/predicate/MinecraftPredicate.java
+++ b/api/src/main/java/org/geysermc/geyser/api/predicate/MinecraftPredicate.java
@@ -25,7 +25,6 @@
 
 package org.geysermc.geyser.api.predicate;
 
-import org.checkerframework.checker.nullness.qual.NonNull;
 import org.geysermc.geyser.api.item.custom.v2.CustomItemDefinition;
 import org.geysermc.geyser.api.predicate.context.MinecraftPredicateContext;
 
@@ -47,19 +46,19 @@ import java.util.function.Predicate;
 public interface MinecraftPredicate<C extends MinecraftPredicateContext> extends Predicate<C> {
 
     @Override
-    default @NonNull MinecraftPredicate<C> and(@NonNull Predicate<? super C> other) {
+    default MinecraftPredicate<C> and(Predicate<? super C> other) {
         Objects.requireNonNull(other);
         return (context) -> this.test(context) && other.test(context);
     }
 
     @Override
-    default @NonNull MinecraftPredicate<C> negate() {
+    default MinecraftPredicate<C> negate() {
         return (context) -> !this.test(context);
     }
 
     @Override
-    default @NonNull MinecraftPredicate<C> or(@NonNull Predicate<? super C> other) {
+    default MinecraftPredicate<C> or(Predicate<? super C> other) {
         Objects.requireNonNull(other);
-        return (context) -> this.test(context) || other.test(context);
+        return context -> this.test(context) || other.test(context);
     }
 }

--- a/api/src/main/java/org/geysermc/geyser/api/predicate/MinecraftPredicate.java
+++ b/api/src/main/java/org/geysermc/geyser/api/predicate/MinecraftPredicate.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024-2025 GeyserMC. http://geysermc.org
+ * Copyright (c) 2024-2026 GeyserMC. http://geysermc.org
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/api/src/main/java/org/geysermc/geyser/api/predicate/context/item/ChargedProjectile.java
+++ b/api/src/main/java/org/geysermc/geyser/api/predicate/context/item/ChargedProjectile.java
@@ -26,7 +26,6 @@
 package org.geysermc.geyser.api.predicate.context.item;
 
 import org.checkerframework.checker.index.qual.Positive;
-import org.checkerframework.checker.nullness.qual.NonNull;
 import org.geysermc.geyser.api.GeyserApi;
 import org.jetbrains.annotations.ApiStatus;
 
@@ -43,7 +42,7 @@ public interface ChargedProjectile {
      * @return the type of the projectile
      * @since 2.9.3
      */
-    @NonNull ChargeType type();
+    ChargeType type();
 
     /**
      * @return the amount present of this projectile
@@ -59,7 +58,7 @@ public interface ChargedProjectile {
      * @return the charged projectile
      * @since 2.9.3
      */
-    static ChargedProjectile of(@NonNull ChargeType type, @Positive int count) {
+    static ChargedProjectile of(ChargeType type, @Positive int count) {
         return GeyserApi.api().provider(ChargedProjectile.class, type, count);
     }
 

--- a/api/src/main/java/org/geysermc/geyser/api/predicate/context/item/ChargedProjectile.java
+++ b/api/src/main/java/org/geysermc/geyser/api/predicate/context/item/ChargedProjectile.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2025 GeyserMC. http://geysermc.org
+ * Copyright (c) 2025-2026 GeyserMC. http://geysermc.org
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/api/src/main/java/org/geysermc/geyser/api/predicate/context/item/ItemPredicateContext.java
+++ b/api/src/main/java/org/geysermc/geyser/api/predicate/context/item/ItemPredicateContext.java
@@ -25,12 +25,11 @@
 
 package org.geysermc.geyser.api.predicate.context.item;
 
-import org.checkerframework.checker.nullness.qual.NonNull;
-import org.checkerframework.checker.nullness.qual.Nullable;
 import org.geysermc.geyser.api.item.custom.v2.CustomItemDefinition;
 import org.geysermc.geyser.api.predicate.context.MinecraftPredicateContext;
 import org.geysermc.geyser.api.util.Identifier;
 import org.jetbrains.annotations.ApiStatus;
+import org.jspecify.annotations.Nullable;
 
 import java.util.List;
 
@@ -93,13 +92,13 @@ public interface ItemPredicateContext extends MinecraftPredicateContext {
      * @return all the charged projectiles in the {@code minecraft:charged_projectiles} component
      * @since 2.9.3
      */
-    @NonNull List<@NonNull ChargedProjectile> chargedProjectiles();
+    List<ChargedProjectile> chargedProjectiles();
 
     /**
      * @return a list of all the components present on the item, including default components
      * @since 2.9.3
      */
-    @NonNull List<@NonNull Identifier> components();
+    List<Identifier> components();
 
     /**
      * @param index the flag index

--- a/api/src/main/java/org/geysermc/geyser/api/predicate/context/item/ItemPredicateContext.java
+++ b/api/src/main/java/org/geysermc/geyser/api/predicate/context/item/ItemPredicateContext.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2025 GeyserMC. http://geysermc.org
+ * Copyright (c) 2025-2026 GeyserMC. http://geysermc.org
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/api/src/main/java/org/geysermc/geyser/api/predicate/context/item/package-info.java
+++ b/api/src/main/java/org/geysermc/geyser/api/predicate/context/item/package-info.java
@@ -1,0 +1,29 @@
+/*
+ * Copyright (c) 2026 GeyserMC. http://geysermc.org
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ *
+ * @author GeyserMC
+ * @link https://github.com/GeyserMC/Geyser
+ */
+
+@NullMarked
+package org.geysermc.geyser.api.predicate.context.item;
+
+import org.jspecify.annotations.NullMarked;

--- a/api/src/main/java/org/geysermc/geyser/api/predicate/context/package-info.java
+++ b/api/src/main/java/org/geysermc/geyser/api/predicate/context/package-info.java
@@ -1,0 +1,29 @@
+/*
+ * Copyright (c) 2026 GeyserMC. http://geysermc.org
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ *
+ * @author GeyserMC
+ * @link https://github.com/GeyserMC/Geyser
+ */
+
+@NullMarked
+package org.geysermc.geyser.api.predicate.context;
+
+import org.jspecify.annotations.NullMarked;

--- a/api/src/main/java/org/geysermc/geyser/api/predicate/item/ChargeTypePredicate.java
+++ b/api/src/main/java/org/geysermc/geyser/api/predicate/item/ChargeTypePredicate.java
@@ -25,7 +25,6 @@
 
 package org.geysermc.geyser.api.predicate.item;
 
-import org.checkerframework.checker.nullness.qual.NonNull;
 import org.geysermc.geyser.api.predicate.MinecraftPredicate;
 import org.geysermc.geyser.api.predicate.context.item.ChargedProjectile;
 import org.geysermc.geyser.api.predicate.context.item.ItemPredicateContext;
@@ -44,7 +43,7 @@ public interface ChargeTypePredicate extends MinecraftPredicate<ItemPredicateCon
      * @return type of the projectile to check for
      * @since 2.9.3
      */
-    ChargedProjectile.@NonNull ChargeType type();
+    ChargedProjectile.ChargeType type();
 
     /**
      * @return whether this predicate is negated

--- a/api/src/main/java/org/geysermc/geyser/api/predicate/item/ChargeTypePredicate.java
+++ b/api/src/main/java/org/geysermc/geyser/api/predicate/item/ChargeTypePredicate.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2025 GeyserMC. http://geysermc.org
+ * Copyright (c) 2025-2026 GeyserMC. http://geysermc.org
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/api/src/main/java/org/geysermc/geyser/api/predicate/item/CustomModelDataPredicate.java
+++ b/api/src/main/java/org/geysermc/geyser/api/predicate/item/CustomModelDataPredicate.java
@@ -26,11 +26,11 @@
 package org.geysermc.geyser.api.predicate.item;
 
 import org.checkerframework.checker.index.qual.NonNegative;
-import org.checkerframework.checker.nullness.qual.Nullable;
 import org.geysermc.geyser.api.predicate.MinecraftPredicate;
 import org.geysermc.geyser.api.predicate.context.item.ItemPredicateContext;
 import org.geysermc.geyser.api.util.GeyserProvided;
 import org.jetbrains.annotations.ApiStatus;
+import org.jspecify.annotations.Nullable;
 
 /**
  * Contains predicates checking the {@code minecraft:custom_model_data} item component.

--- a/api/src/main/java/org/geysermc/geyser/api/predicate/item/CustomModelDataPredicate.java
+++ b/api/src/main/java/org/geysermc/geyser/api/predicate/item/CustomModelDataPredicate.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2025 GeyserMC. http://geysermc.org
+ * Copyright (c) 2025-2026 GeyserMC. http://geysermc.org
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/api/src/main/java/org/geysermc/geyser/api/predicate/item/HasComponentPredicate.java
+++ b/api/src/main/java/org/geysermc/geyser/api/predicate/item/HasComponentPredicate.java
@@ -25,7 +25,6 @@
 
 package org.geysermc.geyser.api.predicate.item;
 
-import org.checkerframework.checker.nullness.qual.NonNull;
 import org.geysermc.geyser.api.predicate.MinecraftPredicate;
 import org.geysermc.geyser.api.predicate.context.item.ItemPredicateContext;
 import org.geysermc.geyser.api.util.GeyserProvided;
@@ -44,7 +43,7 @@ public interface HasComponentPredicate extends MinecraftPredicate<ItemPredicateC
      * @return the identifier of the item data component to check against
      * @since 2.9.3
      */
-    @NonNull Identifier component();
+    Identifier component();
 
     /**
      * @return whether this predicate is negated

--- a/api/src/main/java/org/geysermc/geyser/api/predicate/item/HasComponentPredicate.java
+++ b/api/src/main/java/org/geysermc/geyser/api/predicate/item/HasComponentPredicate.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2025 GeyserMC. http://geysermc.org
+ * Copyright (c) 2025-2026 GeyserMC. http://geysermc.org
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/api/src/main/java/org/geysermc/geyser/api/predicate/item/ItemConditionPredicate.java
+++ b/api/src/main/java/org/geysermc/geyser/api/predicate/item/ItemConditionPredicate.java
@@ -26,7 +26,6 @@
 package org.geysermc.geyser.api.predicate.item;
 
 import org.checkerframework.checker.index.qual.NonNegative;
-import org.checkerframework.checker.nullness.qual.NonNull;
 import org.geysermc.geyser.api.GeyserApi;
 import org.geysermc.geyser.api.predicate.MinecraftPredicate;
 import org.geysermc.geyser.api.predicate.context.item.ItemPredicateContext;
@@ -105,7 +104,7 @@ public interface ItemConditionPredicate {
      * @see HasComponentPredicate
      * @since 2.9.3
      */
-    static MinecraftPredicate<ItemPredicateContext> hasComponent(@NonNull Identifier component) {
+    static MinecraftPredicate<ItemPredicateContext> hasComponent(Identifier component) {
         return GeyserApi.api().provider(HasComponentPredicate.class, component);
     }
 }

--- a/api/src/main/java/org/geysermc/geyser/api/predicate/item/ItemConditionPredicate.java
+++ b/api/src/main/java/org/geysermc/geyser/api/predicate/item/ItemConditionPredicate.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2025 GeyserMC. http://geysermc.org
+ * Copyright (c) 2025-2026 GeyserMC. http://geysermc.org
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/api/src/main/java/org/geysermc/geyser/api/predicate/item/ItemMatchPredicate.java
+++ b/api/src/main/java/org/geysermc/geyser/api/predicate/item/ItemMatchPredicate.java
@@ -26,8 +26,6 @@
 package org.geysermc.geyser.api.predicate.item;
 
 import org.checkerframework.checker.index.qual.NonNegative;
-import org.checkerframework.checker.nullness.qual.NonNull;
-import org.checkerframework.checker.nullness.qual.Nullable;
 import org.geysermc.geyser.api.GeyserApi;
 import org.geysermc.geyser.api.predicate.MatchPredicate;
 import org.geysermc.geyser.api.predicate.MinecraftPredicate;
@@ -35,6 +33,7 @@ import org.geysermc.geyser.api.predicate.context.item.ChargedProjectile;
 import org.geysermc.geyser.api.predicate.context.item.ItemPredicateContext;
 import org.geysermc.geyser.api.util.Identifier;
 import org.jetbrains.annotations.ApiStatus;
+import org.jspecify.annotations.Nullable;
 
 /**
  * Contains factories for often-used "match" predicates, that match for a value in {@link ItemPredicateContext}.
@@ -53,7 +52,7 @@ public interface ItemMatchPredicate extends MatchPredicate {
      * @see ChargeTypePredicate
      * @since 2.9.3
      */
-    static MinecraftPredicate<ItemPredicateContext> chargeType(ChargedProjectile.@NonNull ChargeType type) {
+    static MinecraftPredicate<ItemPredicateContext> chargeType(ChargedProjectile.ChargeType type) {
         return GeyserApi.api().provider(ChargeTypePredicate.class, type);
     }
 
@@ -64,7 +63,7 @@ public interface ItemMatchPredicate extends MatchPredicate {
      * @see TrimMaterialPredicate
      * @since 2.9.3
      */
-    static MinecraftPredicate<ItemPredicateContext> trimMaterial(@NonNull Identifier material) {
+    static MinecraftPredicate<ItemPredicateContext> trimMaterial(Identifier material) {
         return GeyserApi.api().provider(TrimMaterialPredicate.class, material);
     }
 

--- a/api/src/main/java/org/geysermc/geyser/api/predicate/item/ItemMatchPredicate.java
+++ b/api/src/main/java/org/geysermc/geyser/api/predicate/item/ItemMatchPredicate.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2025 GeyserMC. http://geysermc.org
+ * Copyright (c) 2025-2026 GeyserMC. http://geysermc.org
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/api/src/main/java/org/geysermc/geyser/api/predicate/item/RangeDispatchPredicate.java
+++ b/api/src/main/java/org/geysermc/geyser/api/predicate/item/RangeDispatchPredicate.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2025 GeyserMC. http://geysermc.org
+ * Copyright (c) 2025-2026 GeyserMC. http://geysermc.org
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/api/src/main/java/org/geysermc/geyser/api/predicate/item/RangeDispatchPredicate.java
+++ b/api/src/main/java/org/geysermc/geyser/api/predicate/item/RangeDispatchPredicate.java
@@ -26,7 +26,6 @@
 package org.geysermc.geyser.api.predicate.item;
 
 import org.checkerframework.checker.index.qual.NonNegative;
-import org.checkerframework.checker.nullness.qual.NonNull;
 import org.geysermc.geyser.api.predicate.MinecraftPredicate;
 import org.geysermc.geyser.api.predicate.context.item.ItemPredicateContext;
 import org.geysermc.geyser.api.util.GeyserProvided;
@@ -48,7 +47,7 @@ public interface RangeDispatchPredicate extends MinecraftPredicate<ItemPredicate
      * @return the property type to check against
      * @since 2.9.3
      */
-    @NonNull Property property();
+    Property property();
 
     /**
      * @return the threshold above which this predicate is true

--- a/api/src/main/java/org/geysermc/geyser/api/predicate/item/TrimMaterialPredicate.java
+++ b/api/src/main/java/org/geysermc/geyser/api/predicate/item/TrimMaterialPredicate.java
@@ -25,7 +25,6 @@
 
 package org.geysermc.geyser.api.predicate.item;
 
-import org.checkerframework.checker.nullness.qual.NonNull;
 import org.geysermc.geyser.api.predicate.MinecraftPredicate;
 import org.geysermc.geyser.api.predicate.context.item.ItemPredicateContext;
 import org.geysermc.geyser.api.util.GeyserProvided;
@@ -44,7 +43,7 @@ public interface TrimMaterialPredicate extends MinecraftPredicate<ItemPredicateC
      * @return the identifier of the trim material to check for
      * @since 2.9.3
      */
-    @NonNull Identifier trimMaterial();
+    Identifier trimMaterial();
 
     /**
      * @return whether this predicate is negated

--- a/api/src/main/java/org/geysermc/geyser/api/predicate/item/TrimMaterialPredicate.java
+++ b/api/src/main/java/org/geysermc/geyser/api/predicate/item/TrimMaterialPredicate.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2025 GeyserMC. http://geysermc.org
+ * Copyright (c) 2025-2026 GeyserMC. http://geysermc.org
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/api/src/main/java/org/geysermc/geyser/api/predicate/item/package-info.java
+++ b/api/src/main/java/org/geysermc/geyser/api/predicate/item/package-info.java
@@ -1,0 +1,29 @@
+/*
+ * Copyright (c) 2026 GeyserMC. http://geysermc.org
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ *
+ * @author GeyserMC
+ * @link https://github.com/GeyserMC/Geyser
+ */
+
+@NullMarked
+package org.geysermc.geyser.api.predicate.item;
+
+import org.jspecify.annotations.NullMarked;

--- a/api/src/main/java/org/geysermc/geyser/api/predicate/package-info.java
+++ b/api/src/main/java/org/geysermc/geyser/api/predicate/package-info.java
@@ -1,0 +1,29 @@
+/*
+ * Copyright (c) 2026 GeyserMC. http://geysermc.org
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ *
+ * @author GeyserMC
+ * @link https://github.com/GeyserMC/Geyser
+ */
+
+@NullMarked
+package org.geysermc.geyser.api.predicate;
+
+import org.jspecify.annotations.NullMarked;

--- a/api/src/main/java/org/geysermc/geyser/api/skin/package-info.java
+++ b/api/src/main/java/org/geysermc/geyser/api/skin/package-info.java
@@ -1,0 +1,29 @@
+/*
+ * Copyright (c) 2026 GeyserMC. http://geysermc.org
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ *
+ * @author GeyserMC
+ * @link https://github.com/GeyserMC/Geyser
+ */
+
+@NullMarked
+package org.geysermc.geyser.api.skin;
+
+import org.jspecify.annotations.NullMarked;

--- a/api/src/main/java/org/geysermc/geyser/api/util/CreativeCategory.java
+++ b/api/src/main/java/org/geysermc/geyser/api/util/CreativeCategory.java
@@ -25,8 +25,8 @@
 
 package org.geysermc.geyser.api.util;
 
-import org.checkerframework.checker.nullness.qual.NonNull;
-import org.checkerframework.checker.nullness.qual.Nullable;
+
+import org.jspecify.annotations.Nullable;
 
 /**
  * Represents the creative menu categories or tabs.
@@ -53,7 +53,7 @@ public enum CreativeCategory {
      * 
      * @return the name of the category
      */
-    public @NonNull String bedrockName() {
+    public String bedrockName() {
         return bedrockName;
     }
 

--- a/api/src/main/java/org/geysermc/geyser/api/util/CreativeCategory.java
+++ b/api/src/main/java/org/geysermc/geyser/api/util/CreativeCategory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019-2025 GeyserMC. http://geysermc.org
+ * Copyright (c) 2019-2026 GeyserMC. http://geysermc.org
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/api/src/main/java/org/geysermc/geyser/api/util/CreativeCategory.java
+++ b/api/src/main/java/org/geysermc/geyser/api/util/CreativeCategory.java
@@ -25,7 +25,6 @@
 
 package org.geysermc.geyser.api.util;
 
-
 import org.jspecify.annotations.Nullable;
 
 /**

--- a/api/src/main/java/org/geysermc/geyser/api/util/Holders.java
+++ b/api/src/main/java/org/geysermc/geyser/api/util/Holders.java
@@ -25,7 +25,6 @@
 
 package org.geysermc.geyser.api.util;
 
-import org.checkerframework.checker.nullness.qual.NonNull;
 import org.checkerframework.common.returnsreceiver.qual.This;
 import org.geysermc.geyser.api.GeyserApi;
 import org.jetbrains.annotations.ApiStatus;
@@ -47,7 +46,7 @@ public interface Holders {
      * @return a new Holders object
      * @since 2.9.3
      */
-    static @NonNull Holders of(Identifier identifier) {
+    static Holders of(Identifier identifier) {
         return builder().with(identifier).build();
     }
 
@@ -58,7 +57,7 @@ public interface Holders {
      * @return a new Holders object
      * @since 2.9.3
      */
-    static @NonNull Holders of(List<Identifier> identifiers) {
+    static Holders of(List<Identifier> identifiers) {
         Builder builder = builder();
         identifiers.forEach(builder::with);
         return builder.build();
@@ -71,7 +70,7 @@ public interface Holders {
      * @return a new Holders object
      * @since 2.9.3
      */
-    static @NonNull Holders ofTag(Identifier tag) {
+    static Holders ofTag(Identifier tag) {
         return builder().tag(tag).build();
     }
 
@@ -81,7 +80,7 @@ public interface Holders {
      * @return a new builder
      * @since 2.9.3
      */
-    static @NonNull Builder builder() {
+    static Builder builder() {
         return GeyserApi.api().provider(Holders.Builder.class);
     }
 
@@ -101,7 +100,7 @@ public interface Holders {
          * @since 2.9.3
          */
         @This
-        Builder with(@NonNull Identifier identifier);
+        Builder with(Identifier identifier);
 
         /**
          * Sets the tag of the Holders object. A Holders object can only consist of one tag. This will throw when at least one identifier has been
@@ -113,7 +112,7 @@ public interface Holders {
          * @since 2.9.3
          */
         @This
-        Builder tag(@NonNull Identifier tag);
+        Builder tag(Identifier tag);
 
         /**
          * Creates the Holders object.

--- a/api/src/main/java/org/geysermc/geyser/api/util/Holders.java
+++ b/api/src/main/java/org/geysermc/geyser/api/util/Holders.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2025 GeyserMC. http://geysermc.org
+ * Copyright (c) 2025-2026 GeyserMC. http://geysermc.org
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/api/src/main/java/org/geysermc/geyser/api/util/Identifier.java
+++ b/api/src/main/java/org/geysermc/geyser/api/util/Identifier.java
@@ -25,7 +25,6 @@
 
 package org.geysermc.geyser.api.util;
 
-import org.checkerframework.checker.nullness.qual.NonNull;
 import org.geysermc.geyser.api.GeyserApi;
 import org.jetbrains.annotations.ApiStatus;
 
@@ -69,7 +68,7 @@ public interface Identifier {
      * @throws IllegalArgumentException if either namespace or path are invalid.
      * @since 2.9.0
      */
-    static Identifier of(@NonNull String namespace, @NonNull String path) {
+    static Identifier of(String namespace, String path) {
         return GeyserApi.api().provider(Identifier.class, namespace, path);
     }
 

--- a/api/src/main/java/org/geysermc/geyser/api/util/Identifier.java
+++ b/api/src/main/java/org/geysermc/geyser/api/util/Identifier.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024-2025 GeyserMC. http://geysermc.org
+ * Copyright (c) 2024-2026 GeyserMC. http://geysermc.org
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/api/src/main/java/org/geysermc/geyser/api/util/MinecraftVersion.java
+++ b/api/src/main/java/org/geysermc/geyser/api/util/MinecraftVersion.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019-2025 GeyserMC. http://geysermc.org
+ * Copyright (c) 2019-2026 GeyserMC. http://geysermc.org
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/api/src/main/java/org/geysermc/geyser/api/util/MinecraftVersion.java
+++ b/api/src/main/java/org/geysermc/geyser/api/util/MinecraftVersion.java
@@ -25,7 +25,6 @@
 
 package org.geysermc.geyser.api.util;
 
-import org.checkerframework.checker.nullness.qual.NonNull;
 import org.jetbrains.annotations.ApiStatus;
 
 /**
@@ -40,7 +39,7 @@ public interface MinecraftVersion {
      *
      * @return the version string
      */
-    @NonNull String versionString();
+    String versionString();
 
     /**
      * Gets the protocol version of this Minecraft version.

--- a/api/src/main/java/org/geysermc/geyser/api/util/TriState.java
+++ b/api/src/main/java/org/geysermc/geyser/api/util/TriState.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019-2022 GeyserMC. http://geysermc.org
+ * Copyright (c) 2019-2026 GeyserMC. http://geysermc.org
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/api/src/main/java/org/geysermc/geyser/api/util/TriState.java
+++ b/api/src/main/java/org/geysermc/geyser/api/util/TriState.java
@@ -25,8 +25,8 @@
 
 package org.geysermc.geyser.api.util;
 
-import org.checkerframework.checker.nullness.qual.NonNull;
-import org.checkerframework.checker.nullness.qual.Nullable;
+
+import org.jspecify.annotations.Nullable;
 
 /**
  * This is a way to represent a boolean, but with a non set value added.
@@ -67,7 +67,7 @@ public enum TriState {
      * @param value the Boolean value
      * @return the created TriState
      */
-    public static @NonNull TriState fromBoolean(@Nullable Boolean value) {
+    public static TriState fromBoolean(@Nullable Boolean value) {
         return value == null ? NOT_SET : fromBoolean(value.booleanValue());
     }
 
@@ -77,7 +77,7 @@ public enum TriState {
      * @param value the boolean value
      * @return the created TriState
      */
-    public @NonNull static TriState fromBoolean(boolean value) {
+    public static TriState fromBoolean(boolean value) {
         return value ? TRUE : FALSE;
     }
 }

--- a/api/src/main/java/org/geysermc/geyser/api/util/TriState.java
+++ b/api/src/main/java/org/geysermc/geyser/api/util/TriState.java
@@ -25,7 +25,6 @@
 
 package org.geysermc.geyser.api.util;
 
-
 import org.jspecify.annotations.Nullable;
 
 /**

--- a/api/src/main/java/org/geysermc/geyser/api/util/package-info.java
+++ b/api/src/main/java/org/geysermc/geyser/api/util/package-info.java
@@ -1,0 +1,29 @@
+/*
+ * Copyright (c) 2026 GeyserMC. http://geysermc.org
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ *
+ * @author GeyserMC
+ * @link https://github.com/GeyserMC/Geyser
+ */
+
+@NullMarked
+package org.geysermc.geyser.api.util;
+
+import org.jspecify.annotations.NullMarked;

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -24,6 +24,7 @@ adventure-platform = "4.4.1"
 junit = "6.0.0"
 checkerframework = "3.19.0"
 jetbrains-annotations = "24.0.0"
+jspecify = "1.0.0"
 log4j = "2.20.0"
 jline = "3.21.0"
 terminalconsoleappender = "1.2.0"
@@ -136,6 +137,7 @@ bungeecord-proxy = { group = "net.md-5", name = "bungeecord-proxy", version.ref 
 bungeecord-api = { group = "net.md-5", name = "bungeecord-api", version.ref = "bungeecord-api" }
 checker-qual = { group = "org.checkerframework", name = "checker-qual", version.ref = "checkerframework" }
 jetbrains-annotations = { group = "org.jetbrains", name = "annotations", version.ref = "jetbrains-annotations" }
+jspecify = { group = "org.jspecify", name = "jspecify", version.ref = "jspecify" }
 commodore = { group = "me.lucko", name = "commodore", version.ref = "commodore" }
 guava = { group = "com.google.guava", name = "guava", version.ref = "guava" }
 gson = { group = "com.google.code.gson", name = "gson", version.ref = "gson" }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,5 +1,5 @@
 [versions]
-base-api = "1.0.2"
+base-api = "1.0.3"
 bstats = "3.1.0"
 cumulus = "1.1.2"
 configurate = "4.2.0-GeyserMC-20251111.004649-11"
@@ -24,7 +24,6 @@ adventure-platform = "4.4.1"
 junit = "6.0.0"
 checkerframework = "3.19.0"
 jetbrains-annotations = "24.0.0"
-jspecify = "1.0.0"
 log4j = "2.20.0"
 jline = "3.21.0"
 terminalconsoleappender = "1.2.0"
@@ -137,7 +136,6 @@ bungeecord-proxy = { group = "net.md-5", name = "bungeecord-proxy", version.ref 
 bungeecord-api = { group = "net.md-5", name = "bungeecord-api", version.ref = "bungeecord-api" }
 checker-qual = { group = "org.checkerframework", name = "checker-qual", version.ref = "checkerframework" }
 jetbrains-annotations = { group = "org.jetbrains", name = "annotations", version.ref = "jetbrains-annotations" }
-jspecify = { group = "org.jspecify", name = "jspecify", version.ref = "jspecify" }
 commodore = { group = "me.lucko", name = "commodore", version.ref = "commodore" }
 guava = { group = "com.google.guava", name = "guava", version.ref = "guava" }
 gson = { group = "com.google.code.gson", name = "gson", version.ref = "gson" }


### PR DESCRIPTION
This PR switches to JSpecify for nullability annotations in the API module. All packages in the API now have a `package-info.java` file with a [`@NullMarked`](https://jspecify.dev/docs/user-guide/#nullmarked) annotation, which applies to all types in the package. This includes but is not limited to method return values, parameters, fields, generic type parameters, arrays, and more.

Because of this change, all `@NonNull` annotations have been removed, as they are no longer necessary. All `@Nullable` annotations have been replaced by JSpecify's, and those on a separate line have been moved to be in-line, as per JSpecify's standard.

Some extra `@Nullable` annotations have been added where they should be.

This PR is currently targetting 26.1, but can be changed to target master if merged in a later version.

Depends on [api#12](https://github.com/GeyserMC/api/pull/12) for JSpecify in the base API.