### PR TITLE
Add support for new waypoint packets

### DIFF
--- a/core/src/main/java/org/geysermc/geyser/entity/spawn/EntitySpawnContext.java
+++ b/core/src/main/java/org/geysermc/geyser/entity/spawn/EntitySpawnContext.java
@@ -96,7 +96,7 @@ public class EntitySpawnContext {
     // Not assigned by default - preparation for cancellable entity spawning
     public long geyserId() {
         if (geyserId == null) {
-            return geyserId = session.getEntityCache().getNextEntityId().incrementAndGet();
+            return geyserId = session.getEntityCache().nextEntityId();
         }
         return geyserId;
     }

--- a/core/src/main/java/org/geysermc/geyser/entity/type/player/PlayerEntity.java
+++ b/core/src/main/java/org/geysermc/geyser/entity/type/player/PlayerEntity.java
@@ -42,6 +42,7 @@ import org.geysermc.geyser.entity.attribute.GeyserAttributeType;
 import org.geysermc.geyser.entity.spawn.EntitySpawnContext;
 import org.geysermc.geyser.entity.type.Entity;
 import org.geysermc.geyser.entity.type.living.animal.tameable.ParrotEntity;
+import org.geysermc.geyser.session.cache.waypoint.GeyserWaypoint;
 import org.geysermc.geyser.util.PlayerListUtils;
 import org.geysermc.mcprotocollib.auth.GameProfile;
 import org.geysermc.mcprotocollib.protocol.data.game.entity.metadata.EntityMetadata;
@@ -110,9 +111,11 @@ public class PlayerEntity extends AvatarEntity implements GeyserPlayerEntity {
             packet.setAction(PlayerListPacket.Action.REMOVE);
             session.sendUpstreamPacket(packet);
 
-            // To ensure waypoints still remain, if any were added while the
-            // player had a valid player list entry
-            session.getWaypointCache().unlistPlayer(this);
+            if (!GeyserWaypoint.requiresNewWaypointPacket(session)) {
+                // To ensure waypoints still remain, if any were added while the
+                // player had a valid player list entry
+                session.getWaypointCache().removeEntity(this);
+            }
         }
 
         // Since we re-use player entities: Clear flags, held item, etc

--- a/core/src/main/java/org/geysermc/geyser/entity/type/player/PlayerEntity.java
+++ b/core/src/main/java/org/geysermc/geyser/entity/type/player/PlayerEntity.java
@@ -111,7 +111,7 @@ public class PlayerEntity extends AvatarEntity implements GeyserPlayerEntity {
             packet.setAction(PlayerListPacket.Action.REMOVE);
             session.sendUpstreamPacket(packet);
 
-            if (!GeyserWaypoint.requiresNewWaypointPacket(session)) {
+            if (!GeyserWaypoint.usesNewWaypointPacket(session)) {
                 // To ensure waypoints still remain, if any were added while the
                 // player had a valid player list entry
                 session.getWaypointCache().removeEntity(this);

--- a/core/src/main/java/org/geysermc/geyser/entity/type/player/PlayerEntity.java
+++ b/core/src/main/java/org/geysermc/geyser/entity/type/player/PlayerEntity.java
@@ -111,7 +111,7 @@ public class PlayerEntity extends AvatarEntity implements GeyserPlayerEntity {
             packet.setAction(PlayerListPacket.Action.REMOVE);
             session.sendUpstreamPacket(packet);
 
-            if (!GeyserWaypoint.usesNewWaypointPacket(session)) {
+            if (!GeyserWaypoint.uses26_10WaypointPacket(session)) {
                 // To ensure waypoints still remain, if any were added while the
                 // player had a valid player list entry
                 session.getWaypointCache().removeEntity(this);

--- a/core/src/main/java/org/geysermc/geyser/session/GeyserSession.java
+++ b/core/src/main/java/org/geysermc/geyser/session/GeyserSession.java
@@ -970,7 +970,7 @@ public class GeyserSession implements GeyserConnection, GeyserCommandSource {
         // Recipe unlocking
         gamerulePacket.getGameRules().add(new GameRuleData<>("recipesunlock", true));
 
-        if (!GeyserWaypoint.usesNewWaypointPacket(this)) {
+        if (!GeyserWaypoint.uses26_10WaypointPacket(this)) {
             // We disable the locator bar until we are certain that the server wants us to enable it
             // See WaypointCache for details
             gamerulePacket.getGameRules().add(new GameRuleData<>("locatorBar", false));

--- a/core/src/main/java/org/geysermc/geyser/session/GeyserSession.java
+++ b/core/src/main/java/org/geysermc/geyser/session/GeyserSession.java
@@ -185,6 +185,7 @@ import org.geysermc.geyser.session.cache.WorldBorder;
 import org.geysermc.geyser.session.cache.WorldCache;
 import org.geysermc.geyser.session.cache.registry.JavaRegistries;
 import org.geysermc.geyser.session.cache.tags.DialogTag;
+import org.geysermc.geyser.session.cache.waypoint.GeyserWaypoint;
 import org.geysermc.geyser.session.cache.waypoint.WaypointCache;
 import org.geysermc.geyser.session.dialog.BuiltInDialog;
 import org.geysermc.geyser.session.dialog.Dialog;
@@ -968,10 +969,13 @@ public class GeyserSession implements GeyserConnection, GeyserCommandSource {
         gamerulePacket.getGameRules().add(new GameRuleData<>("spawnradius", 0));
         // Recipe unlocking
         gamerulePacket.getGameRules().add(new GameRuleData<>("recipesunlock", true));
-        // We disable the locator bar until we are certain that the server wants us to enable it
-        // See WaypointCache for details
-        gamerulePacket.getGameRules().add(new GameRuleData<>("locatorBar", false));
-        
+
+        if (!GeyserWaypoint.requiresNewWaypointPacket(this)) {
+            // We disable the locator bar until we are certain that the server wants us to enable it
+            // See WaypointCache for details
+            gamerulePacket.getGameRules().add(new GameRuleData<>("locatorBar", false));
+        }
+
         upstream.sendPacket(gamerulePacket);
     }
 

--- a/core/src/main/java/org/geysermc/geyser/session/GeyserSession.java
+++ b/core/src/main/java/org/geysermc/geyser/session/GeyserSession.java
@@ -970,7 +970,7 @@ public class GeyserSession implements GeyserConnection, GeyserCommandSource {
         // Recipe unlocking
         gamerulePacket.getGameRules().add(new GameRuleData<>("recipesunlock", true));
 
-        if (!GeyserWaypoint.requiresNewWaypointPacket(this)) {
+        if (!GeyserWaypoint.usesNewWaypointPacket(this)) {
             // We disable the locator bar until we are certain that the server wants us to enable it
             // See WaypointCache for details
             gamerulePacket.getGameRules().add(new GameRuleData<>("locatorBar", false));

--- a/core/src/main/java/org/geysermc/geyser/session/cache/EntityCache.java
+++ b/core/src/main/java/org/geysermc/geyser/session/cache/EntityCache.java
@@ -29,11 +29,14 @@ import it.unimi.dsi.fastutil.ints.Int2LongMap;
 import it.unimi.dsi.fastutil.ints.Int2LongOpenHashMap;
 import it.unimi.dsi.fastutil.longs.Long2ObjectMap;
 import it.unimi.dsi.fastutil.longs.Long2ObjectOpenHashMap;
+import it.unimi.dsi.fastutil.objects.Object2LongMap;
+import it.unimi.dsi.fastutil.objects.Object2LongOpenHashMap;
 import it.unimi.dsi.fastutil.objects.Object2ObjectOpenHashMap;
 import it.unimi.dsi.fastutil.objects.ObjectArrayList;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import java.util.UUID;
 import java.util.concurrent.atomic.AtomicLong;
 import java.util.function.Consumer;
@@ -42,6 +45,7 @@ import org.geysermc.geyser.entity.type.Entity;
 import org.geysermc.geyser.entity.type.Tickable;
 import org.geysermc.geyser.entity.type.player.PlayerEntity;
 import org.geysermc.geyser.session.GeyserSession;
+import org.geysermc.geyser.session.cache.waypoint.GeyserWaypoint;
 
 /**
  * Each session has its own EntityCache in the occasion that an entity packet is sent specifically
@@ -57,6 +61,7 @@ public class EntityCache {
      */
     private final List<Tickable> tickableEntities = new ObjectArrayList<>();
     private final Int2LongMap entityIdTranslations = new Int2LongOpenHashMap();
+    private final Object2LongMap<UUID> entityUuidTranslations = new Object2LongOpenHashMap<>();
     private final Map<UUID, PlayerEntity> playerEntities = new Object2ObjectOpenHashMap<>();
     private final Map<UUID, BossBar> bossBars = new Object2ObjectOpenHashMap<>();
 
@@ -84,6 +89,9 @@ public class EntityCache {
                 // Start ticking it
                 tickableEntities.add((Tickable) entity);
             }
+            if (GeyserWaypoint.requiresNewWaypointPacket(session)) {
+                session.getWaypointCache().addEntity(entity);
+            }
         }
     }
 
@@ -92,6 +100,9 @@ public class EntityCache {
         if (!entityIdTranslations.containsKey(entity.getEntityId())) {
             entityIdTranslations.put(entity.getEntityId(), entity.geyserId());
             entities.put(entity.geyserId(), entity);
+            if (entity.uuid() != null) {
+                entityUuidTranslations.put(entity.uuid(), entity.geyserId());
+            }
             return true;
         }
         return false;
@@ -110,12 +121,19 @@ public class EntityCache {
             entity.despawnEntity();
         }
         entities.remove(entityIdTranslations.remove(entity.getEntityId()));
+        if (entity.uuid() != null) {
+            entityUuidTranslations.removeLong(entity.uuid());
+        }
 
         // don't track the entity anymore, now that it's removed
         session.getWorldCache().getScoreboard().entityRemoved(entity);
 
         if (entity instanceof Tickable) {
             tickableEntities.remove(entity);
+        }
+
+        if (GeyserWaypoint.requiresNewWaypointPacket(session)) {
+            session.getWaypointCache().removeEntity(entity);
         }
     }
 
@@ -137,6 +155,13 @@ public class EntityCache {
             return session.getPlayerEntity();
         }
         return entities.get(entityIdTranslations.get(javaId));
+    }
+
+    public Entity getEntityByUuid(UUID uuid) {
+        if (Objects.equals(uuid, session.getPlayerEntity().uuid())) {
+            return session.getPlayerEntity();
+        }
+        return entities.get(entityUuidTranslations.getLong(uuid));
     }
 
     public void addPlayerEntity(PlayerEntity entity) {

--- a/core/src/main/java/org/geysermc/geyser/session/cache/EntityCache.java
+++ b/core/src/main/java/org/geysermc/geyser/session/cache/EntityCache.java
@@ -89,7 +89,7 @@ public class EntityCache {
                 // Start ticking it
                 tickableEntities.add((Tickable) entity);
             }
-            if (GeyserWaypoint.requiresNewWaypointPacket(session)) {
+            if (GeyserWaypoint.usesNewWaypointPacket(session)) {
                 session.getWaypointCache().addEntity(entity);
             }
         }
@@ -132,7 +132,7 @@ public class EntityCache {
             tickableEntities.remove(entity);
         }
 
-        if (GeyserWaypoint.requiresNewWaypointPacket(session)) {
+        if (GeyserWaypoint.usesNewWaypointPacket(session)) {
             session.getWaypointCache().removeEntity(entity);
         }
     }

--- a/core/src/main/java/org/geysermc/geyser/session/cache/EntityCache.java
+++ b/core/src/main/java/org/geysermc/geyser/session/cache/EntityCache.java
@@ -89,7 +89,7 @@ public class EntityCache {
                 // Start ticking it
                 tickableEntities.add((Tickable) entity);
             }
-            if (GeyserWaypoint.usesNewWaypointPacket(session)) {
+            if (GeyserWaypoint.uses26_10WaypointPacket(session)) {
                 session.getWaypointCache().addEntity(entity);
             }
         }
@@ -132,7 +132,7 @@ public class EntityCache {
             tickableEntities.remove(entity);
         }
 
-        if (GeyserWaypoint.usesNewWaypointPacket(session)) {
+        if (GeyserWaypoint.uses26_10WaypointPacket(session)) {
             session.getWaypointCache().removeEntity(entity);
         }
     }

--- a/core/src/main/java/org/geysermc/geyser/session/cache/EntityCache.java
+++ b/core/src/main/java/org/geysermc/geyser/session/cache/EntityCache.java
@@ -67,6 +67,10 @@ public class EntityCache {
         this.session = session;
     }
 
+    public long nextEntityId() {
+        return nextEntityId.incrementAndGet();
+    }
+
     public void spawnEntity(Entity entity) {
         if (cacheEntity(entity)) {
             // start tracking newly spawned entities. Doing this before the actual entity spawn can result in combining

--- a/core/src/main/java/org/geysermc/geyser/session/cache/waypoint/AzimuthWaypoint.java
+++ b/core/src/main/java/org/geysermc/geyser/session/cache/waypoint/AzimuthWaypoint.java
@@ -26,13 +26,14 @@
 package org.geysermc.geyser.session.cache.waypoint;
 
 import org.cloudburstmc.math.vector.Vector3f;
-import org.geysermc.geyser.entity.type.player.PlayerEntity;
+import org.geysermc.geyser.entity.type.Entity;
 import org.geysermc.geyser.session.GeyserSession;
 import org.geysermc.mcprotocollib.protocol.data.game.level.waypoint.AzimuthWaypointData;
 import org.geysermc.mcprotocollib.protocol.data.game.level.waypoint.WaypointData;
 
 import java.awt.Color;
 import java.util.Optional;
+import java.util.UUID;
 
 public class AzimuthWaypoint extends GeyserWaypoint implements TickingWaypoint {
 
@@ -43,8 +44,8 @@ public class AzimuthWaypoint extends GeyserWaypoint implements TickingWaypoint {
     // The angle, in radians, where the waypoint should appear on the bar
     private float angle = 0.0F;
 
-    public AzimuthWaypoint(GeyserSession session, Optional<PlayerEntity> player, Color color) {
-        super(session, player, color);
+    public AzimuthWaypoint(GeyserSession session, UUID uuid, Optional<Entity> entity, Color color) {
+        super(session, uuid, entity, color);
     }
 
     @Override
@@ -71,6 +72,6 @@ public class AzimuthWaypoint extends GeyserWaypoint implements TickingWaypoint {
         float dx = (float) -(Math.sin(angle) * WAYPOINT_DISTANCE);
         float dz = (float) (Math.cos(angle) * WAYPOINT_DISTANCE);
         // Set Y to the player's Y since this waypoint always appears in the centre of the bar on Java
-        position = Vector3f.from(playerPosition.getX() + dx, playerPosition.getY(), playerPosition.getZ() + dz);
+        setPosition(Vector3f.from(playerPosition.getX() + dx, playerPosition.getY(), playerPosition.getZ() + dz));
     }
 }

--- a/core/src/main/java/org/geysermc/geyser/session/cache/waypoint/AzimuthWaypoint.java
+++ b/core/src/main/java/org/geysermc/geyser/session/cache/waypoint/AzimuthWaypoint.java
@@ -25,6 +25,7 @@
 
 package org.geysermc.geyser.session.cache.waypoint;
 
+import net.kyori.adventure.key.Key;
 import org.cloudburstmc.math.vector.Vector3f;
 import org.geysermc.geyser.entity.type.Entity;
 import org.geysermc.geyser.session.GeyserSession;
@@ -44,8 +45,8 @@ public class AzimuthWaypoint extends GeyserWaypoint implements TickingWaypoint {
     // The angle, in radians, where the waypoint should appear on the bar
     private float angle = 0.0F;
 
-    public AzimuthWaypoint(GeyserSession session, UUID uuid, Optional<Entity> entity, Color color) {
-        super(session, uuid, entity, color);
+    public AzimuthWaypoint(GeyserSession session, UUID uuid, Key style, Color color, Optional<Entity> entity) {
+        super(session, uuid, style, color, entity);
     }
 
     @Override

--- a/core/src/main/java/org/geysermc/geyser/session/cache/waypoint/ChunkWaypoint.java
+++ b/core/src/main/java/org/geysermc/geyser/session/cache/waypoint/ChunkWaypoint.java
@@ -25,6 +25,7 @@
 
 package org.geysermc.geyser.session.cache.waypoint;
 
+import net.kyori.adventure.key.Key;
 import org.cloudburstmc.math.vector.Vector3f;
 import org.geysermc.geyser.entity.type.Entity;
 import org.geysermc.geyser.session.GeyserSession;
@@ -37,8 +38,8 @@ import java.util.UUID;
 
 public class ChunkWaypoint extends GeyserWaypoint {
 
-    public ChunkWaypoint(GeyserSession session, UUID uuid, Optional<Entity> entity, Color color) {
-        super(session, uuid, entity, color);
+    public ChunkWaypoint(GeyserSession session, UUID uuid, Key style, Color color, Optional<Entity> entity) {
+        super(session, uuid, style, color, entity);
     }
 
     @Override

--- a/core/src/main/java/org/geysermc/geyser/session/cache/waypoint/CoordinatesWaypoint.java
+++ b/core/src/main/java/org/geysermc/geyser/session/cache/waypoint/CoordinatesWaypoint.java
@@ -25,6 +25,7 @@
 
 package org.geysermc.geyser.session.cache.waypoint;
 
+import net.kyori.adventure.key.Key;
 import org.cloudburstmc.math.vector.Vector3i;
 import org.geysermc.geyser.entity.type.Entity;
 import org.geysermc.geyser.session.GeyserSession;
@@ -37,8 +38,8 @@ import java.util.UUID;
 
 public class CoordinatesWaypoint extends GeyserWaypoint {
 
-    public CoordinatesWaypoint(GeyserSession session, UUID uuid, Optional<Entity> entity, Color color) {
-        super(session, uuid, entity, color);
+    public CoordinatesWaypoint(GeyserSession session, UUID uuid, Key style, Color color, Optional<Entity> entity) {
+        super(session, uuid, style, color, entity);
     }
 
     @Override

--- a/core/src/main/java/org/geysermc/geyser/session/cache/waypoint/CoordinatesWaypoint.java
+++ b/core/src/main/java/org/geysermc/geyser/session/cache/waypoint/CoordinatesWaypoint.java
@@ -26,24 +26,25 @@
 package org.geysermc.geyser.session.cache.waypoint;
 
 import org.cloudburstmc.math.vector.Vector3i;
-import org.geysermc.geyser.entity.type.player.PlayerEntity;
+import org.geysermc.geyser.entity.type.Entity;
 import org.geysermc.geyser.session.GeyserSession;
 import org.geysermc.mcprotocollib.protocol.data.game.level.waypoint.Vec3iWaypointData;
 import org.geysermc.mcprotocollib.protocol.data.game.level.waypoint.WaypointData;
 
-import java.awt.*;
+import java.awt.Color;
 import java.util.Optional;
+import java.util.UUID;
 
 public class CoordinatesWaypoint extends GeyserWaypoint {
 
-    public CoordinatesWaypoint(GeyserSession session, Optional<PlayerEntity> player, Color color) {
-        super(session, player, color);
+    public CoordinatesWaypoint(GeyserSession session, UUID uuid, Optional<Entity> entity, Color color) {
+        super(session, uuid, entity, color);
     }
 
     @Override
     public void setData(WaypointData data) {
         if (data instanceof Vec3iWaypointData(Vector3i vector)) {
-            position = vector.toFloat();
+            setPosition(vector.toFloat());
         } else {
             session.getGeyser().getLogger().warning("Received incorrect waypoint data " + data.getClass() + " for coordinates waypoint");
         }

--- a/core/src/main/java/org/geysermc/geyser/session/cache/waypoint/GeyserWaypoint.java
+++ b/core/src/main/java/org/geysermc/geyser/session/cache/waypoint/GeyserWaypoint.java
@@ -68,8 +68,8 @@ public abstract class GeyserWaypoint {
     private final UUID uuid;
     private final LocatorBarWaypoint bedrockWaypoint;
     private final Key style;
-    private final boolean usesNewWaypointPacket;
-    private final boolean usesNewNewWaypointPacket;
+    private final boolean uses26_10WaypointPacket;
+    private final boolean uses26_20WaypointPacket;
     private boolean sendListPackets;
 
     private Vector3f lastSentPosition = null;
@@ -79,8 +79,8 @@ public abstract class GeyserWaypoint {
         this.uuid = uuid;
         this.style = style;
         this.bedrockWaypoint = new LocatorBarWaypoint();
-        this.usesNewWaypointPacket = usesNewWaypointPacket(session);
-        this.usesNewNewWaypointPacket = usesNewNewWaypointPacket(session);
+        this.uses26_10WaypointPacket = uses26_10WaypointPacket(session);
+        this.uses26_20WaypointPacket = uses26_20WaypointPacket(session);
         bedrockWaypoint.setVisible(true);
         bedrockWaypoint.setColor(color);
         initialiseWaypointFromEntity(entity);
@@ -89,9 +89,9 @@ public abstract class GeyserWaypoint {
 
     private void initialiseWaypointFromEntity(Optional<Entity> entity) {
         bedrockWaypoint.setClientPositionAuthority(entity.isPresent());
-        bedrockWaypoint.setEntityUniqueId(entity.map(Entity::geyserId).orElseGet(() -> usesNewWaypointPacket ? null : session.getEntityCache().nextEntityId()));
+        bedrockWaypoint.setEntityUniqueId(entity.map(Entity::geyserId).orElseGet(() -> uses26_10WaypointPacket ? null : session.getEntityCache().nextEntityId()));
 
-        if (usesNewWaypointPacket) {
+        if (uses26_10WaypointPacket) {
             this.sendListPackets = false;
         } else {
             this.sendListPackets = entity.isEmpty();
@@ -105,14 +105,14 @@ public abstract class GeyserWaypoint {
     public void track(WaypointData data) {
         setData(data);
         sendTrackPackets(true);
-        if (!usesNewWaypointPacket) {
+        if (!uses26_10WaypointPacket) {
             sendLocationPacket(false);
         }
     }
 
     private void track() {
         sendTrackPackets(true);
-        if (!usesNewWaypointPacket) {
+        if (!uses26_10WaypointPacket) {
             sendLocationPacket(false);
         }
     }
@@ -123,7 +123,7 @@ public abstract class GeyserWaypoint {
     }
 
     public void untrack() {
-        if (!usesNewWaypointPacket) {
+        if (!uses26_10WaypointPacket) {
             PlayerLocationPacket packet = new PlayerLocationPacket();
             packet.setType(PlayerLocationPacket.Type.HIDE);
             packet.setTargetEntityId(bedrockWaypoint.getEntityUniqueId());
@@ -134,7 +134,7 @@ public abstract class GeyserWaypoint {
     }
 
     public void setEntity(Entity entity) {
-        if (usesNewWaypointPacket) {
+        if (uses26_10WaypointPacket) {
             untrack();
             initialiseWaypointFromEntity(Optional.ofNullable(entity));
             track();
@@ -166,8 +166,8 @@ public abstract class GeyserWaypoint {
     protected void setPosition(Vector3f position) {
         bedrockWaypoint.setWorldPosition(new LocatorBarWaypoint.WorldPosition(position, session.getBedrockDimension().bedrockId()));
         float distanceSquared = session.playerEntity().position().distanceSquared(position);
-        if (usesNewWaypointPacket) {
-            if (usesNewNewWaypointPacket) {
+        if (uses26_10WaypointPacket) {
+            if (uses26_20WaypointPacket) {
                 Pair<String, Vector2f> texture = getWaypointTexture(style, distanceSquared);
                 bedrockWaypoint.setTexturePath(texture.first());
                 bedrockWaypoint.setIconSize(texture.second());
@@ -180,9 +180,9 @@ public abstract class GeyserWaypoint {
     protected void sendLocationPacket(boolean force) {
         Vector3f position = bedrockWaypoint.getWorldPosition().getPosition();
         if (force || lastSentPosition == null || position.distanceSquared(lastSentPosition) > 1.0F) {
-            if (usesNewWaypointPacket) {
+            if (uses26_10WaypointPacket) {
                 LocatorBarPacket packet = new LocatorBarPacket();
-                bedrockWaypoint.setUpdateFlag(WaypointUpdateFlags.WORLD_POS | (usesNewNewWaypointPacket ? WaypointUpdateFlags.TEXTURE_PATH | WaypointUpdateFlags.ICON_SIZE : WaypointUpdateFlags.TEXTURE_ID));
+                bedrockWaypoint.setUpdateFlag(WaypointUpdateFlags.WORLD_POS | (uses26_20WaypointPacket ? WaypointUpdateFlags.TEXTURE_PATH | WaypointUpdateFlags.ICON_SIZE : WaypointUpdateFlags.TEXTURE_ID));
                 packet.setWaypoints(List.of(new LocatorBarPacket.Payload(LocatorBarPacket.Action.UPDATE, uuid, bedrockWaypoint)));
                 session.sendUpstreamPacket(packet);
             } else {
@@ -198,7 +198,7 @@ public abstract class GeyserWaypoint {
     }
 
     private void sendTrackPackets(boolean add) {
-        if (usesNewWaypointPacket) {
+        if (uses26_10WaypointPacket) {
             LocatorBarPacket packet = new LocatorBarPacket();
             bedrockWaypoint.setUpdateFlag(add ? WaypointUpdateFlags.ALL : 0);
             packet.setWaypoints(List.of(new LocatorBarPacket.Payload(add ? LocatorBarPacket.Action.ADD : LocatorBarPacket.Action.REMOVE, uuid, bedrockWaypoint)));
@@ -240,11 +240,11 @@ public abstract class GeyserWaypoint {
         };
     }
 
-    public static boolean usesNewWaypointPacket(GeyserSession session) {
+    public static boolean uses26_10WaypointPacket(GeyserSession session) {
         return GameProtocol.is1_26_10orHigher(session.protocolVersion());
     }
 
-    public static boolean usesNewNewWaypointPacket(GeyserSession session) {
+    public static boolean uses26_20WaypointPacket(GeyserSession session) {
         return GameProtocol.is1_26_20orHigher(session.protocolVersion());
     }
 

--- a/core/src/main/java/org/geysermc/geyser/session/cache/waypoint/GeyserWaypoint.java
+++ b/core/src/main/java/org/geysermc/geyser/session/cache/waypoint/GeyserWaypoint.java
@@ -25,53 +25,72 @@
 
 package org.geysermc.geyser.session.cache.waypoint;
 
-import lombok.Getter;
-import lombok.experimental.Accessors;
 import org.checkerframework.checker.nullness.qual.Nullable;
 import org.cloudburstmc.math.vector.Vector3f;
+import org.cloudburstmc.protocol.bedrock.data.LocatorBarWaypoint;
+import org.cloudburstmc.protocol.bedrock.packet.LocatorBarPacket;
 import org.cloudburstmc.protocol.bedrock.packet.PlayerListPacket;
 import org.cloudburstmc.protocol.bedrock.packet.PlayerLocationPacket;
+import org.geysermc.geyser.entity.type.Entity;
 import org.geysermc.geyser.entity.type.player.PlayerEntity;
+import org.geysermc.geyser.network.GameProtocol;
 import org.geysermc.geyser.session.GeyserSession;
 import org.geysermc.geyser.skin.SkinProvider;
 import org.geysermc.mcprotocollib.protocol.data.game.level.waypoint.TrackedWaypoint;
 import org.geysermc.mcprotocollib.protocol.data.game.level.waypoint.WaypointData;
 
 import java.awt.Color;
+import java.util.List;
 import java.util.Optional;
 import java.util.UUID;
 
-@Accessors(fluent = true)
 public abstract class GeyserWaypoint {
     protected final GeyserSession session;
 
-    @Getter
-    private final Color color;
-    private UUID entityUuid;
-    private long entityId;
+    // On 26.10 and above (new waypoint system): the waypoint group UUID
+    // On 26.0 and below (old waypoint system): the UUID of the waypoint
+    // This is decided by the Java server. When Java sends us a waypoint with a String ID, we turn it into a UUID
+    private final UUID uuid;
+    private final LocatorBarWaypoint bedrockWaypoint;
+    private final boolean requiresNewWaypointPacket;
     private boolean sendListPackets;
 
-    protected Vector3f position = Vector3f.ZERO;
-    private Vector3f lastSent = null;
+    private Vector3f lastSentPosition = null;
 
-    public GeyserWaypoint(GeyserSession session, Optional<PlayerEntity> player, Color color) {
+    public GeyserWaypoint(GeyserSession session, UUID uuid, Optional<Entity> entity, Color color) {
         this.session = session;
-        this.color = color;
+        this.uuid = uuid;
+        this.bedrockWaypoint = new LocatorBarWaypoint();
+        this.requiresNewWaypointPacket = requiresNewWaypointPacket(session);
+        bedrockWaypoint.setVisible(true);
+        bedrockWaypoint.setWorldPosition(new LocatorBarWaypoint.WorldPosition(Vector3f.ZERO, 0));
+        bedrockWaypoint.setTextureId(2);
+        bedrockWaypoint.setColor(color);
+        initialiseWaypointFromEntity(entity);
+    }
 
-        if (player.isPresent()) {
-            this.entityUuid = player.get().uuid();
-            this.entityId = player.get().geyserId();
+    private void initialiseWaypointFromEntity(Optional<Entity> entity) {
+        bedrockWaypoint.setClientPositionAuthority(entity.isPresent());
+        bedrockWaypoint.setEntityUniqueId(entity.map(Entity::geyserId).orElseGet(() -> session.getEntityCache().nextEntityId()));
+
+        if (requiresNewWaypointPacket) {
             this.sendListPackets = false;
         } else {
-            this.entityUuid = UUID.randomUUID();
-            this.entityId = session.getEntityCache().getNextEntityId().incrementAndGet();
-            this.sendListPackets = true;
+            this.sendListPackets = entity.isEmpty();
         }
     }
 
+    public Color color() {
+        return bedrockWaypoint.getColor();
+    }
+
     public void track(WaypointData data) {
-        sendListPackets(PlayerListPacket.Action.ADD);
+        sendTrackPackets(true);
         update(data);
+    }
+
+    private void track() {
+        sendTrackPackets(true);
     }
 
     public void update(WaypointData data) {
@@ -80,56 +99,84 @@ public abstract class GeyserWaypoint {
     }
 
     public void untrack() {
-        PlayerLocationPacket packet = new PlayerLocationPacket();
-        packet.setType(PlayerLocationPacket.Type.HIDE);
-        packet.setTargetEntityId(entityId);
-        session.sendUpstreamPacket(packet);
-        sendListPackets(PlayerListPacket.Action.REMOVE);
+        if (!requiresNewWaypointPacket) {
+            PlayerLocationPacket packet = new PlayerLocationPacket();
+            packet.setType(PlayerLocationPacket.Type.HIDE);
+            packet.setTargetEntityId(bedrockWaypoint.getEntityUniqueId());
+            session.sendUpstreamPacket(packet);
+        }
+        sendTrackPackets(false);
     }
 
-    public void setPlayer(PlayerEntity entity) {
-        if (sendListPackets) {
-            if (entity == null) {
-                // We're already emulating the waypoint with player list packets
-                // Could occur due to player list shenanigans for PlayStation devices
-                return;
-            }
+    public void setEntity(Entity entity) {
+        if (requiresNewWaypointPacket) {
             untrack();
-            entityId = entity.geyserId();
-            entityUuid = entity.uuid();
-            sendListPackets = false;
-            sendLocationPacket(true);
-        } else if (entity == null) { // Previously had an attached player, and now that player is gone
-            entityId = session.getEntityCache().getNextEntityId().incrementAndGet();
-            entityUuid = UUID.randomUUID();
-            sendListPackets = true;
-            sendListPackets(PlayerListPacket.Action.ADD);
-            sendLocationPacket(true);
+            initialiseWaypointFromEntity(Optional.ofNullable(entity));
+            track();
+        } else {
+            // 26.0 and below does not support non-player entities as waypoint target
+            if (!(entity instanceof PlayerEntity)) {
+                entity = null;
+            }
+
+            if (sendListPackets) {
+                if (entity == null) {
+                    // We're already emulating the waypoint with player list packets
+                    // Could occur due to player list shenanigans for PlayStation devices
+                    return;
+                }
+                untrack();
+                initialiseWaypointFromEntity(Optional.of(entity));
+                sendLocationPacket(true);
+            } else if (entity == null) { // Previously had an attached player, and now that player is gone
+                initialiseWaypointFromEntity(Optional.empty());
+                sendTrackPackets(true);
+                sendLocationPacket(true);
+            }
         }
+    }
+
+    protected void setPosition(Vector3f position) {
+        bedrockWaypoint.setWorldPosition(new LocatorBarWaypoint.WorldPosition(position, session.getBedrockDimension().bedrockId()));
     }
 
     protected void sendLocationPacket(boolean force) {
-        if (force || lastSent == null || position.distanceSquared(lastSent) > 1.0F) {
-            PlayerLocationPacket packet = new PlayerLocationPacket();
-            packet.setType(PlayerLocationPacket.Type.COORDINATES);
-            packet.setTargetEntityId(entityId);
-            packet.setPosition(position);
-            session.sendUpstreamPacket(packet);
+        Vector3f position = bedrockWaypoint.getWorldPosition().getPosition();
+        if (force || lastSentPosition == null || position.distanceSquared(lastSentPosition) > 1.0F) {
+            if (requiresNewWaypointPacket) {
+                LocatorBarPacket packet = new LocatorBarPacket();
+                bedrockWaypoint.setUpdateFlag(WaypointUpdateFlags.WORLD_POS);
+                packet.setWaypoints(List.of(new LocatorBarPacket.Payload(LocatorBarPacket.Action.UPDATE, uuid, bedrockWaypoint)));
+                System.out.println("sending " + packet);
+                session.sendUpstreamPacket(packet);
+            } else {
+                PlayerLocationPacket packet = new PlayerLocationPacket();
+                packet.setType(PlayerLocationPacket.Type.COORDINATES);
+                packet.setTargetEntityId(bedrockWaypoint.getEntityUniqueId());
+                packet.setPosition(position);
+                session.sendUpstreamPacket(packet);
+            }
 
-            lastSent = position;
+            lastSentPosition = position;
         }
     }
 
-    private void sendListPackets(PlayerListPacket.Action action) {
-        if (sendListPackets) {
+    private void sendTrackPackets(boolean add) {
+        if (requiresNewWaypointPacket) {
+            LocatorBarPacket packet = new LocatorBarPacket();
+            bedrockWaypoint.setUpdateFlag(add ? WaypointUpdateFlags.ALL : 0);
+            packet.setWaypoints(List.of(new LocatorBarPacket.Payload(add ? LocatorBarPacket.Action.ADD : LocatorBarPacket.Action.REMOVE, uuid, bedrockWaypoint)));
+            System.out.println("sending " + packet);
+            session.sendUpstreamPacket(packet);
+        } else if (sendListPackets) {
             PlayerListPacket packet = new PlayerListPacket();
-            packet.setAction(action);
+            packet.setAction(add ? PlayerListPacket.Action.ADD : PlayerListPacket.Action.REMOVE);
 
             // Not sending a skin causes a player list entry to be invalid,
             // leading to waypoints not showing
-            PlayerListPacket.Entry entry = new PlayerListPacket.Entry(entityUuid);
-            entry.setEntityId(entityId);
-            entry.setColor(color);
+            PlayerListPacket.Entry entry = new PlayerListPacket.Entry(uuid);
+            entry.setEntityId(bedrockWaypoint.getEntityUniqueId());
+            entry.setColor(bedrockWaypoint.getColor());
             entry.setName("");
             entry.setSkin(SkinProvider.EMPTY_SERIALIZED_SKIN);
             entry.setXuid("");
@@ -143,14 +190,22 @@ public abstract class GeyserWaypoint {
 
     public abstract void setData(WaypointData data);
 
-    public static @Nullable GeyserWaypoint create(GeyserSession session, Optional<PlayerEntity> player, TrackedWaypoint waypoint) {
+    public static @Nullable GeyserWaypoint create(GeyserSession session, Optional<Entity> entity, TrackedWaypoint waypoint) {
+        UUID uuid = Optional.ofNullable(waypoint.uuid())
+            .or(() -> Optional.ofNullable(waypoint.id())
+                .map(UUID::fromString))
+            .orElseThrow();
         Color color = getWaypointColor(waypoint);
         return switch (waypoint.type()) {
             case EMPTY -> null;
-            case VEC3I -> new CoordinatesWaypoint(session, player, color);
-            case CHUNK -> new ChunkWaypoint(session, player, color);
-            case AZIMUTH -> new AzimuthWaypoint(session, player, color);
+            case VEC3I -> new CoordinatesWaypoint(session, uuid, entity, color);
+            case CHUNK -> new ChunkWaypoint(session, uuid, entity, color);
+            case AZIMUTH -> new AzimuthWaypoint(session, uuid, entity, color);
         };
+    }
+
+    public static boolean requiresNewWaypointPacket(GeyserSession session) {
+        return GameProtocol.is1_26_10orHigher(session.protocolVersion());
     }
 
     private static Color getWaypointColor(TrackedWaypoint waypoint) {

--- a/core/src/main/java/org/geysermc/geyser/session/cache/waypoint/GeyserWaypoint.java
+++ b/core/src/main/java/org/geysermc/geyser/session/cache/waypoint/GeyserWaypoint.java
@@ -25,6 +25,7 @@
 
 package org.geysermc.geyser.session.cache.waypoint;
 
+import it.unimi.dsi.fastutil.Pair;
 import net.kyori.adventure.key.Key;
 import org.checkerframework.checker.nullness.qual.Nullable;
 import org.cloudburstmc.math.vector.Vector2f;
@@ -53,6 +54,10 @@ public abstract class GeyserWaypoint {
     private static final float VANILLA_NEAR_DISTANCE_SQUARED = 16384.0F;
     private static final float VANILLA_FAR_DISTANCE_SQUARED = 110224.0F;
     private static final Key VANILLA_WAYPOINT_STYLE = MinecraftKey.key("default");
+
+    // These are hardcoded on Java, extracted from BDS
+    private static final Vector2f MEDIUM_WAYPOINT_ICON_SIZE = Vector2f.from(0.6F, 0.6F);
+    private static final Vector2f SMALL_WAYPOINT_ICON_SIZE = Vector2f.from(0.2F, 0.2F);
 
     protected final GeyserSession session;
 
@@ -162,7 +167,9 @@ public abstract class GeyserWaypoint {
         float distanceSquared = session.playerEntity().position().distanceSquared(position);
         if (requiresNewWaypointPacket) {
             if (requiresNewNewWaypointPacket) {
-                bedrockWaypoint.setTexturePath(getWaypointTexture(style, distanceSquared));
+                Pair<String, Vector2f> texture = getWaypointTexture(style, distanceSquared);
+                bedrockWaypoint.setTexturePath(texture.first());
+                bedrockWaypoint.setIconSize(texture.second());
             } else {
                 bedrockWaypoint.setTextureId(getLegacyWaypointTexture(distanceSquared));
             }
@@ -174,7 +181,7 @@ public abstract class GeyserWaypoint {
         if (force || lastSentPosition == null || position.distanceSquared(lastSentPosition) > 1.0F) {
             if (requiresNewWaypointPacket) {
                 LocatorBarPacket packet = new LocatorBarPacket();
-                bedrockWaypoint.setUpdateFlag(WaypointUpdateFlags.WORLD_POS | WaypointUpdateFlags.TEXTURE_ID);
+                bedrockWaypoint.setUpdateFlag(WaypointUpdateFlags.WORLD_POS | (requiresNewNewWaypointPacket ? WaypointUpdateFlags.TEXTURE_PATH | WaypointUpdateFlags.ICON_SIZE : WaypointUpdateFlags.TEXTURE_ID));
                 packet.setWaypoints(List.of(new LocatorBarPacket.Payload(LocatorBarPacket.Action.UPDATE, uuid, bedrockWaypoint)));
                 session.sendUpstreamPacket(packet);
             } else {
@@ -250,25 +257,27 @@ public abstract class GeyserWaypoint {
             .orElseThrow();
     }
 
-    private static String getWaypointTexture(Key style, float distanceSquared) {
+    private static Pair<String, Vector2f> getWaypointTexture(Key style, float distanceSquared) {
+        // Small size is only used for the smallest icon, medium only for the second-smallest
         if (distanceSquared < VANILLA_NEAR_DISTANCE_SQUARED) {
-            return getWaypointTexture(style, 0);
+            return Pair.of(getWaypointTexture(style, 0), Vector2f.ONE);
         } else if (distanceSquared >= VANILLA_FAR_DISTANCE_SQUARED) {
-            return getWaypointTexture(style, 3);
+            return Pair.of(getWaypointTexture(style, 3), SMALL_WAYPOINT_ICON_SIZE);
         }
-        return getWaypointTexture(style, (int) (1 + Math.floor((distanceSquared - VANILLA_NEAR_DISTANCE_SQUARED) / (VANILLA_FAR_DISTANCE_SQUARED - VANILLA_NEAR_DISTANCE_SQUARED) * 2)));
+        int index = (int) (1 + Math.floor((distanceSquared - VANILLA_NEAR_DISTANCE_SQUARED) / (VANILLA_FAR_DISTANCE_SQUARED - VANILLA_NEAR_DISTANCE_SQUARED) * 2));
+        return Pair.of(getWaypointTexture(style, index), index > 1  ? MEDIUM_WAYPOINT_ICON_SIZE : Vector2f.ONE);
     }
 
     private static String getWaypointTexture(Key style, int index) {
         if (style.equals(VANILLA_WAYPOINT_STYLE)) {
             return switch (index) {
-                case 0 -> "ui/locator_bar_dot_0";
-                case 1 -> "ui/locator_bar_dot_1";
-                case 2 -> "ui/locator_bar_dot_2";
-                default -> "ui/locator_bar_dot_3";
+                case 0 -> "textures/ui/locator_bar_dot_0";
+                case 1 -> "textures/ui/locator_bar_dot_1";
+                case 2 -> "textures/ui/locator_bar_dot_2";
+                default -> "textures/ui/locator_bar_dot_3";
             };
         }
-        return "ui/" + style.namespace() + "/locator_bar_dot/" + style.value() + "_" + index;
+        return "textures/ui/" + style.namespace() + "/locator_bar_dot/" + style.value() + "_" + index;
     }
 
     private static int getLegacyWaypointTexture(float distanceSquared) {

--- a/core/src/main/java/org/geysermc/geyser/session/cache/waypoint/GeyserWaypoint.java
+++ b/core/src/main/java/org/geysermc/geyser/session/cache/waypoint/GeyserWaypoint.java
@@ -34,6 +34,7 @@ import org.cloudburstmc.protocol.bedrock.data.LocatorBarWaypoint;
 import org.cloudburstmc.protocol.bedrock.packet.LocatorBarPacket;
 import org.cloudburstmc.protocol.bedrock.packet.PlayerListPacket;
 import org.cloudburstmc.protocol.bedrock.packet.PlayerLocationPacket;
+import org.geysermc.geyser.GeyserImpl;
 import org.geysermc.geyser.entity.type.Entity;
 import org.geysermc.geyser.entity.type.player.PlayerEntity;
 import org.geysermc.geyser.network.GameProtocol;
@@ -140,8 +141,10 @@ public abstract class GeyserWaypoint {
             initialiseWaypointFromEntity(Optional.ofNullable(entity));
             track();
         } else {
-            // 26.0 and below does not support non-player entities as waypoint target
             if (!(entity instanceof PlayerEntity)) {
+                // 26.0 and below does not support non-player entities as waypoint target,
+                // as such, this method should never be called with non-player entities
+                GeyserImpl.getInstance().getLogger().warning("GeyserWaypoint#setEntity called for non-player entity!");
                 entity = null;
             }
 

--- a/core/src/main/java/org/geysermc/geyser/session/cache/waypoint/GeyserWaypoint.java
+++ b/core/src/main/java/org/geysermc/geyser/session/cache/waypoint/GeyserWaypoint.java
@@ -68,8 +68,8 @@ public abstract class GeyserWaypoint {
     private final UUID uuid;
     private final LocatorBarWaypoint bedrockWaypoint;
     private final Key style;
-    private final boolean requiresNewWaypointPacket;
-    private final boolean requiresNewNewWaypointPacket;
+    private final boolean usesNewWaypointPacket;
+    private final boolean usesNewNewWaypointPacket;
     private boolean sendListPackets;
 
     private Vector3f lastSentPosition = null;
@@ -79,11 +79,9 @@ public abstract class GeyserWaypoint {
         this.uuid = uuid;
         this.style = style;
         this.bedrockWaypoint = new LocatorBarWaypoint();
-        this.requiresNewWaypointPacket = requiresNewWaypointPacket(session);
-        this.requiresNewNewWaypointPacket = requiresNewNewWaypointPacket(session);
+        this.usesNewWaypointPacket = usesNewWaypointPacket(session);
+        this.usesNewNewWaypointPacket = usesNewNewWaypointPacket(session);
         bedrockWaypoint.setVisible(true);
-        // I think this is always [1, 1]?
-        bedrockWaypoint.setIconSize(Vector2f.ONE);
         bedrockWaypoint.setColor(color);
         initialiseWaypointFromEntity(entity);
         setPosition(Vector3f.ZERO);
@@ -91,9 +89,9 @@ public abstract class GeyserWaypoint {
 
     private void initialiseWaypointFromEntity(Optional<Entity> entity) {
         bedrockWaypoint.setClientPositionAuthority(entity.isPresent());
-        bedrockWaypoint.setEntityUniqueId(entity.map(Entity::geyserId).orElseGet(() -> requiresNewWaypointPacket ? null : session.getEntityCache().nextEntityId()));
+        bedrockWaypoint.setEntityUniqueId(entity.map(Entity::geyserId).orElseGet(() -> usesNewWaypointPacket ? null : session.getEntityCache().nextEntityId()));
 
-        if (requiresNewWaypointPacket) {
+        if (usesNewWaypointPacket) {
             this.sendListPackets = false;
         } else {
             this.sendListPackets = entity.isEmpty();
@@ -107,14 +105,14 @@ public abstract class GeyserWaypoint {
     public void track(WaypointData data) {
         setData(data);
         sendTrackPackets(true);
-        if (!requiresNewWaypointPacket) {
+        if (!usesNewWaypointPacket) {
             sendLocationPacket(false);
         }
     }
 
     private void track() {
         sendTrackPackets(true);
-        if (!requiresNewWaypointPacket) {
+        if (!usesNewWaypointPacket) {
             sendLocationPacket(false);
         }
     }
@@ -125,7 +123,7 @@ public abstract class GeyserWaypoint {
     }
 
     public void untrack() {
-        if (!requiresNewWaypointPacket) {
+        if (!usesNewWaypointPacket) {
             PlayerLocationPacket packet = new PlayerLocationPacket();
             packet.setType(PlayerLocationPacket.Type.HIDE);
             packet.setTargetEntityId(bedrockWaypoint.getEntityUniqueId());
@@ -136,7 +134,7 @@ public abstract class GeyserWaypoint {
     }
 
     public void setEntity(Entity entity) {
-        if (requiresNewWaypointPacket) {
+        if (usesNewWaypointPacket) {
             untrack();
             initialiseWaypointFromEntity(Optional.ofNullable(entity));
             track();
@@ -168,8 +166,8 @@ public abstract class GeyserWaypoint {
     protected void setPosition(Vector3f position) {
         bedrockWaypoint.setWorldPosition(new LocatorBarWaypoint.WorldPosition(position, session.getBedrockDimension().bedrockId()));
         float distanceSquared = session.playerEntity().position().distanceSquared(position);
-        if (requiresNewWaypointPacket) {
-            if (requiresNewNewWaypointPacket) {
+        if (usesNewWaypointPacket) {
+            if (usesNewNewWaypointPacket) {
                 Pair<String, Vector2f> texture = getWaypointTexture(style, distanceSquared);
                 bedrockWaypoint.setTexturePath(texture.first());
                 bedrockWaypoint.setIconSize(texture.second());
@@ -182,9 +180,9 @@ public abstract class GeyserWaypoint {
     protected void sendLocationPacket(boolean force) {
         Vector3f position = bedrockWaypoint.getWorldPosition().getPosition();
         if (force || lastSentPosition == null || position.distanceSquared(lastSentPosition) > 1.0F) {
-            if (requiresNewWaypointPacket) {
+            if (usesNewWaypointPacket) {
                 LocatorBarPacket packet = new LocatorBarPacket();
-                bedrockWaypoint.setUpdateFlag(WaypointUpdateFlags.WORLD_POS | (requiresNewNewWaypointPacket ? WaypointUpdateFlags.TEXTURE_PATH | WaypointUpdateFlags.ICON_SIZE : WaypointUpdateFlags.TEXTURE_ID));
+                bedrockWaypoint.setUpdateFlag(WaypointUpdateFlags.WORLD_POS | (usesNewNewWaypointPacket ? WaypointUpdateFlags.TEXTURE_PATH | WaypointUpdateFlags.ICON_SIZE : WaypointUpdateFlags.TEXTURE_ID));
                 packet.setWaypoints(List.of(new LocatorBarPacket.Payload(LocatorBarPacket.Action.UPDATE, uuid, bedrockWaypoint)));
                 session.sendUpstreamPacket(packet);
             } else {
@@ -200,7 +198,7 @@ public abstract class GeyserWaypoint {
     }
 
     private void sendTrackPackets(boolean add) {
-        if (requiresNewWaypointPacket) {
+        if (usesNewWaypointPacket) {
             LocatorBarPacket packet = new LocatorBarPacket();
             bedrockWaypoint.setUpdateFlag(add ? WaypointUpdateFlags.ALL : 0);
             packet.setWaypoints(List.of(new LocatorBarPacket.Payload(add ? LocatorBarPacket.Action.ADD : LocatorBarPacket.Action.REMOVE, uuid, bedrockWaypoint)));
@@ -242,11 +240,11 @@ public abstract class GeyserWaypoint {
         };
     }
 
-    public static boolean requiresNewWaypointPacket(GeyserSession session) {
+    public static boolean usesNewWaypointPacket(GeyserSession session) {
         return GameProtocol.is1_26_10orHigher(session.protocolVersion());
     }
 
-    public static boolean requiresNewNewWaypointPacket(GeyserSession session) {
+    public static boolean usesNewNewWaypointPacket(GeyserSession session) {
         return GameProtocol.is1_26_20orHigher(session.protocolVersion());
     }
 

--- a/core/src/main/java/org/geysermc/geyser/session/cache/waypoint/GeyserWaypoint.java
+++ b/core/src/main/java/org/geysermc/geyser/session/cache/waypoint/GeyserWaypoint.java
@@ -25,7 +25,9 @@
 
 package org.geysermc.geyser.session.cache.waypoint;
 
+import net.kyori.adventure.key.Key;
 import org.checkerframework.checker.nullness.qual.Nullable;
+import org.cloudburstmc.math.vector.Vector2f;
 import org.cloudburstmc.math.vector.Vector3f;
 import org.cloudburstmc.protocol.bedrock.data.LocatorBarWaypoint;
 import org.cloudburstmc.protocol.bedrock.packet.LocatorBarPacket;
@@ -36,6 +38,7 @@ import org.geysermc.geyser.entity.type.player.PlayerEntity;
 import org.geysermc.geyser.network.GameProtocol;
 import org.geysermc.geyser.session.GeyserSession;
 import org.geysermc.geyser.skin.SkinProvider;
+import org.geysermc.geyser.util.MinecraftKey;
 import org.geysermc.mcprotocollib.protocol.data.game.level.waypoint.TrackedWaypoint;
 import org.geysermc.mcprotocollib.protocol.data.game.level.waypoint.WaypointData;
 
@@ -45,6 +48,12 @@ import java.util.Optional;
 import java.util.UUID;
 
 public abstract class GeyserWaypoint {
+    // These 2 from: https://mcsrc.dev/1/26.1.2/net/minecraft/client/resources/WaypointStyle
+    // (DEFAULT_NEAR_DISTANCE and DEFAULT_FAR_DISTANCE squared)
+    private static final float VANILLA_NEAR_DISTANCE_SQUARED = 16384.0F;
+    private static final float VANILLA_FAR_DISTANCE_SQUARED = 110224.0F;
+    private static final Key VANILLA_WAYPOINT_STYLE = MinecraftKey.key("default");
+
     protected final GeyserSession session;
 
     // On 26.10 and above (new waypoint system): the waypoint group UUID
@@ -52,21 +61,26 @@ public abstract class GeyserWaypoint {
     // This is decided by the Java server. When Java sends us a waypoint with a String ID, we turn it into a UUID
     private final UUID uuid;
     private final LocatorBarWaypoint bedrockWaypoint;
+    private final Key style;
     private final boolean requiresNewWaypointPacket;
+    private final boolean requiresNewNewWaypointPacket;
     private boolean sendListPackets;
 
     private Vector3f lastSentPosition = null;
 
-    public GeyserWaypoint(GeyserSession session, UUID uuid, Optional<Entity> entity, Color color) {
+    public GeyserWaypoint(GeyserSession session, UUID uuid, Key style, Color color, Optional<Entity> entity) {
         this.session = session;
         this.uuid = uuid;
+        this.style = style;
         this.bedrockWaypoint = new LocatorBarWaypoint();
         this.requiresNewWaypointPacket = requiresNewWaypointPacket(session);
+        this.requiresNewNewWaypointPacket = requiresNewNewWaypointPacket(session);
         bedrockWaypoint.setVisible(true);
-        bedrockWaypoint.setWorldPosition(new LocatorBarWaypoint.WorldPosition(Vector3f.ZERO, 0));
-        bedrockWaypoint.setTextureId(2);
+        // I think this is always [1, 1]?
+        bedrockWaypoint.setIconSize(Vector2f.ONE);
         bedrockWaypoint.setColor(color);
         initialiseWaypointFromEntity(entity);
+        setPosition(Vector3f.ZERO);
     }
 
     private void initialiseWaypointFromEntity(Optional<Entity> entity) {
@@ -145,6 +159,14 @@ public abstract class GeyserWaypoint {
 
     protected void setPosition(Vector3f position) {
         bedrockWaypoint.setWorldPosition(new LocatorBarWaypoint.WorldPosition(position, session.getBedrockDimension().bedrockId()));
+        float distanceSquared = session.playerEntity().position().distanceSquared(position);
+        if (requiresNewWaypointPacket) {
+            if (requiresNewNewWaypointPacket) {
+                bedrockWaypoint.setTexturePath(getWaypointTexture(style, distanceSquared));
+            } else {
+                bedrockWaypoint.setTextureId(getLegacyWaypointTexture(distanceSquared));
+            }
+        }
     }
 
     protected void sendLocationPacket(boolean force) {
@@ -152,7 +174,7 @@ public abstract class GeyserWaypoint {
         if (force || lastSentPosition == null || position.distanceSquared(lastSentPosition) > 1.0F) {
             if (requiresNewWaypointPacket) {
                 LocatorBarPacket packet = new LocatorBarPacket();
-                bedrockWaypoint.setUpdateFlag(WaypointUpdateFlags.WORLD_POS);
+                bedrockWaypoint.setUpdateFlag(WaypointUpdateFlags.WORLD_POS | WaypointUpdateFlags.TEXTURE_ID);
                 packet.setWaypoints(List.of(new LocatorBarPacket.Payload(LocatorBarPacket.Action.UPDATE, uuid, bedrockWaypoint)));
                 session.sendUpstreamPacket(packet);
             } else {
@@ -200,17 +222,22 @@ public abstract class GeyserWaypoint {
             .or(() -> Optional.ofNullable(waypoint.id())
                 .map(UUID::fromString))
             .orElseThrow();
+        Key style = waypoint.icon().style();
         Color color = getWaypointColor(waypoint);
         return switch (waypoint.type()) {
             case EMPTY -> null;
-            case VEC3I -> new CoordinatesWaypoint(session, uuid, entity, color);
-            case CHUNK -> new ChunkWaypoint(session, uuid, entity, color);
-            case AZIMUTH -> new AzimuthWaypoint(session, uuid, entity, color);
+            case VEC3I -> new CoordinatesWaypoint(session, uuid, style, color, entity);
+            case CHUNK -> new ChunkWaypoint(session, uuid, style, color, entity);
+            case AZIMUTH -> new AzimuthWaypoint(session, uuid, style, color, entity);
         };
     }
 
     public static boolean requiresNewWaypointPacket(GeyserSession session) {
         return GameProtocol.is1_26_10orHigher(session.protocolVersion());
+    }
+
+    public static boolean requiresNewNewWaypointPacket(GeyserSession session) {
+        return GameProtocol.is1_26_20orHigher(session.protocolVersion());
     }
 
     private static Color getWaypointColor(TrackedWaypoint waypoint) {
@@ -221,5 +248,35 @@ public abstract class GeyserWaypoint {
             .or(() -> Optional.ofNullable(waypoint.id()).map(String::hashCode))
             .map(i -> new Color(i & 0xFFFFFF))
             .orElseThrow();
+    }
+
+    private static String getWaypointTexture(Key style, float distanceSquared) {
+        if (distanceSquared < VANILLA_NEAR_DISTANCE_SQUARED) {
+            return getWaypointTexture(style, 0);
+        } else if (distanceSquared >= VANILLA_FAR_DISTANCE_SQUARED) {
+            return getWaypointTexture(style, 3);
+        }
+        return getWaypointTexture(style, (int) (1 + Math.floor((distanceSquared - VANILLA_NEAR_DISTANCE_SQUARED) / (VANILLA_FAR_DISTANCE_SQUARED - VANILLA_NEAR_DISTANCE_SQUARED) * 2)));
+    }
+
+    private static String getWaypointTexture(Key style, int index) {
+        if (style.equals(VANILLA_WAYPOINT_STYLE)) {
+            return switch (index) {
+                case 0 -> "ui/locator_bar_dot_0";
+                case 1 -> "ui/locator_bar_dot_1";
+                case 2 -> "ui/locator_bar_dot_2";
+                default -> "ui/locator_bar_dot_3";
+            };
+        }
+        return "ui/" + style.namespace() + "/locator_bar_dot/" + style.value() + "_" + index;
+    }
+
+    private static int getLegacyWaypointTexture(float distanceSquared) {
+        if (distanceSquared < VANILLA_NEAR_DISTANCE_SQUARED) {
+            return 2;
+        } else if (distanceSquared >= VANILLA_FAR_DISTANCE_SQUARED) {
+            return 5;
+        }
+        return (int) (3 + Math.floor((distanceSquared - VANILLA_NEAR_DISTANCE_SQUARED) / (VANILLA_FAR_DISTANCE_SQUARED - VANILLA_NEAR_DISTANCE_SQUARED) * 2));
     }
 }

--- a/core/src/main/java/org/geysermc/geyser/session/cache/waypoint/GeyserWaypoint.java
+++ b/core/src/main/java/org/geysermc/geyser/session/cache/waypoint/GeyserWaypoint.java
@@ -71,7 +71,7 @@ public abstract class GeyserWaypoint {
 
     private void initialiseWaypointFromEntity(Optional<Entity> entity) {
         bedrockWaypoint.setClientPositionAuthority(entity.isPresent());
-        bedrockWaypoint.setEntityUniqueId(entity.map(Entity::geyserId).orElseGet(() -> session.getEntityCache().nextEntityId()));
+        bedrockWaypoint.setEntityUniqueId(entity.map(Entity::geyserId).orElseGet(() -> requiresNewWaypointPacket ? null : session.getEntityCache().nextEntityId()));
 
         if (requiresNewWaypointPacket) {
             this.sendListPackets = false;
@@ -85,12 +85,18 @@ public abstract class GeyserWaypoint {
     }
 
     public void track(WaypointData data) {
+        setData(data);
         sendTrackPackets(true);
-        update(data);
+        if (!requiresNewWaypointPacket) {
+            sendLocationPacket(false);
+        }
     }
 
     private void track() {
         sendTrackPackets(true);
+        if (!requiresNewWaypointPacket) {
+            sendLocationPacket(false);
+        }
     }
 
     public void update(WaypointData data) {
@@ -106,6 +112,7 @@ public abstract class GeyserWaypoint {
             session.sendUpstreamPacket(packet);
         }
         sendTrackPackets(false);
+        lastSentPosition = null;
     }
 
     public void setEntity(Entity entity) {
@@ -147,7 +154,6 @@ public abstract class GeyserWaypoint {
                 LocatorBarPacket packet = new LocatorBarPacket();
                 bedrockWaypoint.setUpdateFlag(WaypointUpdateFlags.WORLD_POS);
                 packet.setWaypoints(List.of(new LocatorBarPacket.Payload(LocatorBarPacket.Action.UPDATE, uuid, bedrockWaypoint)));
-                System.out.println("sending " + packet);
                 session.sendUpstreamPacket(packet);
             } else {
                 PlayerLocationPacket packet = new PlayerLocationPacket();
@@ -166,7 +172,6 @@ public abstract class GeyserWaypoint {
             LocatorBarPacket packet = new LocatorBarPacket();
             bedrockWaypoint.setUpdateFlag(add ? WaypointUpdateFlags.ALL : 0);
             packet.setWaypoints(List.of(new LocatorBarPacket.Payload(add ? LocatorBarPacket.Action.ADD : LocatorBarPacket.Action.REMOVE, uuid, bedrockWaypoint)));
-            System.out.println("sending " + packet);
             session.sendUpstreamPacket(packet);
         } else if (sendListPackets) {
             PlayerListPacket packet = new PlayerListPacket();

--- a/core/src/main/java/org/geysermc/geyser/session/cache/waypoint/WaypointCache.java
+++ b/core/src/main/java/org/geysermc/geyser/session/cache/waypoint/WaypointCache.java
@@ -30,7 +30,6 @@ import org.cloudburstmc.protocol.bedrock.packet.PlayerListPacket;
 import org.cloudburstmc.protocol.bedrock.packet.PlayerLocationPacket;
 import org.geysermc.geyser.entity.type.Entity;
 import org.geysermc.geyser.entity.type.player.PlayerEntity;
-import org.geysermc.geyser.network.GameProtocol;
 import org.geysermc.geyser.session.GeyserSession;
 import org.geysermc.geyser.skin.SkinManager;
 import org.geysermc.mcprotocollib.protocol.data.game.level.waypoint.TrackedWaypoint;
@@ -45,6 +44,7 @@ import java.util.UUID;
 public final class WaypointCache {
     private final GeyserSession session;
     private final Map<String, GeyserWaypoint> waypoints = new Object2ObjectOpenHashMap<>();
+    // TODO: remove when dropping 1.26.0 and below
     private final Map<UUID, Color> waypointColors = new Object2ObjectOpenHashMap<>();
 
     public WaypointCache(GeyserSession session) {
@@ -65,36 +65,46 @@ public final class WaypointCache {
         }
     }
 
-    public void listPlayer(PlayerEntity player) {
-        GeyserWaypoint waypoint = waypoints.get(player.uuid().toString());
+    public void addEntity(Entity entity) {
+        GeyserWaypoint waypoint = waypoints.get(entity.uuid().toString());
         if (waypoint != null) {
+            // On 1.26.0 and below:
             // This will remove the fake player packet previously sent to the client,
             // and change the waypoint to use the player's entity ID instead.
             // This is important because sometimes a waypoint is sent before player info telling us to list the player, so a fake player packet is sent to the client
             // When the player becomes listed the right colour will already be used, this is always put in the colours map, no matter if the
             // player info existed or not
-            waypoint.setEntity(player);
+            // On 1.26.10 and above:
+            // This will re-initialise the waypoint, adding the entity ID to it and letting the client take authority
+            waypoint.setEntity(entity);
         } else {
-            // If we haven't received a waypoint for the player, we need to tell the client to hide them
-            // Bedrock likes to create their own waypoints for players in render distance, but Java doesn't do this, and we don't want this either, since it could
-            // lead to duplicate/wrong waypoints on the locator bar
-            // For example, if a Java server hides a player from the locator bar even when they're not sneaking, bedrock will still show them when in render
-            // distance
-            sendHidePlayerPacket(session, player.geyserId());
+            if (!GeyserWaypoint.requiresNewWaypointPacket(session)) {
+                // On 1.26.0 and below:
+                // If we haven't received a waypoint for the player, we need to tell the client to hide them
+                // Bedrock likes to create their own waypoints for players in render distance, but Java doesn't do this, and we don't want this either, since it could
+                // lead to duplicate/wrong waypoints on the locator bar
+                // For example, if a Java server hides a player from the locator bar even when they're not sneaking, bedrock will still show them when in render
+                // distance
+                sendHidePlayerPacket(session, entity.geyserId());
+            }
         }
     }
 
-    public void unlistPlayer(PlayerEntity player) {
-        GeyserWaypoint waypoint = waypoints.get(player.uuid().toString());
+    public void removeEntity(Entity entity) {
+        GeyserWaypoint waypoint = waypoints.get(entity.uuid().toString());
         if (waypoint != null) {
+            // On 1.26.0 and below:
             // This will remove the player packet previously sent to the client,
             // and change the waypoint to use the player's entity ID instead.
             // This is important because a player waypoint can still show even when a player becomes unlisted,
             // so a fake player packet has to be sent to the client now
+            // On 1.26.10 and above:
+            // This will re-initialise the waypoint, removing the entity ID from it and not letting the client take authority
             waypoint.setEntity(null);
         }
     }
 
+    // TODO: remove when dropping 1.26.0 and below
     public Optional<Color> getWaypointColor(UUID uuid) {
         return Optional.ofNullable(waypointColors.get(uuid));
     }
@@ -111,22 +121,29 @@ public final class WaypointCache {
         untrack(waypoint);
 
         Optional<UUID> uuid = Optional.ofNullable(waypoint.uuid());
-        Optional<Entity> player = uuid.flatMap(id -> Optional.ofNullable(session.getEntityCache().getPlayerEntity(id)));
+        Optional<Entity> entity = uuid.flatMap(id -> Optional.ofNullable(session.getEntityCache().getEntityByUuid(id)));
 
-        GeyserWaypoint tracked = GeyserWaypoint.create(session, player, waypoint);
+        GeyserWaypoint tracked = GeyserWaypoint.create(session, entity, waypoint);
         if (tracked != null) {
             uuid.ifPresent(id -> waypointColors.put(id, tracked.color()));
-            // Resend player entry with new waypoint colour
-            player.ifPresent(entity -> updatePlayerEntry((PlayerEntity) entity));
+            // On 1.26.0 and below, resend player entry with new waypoint colour
+            entity.ifPresent(anEntity -> {
+                if (!GeyserWaypoint.requiresNewWaypointPacket(session) && anEntity instanceof PlayerEntity player) {
+                    updatePlayerEntry(player);
+                }
+            });
 
             tracked.track(waypoint.data());
             waypoints.put(waypointId(waypoint), tracked);
         } else {
-            player.ifPresent(playerEntity -> {
-                // When tracked waypoint is null, the waypoint shouldn't show up on the locator bar (Java type is EMPTY)
-                // If this waypoint is linked to a player, tell the bedrock client to hide it
-                // If we don't do this bedrock will show the waypoint anyway when the player is in render distance (read comments above in trackPlayer)
-                sendHidePlayerPacket(session, playerEntity.geyserId());
+            entity.ifPresent(anEntity -> {
+                if (!GeyserWaypoint.requiresNewWaypointPacket(session) && anEntity instanceof PlayerEntity) {
+                    // On 1.26.0 and below:
+                    // When tracked waypoint is null, the waypoint shouldn't show up on the locator bar (Java type is EMPTY)
+                    // If this waypoint is linked to a player, tell the bedrock client to hide it
+                    // If we don't do this bedrock will show the waypoint anyway when the player is in render distance (read comments above in trackPlayer)
+                    sendHidePlayerPacket(session, anEntity.geyserId());
+                }
             });
         }
     }
@@ -177,11 +194,9 @@ public final class WaypointCache {
     }
 
     private static void sendHidePlayerPacket(GeyserSession session, long playerId) {
-        if (!GeyserWaypoint.requiresNewWaypointPacket(session)) {
-            PlayerLocationPacket locationPacket = new PlayerLocationPacket();
-            locationPacket.setType(PlayerLocationPacket.Type.HIDE);
-            locationPacket.setTargetEntityId(playerId);
-            session.sendUpstreamPacket(locationPacket);
-        }
+        PlayerLocationPacket locationPacket = new PlayerLocationPacket();
+        locationPacket.setType(PlayerLocationPacket.Type.HIDE);
+        locationPacket.setTargetEntityId(playerId);
+        session.sendUpstreamPacket(locationPacket);
     }
 }

--- a/core/src/main/java/org/geysermc/geyser/session/cache/waypoint/WaypointCache.java
+++ b/core/src/main/java/org/geysermc/geyser/session/cache/waypoint/WaypointCache.java
@@ -52,23 +52,16 @@ public final class WaypointCache {
     }
 
     public void handlePacket(ClientboundTrackedWaypointPacket packet) {
-        // FIXME
-        session.sendGameRule("locatorBar", true);
         switch (packet.getOperation()) {
             case TRACK -> track(packet.getWaypoint());
             case UNTRACK -> untrack(packet.getWaypoint());
             case UPDATE -> update(packet.getWaypoint());
         }
 
-        if (packet.getOperation() == WaypointOperation.TRACK || packet.getOperation()== WaypointOperation.UNTRACK) {
+        if ((packet.getOperation() == WaypointOperation.TRACK || packet.getOperation()== WaypointOperation.UNTRACK) && !GeyserWaypoint.requiresNewWaypointPacket(session)) {
             // Only show locator bar when there are waypoints on it
             // This is equivalent to Java, and the Java locator_bar game rule won't work otherwise
-            if (GameProtocol.is1_26_20orHigher(session.protocolVersion())) {
-                session.sendGameRule("playerWaypoints", !waypoints.isEmpty());
-            } else {
-                System.out.println(!waypoints.isEmpty());
-                session.sendGameRule("locatorBar", !waypoints.isEmpty());
-            }
+            session.sendGameRule("locatorBar", !waypoints.isEmpty());
         }
     }
 
@@ -178,7 +171,9 @@ public final class WaypointCache {
 
     public void clear() {
         waypoints.clear();
-        session.sendGameRule("locatorBar", false);
+        if (!GeyserWaypoint.requiresNewWaypointPacket(session)) {
+            session.sendGameRule("locatorBar", false);
+        }
     }
 
     private static void sendHidePlayerPacket(GeyserSession session, long playerId) {

--- a/core/src/main/java/org/geysermc/geyser/session/cache/waypoint/WaypointCache.java
+++ b/core/src/main/java/org/geysermc/geyser/session/cache/waypoint/WaypointCache.java
@@ -28,7 +28,9 @@ package org.geysermc.geyser.session.cache.waypoint;
 import it.unimi.dsi.fastutil.objects.Object2ObjectOpenHashMap;
 import org.cloudburstmc.protocol.bedrock.packet.PlayerListPacket;
 import org.cloudburstmc.protocol.bedrock.packet.PlayerLocationPacket;
+import org.geysermc.geyser.entity.type.Entity;
 import org.geysermc.geyser.entity.type.player.PlayerEntity;
+import org.geysermc.geyser.network.GameProtocol;
 import org.geysermc.geyser.session.GeyserSession;
 import org.geysermc.geyser.skin.SkinManager;
 import org.geysermc.mcprotocollib.protocol.data.game.level.waypoint.TrackedWaypoint;
@@ -50,6 +52,8 @@ public final class WaypointCache {
     }
 
     public void handlePacket(ClientboundTrackedWaypointPacket packet) {
+        // FIXME
+        session.sendGameRule("locatorBar", true);
         switch (packet.getOperation()) {
             case TRACK -> track(packet.getWaypoint());
             case UNTRACK -> untrack(packet.getWaypoint());
@@ -58,8 +62,13 @@ public final class WaypointCache {
 
         if (packet.getOperation() == WaypointOperation.TRACK || packet.getOperation()== WaypointOperation.UNTRACK) {
             // Only show locator bar when there are waypoints on it
-            // This is equivalent to Java, and the Java locatorBar game rule won't work otherwise
-            session.sendGameRule("locatorBar", !waypoints.isEmpty());
+            // This is equivalent to Java, and the Java locator_bar game rule won't work otherwise
+            if (GameProtocol.is1_26_20orHigher(session.protocolVersion())) {
+                session.sendGameRule("playerWaypoints", !waypoints.isEmpty());
+            } else {
+                System.out.println(!waypoints.isEmpty());
+                session.sendGameRule("locatorBar", !waypoints.isEmpty());
+            }
         }
     }
 
@@ -71,17 +80,14 @@ public final class WaypointCache {
             // This is important because sometimes a waypoint is sent before player info telling us to list the player, so a fake player packet is sent to the client
             // When the player becomes listed the right colour will already be used, this is always put in the colours map, no matter if the
             // player info existed or not
-            waypoint.setPlayer(player);
+            waypoint.setEntity(player);
         } else {
             // If we haven't received a waypoint for the player, we need to tell the client to hide them
             // Bedrock likes to create their own waypoints for players in render distance, but Java doesn't do this, and we don't want this either, since it could
             // lead to duplicate/wrong waypoints on the locator bar
             // For example, if a Java server hides a player from the locator bar even when they're not sneaking, bedrock will still show them when in render
             // distance
-            PlayerLocationPacket locationPacket = new PlayerLocationPacket();
-            locationPacket.setType(PlayerLocationPacket.Type.HIDE);
-            locationPacket.setTargetEntityId(player.geyserId());
-            session.sendUpstreamPacket(locationPacket);
+            sendHidePlayerPacket(session, player.geyserId());
         }
     }
 
@@ -92,7 +98,7 @@ public final class WaypointCache {
             // and change the waypoint to use the player's entity ID instead.
             // This is important because a player waypoint can still show even when a player becomes unlisted,
             // so a fake player packet has to be sent to the client now
-            waypoint.setPlayer(null);
+            waypoint.setEntity(null);
         }
     }
 
@@ -112,13 +118,13 @@ public final class WaypointCache {
         untrack(waypoint);
 
         Optional<UUID> uuid = Optional.ofNullable(waypoint.uuid());
-        Optional<PlayerEntity> player = uuid.flatMap(id -> Optional.ofNullable(session.getEntityCache().getPlayerEntity(id)));
+        Optional<Entity> player = uuid.flatMap(id -> Optional.ofNullable(session.getEntityCache().getPlayerEntity(id)));
 
         GeyserWaypoint tracked = GeyserWaypoint.create(session, player, waypoint);
         if (tracked != null) {
             uuid.ifPresent(id -> waypointColors.put(id, tracked.color()));
             // Resend player entry with new waypoint colour
-            player.ifPresent(this::updatePlayerEntry);
+            player.ifPresent(entity -> updatePlayerEntry((PlayerEntity) entity));
 
             tracked.track(waypoint.data());
             waypoints.put(waypointId(waypoint), tracked);
@@ -127,10 +133,7 @@ public final class WaypointCache {
                 // When tracked waypoint is null, the waypoint shouldn't show up on the locator bar (Java type is EMPTY)
                 // If this waypoint is linked to a player, tell the bedrock client to hide it
                 // If we don't do this bedrock will show the waypoint anyway when the player is in render distance (read comments above in trackPlayer)
-                PlayerLocationPacket locationPacket = new PlayerLocationPacket();
-                locationPacket.setType(PlayerLocationPacket.Type.HIDE);
-                locationPacket.setTargetEntityId(playerEntity.geyserId());
-                session.sendUpstreamPacket(locationPacket);
+                sendHidePlayerPacket(session, playerEntity.geyserId());
             });
         }
     }
@@ -176,5 +179,14 @@ public final class WaypointCache {
     public void clear() {
         waypoints.clear();
         session.sendGameRule("locatorBar", false);
+    }
+
+    private static void sendHidePlayerPacket(GeyserSession session, long playerId) {
+        if (!GeyserWaypoint.requiresNewWaypointPacket(session)) {
+            PlayerLocationPacket locationPacket = new PlayerLocationPacket();
+            locationPacket.setType(PlayerLocationPacket.Type.HIDE);
+            locationPacket.setTargetEntityId(playerId);
+            session.sendUpstreamPacket(locationPacket);
+        }
     }
 }

--- a/core/src/main/java/org/geysermc/geyser/session/cache/waypoint/WaypointCache.java
+++ b/core/src/main/java/org/geysermc/geyser/session/cache/waypoint/WaypointCache.java
@@ -58,7 +58,7 @@ public final class WaypointCache {
             case UPDATE -> update(packet.getWaypoint());
         }
 
-        if ((packet.getOperation() == WaypointOperation.TRACK || packet.getOperation()== WaypointOperation.UNTRACK) && !GeyserWaypoint.usesNewWaypointPacket(session)) {
+        if ((packet.getOperation() == WaypointOperation.TRACK || packet.getOperation()== WaypointOperation.UNTRACK) && !GeyserWaypoint.uses26_10WaypointPacket(session)) {
             // Only show locator bar when there are waypoints on it
             // This is equivalent to Java, and the Java locator_bar game rule won't work otherwise
             session.sendGameRule("locatorBar", !waypoints.isEmpty());
@@ -78,7 +78,7 @@ public final class WaypointCache {
             // This will re-initialise the waypoint, adding the entity ID to it and letting the client take authority
             waypoint.setEntity(entity);
         } else {
-            if (!GeyserWaypoint.usesNewWaypointPacket(session)) {
+            if (!GeyserWaypoint.uses26_10WaypointPacket(session)) {
                 // On 1.26.0 and below:
                 // If we haven't received a waypoint for the player, we need to tell the client to hide them
                 // Bedrock likes to create their own waypoints for players in render distance, but Java doesn't do this, and we don't want this either, since it could
@@ -128,7 +128,7 @@ public final class WaypointCache {
             uuid.ifPresent(id -> waypointColors.put(id, tracked.color()));
             // On 1.26.0 and below, resend player entry with new waypoint colour
             entity.ifPresent(anEntity -> {
-                if (!GeyserWaypoint.usesNewWaypointPacket(session) && anEntity instanceof PlayerEntity player) {
+                if (!GeyserWaypoint.uses26_10WaypointPacket(session) && anEntity instanceof PlayerEntity player) {
                     updatePlayerEntry(player);
                 }
             });
@@ -137,7 +137,7 @@ public final class WaypointCache {
             waypoints.put(waypointId(waypoint), tracked);
         } else {
             entity.ifPresent(anEntity -> {
-                if (!GeyserWaypoint.usesNewWaypointPacket(session) && anEntity instanceof PlayerEntity) {
+                if (!GeyserWaypoint.uses26_10WaypointPacket(session) && anEntity instanceof PlayerEntity) {
                     // On 1.26.0 and below:
                     // When tracked waypoint is null, the waypoint shouldn't show up on the locator bar (Java type is EMPTY)
                     // If this waypoint is linked to a player, tell the bedrock client to hide it
@@ -188,7 +188,7 @@ public final class WaypointCache {
 
     public void clear() {
         waypoints.clear();
-        if (!GeyserWaypoint.usesNewWaypointPacket(session)) {
+        if (!GeyserWaypoint.uses26_10WaypointPacket(session)) {
             session.sendGameRule("locatorBar", false);
         }
     }

--- a/core/src/main/java/org/geysermc/geyser/session/cache/waypoint/WaypointCache.java
+++ b/core/src/main/java/org/geysermc/geyser/session/cache/waypoint/WaypointCache.java
@@ -58,7 +58,7 @@ public final class WaypointCache {
             case UPDATE -> update(packet.getWaypoint());
         }
 
-        if ((packet.getOperation() == WaypointOperation.TRACK || packet.getOperation()== WaypointOperation.UNTRACK) && !GeyserWaypoint.requiresNewWaypointPacket(session)) {
+        if ((packet.getOperation() == WaypointOperation.TRACK || packet.getOperation()== WaypointOperation.UNTRACK) && !GeyserWaypoint.usesNewWaypointPacket(session)) {
             // Only show locator bar when there are waypoints on it
             // This is equivalent to Java, and the Java locator_bar game rule won't work otherwise
             session.sendGameRule("locatorBar", !waypoints.isEmpty());
@@ -78,7 +78,7 @@ public final class WaypointCache {
             // This will re-initialise the waypoint, adding the entity ID to it and letting the client take authority
             waypoint.setEntity(entity);
         } else {
-            if (!GeyserWaypoint.requiresNewWaypointPacket(session)) {
+            if (!GeyserWaypoint.usesNewWaypointPacket(session)) {
                 // On 1.26.0 and below:
                 // If we haven't received a waypoint for the player, we need to tell the client to hide them
                 // Bedrock likes to create their own waypoints for players in render distance, but Java doesn't do this, and we don't want this either, since it could
@@ -128,7 +128,7 @@ public final class WaypointCache {
             uuid.ifPresent(id -> waypointColors.put(id, tracked.color()));
             // On 1.26.0 and below, resend player entry with new waypoint colour
             entity.ifPresent(anEntity -> {
-                if (!GeyserWaypoint.requiresNewWaypointPacket(session) && anEntity instanceof PlayerEntity player) {
+                if (!GeyserWaypoint.usesNewWaypointPacket(session) && anEntity instanceof PlayerEntity player) {
                     updatePlayerEntry(player);
                 }
             });
@@ -137,7 +137,7 @@ public final class WaypointCache {
             waypoints.put(waypointId(waypoint), tracked);
         } else {
             entity.ifPresent(anEntity -> {
-                if (!GeyserWaypoint.requiresNewWaypointPacket(session) && anEntity instanceof PlayerEntity) {
+                if (!GeyserWaypoint.usesNewWaypointPacket(session) && anEntity instanceof PlayerEntity) {
                     // On 1.26.0 and below:
                     // When tracked waypoint is null, the waypoint shouldn't show up on the locator bar (Java type is EMPTY)
                     // If this waypoint is linked to a player, tell the bedrock client to hide it
@@ -188,7 +188,7 @@ public final class WaypointCache {
 
     public void clear() {
         waypoints.clear();
-        if (!GeyserWaypoint.requiresNewWaypointPacket(session)) {
+        if (!GeyserWaypoint.usesNewWaypointPacket(session)) {
             session.sendGameRule("locatorBar", false);
         }
     }

--- a/core/src/main/java/org/geysermc/geyser/session/cache/waypoint/WaypointUpdateFlags.java
+++ b/core/src/main/java/org/geysermc/geyser/session/cache/waypoint/WaypointUpdateFlags.java
@@ -29,9 +29,13 @@ public final class WaypointUpdateFlags {
     public static final int WORLD_POS = 1;
     public static final int IS_VISIBLE = 1 << 1;
     public static final int TEXTURE_ID = 1 << 2;
+    public static final int TEXTURE_PATH = 1 << 2;
+    public static final int ICON_SIZE = 1 << 3;
     public static final int COLOR = 1 << 3;
+    public static final int COLOR_NEW = 1 << 4;
     public static final int CLIENT_POSITION_AUTHORITY = 1 << 4;
-    public static final int ALL = 0b11111;
+    public static final int CLIENT_POSITION_AUTHORITY_NEW = 1 << 5;
+    public static final int ALL = 0b111111;
 
     private WaypointUpdateFlags() {}
 }

--- a/core/src/main/java/org/geysermc/geyser/session/cache/waypoint/WaypointUpdateFlags.java
+++ b/core/src/main/java/org/geysermc/geyser/session/cache/waypoint/WaypointUpdateFlags.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2025 GeyserMC. http://geysermc.org
+ * Copyright (c) 2026 GeyserMC. http://geysermc.org
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -25,29 +25,13 @@
 
 package org.geysermc.geyser.session.cache.waypoint;
 
-import org.cloudburstmc.math.vector.Vector3f;
-import org.geysermc.geyser.entity.type.Entity;
-import org.geysermc.geyser.session.GeyserSession;
-import org.geysermc.mcprotocollib.protocol.data.game.level.waypoint.ChunkWaypointData;
-import org.geysermc.mcprotocollib.protocol.data.game.level.waypoint.WaypointData;
+public final class WaypointUpdateFlags {
+    public static final int WORLD_POS = 1;
+    public static final int IS_VISIBLE = 1 << 1;
+    public static final int TEXTURE_ID = 1 << 2;
+    public static final int COLOR = 1 << 3;
+    public static final int CLIENT_POSITION_AUTHORITY = 1 << 4;
+    public static final int ALL = 0b11111;
 
-import java.awt.Color;
-import java.util.Optional;
-import java.util.UUID;
-
-public class ChunkWaypoint extends GeyserWaypoint {
-
-    public ChunkWaypoint(GeyserSession session, UUID uuid, Optional<Entity> entity, Color color) {
-        super(session, uuid, entity, color);
-    }
-
-    @Override
-    public void setData(WaypointData data) {
-        if (data instanceof ChunkWaypointData(int chunkX, int chunkZ)) {
-            // Set position in centre of chunk
-            setPosition(Vector3f.from(chunkX * 16.0F + 8.0F, session.getPlayerEntity().position().getY(), chunkZ * 16.0F + 8.0F));
-        } else {
-            session.getGeyser().getLogger().warning("Received incorrect waypoint data " + data.getClass() + " for chunk waypoint");
-        }
-    }
+    private WaypointUpdateFlags() {}
 }

--- a/core/src/main/java/org/geysermc/geyser/translator/protocol/java/JavaBossEventTranslator.java
+++ b/core/src/main/java/org/geysermc/geyser/translator/protocol/java/JavaBossEventTranslator.java
@@ -39,7 +39,7 @@ public class JavaBossEventTranslator extends PacketTranslator<ClientboundBossEve
         BossBar bossBar = session.getEntityCache().getBossBar(packet.getUuid());
         switch (packet.getAction()) {
             case ADD:
-                long entityId = session.getEntityCache().getNextEntityId().incrementAndGet();
+                long entityId = session.getEntityCache().nextEntityId();
                 bossBar = new BossBar(session, entityId, packet.getTitle(), packet.getHealth(), packet.getColor().ordinal(), 1, 0);
                 session.getEntityCache().addBossBar(packet.getUuid(), bossBar);
                 break;

--- a/core/src/main/java/org/geysermc/geyser/translator/protocol/java/entity/player/JavaPlayerInfoUpdateTranslator.java
+++ b/core/src/main/java/org/geysermc/geyser/translator/protocol/java/entity/player/JavaPlayerInfoUpdateTranslator.java
@@ -95,7 +95,7 @@ public class JavaPlayerInfoUpdateTranslator extends PacketTranslator<Clientbound
                     if (!PlayerListUtils.shouldLimitPlayerListEntries(session)) {
                         PlayerListPacket.Entry playerListEntry = SkinManager.buildEntryFromCachedSkin(session, entity);
                         toAdd.add(playerListEntry);
-                        if (!GeyserWaypoint.usesNewWaypointPacket(session)) {
+                        if (!GeyserWaypoint.uses26_10WaypointPacket(session)) {
                             session.getWaypointCache().addEntity(entity);
                         }
                     }
@@ -103,7 +103,7 @@ public class JavaPlayerInfoUpdateTranslator extends PacketTranslator<Clientbound
                     // No need to unlist players that were never listed
                     if (entity.isListed()) {
                         toRemove.add(new PlayerListPacket.Entry(entity.getTabListUuid()));
-                        if (!GeyserWaypoint.usesNewWaypointPacket(session)) {
+                        if (!GeyserWaypoint.uses26_10WaypointPacket(session)) {
                             session.getWaypointCache().removeEntity(entity);
                         }
                     }

--- a/core/src/main/java/org/geysermc/geyser/translator/protocol/java/entity/player/JavaPlayerInfoUpdateTranslator.java
+++ b/core/src/main/java/org/geysermc/geyser/translator/protocol/java/entity/player/JavaPlayerInfoUpdateTranslator.java
@@ -95,7 +95,7 @@ public class JavaPlayerInfoUpdateTranslator extends PacketTranslator<Clientbound
                     if (!PlayerListUtils.shouldLimitPlayerListEntries(session)) {
                         PlayerListPacket.Entry playerListEntry = SkinManager.buildEntryFromCachedSkin(session, entity);
                         toAdd.add(playerListEntry);
-                        if (!GeyserWaypoint.requiresNewWaypointPacket(session)) {
+                        if (!GeyserWaypoint.usesNewWaypointPacket(session)) {
                             session.getWaypointCache().addEntity(entity);
                         }
                     }
@@ -103,7 +103,7 @@ public class JavaPlayerInfoUpdateTranslator extends PacketTranslator<Clientbound
                     // No need to unlist players that were never listed
                     if (entity.isListed()) {
                         toRemove.add(new PlayerListPacket.Entry(entity.getTabListUuid()));
-                        if (!GeyserWaypoint.requiresNewWaypointPacket(session)) {
+                        if (!GeyserWaypoint.usesNewWaypointPacket(session)) {
                             session.getWaypointCache().removeEntity(entity);
                         }
                     }

--- a/core/src/main/java/org/geysermc/geyser/translator/protocol/java/entity/player/JavaPlayerInfoUpdateTranslator.java
+++ b/core/src/main/java/org/geysermc/geyser/translator/protocol/java/entity/player/JavaPlayerInfoUpdateTranslator.java
@@ -31,6 +31,7 @@ import org.geysermc.geyser.entity.EntityDefinitions;
 import org.geysermc.geyser.entity.spawn.EntitySpawnContext;
 import org.geysermc.geyser.entity.type.player.PlayerEntity;
 import org.geysermc.geyser.session.GeyserSession;
+import org.geysermc.geyser.session.cache.waypoint.GeyserWaypoint;
 import org.geysermc.geyser.skin.SkinManager;
 import org.geysermc.geyser.translator.protocol.PacketTranslator;
 import org.geysermc.geyser.translator.protocol.Translator;
@@ -94,13 +95,17 @@ public class JavaPlayerInfoUpdateTranslator extends PacketTranslator<Clientbound
                     if (!PlayerListUtils.shouldLimitPlayerListEntries(session)) {
                         PlayerListPacket.Entry playerListEntry = SkinManager.buildEntryFromCachedSkin(session, entity);
                         toAdd.add(playerListEntry);
-                        session.getWaypointCache().listPlayer(entity);
+                        if (!GeyserWaypoint.requiresNewWaypointPacket(session)) {
+                            session.getWaypointCache().addEntity(entity);
+                        }
                     }
                 } else {
                     // No need to unlist players that were never listed
                     if (entity.isListed()) {
                         toRemove.add(new PlayerListPacket.Entry(entity.getTabListUuid()));
-                        session.getWaypointCache().unlistPlayer(entity);
+                        if (!GeyserWaypoint.requiresNewWaypointPacket(session)) {
+                            session.getWaypointCache().removeEntity(entity);
+                        }
                     }
                 }
                 entity.setListed(entry.isListed());

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -85,6 +85,7 @@ fastutil-int-boolean-maps = { group = "org.cloudburstmc.fastutil.maps", name = "
 fastutil-object-int-maps = { group = "org.cloudburstmc.fastutil.maps", name = "object-int-maps", version.ref = "fastutil" }
 fastutil-object-object-maps = { group = "org.cloudburstmc.fastutil.maps", name = "object-object-maps", version.ref = "fastutil" }
 fastutil-long-object-maps = { group = "org.cloudburstmc.fastutil.maps", name = "long-object-maps", version.ref = "fastutil" }
+fastutil-object-long-maps = { group = "org.cloudburstmc.fastutil.maps", name = "object-long-maps", version.ref = "fastutil" }
 fastutil-reference-object-maps = { group = "org.cloudburstmc.fastutil.maps", name = "reference-object-maps", version.ref = "fastutil" }
 fastutil-object-boolean-maps = { group = "org.cloudburstmc.fastutil.maps", name = "object-boolean-maps", version.ref = "fastutil" }
 
@@ -178,7 +179,7 @@ runvelocity = { id = "xyz.jpenilla.run-velocity", version.ref = "runtask" }
 runpaper = { id = "xyz.jpenilla.run-paper", version.ref = "runtask" }
 
 [bundles]
-fastutil = [ "fastutil-int-int-maps", "fastutil-int-long-maps", "fastutil-long-object-maps", "fastutil-int-byte-maps", "fastutil-int-boolean-maps", "fastutil-object-int-maps", "fastutil-object-object-maps", "fastutil-reference-object-maps", "fastutil-object-boolean-maps" ]
+fastutil = [ "fastutil-int-int-maps", "fastutil-int-long-maps", "fastutil-long-object-maps", "fastutil-object-long-maps", "fastutil-int-byte-maps", "fastutil-int-boolean-maps", "fastutil-object-int-maps", "fastutil-object-object-maps", "fastutil-reference-object-maps", "fastutil-object-boolean-maps" ]
 adventure = [ "adventure-text-serializer-gson", "adventure-text-serializer-legacy", "adventure-text-serializer-plain" ]
 log4j = [ "log4j-api", "log4j-core", "log4j-slf4j2-impl", "log4j-iostreams", "log4j-jul" ]
 jline = [ "jline-terminal", "jline-terminal-jna", "jline-reader" ]


### PR DESCRIPTION
This PR adds support for the new waypoint/locator bar packets introduced in bedrock 26.10. Support for the old locator packets, used in 26.0 and below, is kept.

The new packets allow using custom waypoint textures, and as such, a basic implementation to support these has been written. Whilst Java's custom waypoint styles allow for any amount of waypoint icons, and for custom near- and far distance values, these styles are defined in the Java resourcepack, and as such these values are unavailable to Geyser. Therefore, Geyser will always use the vanilla near- and far distance values, and will always expect 4 waypoint icons for custom waypoint styles (as is the case for vanilla Java). Possible solutions for this are loading the resourcepack in Geyser, or adding support for a custom mappings file.

For now though, whenever a waypoint style is not `minecraft:default`, Geyser tells bedrock to use the following icons:

- `textures/ui/<style namespace>/locator_bar_dot/<style path>_0.png`
- `textures/ui/<style namespace>/locator_bar_dot/<style path>_1.png`
- `textures/ui/<style namespace>/locator_bar_dot/<style path>_2.png`
- `textures/ui/<style namespace>/locator_bar_dot/<style path>_3.png`

This somewhat matches vanilla Java and bedrock.

The PR also adds a `nextEntityId()` shorthand method to `EntityCache`, and adds methods to `EntityCache` to query an entity by its UUID (from #6010).