### PR TITLE
Fix javaY precision

### DIFF
--- a/core/src/main/java/org/geysermc/geyser/entity/EntityDefinitions.java
+++ b/core/src/main/java/org/geysermc/geyser/entity/EntityDefinitions.java
@@ -692,7 +692,7 @@ public final class EntityDefinitions {
 
         EntityDefinition<AvatarEntity> avatarEntityBase = EntityDefinition.<AvatarEntity>inherited(null, livingEntityBase)
             .height(1.8f).width(0.6f)
-            .offset(1.62f)
+            .offset(1.62001f)
             .addTranslator(null) // Player main hand
             .addTranslator(MetadataTypes.BYTE, AvatarEntity::setSkinVisibility)
             .build();

--- a/core/src/main/java/org/geysermc/geyser/entity/EntityDefinitions.java
+++ b/core/src/main/java/org/geysermc/geyser/entity/EntityDefinitions.java
@@ -692,6 +692,7 @@ public final class EntityDefinitions {
 
         EntityDefinition<AvatarEntity> avatarEntityBase = EntityDefinition.<AvatarEntity>inherited(null, livingEntityBase)
             .height(1.8f).width(0.6f)
+            // This is the offset sent by Bedrock in its player position. Verified on Bedrock 26.23.
             .offset(1.62001f)
             .addTranslator(null) // Player main hand
             .addTranslator(MetadataTypes.BYTE, AvatarEntity::setSkinVisibility)

--- a/core/src/main/java/org/geysermc/geyser/level/physics/CollisionManager.java
+++ b/core/src/main/java/org/geysermc/geyser/level/physics/CollisionManager.java
@@ -159,6 +159,8 @@ public class CollisionManager {
         return playerBoundingBox;
     }
 
+    private static final double PLAYER_OFFSET = Double.parseDouble(Float.toString(EntityDefinitions.PLAYER.offset()));
+
     /**
      * Adjust the Bedrock position before sending to the Java server to account for inaccuracies in movement between
      * the two versions. Will also send corrected movement packets back to Bedrock if they collide with pistons.
@@ -174,9 +176,11 @@ public class CollisionManager {
         if (pistonCache.isPlayerAttachedToHoney()) {
             return null;
         }
+
         // We need to parse the float as a string since casting a float to a double causes us to
         // lose precision and thus, causes players to get stuck when walking near walls
-        double javaY = Double.parseDouble(Float.toString(bedrockPosition.getY())) - EntityDefinitions.PLAYER.offset();
+        double rawY = Double.parseDouble(Float.toString(bedrockPosition.getY()));
+        double javaY = rawY - PLAYER_OFFSET;
 
         Vector3d position = Vector3d.from(Double.parseDouble(Float.toString(bedrockPosition.getX())), javaY, Double.parseDouble(Float.toString(bedrockPosition.getZ())));
 

--- a/core/src/main/java/org/geysermc/geyser/level/physics/CollisionManager.java
+++ b/core/src/main/java/org/geysermc/geyser/level/physics/CollisionManager.java
@@ -61,6 +61,7 @@ public class CollisionManager {
     public static final BlockCollision FLUID_COLLISION = new OtherCollision(new BoundingBox[]{new BoundingBox(0.5, 0.25, 0.5, 1, 0.5, 1)});
     // If you read this, feel free to suggest a more proper way to detect the Bedrock player's own onGround status instead of using a margin
     private static final double POSITION_ADJUSTMENT_MARGIN = 0.05;
+    private static final double PLAYER_OFFSET = Double.parseDouble(Float.toString(EntityDefinitions.PLAYER.offset()));
 
     private final GeyserSession session;
 
@@ -159,8 +160,6 @@ public class CollisionManager {
         return playerBoundingBox;
     }
 
-    private static final double PLAYER_OFFSET = Double.parseDouble(Float.toString(EntityDefinitions.PLAYER.offset()));
-
     /**
      * Adjust the Bedrock position before sending to the Java server to account for inaccuracies in movement between
      * the two versions. Will also send corrected movement packets back to Bedrock if they collide with pistons.
@@ -179,8 +178,7 @@ public class CollisionManager {
 
         // We need to parse the float as a string since casting a float to a double causes us to
         // lose precision and thus, causes players to get stuck when walking near walls
-        double rawY = Double.parseDouble(Float.toString(bedrockPosition.getY()));
-        double javaY = rawY - PLAYER_OFFSET;
+        double javaY = Double.parseDouble(Float.toString(bedrockPosition.getY())) - PLAYER_OFFSET;
 
         Vector3d position = Vector3d.from(Double.parseDouble(Float.toString(bedrockPosition.getX())), javaY, Double.parseDouble(Float.toString(bedrockPosition.getZ())));
 


### PR DESCRIPTION
The previous solution caused coordinates like `70.9999999816513`. With this change, coordinates are now correctly `71.0` and the previous y=2 bug remains fixed.

Also reverts a change that made player offsets `1.62f` instead of `1.62001f`. The bedrock player still sends an offset of `1.62001f` which can be shown by printing the packet position they send.