### PR TITLE
Fix: Duplicate item attribute modifier entries

### DIFF
--- a/core/src/main/java/org/geysermc/geyser/translator/item/ItemTranslator.java
+++ b/core/src/main/java/org/geysermc/geyser/translator/item/ItemTranslator.java
@@ -206,10 +206,12 @@ public final class ItemTranslator {
             nbtBuilder.setCustomName(customName);
         }
 
-        ItemAttributeModifiers attributeModifiers = components.get(DataComponentTypes.ATTRIBUTE_MODIFIERS);
-        if (attributeModifiers != null && tooltip.showInTooltip(DataComponentTypes.ATTRIBUTE_MODIFIERS )) {
-            // only add if attribute modifiers do not indicate to hide them
-            addAttributeLore(session, attributeModifiers, nbtBuilder, session.locale());
+        if (customComponents != null) {
+            ItemAttributeModifiers attributeModifiers = customComponents.get(DataComponentTypes.ATTRIBUTE_MODIFIERS);
+            if (attributeModifiers != null && tooltip.showInTooltip(DataComponentTypes.ATTRIBUTE_MODIFIERS)) {
+                // only add if attribute modifiers do not indicate to hide them
+                addAttributeLore(session, attributeModifiers, nbtBuilder, session.locale());
+            }
         }
 
         if (components.contains(DataComponentTypes.UNBREAKABLE) && tooltip.showInTooltip(DataComponentTypes.UNBREAKABLE)) {


### PR DESCRIPTION
Resolves https://github.com/GeyserMC/Geyser/issues/6114 - we might as well avoid them when we can. Ideally we can override Bedrock's own tooltips somehow... but that's for the future :p