### PR TITLE
Only enable BedrockSession packet logging in debug mode

### DIFF
--- a/core/src/main/java/org/geysermc/geyser/network/GeyserServerInitializer.java
+++ b/core/src/main/java/org/geysermc/geyser/network/GeyserServerInitializer.java
@@ -70,7 +70,7 @@ public class GeyserServerInitializer extends BedrockServerInitializer {
                 }
             }
 
-            bedrockServerSession.setLogging(true);
+            bedrockServerSession.setLogging(this.geyser.config().debugMode());
             GeyserSession session = new GeyserSession(this.geyser, bedrockServerSession, this.eventLoopGroup.next());
 
             if (!bedrockServerSession.isSubClient()) {


### PR DESCRIPTION
With `setLogging(true)`, every inbound and outbound Bedrock packet triggers `BedrockSession.logInbound`/`logOutbound`. These call `log.trace(...)` with the packet as a parameter, which materializes `packet.toString()` and routes the record through SLF4J.

Normally an SLF4J TRACE call is cheap when the underlying logger filters it out - the record never gets constructed. But this breaks down on BungeeCord.

BungeeCord's `BungeeLogger` sets its root logger to `Level.ALL`. Every SLF4J call made from within BungeeCord's classloader (which includes Geyser when run as a plugin) is routed through `JDK14LoggerFactory.LOGGER`, which points at that same Level.ALL logger. Because the logger accepts everything, the TRACE record is fully constructed - `fillCallerData()`, `Throwable.getStackTrace()`, `MessageFormatter` parameter expansion, `packet.toString()` - and only discarded later at the handler level.

The result: on BungeeCord, every single Bedrock packet pays the full log-record construction cost, even though no log output is ever produced. The fix is to not ask for packet logging in the first place unless the user actually wants it.