### PR TITLE
Limit item stack size

### DIFF
--- a/core/src/main/java/org/geysermc/geyser/item/type/Item.java
+++ b/core/src/main/java/org/geysermc/geyser/item/type/Item.java
@@ -65,6 +65,7 @@ import java.util.List;
 import java.util.Map;
 
 public class Item {
+    public static final int BEDROCK_MAX_STACK_SIZE = 64;
     private static final Map<Block, Item> BLOCK_TO_ITEM = new HashMap<>();
     protected final Key javaIdentifier;
     private int javaId = -1;
@@ -160,7 +161,7 @@ public class Item {
         return ItemData.builder()
                 .definition(mapping.getBedrockDefinition())
                 .damage(mapping.getBedrockData())
-                .count(count);
+                .count(Math.min(count, BEDROCK_MAX_STACK_SIZE));
     }
 
     public @NonNull GeyserItemStack translateToJava(GeyserSession session, @NonNull ItemData itemData, @NonNull ItemMapping mapping, @NonNull ItemMappings mappings) {

--- a/core/src/main/java/org/geysermc/geyser/item/type/PotionItem.java
+++ b/core/src/main/java/org/geysermc/geyser/item/type/PotionItem.java
@@ -56,13 +56,13 @@ public class PotionItem extends Item {
                     return ItemData.builder()
                             .definition(mapping.getBedrockDefinition())
                             .damage(potion.getBedrockId())
-                            .count(count);
+                            .count(Math.min(count, BEDROCK_MAX_STACK_SIZE));
                 }
                 GeyserImpl.getInstance().getLogger().debug("Unknown Java potion: " + potionContents.getPotionId());
             } else {
                 return ItemData.builder()
                         .definition(customItemDefinition)
-                        .count(count);
+                        .count(Math.min(count, BEDROCK_MAX_STACK_SIZE));
             }
         }
         return super.translateToBedrock(session, count, components, mapping, mappings);

--- a/core/src/main/java/org/geysermc/geyser/item/type/TippedArrowItem.java
+++ b/core/src/main/java/org/geysermc/geyser/item/type/TippedArrowItem.java
@@ -50,7 +50,7 @@ public class TippedArrowItem extends ArrowItem {
                     return ItemData.builder()
                             .definition(mapping.getBedrockDefinition())
                             .damage(potion.tippedArrowId())
-                            .count(count);
+                            .count(Math.min(count, BEDROCK_MAX_STACK_SIZE));
                 }
                 GeyserImpl.getInstance().getLogger().debug("Unknown Java potion (tipped arrow): " + potionContents.getPotionId());
             }

--- a/core/src/main/java/org/geysermc/geyser/registry/populator/CustomItemRegistryPopulator.java
+++ b/core/src/main/java/org/geysermc/geyser/registry/populator/CustomItemRegistryPopulator.java
@@ -468,6 +468,10 @@ public class CustomItemRegistryPopulator {
                 stackSize = 1;
             }
         }
+        // Bedrock's stack size can be at most 64
+        if (stackSize > 64) {
+            stackSize = 64;
+        }
 
         itemProperties.putInt("max_stack_size", stackSize);
 

--- a/core/src/main/java/org/geysermc/geyser/registry/populator/custom/CustomItemContext.java
+++ b/core/src/main/java/org/geysermc/geyser/registry/populator/custom/CustomItemContext.java
@@ -105,6 +105,9 @@ public record CustomItemContext(CustomItemDefinition definition, DataComponents 
         if (equippable != null && stackSize > 1 && firstPass) {
             GeyserImpl.getInstance().getLogger().warning("Bedrock doesn't support stackable equippable items! Custom item %s with stack size %s and equippable component for slot %s will not work as expected!"
                 .formatted(definition.bedrockIdentifier(), stackSize, equippable.slot()));
+        } else if (stackSize > 64 && firstPass) {
+            GeyserImpl.getInstance().getLogger().warning("Bedrock doesn't support stack sizes above 64! Custom item %s with stack size %s will be clamped to 64!"
+                .formatted(definition.bedrockIdentifier(), stackSize));
         } else if (stackSize > 1 && maxDamage > 0) {
             throw new InvalidItemComponentsException("Stack size must be 1 when max damage is above 0");
         }


### PR DESCRIPTION
When an item stack which is larger than 64 is sent, the client just disconnects without any information.