### PR TITLE
Fix network handler order

### DIFF
--- a/core/src/main/java/org/geysermc/geyser/network/netty/GeyserServer.java
+++ b/core/src/main/java/org/geysermc/geyser/network/netty/GeyserServer.java
@@ -153,9 +153,9 @@ public final class GeyserServer {
             }
 
             Channel channel = f.channel();
-            // Add our ping handler
+            // Add our handlers
             channel.pipeline()
-                .addFirst(RakConnectionRequestHandler.NAME, new RakConnectionRequestHandler(this))
+                .addBefore(RakServerOfflineHandler.NAME, RakConnectionRequestHandler.NAME, new RakConnectionRequestHandler(this))
                 .addAfter(RakServerOfflineHandler.NAME, RakPingHandler.NAME, new RakPingHandler(this));
         });
     }


### PR DESCRIPTION
Moves the RakConnectionRequestHandler directly in front of the RakServerOfflineHandler, and this way after the proxy protocol handler and connection throttler.