### PR TITLE
Fix block breaking

### DIFF
--- a/core/src/main/java/org/geysermc/geyser/session/cache/BlockBreakHandler.java
+++ b/core/src/main/java/org/geysermc/geyser/session/cache/BlockBreakHandler.java
@@ -68,6 +68,7 @@ import org.geysermc.mcprotocollib.protocol.data.game.item.component.AdventureMod
 import org.geysermc.mcprotocollib.protocol.data.game.item.component.DataComponentTypes;
 import org.geysermc.mcprotocollib.protocol.data.game.item.component.ToolData;
 import org.geysermc.mcprotocollib.protocol.packet.ingame.serverbound.player.ServerboundAttackPacket;
+import org.geysermc.mcprotocollib.protocol.packet.ingame.serverbound.player.ServerboundMovePlayerStatusOnlyPacket;
 import org.geysermc.mcprotocollib.protocol.packet.ingame.serverbound.player.ServerboundPlayerActionPacket;
 import org.geysermc.mcprotocollib.protocol.packet.ingame.serverbound.player.ServerboundUseItemOnPacket;
 
@@ -308,6 +309,7 @@ public class BlockBreakHandler {
 
     protected void handleStartBreak(@NonNull Vector3i position, @NonNull BlockState state, Direction blockFace, long tick) {
         GeyserItemStack item = session.getPlayerInventory().getItemInHand();
+        sendFlyingBreakGroundState();
 
         // Account for fire - the client likes to hit the block behind.
         Vector3i fireBlockPos = BlockUtils.getBlockPosition(position, blockFace);
@@ -562,6 +564,8 @@ public class BlockBreakHandler {
     }
 
     protected void destroyBlock(BlockState state, Vector3i vector, Direction direction, boolean instamine) {
+        sendFlyingBreakGroundState();
+
         // Send java packet
         session.sendDownstreamGamePacket(new ServerboundPlayerActionPacket(instamine ? PlayerAction.START_DIGGING : PlayerAction.FINISH_DIGGING,
             vector, direction.mcpl(), session.getWorldCache().nextPredictionSequence()));
@@ -578,6 +582,21 @@ public class BlockBreakHandler {
 
     protected float calculateBreakProgress(BlockState state, Vector3i vector, GeyserItemStack stack) {
         return BlockUtils.getBlockMiningProgressPerTick(session, state.block(), stack);
+    }
+
+    public boolean shouldSpoofOnGroundForFlyingBreak() {
+        return currentBlockPos != null && shouldIgnoreAirborneMiningPenalty();
+    }
+
+    public boolean shouldIgnoreAirborneMiningPenalty() {
+        return session.isFlying() && !session.isInstabuild() && session.getGameMode() != GameMode.SPECTATOR;
+    }
+
+    private void sendFlyingBreakGroundState() {
+        if (shouldIgnoreAirborneMiningPenalty() && !session.getPlayerEntity().isOnGround()) {
+            session.sendDownstreamGamePacket(new ServerboundMovePlayerStatusOnlyPacket(
+                true, session.getInputCache().lastHorizontalCollision()));
+        }
     }
 
     /**

--- a/core/src/main/java/org/geysermc/geyser/session/cache/InputCache.java
+++ b/core/src/main/java/org/geysermc/geyser/session/cache/InputCache.java
@@ -44,6 +44,8 @@ public final class InputCache {
     private ServerboundPlayerInputPacket inputPacket = new ServerboundPlayerInputPacket(false, false, false, false, false, false, false);
     @Setter
     private boolean lastHorizontalCollision;
+    @Setter
+    private boolean lastJavaOnGround;
     private int ticksSinceLastMovePacket;
     @Getter @Setter
     private int jumpingTicks;
@@ -162,6 +164,10 @@ public final class InputCache {
 
     public boolean lastHorizontalCollision() {
         return lastHorizontalCollision;
+    }
+
+    public boolean lastJavaOnGround() {
+        return lastJavaOnGround;
     }
 
     /*

--- a/core/src/main/java/org/geysermc/geyser/translator/protocol/bedrock/entity/player/input/BedrockMovePlayer.java
+++ b/core/src/main/java/org/geysermc/geyser/translator/protocol/bedrock/entity/player/input/BedrockMovePlayer.java
@@ -159,12 +159,13 @@ final class BedrockMovePlayer {
         // (Press into a wall in a corner - you're trying to move but nothing actually happens)
         // This isn't sent when a player is riding a vehicle (as of 1.21.62)
         boolean horizontalCollision = packet.getInputData().contains(PlayerAuthInputData.HORIZONTAL_COLLISION);
+        boolean javaOnGround = isOnGround || session.getBlockBreakHandler().shouldSpoofOnGroundForFlyingBreak();
 
         // If only the pitch and yaw changed
         // This isn't needed, but it makes the packets closer to vanilla
         // It also means you can't "lag back" while only looking, in theory
         if (!positionChangedAndShouldUpdate && rotationChanged) {
-            ServerboundMovePlayerRotPacket playerRotationPacket = new ServerboundMovePlayerRotPacket(isOnGround, horizontalCollision, javaYaw, pitch);
+            ServerboundMovePlayerRotPacket playerRotationPacket = new ServerboundMovePlayerRotPacket(javaOnGround, horizontalCollision, javaYaw, pitch);
 
             entity.setYaw(yaw);
             entity.setJavaYaw(javaYaw);
@@ -189,7 +190,7 @@ final class BedrockMovePlayer {
                         if (rotationChanged) {
                             // Send rotation updates as well
                             movePacket = new ServerboundMovePlayerPosRotPacket(
-                                isOnGround,
+                                javaOnGround,
                                 horizontalCollision,
                                 position.getX(), position.getY(), position.getZ(),
                                 javaYaw, pitch
@@ -200,7 +201,7 @@ final class BedrockMovePlayer {
                             entity.setHeadYaw(headYaw);
                         } else {
                             // Rotation did not change; don't send an update with rotation
-                            movePacket = new ServerboundMovePlayerPosPacket(isOnGround, horizontalCollision, position.getX(), position.getY(), position.getZ());
+                            movePacket = new ServerboundMovePlayerPosPacket(javaOnGround, horizontalCollision, position.getX(), position.getY(), position.getZ());
                         }
 
                         entity.setPositionFromBedrockPos(packet.getPosition());
@@ -219,11 +220,13 @@ final class BedrockMovePlayer {
                 session.getGeyser().getLogger().debug("Recalculating position...");
                 session.getCollisionManager().recalculatePosition();
             }
-        } else if (horizontalCollision != session.getInputCache().lastHorizontalCollision() || isOnGround != entity.isOnGround()) {
-            session.sendDownstreamGamePacket(new ServerboundMovePlayerStatusOnlyPacket(isOnGround, horizontalCollision));
+        } else if (horizontalCollision != session.getInputCache().lastHorizontalCollision()
+            || javaOnGround != session.getInputCache().lastJavaOnGround()) {
+            session.sendDownstreamGamePacket(new ServerboundMovePlayerStatusOnlyPacket(javaOnGround, horizontalCollision));
         }
 
         session.getInputCache().setLastHorizontalCollision(horizontalCollision);
+        session.getInputCache().setLastJavaOnGround(javaOnGround);
         entity.setOnGround(isOnGround);
 
         entity.setLastTickEndVelocity(packet.getDelta());
@@ -248,7 +251,7 @@ final class BedrockMovePlayer {
         }
         if (currentPosition.distanceSquared(newPosition) > 300) {
             session.getGeyser().getLogger().debug(ChatColor.RED + session.bedrockUsername() + " moved too quickly." +
-                    " current position: " + currentPosition + ", new position: " + newPosition);
+                " current position: " + currentPosition + ", new position: " + newPosition);
 
             return false;
         }

--- a/core/src/main/java/org/geysermc/geyser/util/BlockUtils.java
+++ b/core/src/main/java/org/geysermc/geyser/util/BlockUtils.java
@@ -133,7 +133,8 @@ public final class BlockUtils {
             destroySpeed *= (float) session.getPlayerEntity().getSubmergedMiningSpeed();
         }
 
-        if (!session.getPlayerEntity().isOnGround()) {
+        if (!session.getPlayerEntity().isOnGround()
+            && !session.getBlockBreakHandler().shouldIgnoreAirborneMiningPenalty()) {
             destroySpeed /= 5.0F;
         }
 


### PR DESCRIPTION
I have improved the block-breaking fix while the player is in flight mode. It should now avoid issues with anti-cheats and should also handle different pickaxe efficiencies/effects more correctly.

What do you think about this solution?

Old pr - https://github.com/GeyserMC/Geyser/pull/6187