### PR TITLE
Null-check entity UUID in WaypointCache

### DIFF
--- a/core/src/main/java/org/geysermc/geyser/session/cache/waypoint/WaypointCache.java
+++ b/core/src/main/java/org/geysermc/geyser/session/cache/waypoint/WaypointCache.java
@@ -101,7 +101,7 @@ public final class WaypointCache {
             return;
         }
 
-        GeyserWaypoint waypoint = waypoints.get(uuid().toString());
+        GeyserWaypoint waypoint = waypoints.get(uuid.toString());
         if (waypoint != null) {
             // On 1.26.0 and below:
             // This will remove the player packet previously sent to the client,

--- a/core/src/main/java/org/geysermc/geyser/session/cache/waypoint/WaypointCache.java
+++ b/core/src/main/java/org/geysermc/geyser/session/cache/waypoint/WaypointCache.java
@@ -101,7 +101,7 @@ public final class WaypointCache {
             return;
         }
 
-        GeyserWaypoint waypoint = waypoints.get(entity.uuid().toString());
+        GeyserWaypoint waypoint = waypoints.get(uuid().toString());
         if (waypoint != null) {
             // On 1.26.0 and below:
             // This will remove the player packet previously sent to the client,

--- a/core/src/main/java/org/geysermc/geyser/session/cache/waypoint/WaypointCache.java
+++ b/core/src/main/java/org/geysermc/geyser/session/cache/waypoint/WaypointCache.java
@@ -66,7 +66,12 @@ public final class WaypointCache {
     }
 
     public void addEntity(Entity entity) {
-        GeyserWaypoint waypoint = waypoints.get(entity.uuid().toString());
+        UUID uuid = entity.uuid();
+        if (uuid == null) {
+            return;
+        }
+
+        GeyserWaypoint waypoint = waypoints.get(uuid.toString());
         if (waypoint != null) {
             // On 1.26.0 and below:
             // This will remove the fake player packet previously sent to the client,
@@ -91,6 +96,11 @@ public final class WaypointCache {
     }
 
     public void removeEntity(Entity entity) {
+        UUID uuid = entity.uuid();
+        if (uuid == null) {
+            return;
+        }
+
         GeyserWaypoint waypoint = waypoints.get(entity.uuid().toString());
         if (waypoint != null) {
             // On 1.26.0 and below:


### PR DESCRIPTION
This PR fixes #6417 by adding a null check for the entity UUID in WaypointCache.


