### PR TITLE
Don't send swing packets to the server while in spectator mode

### DIFF
--- a/core/src/main/java/org/geysermc/geyser/translator/protocol/bedrock/BedrockAnimateTranslator.java
+++ b/core/src/main/java/org/geysermc/geyser/translator/protocol/bedrock/BedrockAnimateTranslator.java
@@ -29,6 +29,7 @@ import org.cloudburstmc.protocol.bedrock.packet.AnimatePacket;
 import org.geysermc.geyser.session.GeyserSession;
 import org.geysermc.geyser.translator.protocol.PacketTranslator;
 import org.geysermc.geyser.translator.protocol.Translator;
+import org.geysermc.mcprotocollib.protocol.data.game.entity.player.GameMode;
 import org.geysermc.mcprotocollib.protocol.data.game.entity.player.Hand;
 import org.geysermc.mcprotocollib.protocol.packet.ingame.serverbound.player.ServerboundSwingPacket;
 
@@ -60,7 +61,7 @@ public class BedrockAnimateTranslator extends PacketTranslator<AnimatePacket> {
 
             // We also send this right after entity attack to ensure packet order.
             session.scheduleInEventLoop(() -> {
-                    if (session.getArmAnimationTicks() != 0 && (session.getTicks() - session.getLastAirHitTick() > 2)) {
+                    if (session.getArmAnimationTicks() != 0 && (session.getTicks() - session.getLastAirHitTick() > 2) && session.getGameMode() != GameMode.SPECTATOR) {
                         // So, generally, a Java player can only do one *thing* at a time.
                         // If a player right-clicks, for example, then there's probably only one action associated with
                         // that right-click that will send a swing.

--- a/core/src/main/java/org/geysermc/geyser/translator/protocol/bedrock/entity/player/input/BedrockPlayerAuthInputTranslator.java
+++ b/core/src/main/java/org/geysermc/geyser/translator/protocol/bedrock/entity/player/input/BedrockPlayerAuthInputTranslator.java
@@ -170,7 +170,7 @@ public final class BedrockPlayerAuthInputTranslator extends PacketTranslator<Pla
                 case MISSED_SWING -> {
                     session.setLastAirHitTick(session.getTicks());
 
-                    if (session.getArmAnimationTicks() != 0 && session.getArmAnimationTicks() != 1) {
+                    if (session.getArmAnimationTicks() != 0 && session.getArmAnimationTicks() != 1 && session.getGameMode() != GameMode.SPECTATOR) {
                         session.sendDownstreamGamePacket(new ServerboundSwingPacket(Hand.MAIN_HAND));
                         session.activateArmAnimationTicking();
                     }


### PR DESCRIPTION
Matches 26.2 (MC-307272): a spectator's left-clicks are no longer sent to the server.
Tested on vanilla 26.2 with a Bedrock client: 0 swings were sent across 67 spectator clicks. Normal swings remain unaffected in other gamemodes.
