### PR TITLE
Indicate recent Minecraft version support in Geyser

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,8 +18,8 @@ Special thanks to the DragonProxy project for being a trailblazer in protocol tr
 
 | Edition | Supported Versions                                                                                   |
 |---------|------------------------------------------------------------------------------------------------------|
-| Bedrock | 1.21.130 - 1.21.132, 26.0, 26.1, 26.2, 26.3, 26.10, 26.20                                            |
-| Java    | 26.1 (For older versions, [see this guide](https://geysermc.org/wiki/geyser/supported-versions/)) |
+| Bedrock | 1.21.130 - 1.21.132, 26.0, 26.1, 26.2, 26.3, 26.10, 26.20, 26.21, 26.22, 26.23                       |
+| Java    | 26.1 - 26.1.2 (For older versions, [see this guide](https://geysermc.org/wiki/geyser/supported-versions/)) |
 
 ## Setting Up
 Take a look [here](https://geysermc.org/wiki/geyser/setup/) for how to set up Geyser.

--- a/core/src/main/java/org/geysermc/geyser/network/GameProtocol.java
+++ b/core/src/main/java/org/geysermc/geyser/network/GameProtocol.java
@@ -151,7 +151,7 @@ public final class GameProtocol {
      * @return the supported Minecraft: Java Edition version names
      */
     public static List<String> getJavaVersions() {
-        return List.of(DEFAULT_JAVA_CODEC.getMinecraftVersion());
+        return List.of(DEFAULT_JAVA_CODEC.getMinecraftVersion(), "26.1.1", "26.1.2");
     }
 
     /**

--- a/core/src/main/java/org/geysermc/geyser/network/GameProtocol.java
+++ b/core/src/main/java/org/geysermc/geyser/network/GameProtocol.java
@@ -85,7 +85,7 @@ public final class GameProtocol {
         register(Bedrock_v898.CODEC, "1.21.130", "1.21.131", "1.21.132");
         register(Bedrock_v924.CODEC, "26.0", "26.1", "26.2", "26.3");
         register(Bedrock_v944.CODEC, "26.10");
-        register(Bedrock_v975.CODEC, "26.20");
+        register(Bedrock_v975.CODEC, "26.20", "26.21", "26.22", "26.23");
 
         MinecraftVersion latestBedrock = SUPPORTED_BEDROCK_VERSIONS.getLast();
         DEFAULT_BEDROCK_VERSION = latestBedrock.versionString();


### PR DESCRIPTION
This pull request updates the GameProtocol file to include Minecraft: Bedrock Edition 26.21, 26.22, and 26.23.