### PR TITLE
Fix: Boat entities bugging into the ground & pistons being able to produce ghost blocks in specific circumstances

### DIFF
--- a/core/src/main/java/org/geysermc/geyser/entity/type/BoatEntity.java
+++ b/core/src/main/java/org/geysermc/geyser/entity/type/BoatEntity.java
@@ -31,6 +31,7 @@ import org.cloudburstmc.math.vector.Vector3f;
 import org.cloudburstmc.protocol.bedrock.data.entity.EntityDataTypes;
 import org.cloudburstmc.protocol.bedrock.data.entity.EntityFlag;
 import org.cloudburstmc.protocol.bedrock.packet.MoveEntityAbsolutePacket;
+import org.geysermc.geyser.entity.EntityDefinitions;
 import org.geysermc.geyser.entity.spawn.EntitySpawnContext;
 import org.geysermc.geyser.entity.vehicle.BoatVehicleComponent;
 import org.geysermc.geyser.entity.vehicle.ClientVehicle;
@@ -214,6 +215,14 @@ public class BoatEntity extends Entity implements Tickable, Leashable, ClientVeh
         if (isPaddlingLeft || isPaddlingRight) {
             updateBedrockMetadata();
         }
+    }
+
+    @Override
+    public Vector3f bedrockPosition() {
+        if (session.getPlayerEntity().getVehicle() == this && session.getPlayerEntity().isRidingInFront()) {
+            return position.up(EntityDefinitions.PLAYER.offset());
+        }
+        return super.bedrockPosition();
     }
 
     @Override

--- a/core/src/main/java/org/geysermc/geyser/translator/level/block/entity/PistonBlockEntity.java
+++ b/core/src/main/java/org/geysermc/geyser/translator/level/block/entity/PistonBlockEntity.java
@@ -651,7 +651,7 @@ public class PistonBlockEntity {
             blockPos = blockPos.add(movement);
             // Don't place blocks that collide with the player
             if (!SOLID_BOUNDING_BOX.checkIntersection(blockPos.toDouble(), playerBoundingBox)) {
-                ChunkUtils.updateBlock(session, state, blockPos);
+                ChunkUtils.updateBlock(session, session.getGeyser().getWorldManager().blockAt(session, blockPos), blockPos);
             }
         });
         if (action == PistonValueType.PUSHING) {
@@ -695,17 +695,16 @@ public class PistonBlockEntity {
      * @return 0 - Fully retracted, 1 - Extending, 2 - Fully extended, 3 - Retracting
      */
     private byte getState() {
-        switch (action) {
-            case PUSHING:
-                return (byte) (isDone() ? 2 : 1);
-            case PULLING:
-                return (byte) (isDone() ? 0 : 3);
-            default:
+        return switch (action) {
+            case PUSHING -> (byte) (isDone() ? 2 : 1);
+            case PULLING -> (byte) (isDone() ? 0 : 3);
+            default -> {
                 if (progress == 1.0f) {
-                    return 2;
+                    yield 2;
                 }
-                return (byte) (isDone() ? 0 : 2);
-        }
+                yield (byte) (isDone() ? 0 : 2);
+            }
+        };
     }
 
     /**


### PR DESCRIPTION
Should resolve https://github.com/GeyserMC/Geyser/issues/6321 

For pistons: We currently cache the attached blocks to a piston across ticks. If the server updates those, it can cause de-syncs.. this fixes the "main" issue where our cached version would be able to override the true state sent by the server; but it doesn't properly address further issues related to e.g. recalculate them each tick to ensure we don't have an outdated representation of moved blocks. Not sure if that is worth addressing further - could potentially be quite expensive, and would essentially make our optimizations by having platform piston listeners obsolete...