### PR TITLE
Include common default clocks for vanilla dimensions, which are not sent by ViaVersion

### DIFF
--- a/core/src/main/java/org/geysermc/geyser/level/JavaDimension.java
+++ b/core/src/main/java/org/geysermc/geyser/level/JavaDimension.java
@@ -91,7 +91,6 @@ public record JavaDimension(int minY, int height, boolean piglinSafe, boolean ul
         }
         if (defaultClock == null) {
             defaultClock = COMMON_CLOCKS.get(entry.id());
-            System.out.println("falling back to " + defaultClock);
         }
 
         if (minY % 16 != 0) {

--- a/core/src/main/java/org/geysermc/geyser/level/JavaDimension.java
+++ b/core/src/main/java/org/geysermc/geyser/level/JavaDimension.java
@@ -33,6 +33,8 @@ import org.geysermc.geyser.session.cache.registry.RegistryEntryContext;
 import org.geysermc.geyser.util.DimensionUtils;
 import org.geysermc.geyser.util.MinecraftKey;
 
+import java.util.Map;
+
 /**
  * Represents the information we store from the current Java dimension
  * @param piglinSafe Whether piglins and hoglins are safe from conversion in this dimension.
@@ -44,6 +46,10 @@ import org.geysermc.geyser.util.MinecraftKey;
  * is logged in before utilizing this field.
  */
 public record JavaDimension(int minY, int height, boolean piglinSafe, boolean ultrawarm, int bedrockId, boolean isNetherLike, @Nullable Key defaultClock) {
+    private static final Map<Key, Key> COMMON_CLOCKS = Map.of(
+        MinecraftKey.key("overworld"), MinecraftKey.key("overworld"),
+        MinecraftKey.key("the_end"), MinecraftKey.key("the_end")
+    );
 
     public static JavaDimension read(RegistryEntryContext entry) {
         NbtMap dimension = entry.data();
@@ -82,6 +88,10 @@ public record JavaDimension(int minY, int height, boolean piglinSafe, boolean ul
             defaultClock = MinecraftKey.nullableKey(dimension.getString("default_clock", null));
         } catch (InvalidKeyException exception) {
             defaultClock = null;
+        }
+        if (defaultClock == null) {
+            defaultClock = COMMON_CLOCKS.get(entry.id());
+            System.out.println("falling back to " + defaultClock);
         }
 
         if (minY % 16 != 0) {


### PR DESCRIPTION
This PR adds a map of common default clocks for vanilla dimensions, to be used as fallback when no default clock is sent by the server (or more commonly, ViaVersion). This should resolve some time issues occurring with the latest release of ViaVersion, which started happening because ViaVersion started sending more than one world clock (`overworld` and `the_end`), which caused Geyser's fallback system in `JavaSetTimeTranslator` (which is to check if there is only one clock registered, and if so, always use that) to fail.