### PR TITLE
Fix: don't spam sneaking when dismount vehicle.

### DIFF
--- a/core/src/main/java/org/geysermc/geyser/session/cache/InputCache.java
+++ b/core/src/main/java/org/geysermc/geyser/session/cache/InputCache.java
@@ -145,6 +145,8 @@ public final class InputCache {
         if (oldInputPacket != this.inputPacket) { // Simple equality check is fine since we're checking for an instance change.
             session.sendDownstreamGamePacket(this.inputPacket);
         }
+
+        session.setShouldSendSneak(false);
     }
 
     public boolean wasJumping() {

--- a/core/src/main/java/org/geysermc/geyser/translator/protocol/java/entity/JavaSetPassengersTranslator.java
+++ b/core/src/main/java/org/geysermc/geyser/translator/protocol/java/entity/JavaSetPassengersTranslator.java
@@ -112,6 +112,7 @@ public class JavaSetPassengersTranslator extends PacketTranslator<ClientboundSet
                         // Note that this isn't present in JavaSetPassengersTranslator as that code is not called for players
                         // as of Java 1.19.3, but the scheduled future checks for the vehicle being null anyway.
                         session.getMountVehicleScheduledFuture().cancel(false);
+                        session.setShouldSendSneak(false);
                     }
 
                     // Reset steering to avoid session#isHandsBusy from triggering


### PR DESCRIPTION
Should resolve #6425, also for cases where the server preventing dismounting by re-mounting the player.