### PR TITLE
Propagate vehicle yaw to armor stand passengers

### DIFF
--- a/core/src/main/java/org/geysermc/geyser/entity/type/Entity.java
+++ b/core/src/main/java/org/geysermc/geyser/entity/type/Entity.java
@@ -52,6 +52,7 @@ import org.geysermc.geyser.entity.properties.GeyserEntityProperties;
 import org.geysermc.geyser.entity.properties.GeyserEntityPropertyManager;
 import org.geysermc.geyser.entity.properties.type.PropertyType;
 import org.geysermc.geyser.entity.spawn.EntitySpawnContext;
+import org.geysermc.geyser.entity.type.living.ArmorStandEntity;
 import org.geysermc.geyser.entity.type.living.MobEntity;
 import org.geysermc.geyser.entity.type.player.PlayerEntity;
 import org.geysermc.geyser.entity.vehicle.ClientVehicle;
@@ -321,6 +322,10 @@ public class Entity implements GeyserEntity {
                 moveEntityPacket.getFlags().add(MoveEntityDeltaPacket.Flag.ON_GROUND);
             }
             session.sendUpstreamPacket(moveEntityPacket);
+
+            if (dirtyYaw || dirtyHeadYaw) {
+                updatePassengerRotation();
+            }
         }
     }
 
@@ -349,6 +354,8 @@ public class Entity implements GeyserEntity {
             moveEntityPacket.setTeleported(teleported);
 
             session.sendUpstreamPacket(moveEntityPacket);
+
+            updatePassengerRotation();
         }
     }
 
@@ -717,6 +724,23 @@ public class Entity implements GeyserEntity {
                 boolean rider = i == 0;
                 EntityUtils.updateMountOffset(passenger, this, rider, true, i, passengers.size());
                 passenger.updateBedrockMetadata();
+            }
+        }
+    }
+
+    /**
+     * Propagate this vehicle's yaw to passengers that should visually rotate with it.
+     * Java clients render passengers as rotating with the vehicle automatically, but Bedrock
+     * needs the passenger's own rotation packet. Plugins like HMCCosmetics attach an invisible
+     * armor stand as a passenger; without this the cosmetic stays facing one direction.
+     */
+    protected void updatePassengerRotation() {
+        if (passengers.isEmpty()) {
+            return;
+        }
+        for (Entity passenger : passengers) {
+            if (passenger instanceof ArmorStandEntity stand && stand.isValid()) {
+                stand.followVehicleYaw(this.yaw);
             }
         }
     }

--- a/core/src/main/java/org/geysermc/geyser/entity/type/living/ArmorStandEntity.java
+++ b/core/src/main/java/org/geysermc/geyser/entity/type/living/ArmorStandEntity.java
@@ -438,4 +438,17 @@ public class ArmorStandEntity extends LivingEntity {
     public Vector3f bedrockRotation() {
         return Vector3f.from(getYaw(), getYaw(), getYaw());
     }
+
+    /**
+     * Called when this armor stand is a passenger and its vehicle's yaw changes.
+     * Java clients render passengers as rotating with the vehicle automatically, but on Bedrock
+     * the armor stand keeps its last yaw unless its own rotation packet is sent. Plugins like
+     * HMCCosmetics rely on this to keep an attached cosmetic facing the same way as the player.
+     */
+    public void followVehicleYaw(float vehicleYaw) {
+        if (vehicleYaw == this.yaw) {
+            return;
+        }
+        moveAbsoluteRaw(this.position, vehicleYaw, this.pitch, vehicleYaw, this.onGround, false);
+    }
 }

--- a/core/src/main/java/org/geysermc/geyser/translator/protocol/java/entity/JavaSetPassengersTranslator.java
+++ b/core/src/main/java/org/geysermc/geyser/translator/protocol/java/entity/JavaSetPassengersTranslator.java
@@ -31,6 +31,7 @@ import org.cloudburstmc.protocol.bedrock.data.entity.EntityDataTypes;
 import org.cloudburstmc.protocol.bedrock.data.entity.EntityLinkData;
 import org.cloudburstmc.protocol.bedrock.packet.SetEntityLinkPacket;
 import org.geysermc.geyser.entity.type.Entity;
+import org.geysermc.geyser.entity.type.living.ArmorStandEntity;
 import org.geysermc.geyser.entity.vehicle.ClientVehicle;
 import org.geysermc.geyser.session.GeyserSession;
 import org.geysermc.geyser.translator.protocol.PacketTranslator;
@@ -83,6 +84,9 @@ public class JavaSetPassengersTranslator extends PacketTranslator<ClientboundSet
             // Force an update to the passenger metadata
             passenger.updateBedrockMetadata();
             passenger.setMotion(Vector3f.ZERO);
+            if (passenger instanceof ArmorStandEntity stand) {
+                stand.followVehicleYaw(entity.getYaw());
+            }
         }
 
         // Handle passengers that were removed


### PR DESCRIPTION
Java clients automatically render passengers as rotating with their vehicle, but Bedrock requires the passenger's own rotation packet. Plugins like HMCCosmetics attach an invisible armor stand to a player to render a cosmetic; without this the cosmetic stays facing one direction while the player turns.

When a vehicle's yaw changes, send a rotation update to any armor stand passengers. Also snap the yaw on initial mount so the cosmetic doesn't appear rotated until the player first turns.