### PR TITLE
Fix: Teleports on chests causing players to get stuck

### DIFF
--- a/core/src/main/java/org/geysermc/geyser/entity/type/Entity.java
+++ b/core/src/main/java/org/geysermc/geyser/entity/type/Entity.java
@@ -104,7 +104,7 @@ public class Entity implements GeyserEntity {
 
     protected Vector3f position;
     protected Vector3f motion;
-    protected float offset;
+    private float offset;
 
     /**
      * x = Yaw, y = Pitch, z = HeadYaw
@@ -701,6 +701,7 @@ public class Entity implements GeyserEntity {
      * Gets the Bedrock edition position with the offset applied
      */
     public Vector3f bedrockPosition() {
+        float offset = getOffset();
         if (offset == 0f) {
             return position;
         }

--- a/core/src/main/java/org/geysermc/geyser/entity/type/FishingHookEntity.java
+++ b/core/src/main/java/org/geysermc/geyser/entity/type/FishingHookEntity.java
@@ -35,6 +35,7 @@ import org.geysermc.geyser.entity.type.player.PlayerEntity;
 import org.geysermc.geyser.level.block.BlockStateValues;
 import org.geysermc.geyser.level.block.type.Block;
 import org.geysermc.geyser.level.physics.BoundingBox;
+import org.geysermc.geyser.level.physics.CollisionManager;
 import org.geysermc.geyser.session.GeyserSession;
 import org.geysermc.geyser.translator.collision.BlockCollision;
 import org.geysermc.geyser.util.BlockUtils;
@@ -102,7 +103,7 @@ public class FishingHookEntity extends ProjectileEntity {
 
         boolean touchingWater = false;
         boolean collided = false;
-        for (BlockPositionIterator iter = session.getCollisionManager().collidableBlocksIterator(boundingBox); iter.hasNext(); iter.next()) {
+        for (BlockPositionIterator iter = CollisionManager.collidableBlocksIterator(session, boundingBox); iter.hasNext(); iter.next()) {
             int blockID = session.getGeyser().getWorldManager().getBlockAt(session, iter.getX(), iter.getY(), iter.getZ());
             BlockCollision blockCollision = BlockUtils.getCollision(blockID);
             if (blockCollision != null) {

--- a/core/src/main/java/org/geysermc/geyser/entity/type/living/merchant/VillagerEntity.java
+++ b/core/src/main/java/org/geysermc/geyser/entity/type/living/merchant/VillagerEntity.java
@@ -154,7 +154,7 @@ public class VillagerEntity extends AbstractMerchantEntity {
         MoveEntityAbsolutePacket moveEntityPacket = new MoveEntityAbsolutePacket();
         moveEntityPacket.setRuntimeEntityId(geyserId);
         moveEntityPacket.setRotation(Vector3f.from(0, 0, bedRotation));
-        moveEntityPacket.setPosition(Vector3f.from(position.getX() + xOffset, position.getY() + offset, position.getZ() + zOffset));
+        moveEntityPacket.setPosition(Vector3f.from(position.getX() + xOffset, position.getY() + getOffset(), position.getZ() + zOffset));
         moveEntityPacket.setOnGround(isOnGround);
         moveEntityPacket.setTeleported(false);
         session.sendUpstreamPacket(moveEntityPacket);

--- a/core/src/main/java/org/geysermc/geyser/entity/type/player/AvatarEntity.java
+++ b/core/src/main/java/org/geysermc/geyser/entity/type/player/AvatarEntity.java
@@ -349,12 +349,12 @@ public abstract class AvatarEntity extends LivingEntity {
     }
 
     @Override
-    public Vector3f bedrockPosition() {
-        // Don't apply the full bedrock y offset when le player is sleeping
+    public float getOffset() {
+        // Don't apply the full bedrock y offset when the player is sleeping
         if (bedPosition != null && getFlag(EntityFlag.SLEEPING)) {
-            return position.up(0.2f);
+            return 0.2f;
         }
-        return super.bedrockPosition();
+        return super.getOffset();
     }
 
     public @Nullable String getSkinId() {

--- a/core/src/main/java/org/geysermc/geyser/entity/type/player/SessionPlayerEntity.java
+++ b/core/src/main/java/org/geysermc/geyser/entity/type/player/SessionPlayerEntity.java
@@ -172,7 +172,7 @@ public class SessionPlayerEntity extends PlayerEntity {
     public Vector3f bedrockPosition() {
         TeleportCache unconfirmedTeleport = session.getUnconfirmedTeleport();
         if (unconfirmedTeleport != null) {
-            return unconfirmedTeleport.getAdjustedPosition().up(EntityDefinitions.PLAYER.offset());
+            return unconfirmedTeleport.getAdjustedPosition().up(getOffset());
         }
         return super.bedrockPosition();
     }
@@ -232,13 +232,11 @@ public class SessionPlayerEntity extends PlayerEntity {
      * @param position the new position of the Bedrock player
      */
     public void setPositionFromBedrockPos(Vector3f position) {
-        // Special handling: position while sleeping
-        if (bedPosition != null && getFlag(EntityFlag.SLEEPING)) {
-            this.position = position.down(0.2f);
-        } else if (this.vehicle != null) {
+        if (this.vehicle != null) {
             this.position = position.down(this.vehicle.getOffset());
         } else {
-            this.position = position.down(offset);
+            // getOffset will also account for a reduced offset (0.2) when sleeping
+            this.position = position.down(getOffset());
         }
 
         // Player is "above" the void so they're not supposed to no clip.

--- a/core/src/main/java/org/geysermc/geyser/entity/type/player/SessionPlayerEntity.java
+++ b/core/src/main/java/org/geysermc/geyser/entity/type/player/SessionPlayerEntity.java
@@ -38,7 +38,6 @@ import org.cloudburstmc.protocol.bedrock.data.entity.EntityFlag;
 import org.cloudburstmc.protocol.bedrock.packet.MovePlayerPacket;
 import org.cloudburstmc.protocol.bedrock.packet.SetEntityMotionPacket;
 import org.cloudburstmc.protocol.bedrock.packet.UpdateAttributesPacket;
-import org.geysermc.erosion.util.BlockPositionIterator;
 import org.geysermc.geyser.entity.EntityDefinitions;
 import org.geysermc.geyser.entity.attribute.GeyserAttributeType;
 import org.geysermc.geyser.entity.spawn.EntitySpawnContext;
@@ -52,14 +51,10 @@ import org.geysermc.geyser.level.block.Blocks;
 import org.geysermc.geyser.level.block.property.Properties;
 import org.geysermc.geyser.level.block.type.BlockState;
 import org.geysermc.geyser.level.block.type.TrapDoorBlock;
-import org.geysermc.geyser.level.physics.BoundingBox;
-import org.geysermc.geyser.level.physics.CollisionManager;
 import org.geysermc.geyser.session.GeyserSession;
 import org.geysermc.geyser.session.cache.TeleportCache;
 import org.geysermc.geyser.session.cache.tags.BlockTag;
-import org.geysermc.geyser.translator.collision.BlockCollision;
 import org.geysermc.geyser.util.AttributeUtils;
-import org.geysermc.geyser.util.BlockUtils;
 import org.geysermc.geyser.util.DimensionUtils;
 import org.geysermc.geyser.util.MathUtils;
 import org.geysermc.mcprotocollib.protocol.data.game.entity.Effect;
@@ -171,48 +166,6 @@ public class SessionPlayerEntity extends PlayerEntity {
     public void setYaw(float yaw) {
         super.setYaw(yaw);
         this.javaYaw = yaw;
-    }
-
-    public Vector3f adjustPositionForBedrock(Vector3f position) {
-        // Checks for Bedrock collision differences and adjust the position sent to Bedrock if needed
-        // For example: Java teleports to 72.875 on top of a chest, but Bedrock believes chests are 72.95 high... so we fall through instead
-        // ...which leads the server to teleport again, et voila.
-        BoundingBox playerBox = session.getCollisionManager().getPlayerBoundingBox().clone();
-        playerBox.setMiddleX(position.getX());
-        playerBox.setMiddleY(position.getY() + (playerBox.getSizeY() / 2.0));
-        playerBox.setMiddleZ(position.getZ());
-
-        // Check blocks which we're on top off, according to the Java server
-        BlockPositionIterator iter = CollisionManager.collidableBlocksIterator(session, playerBox);
-        double totalPushUp = 0;
-        while (iter.hasNext()) {
-            int blockId = session.getGeyser().getWorldManager().getBlockAt(session, iter.getX(), iter.getY(), iter.getZ());
-            BlockCollision collision = BlockUtils.getCollision(blockId);
-            if (collision != null) {
-                for (BoundingBox box : collision.getBoundingBoxes()) {
-                    // Check if the player is within the block's X/Z bounds
-                    if (Math.abs((box.getMiddleX() + iter.getX()) - playerBox.getMiddleX()) * 2 < (box.getSizeX() + playerBox.getSizeX()) &&
-                        Math.abs((box.getMiddleZ() + iter.getZ()) - playerBox.getMiddleZ()) * 2 < (box.getSizeZ() + playerBox.getSizeZ())) {
-
-                        double pushUp = collision.pushUpForTeleport();
-                        if (pushUp > 0) {
-                            double blockMaxY = iter.getY() + box.getMiddleY() + (box.getSizeY() / 2.0);
-                            double playerMinY = playerBox.getMiddleY() - (playerBox.getSizeY() / 2.0);
-                            // If the player is on top of or slightly inside the Bedrock collision zone
-                            if (playerMinY >= blockMaxY - 0.05 && playerMinY < blockMaxY + pushUp) {
-                                totalPushUp = Math.max(totalPushUp, blockMaxY + pushUp - playerMinY);
-                            }
-                        }
-                    }
-                }
-            }
-            iter.next();
-        }
-
-        if (totalPushUp > 0) {
-            return Vector3f.from(position.getX(), (float) (position.getY() + totalPushUp), position.getZ());
-        }
-        return position;
     }
 
     @Override

--- a/core/src/main/java/org/geysermc/geyser/entity/type/player/SessionPlayerEntity.java
+++ b/core/src/main/java/org/geysermc/geyser/entity/type/player/SessionPlayerEntity.java
@@ -38,6 +38,7 @@ import org.cloudburstmc.protocol.bedrock.data.entity.EntityFlag;
 import org.cloudburstmc.protocol.bedrock.packet.MovePlayerPacket;
 import org.cloudburstmc.protocol.bedrock.packet.SetEntityMotionPacket;
 import org.cloudburstmc.protocol.bedrock.packet.UpdateAttributesPacket;
+import org.geysermc.erosion.util.BlockPositionIterator;
 import org.geysermc.geyser.entity.EntityDefinitions;
 import org.geysermc.geyser.entity.attribute.GeyserAttributeType;
 import org.geysermc.geyser.entity.spawn.EntitySpawnContext;
@@ -51,9 +52,14 @@ import org.geysermc.geyser.level.block.Blocks;
 import org.geysermc.geyser.level.block.property.Properties;
 import org.geysermc.geyser.level.block.type.BlockState;
 import org.geysermc.geyser.level.block.type.TrapDoorBlock;
+import org.geysermc.geyser.level.physics.BoundingBox;
+import org.geysermc.geyser.level.physics.CollisionManager;
 import org.geysermc.geyser.session.GeyserSession;
+import org.geysermc.geyser.session.cache.TeleportCache;
 import org.geysermc.geyser.session.cache.tags.BlockTag;
+import org.geysermc.geyser.translator.collision.BlockCollision;
 import org.geysermc.geyser.util.AttributeUtils;
+import org.geysermc.geyser.util.BlockUtils;
 import org.geysermc.geyser.util.DimensionUtils;
 import org.geysermc.geyser.util.MathUtils;
 import org.geysermc.mcprotocollib.protocol.data.game.entity.Effect;
@@ -167,6 +173,57 @@ public class SessionPlayerEntity extends PlayerEntity {
         this.javaYaw = yaw;
     }
 
+    public Vector3f adjustPositionForBedrock(Vector3f position) {
+        // Checks for Bedrock collision differences and adjust the position sent to Bedrock if needed
+        // For example: Java teleports to 72.875 on top of a chest, but Bedrock believes chests are 72.95 high... so we fall through instead
+        // ...which leads the server to teleport again, et voila.
+        BoundingBox playerBox = session.getCollisionManager().getPlayerBoundingBox().clone();
+        playerBox.setMiddleX(position.getX());
+        playerBox.setMiddleY(position.getY() + (playerBox.getSizeY() / 2.0));
+        playerBox.setMiddleZ(position.getZ());
+
+        // Check blocks which we're on top off, according to the Java server
+        BlockPositionIterator iter = CollisionManager.collidableBlocksIterator(session, playerBox);
+        double totalPushUp = 0;
+        while (iter.hasNext()) {
+            int blockId = session.getGeyser().getWorldManager().getBlockAt(session, iter.getX(), iter.getY(), iter.getZ());
+            BlockCollision collision = BlockUtils.getCollision(blockId);
+            if (collision != null) {
+                for (BoundingBox box : collision.getBoundingBoxes()) {
+                    // Check if the player is within the block's X/Z bounds
+                    if (Math.abs((box.getMiddleX() + iter.getX()) - playerBox.getMiddleX()) * 2 < (box.getSizeX() + playerBox.getSizeX()) &&
+                        Math.abs((box.getMiddleZ() + iter.getZ()) - playerBox.getMiddleZ()) * 2 < (box.getSizeZ() + playerBox.getSizeZ())) {
+
+                        double pushUp = collision.pushUpForTeleport();
+                        if (pushUp > 0) {
+                            double blockMaxY = iter.getY() + box.getMiddleY() + (box.getSizeY() / 2.0);
+                            double playerMinY = playerBox.getMiddleY() - (playerBox.getSizeY() / 2.0);
+                            // If the player is on top of or slightly inside the Bedrock collision zone
+                            if (playerMinY >= blockMaxY - 0.05 && playerMinY < blockMaxY + pushUp) {
+                                totalPushUp = Math.max(totalPushUp, blockMaxY + pushUp - playerMinY);
+                            }
+                        }
+                    }
+                }
+            }
+            iter.next();
+        }
+
+        if (totalPushUp > 0) {
+            return Vector3f.from(position.getX(), (float) (position.getY() + totalPushUp), position.getZ());
+        }
+        return position;
+    }
+
+    @Override
+    public Vector3f bedrockPosition() {
+        TeleportCache unconfirmedTeleport = session.getUnconfirmedTeleport();
+        if (unconfirmedTeleport != null) {
+            return unconfirmedTeleport.getAdjustedPosition().up(EntityDefinitions.PLAYER.offset());
+        }
+        return super.bedrockPosition();
+    }
+
     @Override
     public void moveRelativeRaw(double relX, double relY, double relZ, float yaw, float pitch, float headYaw, boolean isOnGround) {
         super.moveRelativeRaw(relX, relY, relZ, yaw, pitch, headYaw, isOnGround);
@@ -232,7 +289,7 @@ public class SessionPlayerEntity extends PlayerEntity {
         }
 
         // Player is "above" the void so they're not supposed to no clip.
-        if (session.isNoClip() && position.getY() - EntityDefinitions.PLAYER.offset() >= session.getBedrockDimension().minY() - 5) {
+        if (session.isNoClip() && this.position.getY() >= session.getBedrockDimension().minY() - 5) {
             session.setNoClip(false);
         }
     }

--- a/core/src/main/java/org/geysermc/geyser/entity/vehicle/BoatVehicleComponent.java
+++ b/core/src/main/java/org/geysermc/geyser/entity/vehicle/BoatVehicleComponent.java
@@ -41,6 +41,7 @@ import org.geysermc.geyser.level.block.type.Block;
 import org.geysermc.geyser.level.block.type.BlockState;
 import org.geysermc.geyser.level.physics.Axis;
 import org.geysermc.geyser.level.physics.BoundingBox;
+import org.geysermc.geyser.level.physics.CollisionManager;
 import org.geysermc.geyser.translator.collision.BlockCollision;
 import org.geysermc.geyser.util.BlockUtils;
 import org.geysermc.mcprotocollib.protocol.packet.ingame.serverbound.level.ServerboundMoveVehiclePacket;
@@ -182,7 +183,7 @@ public class BoatVehicleComponent extends VehicleComponent<BoatEntity> {
             box.translate(0, targetY - getBoundingBox().getMin(Axis.Y), 0);
 
             boolean empty = true;
-            for (BlockPositionIterator iter = vehicle.getSession().getCollisionManager().collidableBlocksIterator(box); iter.hasNext(); iter.next()) {
+            for (BlockPositionIterator iter = CollisionManager.collidableBlocksIterator(vehicle.getSession(), box); iter.hasNext(); iter.next()) {
                 final BlockCollision collision = BlockUtils.getCollision(context.getBlockId(iter.getX(), iter.getY(), iter.getZ()));
                 if (collision != null && collision.checkIntersection(Vector3i.from(iter.getX(), iter.getY(), iter.getZ()), box)) {
                     empty = false;

--- a/core/src/main/java/org/geysermc/geyser/entity/vehicle/VehicleComponent.java
+++ b/core/src/main/java/org/geysermc/geyser/entity/vehicle/VehicleComponent.java
@@ -501,7 +501,7 @@ public class VehicleComponent<T extends Entity & ClientVehicle> {
         box.translate(vehicle.getMotion().toDouble().up(0.6f - ctx.centerPos().getY() + originalY));
         box.expand(-1.0E-7);
 
-        BlockPositionIterator iter = vehicle.getSession().getCollisionManager().collidableBlocksIterator(box);
+        BlockPositionIterator iter = CollisionManager.collidableBlocksIterator(vehicle.getSession(), box);
         for (iter.reset(); iter.hasNext(); iter.next()) {
             int blockId = ctx.getBlockId(iter);
 

--- a/core/src/main/java/org/geysermc/geyser/level/physics/CollisionManager.java
+++ b/core/src/main/java/org/geysermc/geyser/level/physics/CollisionManager.java
@@ -59,7 +59,7 @@ import java.util.Locale;
 public class CollisionManager {
     public static final BlockCollision SOLID_COLLISION = new SolidCollision(null);
     public static final BlockCollision FLUID_COLLISION = new OtherCollision(new BoundingBox[]{new BoundingBox(0.5, 0.25, 0.5, 1, 0.5, 1)});
-    // If you read this, feel free to suggest a more proper way to detect alse
+    // If you read this, feel free to suggest a more proper way to detect else
     public static final double POSITION_ADJUSTMENT_MARGIN = 0.05;
 
     private final GeyserSession session;

--- a/core/src/main/java/org/geysermc/geyser/level/physics/CollisionManager.java
+++ b/core/src/main/java/org/geysermc/geyser/level/physics/CollisionManager.java
@@ -467,7 +467,7 @@ public class CollisionManager {
         // Checks for Bedrock collision differences and adjust the position sent to Bedrock if needed
         // For example: Java teleports to 72.875 on top of a chest, but Bedrock believes chests are 72.95 high... so we fall through instead
         // ...which leads the server to teleport again, et voila.
-        BoundingBox playerBox = session.getCollisionManager().getPlayerBoundingBox().clone();
+        BoundingBox playerBox = playerBoundingBox.clone();
         playerBox.setMiddleX(position.getX());
         playerBox.setMiddleY(position.getY() + (playerBox.getSizeY() / 2.0));
         playerBox.setMiddleZ(position.getZ());

--- a/core/src/main/java/org/geysermc/geyser/level/physics/CollisionManager.java
+++ b/core/src/main/java/org/geysermc/geyser/level/physics/CollisionManager.java
@@ -59,7 +59,7 @@ import java.util.Locale;
 public class CollisionManager {
     public static final BlockCollision SOLID_COLLISION = new SolidCollision(null);
     public static final BlockCollision FLUID_COLLISION = new OtherCollision(new BoundingBox[]{new BoundingBox(0.5, 0.25, 0.5, 1, 0.5, 1)});
-    // If you read this, feel free to suggest a more proper way to detect else
+    // If you read this, feel free to suggest a more proper way to detect the Bedrock player's own onGround status here
     public static final double POSITION_ADJUSTMENT_MARGIN = 0.05;
 
     private final GeyserSession session;

--- a/core/src/main/java/org/geysermc/geyser/level/physics/CollisionManager.java
+++ b/core/src/main/java/org/geysermc/geyser/level/physics/CollisionManager.java
@@ -232,7 +232,7 @@ public class CollisionManager {
         session.sendUpstreamPacket(movePlayerPacket);
     }
 
-    public BlockPositionIterator collidableBlocksIterator(BoundingBox box) {
+    public static BlockPositionIterator collidableBlocksIterator(GeyserSession session, BoundingBox box) {
         Vector3d position = Vector3d.from(box.getMiddleX(), box.getMiddleY() - (box.getSizeY() / 2), box.getMiddleZ());
 
         // Expand volume by 1 in each direction to include moving blocks
@@ -253,7 +253,7 @@ public class CollisionManager {
     }
 
     public BlockPositionIterator playerCollidableBlocksIterator() {
-        return collidableBlocksIterator(playerBoundingBox);
+        return collidableBlocksIterator(session, playerBoundingBox);
     }
 
     /**
@@ -354,7 +354,7 @@ public class CollisionManager {
 
         BoundingBox movementBoundingBox = boundingBox.clone();
         movementBoundingBox.extend(movement);
-        BlockPositionIterator iter = collidableBlocksIterator(movementBoundingBox);
+        BlockPositionIterator iter = collidableBlocksIterator(session, movementBoundingBox);
         if (Math.abs(movementY) > CollisionManager.COLLISION_TOLERANCE) {
             movementY = computeCollisionOffset(boundingBox, Axis.Y, movementY, iter, checkWorld, walkOnLava);
             boundingBox.translate(0, movementY, 0);

--- a/core/src/main/java/org/geysermc/geyser/level/physics/CollisionManager.java
+++ b/core/src/main/java/org/geysermc/geyser/level/physics/CollisionManager.java
@@ -464,9 +464,9 @@ public class CollisionManager {
     }
 
     public Vector3f adjustPositionForBedrock(Vector3f position) {
-        // Checks for Bedrock collision differences and adjust the position sent to Bedrock if needed
-        // For example: Java teleports to 72.875 on top of a chest, but Bedrock believes chests are 72.95 high... so we fall through instead
-        // ...which leads the server to teleport again, et voila.
+        // Checks for Bedrock collision differences and adjusts the position sent to Bedrock, if needed
+        // For example: Java teleports to 72.875 on top of a chest, but Bedrock believes chests are 72.95 high - so we fall through instead
+        // ...which leads the server to teleport again, et voila, players get stuck.
         BoundingBox playerBox = playerBoundingBox.clone();
         playerBox.setMiddleX(position.getX());
         playerBox.setMiddleY(position.getY() + (playerBox.getSizeY() / 2.0));

--- a/core/src/main/java/org/geysermc/geyser/level/physics/CollisionManager.java
+++ b/core/src/main/java/org/geysermc/geyser/level/physics/CollisionManager.java
@@ -59,6 +59,8 @@ import java.util.Locale;
 public class CollisionManager {
     public static final BlockCollision SOLID_COLLISION = new SolidCollision(null);
     public static final BlockCollision FLUID_COLLISION = new OtherCollision(new BoundingBox[]{new BoundingBox(0.5, 0.25, 0.5, 1, 0.5, 1)});
+    // If you read this, feel free to suggest a more proper way to detect alse
+    public static final double POSITION_ADJUSTMENT_MARGIN = 0.05;
 
     private final GeyserSession session;
 
@@ -459,5 +461,47 @@ public class CollisionManager {
         if (updateMetadata) {
             session.getPlayerEntity().updateBedrockMetadata();
         }
+    }
+
+    public Vector3f adjustPositionForBedrock(Vector3f position) {
+        // Checks for Bedrock collision differences and adjust the position sent to Bedrock if needed
+        // For example: Java teleports to 72.875 on top of a chest, but Bedrock believes chests are 72.95 high... so we fall through instead
+        // ...which leads the server to teleport again, et voila.
+        BoundingBox playerBox = session.getCollisionManager().getPlayerBoundingBox().clone();
+        playerBox.setMiddleX(position.getX());
+        playerBox.setMiddleY(position.getY() + (playerBox.getSizeY() / 2.0));
+        playerBox.setMiddleZ(position.getZ());
+
+        // Check blocks which we're on top of, according to the Java server
+        BlockPositionIterator iter = CollisionManager.collidableBlocksIterator(session, playerBox);
+        double totalPushUp = 0;
+        while (iter.hasNext()) {
+            int blockId = session.getGeyser().getWorldManager().getBlockAt(session, iter.getX(), iter.getY(), iter.getZ());
+            BlockCollision collision = BlockUtils.getCollision(blockId);
+            if (collision != null) {
+                for (BoundingBox box : collision.getBoundingBoxes()) {
+                    // Check if the player is within the block's X/Z bounds
+                    if (Math.abs((box.getMiddleX() + iter.getX()) - playerBox.getMiddleX()) * 2 < (box.getSizeX() + playerBox.getSizeX()) &&
+                        Math.abs((box.getMiddleZ() + iter.getZ()) - playerBox.getMiddleZ()) * 2 < (box.getSizeZ() + playerBox.getSizeZ())) {
+
+                        double pushUp = collision.pushUpForTeleport();
+                        if (pushUp > 0) {
+                            double blockMaxY = iter.getY() + box.getMiddleY() + (box.getSizeY() / 2.0);
+                            double playerMinY = playerBox.getMiddleY() - (playerBox.getSizeY() / 2.0);
+                            // If the player is on top of or slightly inside the Bedrock collision zone
+                            if (playerMinY >= blockMaxY - POSITION_ADJUSTMENT_MARGIN && playerMinY < blockMaxY + pushUp) {
+                                totalPushUp = Math.max(totalPushUp, blockMaxY + pushUp - playerMinY);
+                            }
+                        }
+                    }
+                }
+            }
+            iter.next();
+        }
+
+        if (totalPushUp > 0) {
+            return Vector3f.from(position.getX(), (float) (position.getY() + totalPushUp), position.getZ());
+        }
+        return position;
     }
 }

--- a/core/src/main/java/org/geysermc/geyser/level/physics/CollisionManager.java
+++ b/core/src/main/java/org/geysermc/geyser/level/physics/CollisionManager.java
@@ -59,8 +59,8 @@ import java.util.Locale;
 public class CollisionManager {
     public static final BlockCollision SOLID_COLLISION = new SolidCollision(null);
     public static final BlockCollision FLUID_COLLISION = new OtherCollision(new BoundingBox[]{new BoundingBox(0.5, 0.25, 0.5, 1, 0.5, 1)});
-    // If you read this, feel free to suggest a more proper way to detect the Bedrock player's own onGround status here
-    public static final double POSITION_ADJUSTMENT_MARGIN = 0.05;
+    // If you read this, feel free to suggest a more proper way to detect the Bedrock player's own onGround status instead of using a margin
+    private static final double POSITION_ADJUSTMENT_MARGIN = 0.05;
 
     private final GeyserSession session;
 

--- a/core/src/main/java/org/geysermc/geyser/session/cache/TeleportCache.java
+++ b/core/src/main/java/org/geysermc/geyser/session/cache/TeleportCache.java
@@ -51,7 +51,7 @@ public class TeleportCache {
 
     public TeleportCache(GeyserSession session, Vector3f position, float pitch, float yaw, int teleportConfirmId) {
         this.position = position;
-        this.adjustedPosition = session.getPlayerEntity().adjustPositionForBedrock(position);
+        this.adjustedPosition = session.getCollisionManager().adjustPositionForBedrock(position);
         this.velocity = Vector3f.ZERO;
         this.pitch = pitch;
         this.yaw = yaw;
@@ -61,7 +61,7 @@ public class TeleportCache {
 
     public TeleportCache(GeyserSession session, Vector3f position, Vector3f velocity, float pitch, float yaw, int teleportConfirmId, TeleportType teleportType) {
         this.position = position;
-        this.adjustedPosition = session.getPlayerEntity().adjustPositionForBedrock(position);
+        this.adjustedPosition = session.getCollisionManager().adjustPositionForBedrock(position);
         this.velocity = velocity;
         this.pitch = pitch;
         this.yaw = yaw;

--- a/core/src/main/java/org/geysermc/geyser/session/cache/TeleportCache.java
+++ b/core/src/main/java/org/geysermc/geyser/session/cache/TeleportCache.java
@@ -26,8 +26,8 @@
 package org.geysermc.geyser.session.cache;
 
 import lombok.Data;
-import lombok.RequiredArgsConstructor;
 import org.cloudburstmc.math.vector.Vector3f;
+import org.geysermc.geyser.session.GeyserSession;
 
 /**
  * Represents a teleport ID and corresponding coordinates that need to be confirmed. <br>
@@ -38,7 +38,6 @@ import org.cloudburstmc.math.vector.Vector3f;
  * Bedrock player actually moves close to that point, so we store the teleport until we get a movement packet from
  * Bedrock that the teleport was successful.
  */
-@RequiredArgsConstructor
 @Data
 public class TeleportCache {
 
@@ -50,8 +49,9 @@ public class TeleportCache {
      */
     private static final int RESEND_THRESHOLD = 20; // Make it one full second with auth input
 
-    public TeleportCache(Vector3f position, float pitch, float yaw, int teleportConfirmId) {
+    public TeleportCache(GeyserSession session, Vector3f position, float pitch, float yaw, int teleportConfirmId) {
         this.position = position;
+        this.adjustedPosition = session.getPlayerEntity().adjustPositionForBedrock(position);
         this.velocity = Vector3f.ZERO;
         this.pitch = pitch;
         this.yaw = yaw;
@@ -59,7 +59,18 @@ public class TeleportCache {
         this.teleportType = TeleportType.NORMAL;
     }
 
+    public TeleportCache(GeyserSession session, Vector3f position, Vector3f velocity, float pitch, float yaw, int teleportConfirmId, TeleportType teleportType) {
+        this.position = position;
+        this.adjustedPosition = session.getPlayerEntity().adjustPositionForBedrock(position);
+        this.velocity = velocity;
+        this.pitch = pitch;
+        this.yaw = yaw;
+        this.teleportConfirmId = teleportConfirmId;
+        this.teleportType = teleportType;
+    }
+
     private final Vector3f position;
+    private final Vector3f adjustedPosition;
     private final Vector3f velocity;
     private final float pitch, yaw;
     private final int teleportConfirmId;
@@ -68,9 +79,9 @@ public class TeleportCache {
     private int unconfirmedFor = 0;
 
     public boolean canConfirm(Vector3f position) {
-        final float distanceX = Math.abs(this.position.getX() - position.getX());
-        final float distanceY = Math.abs(this.position.getY() - position.getY());
-        final float distanceZ = Math.abs(this.position.getZ() - position.getZ());
+        final float distanceX = Math.abs(this.adjustedPosition.getX() - position.getX());
+        final float distanceY = Math.abs(this.adjustedPosition.getY() - position.getY());
+        final float distanceZ = Math.abs(this.adjustedPosition.getZ() - position.getZ());
 
         return distanceX < ERROR_X_AND_Z && distanceY < ERROR_Y && distanceZ < ERROR_X_AND_Z;
     }

--- a/core/src/main/java/org/geysermc/geyser/translator/collision/BlockCollision.java
+++ b/core/src/main/java/org/geysermc/geyser/translator/collision/BlockCollision.java
@@ -27,7 +27,9 @@ package org.geysermc.geyser.translator.collision;
 
 import lombok.EqualsAndHashCode;
 import lombok.Getter;
+import org.cloudburstmc.math.vector.Vector3f;
 import org.cloudburstmc.math.vector.Vector3i;
+import org.geysermc.geyser.entity.type.player.SessionPlayerEntity;
 import org.geysermc.geyser.level.physics.Axis;
 import org.geysermc.geyser.level.physics.BoundingBox;
 import org.geysermc.geyser.level.physics.CollisionManager;
@@ -89,6 +91,14 @@ public class BlockCollision {
     }
 
     protected void correctPosition(GeyserSession session, int x, int y, int z, BoundingBox blockCollision, BoundingBox playerCollision, double ulpX, double ulpZ) {
+    }
+
+    /**
+     * See {@link SessionPlayerEntity#adjustPositionForBedrock(Vector3f)}
+     * @return the distance to push the player up by, if they are on this block on Java, but "in" the block on Bedrock
+     */
+    public double pushUpForTeleport() {
+        return 0;
     }
 
     public boolean checkIntersection(double x, double y, double z, BoundingBox playerCollision) {

--- a/core/src/main/java/org/geysermc/geyser/translator/collision/BlockCollision.java
+++ b/core/src/main/java/org/geysermc/geyser/translator/collision/BlockCollision.java
@@ -29,7 +29,6 @@ import lombok.EqualsAndHashCode;
 import lombok.Getter;
 import org.cloudburstmc.math.vector.Vector3f;
 import org.cloudburstmc.math.vector.Vector3i;
-import org.geysermc.geyser.entity.type.player.SessionPlayerEntity;
 import org.geysermc.geyser.level.physics.Axis;
 import org.geysermc.geyser.level.physics.BoundingBox;
 import org.geysermc.geyser.level.physics.CollisionManager;
@@ -94,7 +93,7 @@ public class BlockCollision {
     }
 
     /**
-     * See {@link SessionPlayerEntity#adjustPositionForBedrock(Vector3f)}
+     * See {@link CollisionManager#adjustPositionForBedrock(Vector3f)}
      * @return the distance to push the player up by, if they are on this block on Java, but "in" the block on Bedrock
      */
     public double pushUpForTeleport() {

--- a/core/src/main/java/org/geysermc/geyser/translator/collision/fixes/ChestCollision.java
+++ b/core/src/main/java/org/geysermc/geyser/translator/collision/fixes/ChestCollision.java
@@ -86,4 +86,9 @@ public class ChestCollision extends BlockCollision {
         previous.translate(0, yVelocity, 0);
         playerCollision.setMiddleY(previous.getMiddleY());
     }
+
+    @Override
+    public double pushUpForTeleport() {
+        return 0.075;
+    }
 }

--- a/core/src/main/java/org/geysermc/geyser/translator/collision/fixes/SeaPickleCollision.java
+++ b/core/src/main/java/org/geysermc/geyser/translator/collision/fixes/SeaPickleCollision.java
@@ -44,7 +44,7 @@ public class SeaPickleCollision extends BlockCollision {
 
     @Override
     protected void correctPosition(GeyserSession session, int x, int y, int z, BoundingBox blockCollision, BoundingBox playerCollision, double ulpX, double ulpZ) {
-        // Sea pickles have no collision on Bedrock but do on Java).
+        // Sea pickles have no collision on Bedrock but do on Java.
         double maxY = blockCollision.getMax(Axis.Y) - y;
         blockCollision.pushOutOfBoundingBox(playerCollision, Direction.UP, maxY + CollisionManager.COLLISION_TOLERANCE * 1.01F);
     }

--- a/core/src/main/java/org/geysermc/geyser/translator/protocol/java/entity/player/JavaPlayerPositionTranslator.java
+++ b/core/src/main/java/org/geysermc/geyser/translator/protocol/java/entity/player/JavaPlayerPositionTranslator.java
@@ -135,7 +135,7 @@ public class JavaPlayerPositionTranslator extends PacketTranslator<ClientboundPl
         TeleportCache.TeleportType type = (deltaMovement.distanceSquared(Vector3f.ZERO) > 1.0E-8F) ?
             TeleportCache.TeleportType.KEEP_VELOCITY : TeleportCache.TeleportType.NORMAL;
 
-        // We need to set the unconfirmed teleport to ensure we use the proper Bedrock position in moveAbsolute (see SessionPlayerEntity#adjustPositionForBedrock)
+        // Set the unconfirmed teleport to ensure we send the adjusted Bedrock position in moveAbsolute (see CollisionManager#adjustPositionForBedrock)
         session.setUnconfirmedTeleport(new TeleportCache(session, teleportDestination, deltaMovement, newPitch, newYaw, teleportId, type));
         entity.moveAbsolute(teleportDestination, newYaw, newPitch, false, true);
 

--- a/core/src/main/java/org/geysermc/geyser/translator/protocol/java/entity/player/JavaPlayerPositionTranslator.java
+++ b/core/src/main/java/org/geysermc/geyser/translator/protocol/java/entity/player/JavaPlayerPositionTranslator.java
@@ -135,14 +135,14 @@ public class JavaPlayerPositionTranslator extends PacketTranslator<ClientboundPl
         TeleportCache.TeleportType type = (deltaMovement.distanceSquared(Vector3f.ZERO) > 1.0E-8F) ?
             TeleportCache.TeleportType.KEEP_VELOCITY : TeleportCache.TeleportType.NORMAL;
 
+        // We need to set the unconfirmed teleport to ensure we use the proper Bedrock position in moveAbsolute (see SessionPlayerEntity#adjustPositionForBedrock)
+        session.setUnconfirmedTeleport(new TeleportCache(session, teleportDestination, deltaMovement, newPitch, newYaw, teleportId, type));
+        entity.moveAbsolute(teleportDestination, newYaw, newPitch, false, true);
+
         // Bedrock ignores teleports that are extremely close to the player's original position and orientation, so check if we need to cache the teleport
         if (lastPlayerPosition.distanceSquared(teleportDestination) < 0.001 && Math.abs(newPitch - lastPlayerPitch) < 5 && Math.abs(newYaw - lastPlayerYaw) < 5) {
             session.setUnconfirmedTeleport(null);
-        } else {
-            session.setUnconfirmedTeleport(new TeleportCache(session, teleportDestination, deltaMovement, newPitch, newYaw, teleportId, type));
         }
-
-        entity.moveAbsolute(teleportDestination, newYaw, newPitch, false, true);
 
         if (type == TeleportCache.TeleportType.KEEP_VELOCITY) {
             entity.setMotion(deltaMovement);

--- a/core/src/main/java/org/geysermc/geyser/translator/protocol/java/entity/player/JavaPlayerPositionTranslator.java
+++ b/core/src/main/java/org/geysermc/geyser/translator/protocol/java/entity/player/JavaPlayerPositionTranslator.java
@@ -93,10 +93,10 @@ public class JavaPlayerPositionTranslator extends PacketTranslator<ClientboundPl
             // Log out and back in - and you're looking elsewhere :)
             entity.updateOwnRotation(entity.getYaw(), entity.getPitch(), entity.getHeadYaw());
             session.setSpawned(true);
-            // DataComponentHashers.testHashing(session); // TODO remove me
 
             // Make sure the player moves away from (0, 32767, 0) before accepting movement packets
-            session.setUnconfirmedTeleport(new TeleportCache(entity.position(), packet.getXRot(), packet.getYRot(), packet.getId()));
+            Vector3f entityPosition = entity.position();
+            session.setUnconfirmedTeleport(new TeleportCache(session, entityPosition, packet.getXRot(), packet.getYRot(), packet.getId()));
 
             if (session.getServerRenderDistance() > 32 && !session.isEmulatePost1_13Logic()) {
                 // See DimensionUtils for an explanation
@@ -107,7 +107,7 @@ public class JavaPlayerPositionTranslator extends PacketTranslator<ClientboundPl
                 session.setLastChunkPosition(null);
             }
 
-            ChunkUtils.updateChunkPosition(session, position.toInt());
+            ChunkUtils.updateChunkPosition(session, entityPosition.toInt());
 
             if (session.getGeyser().config().debugMode()) {
                 session.getGeyser().getLogger().debug("Spawned player at " + packet.getPosition());
@@ -132,26 +132,25 @@ public class JavaPlayerPositionTranslator extends PacketTranslator<ClientboundPl
             deltaMovement = MathUtils.xYRot(deltaMovement, (float) Math.toRadians(lastPlayerPitch - newPitch), (float) Math.toRadians(lastPlayerYaw - newYaw));
         }
 
-        entity.moveAbsolute(teleportDestination, newYaw, newPitch, false, true);
-
-        TeleportCache.TeleportType type = TeleportCache.TeleportType.NORMAL;
-        if (deltaMovement.distanceSquared(Vector3f.ZERO) > 1.0E-8F) {
-            entity.setMotion(deltaMovement);
-
-            // Our motion got reset by the teleport but the deltaMovement is not 0 so send a motion packet to fix that.
-            SetEntityMotionPacket entityMotionPacket = new SetEntityMotionPacket();
-            entityMotionPacket.setRuntimeEntityId(entity.geyserId());
-            entityMotionPacket.setMotion(entity.getMotion());
-            session.sendUpstreamPacket(entityMotionPacket);
-
-            type = TeleportCache.TeleportType.KEEP_VELOCITY;
-        }
+        TeleportCache.TeleportType type = (deltaMovement.distanceSquared(Vector3f.ZERO) > 1.0E-8F) ?
+            TeleportCache.TeleportType.KEEP_VELOCITY : TeleportCache.TeleportType.NORMAL;
 
         // Bedrock ignores teleports that are extremely close to the player's original position and orientation, so check if we need to cache the teleport
         if (lastPlayerPosition.distanceSquared(teleportDestination) < 0.001 && Math.abs(newPitch - lastPlayerPitch) < 5 && Math.abs(newYaw - lastPlayerYaw) < 5) {
             session.setUnconfirmedTeleport(null);
         } else {
-            session.setUnconfirmedTeleport(new TeleportCache(teleportDestination, deltaMovement, newPitch, newYaw, teleportId, type));
+            session.setUnconfirmedTeleport(new TeleportCache(session, teleportDestination, deltaMovement, newPitch, newYaw, teleportId, type));
+        }
+
+        entity.moveAbsolute(teleportDestination, newYaw, newPitch, false, true);
+
+        if (type == TeleportCache.TeleportType.KEEP_VELOCITY) {
+            entity.setMotion(deltaMovement);
+            // Our motion got reset by the teleport but the deltaMovement is not 0 so send a motion packet to fix that.
+            SetEntityMotionPacket entityMotionPacket = new SetEntityMotionPacket();
+            entityMotionPacket.setRuntimeEntityId(entity.geyserId());
+            entityMotionPacket.setMotion(entity.getMotion());
+            session.sendUpstreamPacket(entityMotionPacket);
         }
 
         session.getGeyser().getLogger().debug("to " + entity.position());


### PR DESCRIPTION
We now check if the Bedrock player is standing on any blocks (currently, only chests) that have a different collision size; and then bump the teleport position up. Otherwise, we teleport the player into the chest, which causes the player to "fall through it" - which causes the server to re-send the teleport, causing a loop. Thanks to oxy's ChestCollision impl we'd correct the movement to match Java collisions anyways, so this correction would be only on the Bedrock player's end.

To reproduce it currently: 
- Stand on a chest block (of any kind)
- run `/tp @s @s`
- ...voila!

Note: AI tools were used in the making of the PR, but the final changes are manually reviewed & tested by me and do resolve the issue. Would appreciate a look over GeyserPlayerEntity#adjustPositionForBedrock - maybe there's a cleaner way to do it? 