### PR TITLE
Fix NPE when bedrock HAProxy clientAddress is null

### DIFF
--- a/core/src/main/java/org/geysermc/geyser/network/netty/GeyserServer.java
+++ b/core/src/main/java/org/geysermc/geyser/network/netty/GeyserServer.java
@@ -37,6 +37,7 @@ import io.netty.channel.uring.IoUring;
 import io.netty.util.concurrent.DefaultThreadFactory;
 import io.netty.util.concurrent.Future;
 import lombok.Getter;
+import org.checkerframework.checker.nullness.qual.Nullable;
 import org.cloudburstmc.netty.channel.raknet.RakChannelFactory;
 import org.cloudburstmc.netty.channel.raknet.config.DefaultRakServerThrottle;
 import org.cloudburstmc.netty.channel.raknet.config.RakChannelOption;
@@ -234,9 +235,24 @@ public final class GeyserServer {
             .childHandler(serverInitializer);
     }
 
-    public boolean onConnectionRequest(InetSocketAddress inetSocketAddress, InetSocketAddress clientAddress) {
+    public boolean onConnectionRequest(InetSocketAddress inetSocketAddress, @Nullable InetSocketAddress clientAddress) {
+        boolean haproxyEnabled = geyser.config().advanced().bedrock().useHaproxyProtocol();
+
+        if (clientAddress == null) {
+            // getClientAddress returns null when no PROXY header has been cached for this sender:
+            // upstream not emitting a header per UDP datagram, a PROXY v2 LOCAL frame the upstream
+            // library mishandles, or the cached entry expired.
+            if (haproxyEnabled) {
+                geyser.getLogger().warning(
+                    "Rejecting Bedrock connection from " + inetSocketAddress + ": use-haproxy-protocol is enabled but no PROXY header was received. Verify your reverse proxy sends a PROXY v2 header on every UDP datagram."
+                );
+            }
+            connectionAttempts++;
+            return false;
+        }
+
         List<String> allowedProxyIPs = geyser.config().advanced().bedrock().haproxyProtocolWhitelistedIps();
-        if (geyser.config().advanced().bedrock().useHaproxyProtocol() && !allowedProxyIPs.isEmpty()) {
+        if (haproxyEnabled && !allowedProxyIPs.isEmpty()) {
             boolean isWhitelistedIP = false;
             for (CIDRMatcher matcher : getWhitelistedIPsMatchers()) {
                 if (matcher.matches(inetSocketAddress.getAddress())) {
@@ -255,7 +271,7 @@ public final class GeyserServer {
 
         ConnectionRequestEvent requestEvent = new ConnectionRequestEvent(
             clientAddress,
-            geyser.config().advanced().bedrock().useHaproxyProtocol() ? inetSocketAddress : null
+            haproxyEnabled ? inetSocketAddress : null
         );
         geyser.eventBus().fire(requestEvent);
         if (requestEvent.isCancelled()) {

--- a/core/src/main/java/org/geysermc/geyser/network/netty/handler/RakPingHandler.java
+++ b/core/src/main/java/org/geysermc/geyser/network/netty/handler/RakPingHandler.java
@@ -50,6 +50,12 @@ public class RakPingHandler extends SimpleChannelInboundHandler<RakPing> {
 
         InetSocketAddress address = msg.getSender();
         InetSocketAddress clientAddress = ((RakServerChannel) ctx.channel()).getClientAddress(address);
+        if (clientAddress == null) {
+            // Drop silently when no PROXY header was resolved. Responding with the raw sender (the
+            // proxy's IP) would leak that address to ping passthrough. GeyserServer#onConnectionRequest
+            // surfaces the misconfiguration via a warning when a client actually tries to connect.
+            return;
+        }
         RakPong pong = msg.reply(guid, this.server.onQuery(ctx.channel(), clientAddress).toByteBuf());
         ctx.writeAndFlush(pong);
     }


### PR DESCRIPTION
After #6390 moved HAProxy handling into cloudburst-netty, RakServerChannel#getClientAddress can return null when no PROXY header has been cached for a sender. This happens on the first packet from a new sender, an expired session-cache entry, a malformed header, or a PROXY v2 LOCAL frame (which the upstream RakProxyServerHandler currently mishandles by passing null source addresses into InetSocketAddress).

Geyser passed that null straight through to onConnectionRequest, where clientAddress.toString() threw NullPointerException and the connection was dropped with a noisy stack trace, leaving operators without a useful diagnostic.

This change:
- Adds an early null check in onConnectionRequest that rejects the connection cleanly and logs a WARN per occurrence when use-haproxy-protocol is enabled, pointing operators at the most likely upstream-proxy misconfiguration. RakNet's existing per-IP and global packet rate limiting (RAK_PACKET_LIMIT, DefaultRakServerThrottle) caps the realistic log rate.
- Drops pings silently in RakPingHandler when no client address is resolved, so the server visibly appears offline instead of leaking the proxy's address to ping passthrough.