### PR TITLE
Automate the Minecraft version in the Fabric and NeoForge mod metadata

### DIFF
--- a/bootstrap/mod/fabric/src/main/resources/fabric.mod.json
+++ b/bootstrap/mod/fabric/src/main/resources/fabric.mod.json
@@ -25,6 +25,6 @@
   "depends": {
     "fabricloader": ">=0.19.3",
     "fabric-api": "*",
-    "minecraft": "~26.2"
+    "minecraft": "~${minecraft}"
   }
 }

--- a/bootstrap/mod/gametest/build.gradle.kts
+++ b/bootstrap/mod/gametest/build.gradle.kts
@@ -49,18 +49,4 @@ tasks {
     withType(PublishToMavenRepository::class).configureEach {
         enabled = false
     }
-
-    // it'd be processGametestResources if we had a separate source set for tests
-    getByName("processResources", ProcessResources::class) {
-        filesMatching("fabric.mod.json") {
-            expand(
-                "id" to "geyser",
-                "name" to "Geyser",
-                "version" to project.version,
-                "description" to project.description!!,
-                "url" to "https://geysermc.org",
-                "author" to "GeyserMC"
-            )
-        }
-    }
 }

--- a/bootstrap/mod/gametest/src/main/resources/fabric.mod.json
+++ b/bootstrap/mod/gametest/src/main/resources/fabric.mod.json
@@ -29,6 +29,6 @@
   "depends": {
     "fabricloader": ">=0.19.3",
     "fabric-api": "*",
-    "minecraft": "~26.2"
+    "minecraft": "~${minecraft}"
   }
 }

--- a/bootstrap/mod/neoforge/src/main/resources/META-INF/neoforge.mods.toml
+++ b/bootstrap/mod/neoforge/src/main/resources/META-INF/neoforge.mods.toml
@@ -22,6 +22,6 @@ config = "geyser_neoforge.mixins.json"
 [[dependencies.geyser_neoforge]]
     modId="minecraft"
     type="required"
-    versionRange="[26.2,26.3)"
+    versionRange="[${minecraft},${minecraftNext})"
     ordering="NONE"
     side="BOTH"

--- a/build-logic/src/main/kotlin/geyser.platform-conventions.gradle.kts
+++ b/build-logic/src/main/kotlin/geyser.platform-conventions.gradle.kts
@@ -3,6 +3,13 @@ plugins {
     id("io.freefair.lombok")
 }
 
+// Major.minor + the next minor, for the mod metadata version ranges.
+// Strips any patch/pre-release suffix (26.2.1 / 26.2-rc-2 -> 26.2).
+val minecraftVersion = libs.minecraft.get().version as String
+val minecraftLine = Regex("^\\d+\\.\\d+").find(minecraftVersion)?.value ?: minecraftVersion
+val (minecraftMajor, minecraftMinor) = minecraftLine.split(".")
+val minecraftNext = "$minecraftMajor.${minecraftMinor.toInt() + 1}"
+
 tasks {
     processResources {
         // Spigot, BungeeCord, Velocity, Fabric, ViaProxy, NeoForge
@@ -17,7 +24,9 @@ tasks {
                 ),
                 "description" to project.description as String,
                 "url" to "https://geysermc.org",
-                "author" to "GeyserMC"
+                "author" to "GeyserMC",
+                "minecraft" to minecraftLine,
+                "minecraftNext" to minecraftNext
             )
         }
     }


### PR DESCRIPTION
The supported Minecraft version was previously hardcoded in the Fabric, NeoForge, and gametest mod metadata. This change derives the current major.minor version and the next minor version from the shared version catalog during processResources, and uses those values to populate the metadata templates automatically.