### PR TITLE
Revert the crashing furnace fix

### DIFF
--- a/core/src/main/java/org/geysermc/geyser/inventory/recipe/GeyserShapelessRecipe.java
+++ b/core/src/main/java/org/geysermc/geyser/inventory/recipe/GeyserShapelessRecipe.java
@@ -25,16 +25,12 @@
 
 package org.geysermc.geyser.inventory.recipe;
 
-import it.unimi.dsi.fastutil.ints.IntList;
-import lombok.Getter;
-import lombok.experimental.Accessors;
 import org.cloudburstmc.protocol.bedrock.data.inventory.ItemData;
 import org.cloudburstmc.protocol.bedrock.data.inventory.crafting.RecipeUnlockingRequirement;
 import org.cloudburstmc.protocol.bedrock.data.inventory.crafting.recipe.RecipeData;
 import org.cloudburstmc.protocol.bedrock.data.inventory.crafting.recipe.ShapelessRecipeData;
 import org.cloudburstmc.protocol.bedrock.data.inventory.descriptor.ItemDescriptorWithCount;
 import org.geysermc.geyser.session.GeyserSession;
-import org.geysermc.mcprotocollib.protocol.data.game.recipe.display.FurnaceRecipeDisplay;
 import org.geysermc.mcprotocollib.protocol.data.game.recipe.display.ShapelessCraftingRecipeDisplay;
 import org.geysermc.mcprotocollib.protocol.data.game.recipe.display.slot.SlotDisplay;
 
@@ -46,15 +42,10 @@ import java.util.UUID;
 public record GeyserShapelessRecipe(int id,
                                     int netId,
                                     List<SlotDisplay> ingredients,
-                                    SlotDisplay result,
-                                    String tag) implements GeyserRecipe {
+                                    SlotDisplay result) implements GeyserRecipe {
 
     public GeyserShapelessRecipe(int id, int netId, ShapelessCraftingRecipeDisplay data) {
-        this(id, netId, data.ingredients(), data.result(), "crafting_table");
-    }
-
-    public GeyserShapelessRecipe(int id, int netId, FurnaceRecipeDisplay data, int category) {
-        this(id, netId, List.of(data.ingredient()), data.result(), FurnaceRecipeType.fromCategory(category).tag);
+        this(id, netId, data.ingredients(), data.result());
     }
 
     @Override
@@ -75,36 +66,10 @@ public record GeyserShapelessRecipe(int id,
         int i = 0;
         for (List<ItemDescriptorWithCount> inputs : left) {
             recipeData.add(ShapelessRecipeData.shapeless(id + "_" + i, inputs,
-                    Collections.singletonList(output), UUID.randomUUID(), tag, 0,
+                    Collections.singletonList(output), UUID.randomUUID(), "crafting_table", 0,
                     netId + i, RecipeUnlockingRequirement.INVALID));
             i++;
         }
         return recipeData;
-    }
-
-    public enum FurnaceRecipeType {
-        FURNACE("furnace", 4, 5, 6), // furnace
-        BLAST_FURNACE("blast_furnace", 7, 8), // blast_furnace_blocks, blast_furnace_misc
-        SMOKER("smoker", 9, 12); // smoker_food, campfire
-
-        private final String tag;
-        @Getter
-        @Accessors(fluent = true)
-        private final IntList categories;
-
-        FurnaceRecipeType(String tag, int... categories) {
-            this.tag = tag;
-            this.categories = IntList.of(categories);
-        }
-
-        public static FurnaceRecipeType fromCategory(int category) {
-            for (FurnaceRecipeType type : values()) {
-                if (type.categories.contains(category)) {
-                    return type;
-                }
-            }
-
-            return FURNACE; // /shrug
-        }
     }
 }

--- a/core/src/main/java/org/geysermc/geyser/translator/protocol/java/JavaRecipeBookAddTranslator.java
+++ b/core/src/main/java/org/geysermc/geyser/translator/protocol/java/JavaRecipeBookAddTranslator.java
@@ -34,27 +34,19 @@ import org.geysermc.geyser.inventory.recipe.GeyserRecipe;
 import org.geysermc.geyser.inventory.recipe.GeyserShapedRecipe;
 import org.geysermc.geyser.inventory.recipe.GeyserShapelessRecipe;
 import org.geysermc.geyser.inventory.recipe.GeyserSmithingRecipe;
-import org.geysermc.geyser.item.Items;
-import org.geysermc.geyser.network.GameProtocol;
 import org.geysermc.geyser.session.GeyserSession;
 import org.geysermc.geyser.translator.protocol.PacketTranslator;
 import org.geysermc.geyser.translator.protocol.Translator;
-import org.geysermc.mcprotocollib.protocol.data.game.recipe.display.FurnaceRecipeDisplay;
 import org.geysermc.mcprotocollib.protocol.data.game.recipe.display.RecipeDisplay;
 import org.geysermc.mcprotocollib.protocol.data.game.recipe.display.RecipeDisplayEntry;
 import org.geysermc.mcprotocollib.protocol.data.game.recipe.display.ShapedCraftingRecipeDisplay;
 import org.geysermc.mcprotocollib.protocol.data.game.recipe.display.ShapelessCraftingRecipeDisplay;
 import org.geysermc.mcprotocollib.protocol.data.game.recipe.display.SmithingRecipeDisplay;
