### PR TITLE
Fix: publish the correct modded JAR files to Modrinth

### DIFF
--- a/bootstrap/mod/build.gradle.kts
+++ b/bootstrap/mod/build.gradle.kts
@@ -8,8 +8,18 @@ architectury {
 
 afterEvaluate {
     // We don't need these
-    tasks.named("mergeShadowAndJarJar").configure {
-        enabled = false
+    tasks {
+        named("mergeShadowAndJarJar").configure {
+            enabled = false
+        }
+
+        named("renameModrinthJar").configure {
+            enabled = false
+        }
+
+        modrinth.configure {
+            enabled = false
+        }
     }
 }
 

--- a/bootstrap/mod/fabric/build.gradle.kts
+++ b/bootstrap/mod/fabric/build.gradle.kts
@@ -1,6 +1,5 @@
 plugins {
     id("geyser.modded-conventions")
-    id("geyser.modrinth-uploading-conventions")
 }
 
 architectury {
@@ -101,7 +100,6 @@ tasks {
 
 modrinth {
     loaders.add("fabric")
-    uploadFile.set(tasks.getByName("renameModrinthJar"))
     dependencies {
         required.project("fabric-api")
     }

--- a/bootstrap/mod/neoforge/build.gradle.kts
+++ b/bootstrap/mod/neoforge/build.gradle.kts
@@ -1,6 +1,5 @@
 plugins {
     id("geyser.modded-conventions")
-    id("geyser.modrinth-uploading-conventions")
 }
 
 architectury {
@@ -79,5 +78,4 @@ tasks {
 
 modrinth {
     loaders.add("neoforge")
-    uploadFile.set(tasks.getByName("renameModrinthJar"))
 }

--- a/build-logic/src/main/kotlin/geyser.modded-conventions.gradle.kts
+++ b/build-logic/src/main/kotlin/geyser.modded-conventions.gradle.kts
@@ -4,6 +4,7 @@ plugins {
     id("geyser.platform-conventions")
     id("architectury-plugin")
     id("dev.architectury.loom-no-remap")
+    id("geyser.modrinth-uploading-conventions")
 }
 
 // These are provided by Minecraft/modded platforms already, no need to include them
@@ -85,26 +86,33 @@ tasks {
     // and the shadowJar for the final jar.
     // thanks bluemap
     // https://github.com/BlueMap-Minecraft/BlueMap/blob/cfe73115dc4d1bdd97bc659f41364da65a6a2179/implementations/fabric/build.gradle.kts#L93-L107
-    register<Jar>("mergeShadowAndJarJar") {
+    val mergeShadowAndJarJar = register<Jar>("mergeShadowAndJarJar") {
         dependsOn( tasks.shadowJar, tasks.jar )
         // from sources / final name are configured in the respective projects
         archiveVersion.set("")
         archiveClassifier.set("")
     }
 
-    tasks.register<Copy>("renameModrinthJar") {
-        val sourceJar = tasks.named<Jar>("mergeShadowAndJarJar")
-        dependsOn(sourceJar)
+    val renameModrinthJar = tasks.register<Copy>("renameModrinthJar") {
+        dependsOn(mergeShadowAndJarJar)
 
-        from(sourceJar.flatMap { it.archiveFile })
+        from(mergeShadowAndJarJar.flatMap { it.archiveFile })
         into(layout.buildDirectory.dir("libs"))
 
         rename { "${versionName(project)}.jar" }
     }
 
-    build {
-        dependsOn(tasks.getByName("mergeShadowAndJarJar"))
+    modrinth.configure {
+        dependsOn(renameModrinthJar)
     }
+
+    build {
+        dependsOn(mergeShadowAndJarJar)
+    }
+}
+
+modrinth {
+    uploadFile.set(layout.buildDirectory.file("libs/${versionName(project)}.jar"))
 }
 
 afterEvaluate {

--- a/build-logic/src/main/kotlin/geyser.modrinth-uploading-conventions.gradle.kts
+++ b/build-logic/src/main/kotlin/geyser.modrinth-uploading-conventions.gradle.kts
@@ -2,7 +2,7 @@ plugins {
     id("com.modrinth.minotaur")
 }
 
-// Ensure that the readme is synched
+// Ensure that the readme is synced
 tasks.modrinth.get().dependsOn(tasks.modrinthSyncBody)
 
 modrinth {

--- a/core/src/main/java/org/geysermc/geyser/inventory/recipe/GeyserShapelessRecipe.java
+++ b/core/src/main/java/org/geysermc/geyser/inventory/recipe/GeyserShapelessRecipe.java
@@ -25,6 +25,9 @@
 
 package org.geysermc.geyser.inventory.recipe;
 
+import it.unimi.dsi.fastutil.ints.IntList;
+import lombok.Getter;
+import lombok.experimental.Accessors;
 import org.cloudburstmc.protocol.bedrock.data.inventory.ItemData;
 import org.cloudburstmc.protocol.bedrock.data.inventory.crafting.RecipeUnlockingRequirement;
 import org.cloudburstmc.protocol.bedrock.data.inventory.crafting.recipe.RecipeData;
@@ -51,7 +54,7 @@ public record GeyserShapelessRecipe(int id,
     }
 
     public GeyserShapelessRecipe(int id, int netId, FurnaceRecipeDisplay data, int category) {
-        this(id, netId, List.of(data.ingredient()), data.result(), tagFromFurnaceRecipeCategory(category));
+        this(id, netId, List.of(data.ingredient()), data.result(), FurnaceRecipeType.fromCategory(category).tag);
     }
 
     @Override
@@ -79,12 +82,29 @@ public record GeyserShapelessRecipe(int id,
         return recipeData;
     }
 
-    private static String tagFromFurnaceRecipeCategory(int group) {
-        return switch (group) {
-            case 4, 5, 6 -> "furnace"; // furnace
-            case 7, 8 -> "blast_furnace"; // blast_furnace_blocks, blast_furnace_misc
-            case 9, 12 -> "smoker"; // smoker_food, campfire
-            default -> "furnace"; // /shrug
-        };
+    public enum FurnaceRecipeType {
+        FURNACE("furnace", 4, 5, 6), // furnace
+        BLAST_FURNACE("blast_furnace", 7, 8), // blast_furnace_blocks, blast_furnace_misc
+        SMOKER("smoker", 9, 12); // smoker_food, campfire
+
+        private final String tag;
+        @Getter
+        @Accessors(fluent = true)
+        private final IntList categories;
+
+        FurnaceRecipeType(String tag, int... categories) {
+            this.tag = tag;
+            this.categories = IntList.of(categories);
+        }
+
+        public static FurnaceRecipeType fromCategory(int category) {
+            for (FurnaceRecipeType type : values()) {
+                if (type.categories.contains(category)) {
+                    return type;
+                }
+            }
+
+            return FURNACE; // /shrug
+        }
     }
 }

--- a/core/src/main/java/org/geysermc/geyser/inventory/recipe/GeyserShapelessRecipe.java
+++ b/core/src/main/java/org/geysermc/geyser/inventory/recipe/GeyserShapelessRecipe.java
@@ -31,6 +31,7 @@ import org.cloudburstmc.protocol.bedrock.data.inventory.crafting.recipe.RecipeDa
 import org.cloudburstmc.protocol.bedrock.data.inventory.crafting.recipe.ShapelessRecipeData;
 import org.cloudburstmc.protocol.bedrock.data.inventory.descriptor.ItemDescriptorWithCount;
 import org.geysermc.geyser.session.GeyserSession;
+import org.geysermc.mcprotocollib.protocol.data.game.recipe.display.FurnaceRecipeDisplay;
 import org.geysermc.mcprotocollib.protocol.data.game.recipe.display.ShapelessCraftingRecipeDisplay;
 import org.geysermc.mcprotocollib.protocol.data.game.recipe.display.slot.SlotDisplay;
 
@@ -42,10 +43,15 @@ import java.util.UUID;
 public record GeyserShapelessRecipe(int id,
                                     int netId,
                                     List<SlotDisplay> ingredients,
-                                    SlotDisplay result) implements GeyserRecipe {
+                                    SlotDisplay result,
+                                    String tag) implements GeyserRecipe {
 
     public GeyserShapelessRecipe(int id, int netId, ShapelessCraftingRecipeDisplay data) {
-        this(id, netId, data.ingredients(), data.result());
+        this(id, netId, data.ingredients(), data.result(), "crafting_table");
+    }
+
+    public GeyserShapelessRecipe(int id, int netId, FurnaceRecipeDisplay data, int category) {
+        this(id, netId, List.of(data.ingredient()), data.result(), tagFromFurnaceRecipeCategory(category));
     }
 
     @Override
@@ -66,10 +72,19 @@ public record GeyserShapelessRecipe(int id,
         int i = 0;
         for (List<ItemDescriptorWithCount> inputs : left) {
             recipeData.add(ShapelessRecipeData.shapeless(id + "_" + i, inputs,
-                    Collections.singletonList(output), UUID.randomUUID(), "crafting_table", 0,
+                    Collections.singletonList(output), UUID.randomUUID(), tag, 0,
                     netId + i, RecipeUnlockingRequirement.INVALID));
             i++;
         }
         return recipeData;
+    }
+
+    private static String tagFromFurnaceRecipeCategory(int group) {
+        return switch (group) {
+            case 4, 5, 6 -> "furnace"; // furnace
+            case 7, 8 -> "blast_furnace"; // blast_furnace_blocks, blast_furnace_misc
+            case 9, 12 -> "smoker"; // smoker_food, campfire
+            default -> throw new IllegalArgumentException("no furnace tag for category " + group);
+        };
     }
 }

--- a/core/src/main/java/org/geysermc/geyser/inventory/recipe/GeyserShapelessRecipe.java
+++ b/core/src/main/java/org/geysermc/geyser/inventory/recipe/GeyserShapelessRecipe.java
@@ -84,7 +84,7 @@ public record GeyserShapelessRecipe(int id,
             case 4, 5, 6 -> "furnace"; // furnace
             case 7, 8 -> "blast_furnace"; // blast_furnace_blocks, blast_furnace_misc
             case 9, 12 -> "smoker"; // smoker_food, campfire
-            default -> throw new IllegalArgumentException("no furnace tag for category " + group);
+            default -> "furnace"; // /shrug
         };
     }
 }

--- a/core/src/main/java/org/geysermc/geyser/translator/protocol/java/JavaRecipeBookAddTranslator.java
+++ b/core/src/main/java/org/geysermc/geyser/translator/protocol/java/JavaRecipeBookAddTranslator.java
@@ -34,6 +34,7 @@ import org.geysermc.geyser.inventory.recipe.GeyserRecipe;
 import org.geysermc.geyser.inventory.recipe.GeyserShapedRecipe;
 import org.geysermc.geyser.inventory.recipe.GeyserShapelessRecipe;
 import org.geysermc.geyser.inventory.recipe.GeyserSmithingRecipe;
+import org.geysermc.geyser.item.Items;
 import org.geysermc.geyser.network.GameProtocol;
 import org.geysermc.geyser.session.GeyserSession;
 import org.geysermc.geyser.translator.protocol.PacketTranslator;
@@ -44,11 +45,16 @@ import org.geysermc.mcprotocollib.protocol.data.game.recipe.display.RecipeDispla
 import org.geysermc.mcprotocollib.protocol.data.game.recipe.display.ShapedCraftingRecipeDisplay;
 import org.geysermc.mcprotocollib.protocol.data.game.recipe.display.ShapelessCraftingRecipeDisplay;
 import org.geysermc.mcprotocollib.protocol.data.game.recipe.display.SmithingRecipeDisplay;
+import org.geysermc.mcprotocollib.protocol.data.game.recipe.display.slot.AnyFuelSlotDisplay;
+import org.geysermc.mcprotocollib.protocol.data.game.recipe.display.slot.ItemSlotDisplay;
+import org.geysermc.mcprotocollib.protocol.data.game.recipe.display.slot.SlotDisplay;
 import org.geysermc.mcprotocollib.protocol.data.game.recipe.display.slot.SmithingTrimDemoSlotDisplay;
 import org.geysermc.mcprotocollib.protocol.packet.ingame.clientbound.ClientboundRecipeBookAddPacket;
 
 import java.util.ArrayList;
+import java.util.HashSet;
 import java.util.List;
+import java.util.Set;
 
 @Translator(packet = ClientboundRecipeBookAddPacket.class)
 public class JavaRecipeBookAddTranslator extends PacketTranslator<ClientboundRecipeBookAddPacket> {
@@ -63,6 +69,9 @@ public class JavaRecipeBookAddTranslator extends PacketTranslator<ClientboundRec
         UnlockedRecipesPacket recipesPacket = new UnlockedRecipesPacket();
         recipesPacket.setAction(packet.isReplace() ? UnlockedRecipesPacket.ActionType.INITIALLY_UNLOCKED : UnlockedRecipesPacket.ActionType.NEWLY_UNLOCKED);
 
+        // Hacky fix, see below
+        Set<GeyserShapelessRecipe.FurnaceRecipeType> knownFurnaceRecipes = new HashSet<>();
+
         for (ClientboundRecipeBookAddPacket.Entry entry : packet.getEntries()) {
             RecipeDisplayEntry contents = entry.contents();
             if (javaToBedrockRecipeIds.containsKey(contents.id())) {
@@ -75,6 +84,7 @@ public class JavaRecipeBookAddTranslator extends PacketTranslator<ClientboundRec
             // TODO rewrite this, but properly
             if (display instanceof FurnaceRecipeDisplay furnaceRecipe && GameProtocol.is1_26_20orHigher(session.protocolVersion())) {
                 GeyserRecipe geyserRecipe = new GeyserShapelessRecipe(contents.id(), netId, furnaceRecipe, contents.category());
+                knownFurnaceRecipes.add(GeyserShapelessRecipe.FurnaceRecipeType.fromCategory(contents.category()));
 
                 List<RecipeData> recipeData = geyserRecipe.asRecipeData(session);
                 craftingDataPacket.getCraftingData().addAll(recipeData);
@@ -137,6 +147,35 @@ public class JavaRecipeBookAddTranslator extends PacketTranslator<ClientboundRec
                 }
                 default -> {
                     GeyserImpl.getInstance().getLogger().debug("Ignoring unknown recipe display type! " + entry);
+                }
+            }
+        }
+
+        if (GameProtocol.is1_26_20orHigher(session.protocolVersion())) {
+            int placeholderRecipes = 0;
+
+            SlotDisplay stoneSlotDisplay = new ItemSlotDisplay(Items.STONE.javaId());
+            FurnaceRecipeDisplay placeholderFurnaceRecipe = new FurnaceRecipeDisplay(stoneSlotDisplay, new AnyFuelSlotDisplay(), stoneSlotDisplay, stoneSlotDisplay, 1, 1.0F);
+
+            for (GeyserShapelessRecipe.FurnaceRecipeType type : GeyserShapelessRecipe.FurnaceRecipeType.values()) {
+                // Bedrock HAS to have a recipe or else it will crash on 1.26.20 and above, so send a bogus recipe
+                // Again, very hacky, FIXME please
+                if (!knownFurnaceRecipes.contains(type)) {
+                    int id = Integer.MIN_VALUE + placeholderRecipes;
+                    GeyserRecipe geyserRecipe = new GeyserShapelessRecipe(id, netId, placeholderFurnaceRecipe, type.categories().getFirst());
+
+                    List<RecipeData> recipeData = geyserRecipe.asRecipeData(session);
+                    craftingDataPacket.getCraftingData().addAll(recipeData);
+
+                    List<String> bedrockRecipeIds = new ArrayList<>();
+                    for (int i = 0; i < recipeData.size(); i++) {
+                        String recipeId = id + "_" + i;
+                        recipesPacket.getUnlockedRecipes().add(recipeId);
+                        bedrockRecipeIds.add(recipeId);
+                        geyserRecipes.put(netId++, geyserRecipe);
+                    }
+                    javaToBedrockRecipeIds.put(id, List.copyOf(bedrockRecipeIds));
+                    placeholderRecipes++;
                 }
             }
         }

--- a/core/src/main/java/org/geysermc/geyser/translator/protocol/java/JavaRecipeBookAddTranslator.java
+++ b/core/src/main/java/org/geysermc/geyser/translator/protocol/java/JavaRecipeBookAddTranslator.java
@@ -34,9 +34,11 @@ import org.geysermc.geyser.inventory.recipe.GeyserRecipe;
 import org.geysermc.geyser.inventory.recipe.GeyserShapedRecipe;
 import org.geysermc.geyser.inventory.recipe.GeyserShapelessRecipe;
 import org.geysermc.geyser.inventory.recipe.GeyserSmithingRecipe;
+import org.geysermc.geyser.network.GameProtocol;
 import org.geysermc.geyser.session.GeyserSession;
 import org.geysermc.geyser.translator.protocol.PacketTranslator;
 import org.geysermc.geyser.translator.protocol.Translator;
+import org.geysermc.mcprotocollib.protocol.data.game.recipe.display.FurnaceRecipeDisplay;
 import org.geysermc.mcprotocollib.protocol.data.game.recipe.display.RecipeDisplay;
 import org.geysermc.mcprotocollib.protocol.data.game.recipe.display.RecipeDisplayEntry;
 import org.geysermc.mcprotocollib.protocol.data.game.recipe.display.ShapedCraftingRecipeDisplay;
@@ -68,6 +70,26 @@ public class JavaRecipeBookAddTranslator extends PacketTranslator<ClientboundRec
             }
 
             RecipeDisplay display = contents.display();
+            // Hacky fix: on 1.26.20 and above, the client crashes when there are no furnace recipes. Furnace recipes also have to be shapeless.
+            // Before this fix, Geyser did not translate furnace recipes at all.
+            // TODO rewrite this, but properly
+            if (display instanceof FurnaceRecipeDisplay furnaceRecipe && GameProtocol.is1_26_20orHigher(session.protocolVersion())) {
+                GeyserRecipe geyserRecipe = new GeyserShapelessRecipe(contents.id(), netId, furnaceRecipe, contents.category());
+
+                List<RecipeData> recipeData = geyserRecipe.asRecipeData(session);
+                craftingDataPacket.getCraftingData().addAll(recipeData);
+
+                List<String> bedrockRecipeIds = new ArrayList<>();
+                for (int i = 0; i < recipeData.size(); i++) {
+                    String recipeId = contents.id() + "_" + i;
+                    recipesPacket.getUnlockedRecipes().add(recipeId);
+                    bedrockRecipeIds.add(recipeId);
+                    geyserRecipes.put(netId++, geyserRecipe);
+                }
+                javaToBedrockRecipeIds.put(contents.id(), List.copyOf(bedrockRecipeIds));
+                continue;
+            }
+
             switch (display) {
                 case ShapedCraftingRecipeDisplay shapedRecipe -> {
                     GeyserRecipe geyserRecipe = new GeyserShapedRecipe(contents.id(), netId, shapedRecipe);


### PR DESCRIPTION
This PR fixes the buildscripts to publish the correct JAR files to Modrinth for the modded platforms.

The PR also updates the mappings submodule to include the latest commit, and includes a client crash fix that occurs when no (blast) furnace/smoker recipes are sent (#6353). This is meant to be a temporary fix.