### PR TITLE
Fix: timecycle on ViaVersion (#6354), unimplemented slot display inputs

### DIFF
--- a/core/src/main/java/org/geysermc/geyser/inventory/GeyserItemStack.java
+++ b/core/src/main/java/org/geysermc/geyser/inventory/GeyserItemStack.java
@@ -111,6 +111,7 @@ public class GeyserItemStack {
     }
 
     public static @NonNull GeyserItemStack from(@Nullable GeyserSession session, @NonNull SlotDisplay slotDisplay) {
+        // TODO possible code duplication with RecipeUtil#translateToOutput?
         return switch (slotDisplay) {
             case EmptySlotDisplay ignored -> GeyserItemStack.EMPTY;
             case ItemSlotDisplay(int itemId) -> GeyserItemStack.of(session, itemId, 1);

--- a/core/src/main/java/org/geysermc/geyser/inventory/recipe/RecipeUtil.java
+++ b/core/src/main/java/org/geysermc/geyser/inventory/recipe/RecipeUtil.java
@@ -180,6 +180,9 @@ public class RecipeUtil {
             // FIXME I don't think there's a proper way to do this? How do we tell bedrock that the item has to have a certain component?
             return translateToInput(session, source);
         }
+        if (slotDisplay instanceof DyedSlotDisplay(SlotDisplay ignored, SlotDisplay target)) {
+            return translateToInput(session, target);
+        }
         if (slotDisplay instanceof WithAnyPotionSlotDisplay(SlotDisplay display)) {
             // Not sure how I feel about this...
             GeyserItemStack stack = GeyserItemStack.from(session, display);

--- a/core/src/main/java/org/geysermc/geyser/translator/protocol/java/level/JavaSetTimeTranslator.java
+++ b/core/src/main/java/org/geysermc/geyser/translator/protocol/java/level/JavaSetTimeTranslator.java
@@ -27,6 +27,7 @@ package org.geysermc.geyser.translator.protocol.java.level;
 
 import net.kyori.adventure.key.Key;
 import org.geysermc.geyser.session.cache.registry.JavaRegistries;
+import org.geysermc.geyser.session.cache.registry.JavaRegistry;
 import org.geysermc.mcprotocollib.protocol.data.game.level.ClockNetworkState;
 import org.geysermc.mcprotocollib.protocol.packet.ingame.clientbound.level.ClientboundSetTimePacket;
 import org.geysermc.geyser.session.GeyserSession;
@@ -40,16 +41,26 @@ public class JavaSetTimeTranslator extends PacketTranslator<ClientboundSetTimePa
     public void translate(GeyserSession session, ClientboundSetTimePacket packet) {
         session.setGameTicks(packet.getGameTime());
 
-        // We only translate the dimension's default clock right now, which will work for vanilla, but probably less so for custom dimensions
+        // We only translate the dimension's default clock right now (or, if only one clock exists, we translate that),
+        // which will work for vanilla, but probably less so for custom dimensions
         // Nevertheless, this is the best effort we can do right now, and better than just translating the overworld clock
+        ClockNetworkState defaultClockState = packet.getClockUpdates().get(defaultClockId(session));
+        if (defaultClockState != null) {
+            session.setTimeTicks(defaultClockState.totalTicks(), defaultClockState.partialTick());
+            // We need to send a gamerule if this changed
+            session.setClockRate(defaultClockState.rate());
+        }
+    }
+
+    private static int defaultClockId(GeyserSession session) {
         Key defaultClock = session.getDimensionType().defaultClock();
         if (defaultClock != null) {
-            ClockNetworkState currentDimensionState = packet.getClockUpdates().get(JavaRegistries.WORLD_CLOCK.networkId(session, defaultClock));
-            if (currentDimensionState != null) {
-                session.setTimeTicks(currentDimensionState.totalTicks(), currentDimensionState.partialTick());
-                // We need to send a gamerule if this changed
-                session.setClockRate(currentDimensionState.rate());
-            }
+            return JavaRegistries.WORLD_CLOCK.networkId(session, defaultClock);
         }
+        JavaRegistry<?> clockRegistry = session.getRegistryCache().registry(JavaRegistries.WORLD_CLOCK);
+        if (clockRegistry.entries().size() == 1) {
+            return clockRegistry.entries().getFirst().id();
+        }
+        return -1;
     }
 }

--- a/core/src/main/java/org/geysermc/geyser/util/InventoryUtils.java
+++ b/core/src/main/java/org/geysermc/geyser/util/InventoryUtils.java
@@ -57,14 +57,17 @@ import org.geysermc.geyser.text.GeyserLocale;
 import org.geysermc.geyser.translator.protocol.java.inventory.JavaMerchantOffersTranslator;
 import org.geysermc.mcprotocollib.protocol.data.game.item.ItemStack;
 import org.geysermc.mcprotocollib.protocol.data.game.item.component.DataComponentType;
+import org.geysermc.mcprotocollib.protocol.data.game.item.component.DataComponentTypes;
 import org.geysermc.mcprotocollib.protocol.data.game.item.component.DataComponents;
 import org.geysermc.mcprotocollib.protocol.data.game.recipe.display.slot.CompositeSlotDisplay;
+import org.geysermc.mcprotocollib.protocol.data.game.recipe.display.slot.DyedSlotDisplay;
 import org.geysermc.mcprotocollib.protocol.data.game.recipe.display.slot.EmptySlotDisplay;
 import org.geysermc.mcprotocollib.protocol.data.game.recipe.display.slot.ItemSlotDisplay;
 import org.geysermc.mcprotocollib.protocol.data.game.recipe.display.slot.ItemStackSlotDisplay;
 import org.geysermc.mcprotocollib.protocol.data.game.recipe.display.slot.OnlyWithComponentSlotDisplay;
 import org.geysermc.mcprotocollib.protocol.data.game.recipe.display.slot.SlotDisplay;
 import org.geysermc.mcprotocollib.protocol.data.game.recipe.display.slot.TagSlotDisplay;
+import org.geysermc.mcprotocollib.protocol.data.game.recipe.display.slot.WithAnyPotionSlotDisplay;
 import org.geysermc.mcprotocollib.protocol.data.game.recipe.display.slot.WithRemainderSlotDisplay;
 import org.geysermc.mcprotocollib.protocol.packet.ingame.clientbound.inventory.ClientboundOpenBookPacket;
 import org.geysermc.mcprotocollib.protocol.packet.ingame.serverbound.inventory.ServerboundContainerClosePacket;
@@ -360,6 +363,7 @@ public class InventoryUtils {
      * Returns if the provided item stack would be accepted by the slot display.
      */
     public static boolean acceptsAsInput(GeyserSession session, SlotDisplay slotDisplay, GeyserItemStack itemStack) {
+        // TODO possible code duplication with RecipeUtil#translateToInput
         if (slotDisplay instanceof EmptySlotDisplay) {
             return itemStack.isEmpty();
         }
@@ -386,7 +390,24 @@ public class InventoryUtils {
         if (slotDisplay instanceof OnlyWithComponentSlotDisplay(SlotDisplay source, DataComponentType<?> component)) {
             return itemStack.has(component) && acceptsAsInput(session, source, itemStack);
         }
-        // TODO WithAnyPotion?
+        if (slotDisplay instanceof DyedSlotDisplay(SlotDisplay ignored, SlotDisplay target)) {
+            return acceptsAsInput(session, target, itemStack);
+        }
+        if (slotDisplay instanceof WithAnyPotionSlotDisplay(SlotDisplay display)) {
+            if (display instanceof ItemStackSlotDisplay(ItemStack stack)) {
+                DataComponents clonedComponents = stack.getDataComponentsPatch() == null ? null : stack.getDataComponentsPatch().clone();
+                if (clonedComponents != null) {
+                    clonedComponents.remove(DataComponentTypes.POTION_CONTENTS);
+                }
+                ItemStack stackWithoutPotions = new ItemStack(stack.getId(), stack.getAmount(), clonedComponents);
+                GeyserItemStack originalWithoutPotions = itemStack.copy();
+                if (originalWithoutPotions.getComponents() != null) {
+                    originalWithoutPotions.getComponents().remove(DataComponentTypes.POTION_CONTENTS);
+                }
+                return acceptsAsInput(session, new ItemStackSlotDisplay(stackWithoutPotions), originalWithoutPotions);
+            }
+            return acceptsAsInput(session, display, itemStack);
+        }
         session.getGeyser().getLogger().warning("Unknown slot display type: " + slotDisplay);
         return false;
     }


### PR DESCRIPTION
This PR fixes 2 issues introduced with the Java 26.1 update. The first is described in #6354, causing time to not progress when using a server with ViaVersion. This issue occurs because ViaVersion does not send default dimension clocks, leading to Geyser not using any. The issue has been resolved by always translating a clock if only one clock is registered, which is always the case for Minecraft Java 1.21.11 and below.

The second causes the following to appear in Geyser instance logs:

> `Unknown slot display type: DyedSlotDisplay[dye=OnlyWithComponentSlotDisplay[source=TagSlotDisplay[tag=minecraft:dyes], component=IntComponentType(id=43 , key=minecraft:dye)], target=CompositeSlotDisplay[contents=[ItemSlotDisplay[item=956]]]]`

This has been resolved by writing basic implementations for `DyedSlotDisplay` in `RecipeUtil#translateToInput` and `InventoryUtils#acceptsAsInput`, and an implementation for `WithAnyPotionSlotDisplay` in `InventoryUtils#acceptsAsInput`.