-import org.geysermc.mcprotocollib.protocol.data.game.recipe.display.slot.AnyFuelSlotDisplay;
-import org.geysermc.mcprotocollib.protocol.data.game.recipe.display.slot.ItemSlotDisplay;
-import org.geysermc.mcprotocollib.protocol.data.game.recipe.display.slot.SlotDisplay;
 import org.geysermc.mcprotocollib.protocol.data.game.recipe.display.slot.SmithingTrimDemoSlotDisplay;
 import org.geysermc.mcprotocollib.protocol.packet.ingame.clientbound.ClientboundRecipeBookAddPacket;
 
 import java.util.ArrayList;
-import java.util.HashSet;
 import java.util.List;
-import java.util.Set;
 
 @Translator(packet = ClientboundRecipeBookAddPacket.class)
 public class JavaRecipeBookAddTranslator extends PacketTranslator<ClientboundRecipeBookAddPacket> {
@@ -69,9 +61,6 @@ public class JavaRecipeBookAddTranslator extends PacketTranslator<ClientboundRec
         UnlockedRecipesPacket recipesPacket = new UnlockedRecipesPacket();
         recipesPacket.setAction(packet.isReplace() ? UnlockedRecipesPacket.ActionType.INITIALLY_UNLOCKED : UnlockedRecipesPacket.ActionType.NEWLY_UNLOCKED);
 
-        // Hacky fix, see below
-        Set<GeyserShapelessRecipe.FurnaceRecipeType> knownFurnaceRecipes = new HashSet<>();
-
         for (ClientboundRecipeBookAddPacket.Entry entry : packet.getEntries()) {
             RecipeDisplayEntry contents = entry.contents();
             if (javaToBedrockRecipeIds.containsKey(contents.id())) {
@@ -79,27 +68,6 @@ public class JavaRecipeBookAddTranslator extends PacketTranslator<ClientboundRec
             }
 
             RecipeDisplay display = contents.display();
-            // Hacky fix: on 1.26.20 and above, the client crashes when there are no furnace recipes. Furnace recipes also have to be shapeless.
-            // Before this fix, Geyser did not translate furnace recipes at all.
-            // TODO rewrite this, but properly
-            if (display instanceof FurnaceRecipeDisplay furnaceRecipe && GameProtocol.is1_26_20orHigher(session.protocolVersion())) {
-                GeyserRecipe geyserRecipe = new GeyserShapelessRecipe(contents.id(), netId, furnaceRecipe, contents.category());
-                knownFurnaceRecipes.add(GeyserShapelessRecipe.FurnaceRecipeType.fromCategory(contents.category()));
-
-                List<RecipeData> recipeData = geyserRecipe.asRecipeData(session);
-                craftingDataPacket.getCraftingData().addAll(recipeData);
-
-                List<String> bedrockRecipeIds = new ArrayList<>();
-                for (int i = 0; i < recipeData.size(); i++) {
-                    String recipeId = contents.id() + "_" + i;
-                    recipesPacket.getUnlockedRecipes().add(recipeId);
-                    bedrockRecipeIds.add(recipeId);
-                    geyserRecipes.put(netId++, geyserRecipe);
-                }
-                javaToBedrockRecipeIds.put(contents.id(), List.copyOf(bedrockRecipeIds));
-                continue;
-            }
-
             switch (display) {
                 case ShapedCraftingRecipeDisplay shapedRecipe -> {
                     GeyserRecipe geyserRecipe = new GeyserShapedRecipe(contents.id(), netId, shapedRecipe);
@@ -147,35 +115,6 @@ public class JavaRecipeBookAddTranslator extends PacketTranslator<ClientboundRec
                 }
                 default -> {
                     GeyserImpl.getInstance().getLogger().debug("Ignoring unknown recipe display type! " + entry);
-                }
-            }
-        }
-
-        if (GameProtocol.is1_26_20orHigher(session.protocolVersion())) {
-            int placeholderRecipes = 0;
-
-            SlotDisplay stoneSlotDisplay = new ItemSlotDisplay(Items.STONE.javaId());
-            FurnaceRecipeDisplay placeholderFurnaceRecipe = new FurnaceRecipeDisplay(stoneSlotDisplay, new AnyFuelSlotDisplay(), stoneSlotDisplay, stoneSlotDisplay, 1, 1.0F);
-
-            for (GeyserShapelessRecipe.FurnaceRecipeType type : GeyserShapelessRecipe.FurnaceRecipeType.values()) {
-                // Bedrock HAS to have a recipe or else it will crash on 1.26.20 and above, so send a bogus recipe
-                // Again, very hacky, FIXME please
-                if (!knownFurnaceRecipes.contains(type)) {
-                    int id = Integer.MIN_VALUE + placeholderRecipes;
-                    GeyserRecipe geyserRecipe = new GeyserShapelessRecipe(id, netId, placeholderFurnaceRecipe, type.categories().getFirst());
-
-                    List<RecipeData> recipeData = geyserRecipe.asRecipeData(session);
-                    craftingDataPacket.getCraftingData().addAll(recipeData);
-
-                    List<String> bedrockRecipeIds = new ArrayList<>();
-                    for (int i = 0; i < recipeData.size(); i++) {
-                        String recipeId = id + "_" + i;
-                        recipesPacket.getUnlockedRecipes().add(recipeId);
-                        bedrockRecipeIds.add(recipeId);
-                        geyserRecipes.put(netId++, geyserRecipe);
-                    }
-                    javaToBedrockRecipeIds.put(id, List.copyOf(bedrockRecipeIds));
-                    placeholderRecipes++;
                 }
             }
         }


### PR DESCRIPTION
This PR reverts the hacky furnace fix implemented in #6351. 

Mojang fixed a freeze when opening a furnace without recipes in Bedrock Hotfix 26.21.



