### PR TITLE
Send skin plugin message after session spawn

### DIFF
--- a/core/src/main/java/org/geysermc/geyser/skin/FloodgateSkinUploader.java
+++ b/core/src/main/java/org/geysermc/geyser/skin/FloodgateSkinUploader.java
@@ -144,7 +144,10 @@ public final class FloodgateSkinUploader {
 
                                 byte[] bytes = (value + '\0' + signature)
                                         .getBytes(StandardCharsets.UTF_8);
-                                PluginMessageUtils.sendMessage(session, PluginMessageChannels.SKIN, bytes);
+                                // Wait until the session is actually spawned before sending, otherwise
+                                // the plugin message can land during the proxy's null-connection window
+                                // on initial join and be silently dropped by Velocity.
+                                sendSkinWhenSpawned(geyser, session, bytes, 0);
                             }
                             break;
                         case LOG_MESSAGE:
@@ -240,6 +243,19 @@ public final class FloodgateSkinUploader {
                 skinQueue.addLast(jsonString);
             }
         }
+    }
+
+    private void sendSkinWhenSpawned(GeyserImpl geyser, GeyserSession session, byte[] bytes, int attempt) {
+        if (session.isClosed() || attempt >= 10) {
+            return;
+        }
+        if (session.isSpawned()) {
+            PluginMessageUtils.sendMessage(session, PluginMessageChannels.SKIN, bytes);
+            return;
+        }
+        geyser.getScheduledThread().schedule(
+                () -> sendSkinWhenSpawned(geyser, session, bytes, attempt + 1),
+                500, TimeUnit.MILLISECONDS);
     }
 
     private void reconnectLater(GeyserImpl geyser) {


### PR DESCRIPTION
Fixes #6288.

When Floodgate's websocket is the only subscriber on the skin API, Geyser itself delivers the skin to the backend via a plugin message. On Velocity this can land in the null-connection window right after player auth but before the backend connection is ready, and gets silently dropped. Player ends up as Steve/Alex to Java players.

Fix: wait until the session is actually spawned before sending. isSpawned flips to true when the Java server sends the player's first position packet, which only happens after the proxy-backend transition is complete. Polls every 500ms with a 5s safety cap.

Haven't tested live, the timing window is hard to reliably hit.