### PR TITLE
Fix: always enable locatorBar gamerule on 26.10 and above

### DIFF
--- a/core/src/main/java/org/geysermc/geyser/session/GeyserSession.java
+++ b/core/src/main/java/org/geysermc/geyser/session/GeyserSession.java
@@ -980,6 +980,10 @@ public class GeyserSession implements GeyserConnection, GeyserCommandSource {
             // We disable the locator bar until we are certain that the server wants us to enable it
             // See WaypointCache for details
             gamerulePacket.getGameRules().add(new GameRuleData<>("locatorBar", false));
+        } else {
+            // On bedrock 26.10 and above, the client only shows the locator bar when there are
+            // waypoints on it, so we're fine doing this
+            gamerulePacket.getGameRules().add(new GameRuleData<>("locatorBar", true));
         }
 
         upstream.sendPacket(gamerulePacket);


### PR DESCRIPTION
The behaviour of the `locatorBar` gamerule apparently differs depending on the platform the client is on: on desktop, the client doesn't care about it, however, on other platforms, the locator bar won't show without it.

This PR always sends the `locatorBar` gamerule with a value of `true` to clients of version 26.10 and above. The client still hides the locator bar whenever there are no waypoints on it, matching Java behaviour, but now all platforms (presumably) will show it.

This PR has been tested on desktop (mcpelauncher) and mobile (iOS).