### PR TITLE
Escape percent signs where necessary

### DIFF
--- a/core/src/main/java/org/geysermc/geyser/scoreboard/Objective.java
+++ b/core/src/main/java/org/geysermc/geyser/scoreboard/Objective.java
@@ -83,7 +83,7 @@ public final class Objective {
     }
 
     public void updateProperties(Component displayNameComponent, ScoreType type, NumberFormat format) {
-        String displayName = MessageTranslator.convertMessageRaw(displayNameComponent, scoreboard.session().locale());
+        String displayName = MessageTranslator.convertMessageRaw(displayNameComponent, scoreboard.session().locale()).replace("%", "%%");
         boolean changed = !Objects.equals(this.displayName, displayName) || this.type != type;
 
         this.displayName = displayName;

--- a/core/src/main/java/org/geysermc/geyser/session/cache/BossBar.java
+++ b/core/src/main/java/org/geysermc/geyser/session/cache/BossBar.java
@@ -59,7 +59,7 @@ public class BossBar {
         BossEventPacket bossEventPacket = new BossEventPacket();
         bossEventPacket.setBossUniqueEntityId(entityId);
         bossEventPacket.setAction(BossEventPacket.Action.CREATE);
-        bossEventPacket.setTitle(MessageTranslator.convertMessage(title, session.locale()));
+        bossEventPacket.setTitle(MessageTranslator.convertMessage(title, session.locale()).replace("%", "%%%%"));
         bossEventPacket.setHealthPercentage(health);
         bossEventPacket.setColor(color);
         bossEventPacket.setOverlay(overlay);
@@ -73,7 +73,7 @@ public class BossBar {
         BossEventPacket bossEventPacket = new BossEventPacket();
         bossEventPacket.setBossUniqueEntityId(entityId);
         bossEventPacket.setAction(BossEventPacket.Action.UPDATE_NAME);
-        bossEventPacket.setTitle(MessageTranslator.convertMessage(title, session.locale()));
+        bossEventPacket.setTitle(MessageTranslator.convertMessage(title, session.locale()).replace("%", "%%%%"));
 
         session.sendUpstreamPacket(bossEventPacket);
     }

--- a/core/src/main/java/org/geysermc/geyser/translator/protocol/java/entity/player/JavaPlayerCombatKillTranslator.java
+++ b/core/src/main/java/org/geysermc/geyser/translator/protocol/java/entity/player/JavaPlayerCombatKillTranslator.java
@@ -42,7 +42,7 @@ public class JavaPlayerCombatKillTranslator extends PacketTranslator<Clientbound
             Component deathMessage = packet.getMessage();
             // TODO - could inject score in, but as of 1.19.10 newlines don't center and start at the left of the first text
             DeathInfoPacket deathInfoPacket = new DeathInfoPacket();
-            deathInfoPacket.setCauseAttackName(MessageTranslator.convertMessage(deathMessage, session.locale()));
+            deathInfoPacket.setCauseAttackName(MessageTranslator.convertMessage(deathMessage, session.locale()).replace("%", "%%"));
             session.sendUpstreamPacket(deathInfoPacket);
         }
     }


### PR DESCRIPTION
Percent signs are used for translatables in Bedrock at some places, which we don't need