### PR TITLE
Fix Java player skins not rendering on Bedrock when texture signature is absent

### DIFF
--- a/core/src/main/java/org/geysermc/geyser/entity/type/player/PlayerEntity.java
+++ b/core/src/main/java/org/geysermc/geyser/entity/type/player/PlayerEntity.java
@@ -78,7 +78,7 @@ public class PlayerEntity extends AvatarEntity implements GeyserPlayerEntity {
         super(context, profile.getName());
         this.customNameVisible = true;
         try {
-            this.textures = profile.getTextures(true);
+            this.textures = profile.getTextures(false);
         } catch (Exception e) {
             GeyserImpl.getInstance().getLogger().debug("Error loading textures for player!" + profile, e);
             this.textures = null;


### PR DESCRIPTION
### Problem

`PlayerEntity`'s `GameProfile` constructor calls `profile.getTextures(true)`, which requires a valid texture signature. Every other texture call site uses `false`:

- `skin/SkinManager.java` → `profile.getTextures(false)`
- `entity/type/player/AvatarEntity.java` → `profile.getTextures(false)`

When a player's `textures` property has no signature (`signature=null`), `getTextures(true)` throws, the `catch` sets `textures = null`, and that player renders as the default (Steve) skin for Bedrock viewers.

This reproduces consistently on Minecraft Java 26.2 (tested via the #6452 preview build): Java players' profiles arrive with the texture value present but `signature=null`, so all Java players show as default skins to Bedrock players.

Debug log:

```
Error loading textures for player! GameProfile{name=..., properties=[Property{name=textures, value=<valid skin+cape>, signature=null}]}
```

### Fix

Use `profile.getTextures(false)` in `PlayerEntity`, matching the other call sites. The skin/cape URLs are still present and usable without signature verification.

### Testing

Built and ran on a Paper 26.2 server with Geyser + Floodgate. Java players' skins and capes now render correctly for Bedrock players.
