### PR TITLE
Don't cancel Microsoft auth flow on Bedrock disconnect

### DIFF
--- a/core/src/main/java/org/geysermc/geyser/session/GeyserSession.java
+++ b/core/src/main/java/org/geysermc/geyser/session/GeyserSession.java
@@ -1201,12 +1201,8 @@ public class GeyserSession implements GeyserConnection, GeyserCommandSource {
 
             // Remove from session manager
             geyser.getSessionManager().removeSession(this);
-            if (authData != null) {
-                PendingMicrosoftAuthentication.AuthenticationTask task = geyser.getPendingMicrosoftAuthentication().getTask(authData.xuid());
-                if (task != null) {
-                    task.resetRunningFlow();
-                }
-            }
+            // Don't cancel any pending Microsoft auth here - the whole point of PendingMicrosoftAuthentication
+            // is to let mobile users disconnect to finish auth in the browser. Task cleans up on timeout.
         }
 
         if (tickThread != null) {


### PR DESCRIPTION
Fixes #6319.

Cancelling the auth future on disconnect defeats the purpose of PendingMicrosoftAuthentication, it's meant to survive disconnects so mobile users can switch to the browser to finish auth. resetRunningFlow was resetTimer (no-op) before the MinecraftAuth port, call site was never updated to match the new semantic. Task cleanup still happens via the configured timeout.

Haven't tested on mobile since I don't have the setup - reasoning is from reading the git blame.
Overall i'm pretty positive it's fixed though