### PR TITLE
Attempt to lower scoreboard allocs

### DIFF
--- a/core/build.gradle.kts
+++ b/core/build.gradle.kts
@@ -92,6 +92,8 @@ dependencies {
     api(libs.events)
 
     api(libs.bstats)
+
+    implementation(libs.jol)
 }
 
 abstract class CommitMessageValueSource : RepositoryValueSource.Parameterless<String>() {

--- a/core/src/main/java/org/geysermc/geyser/debug/ScoreboardPacketType.java
+++ b/core/src/main/java/org/geysermc/geyser/debug/ScoreboardPacketType.java
@@ -1,0 +1,42 @@
+/*
+ * Copyright (c) 2026 GeyserMC. http://geysermc.org
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ *
+ * @author GeyserMC
+ * @link https://github.com/GeyserMC/Geyser
+ */
+
+package org.geysermc.geyser.debug;
+
+public enum ScoreboardPacketType {
+    SCORE_RESET,
+    OBJECTIVE_DISPLAY,
+    OBJECTIVE_CRU,
+    OBJECTIVE_DEL,
+    TEAM_CREATE,
+    TEAM_UPDATE,
+    TEAM_PLAYER_ADD,
+    TEAM_PLAYER_REMOVE,
+    TEAM_REMOVE,
+    SCORE_ADD,
+    SCORE_UPDATE;
+
+    public static final int length = values().length;
+}

--- a/core/src/main/java/org/geysermc/geyser/debug/StatsCollector.java
+++ b/core/src/main/java/org/geysermc/geyser/debug/StatsCollector.java
@@ -43,6 +43,8 @@ import org.geysermc.geyser.session.GeyserSession;
 import org.openjdk.jol.info.GraphLayout;
 
 public class StatsCollector {
+    private static final boolean ENABLED = System.getenv("STATS_COLLECTOR_ENABLED") != null;
+
     private static final Queue<String> allocationLinesToWrite = new ConcurrentLinkedQueue<>();
     private static volatile long allocationLastSafeNanos = System.nanoTime();
 
@@ -54,6 +56,10 @@ public class StatsCollector {
     private static final AtomicLongArray packetCounts = new AtomicLongArray(ScoreboardPacketType.length);
 
     public static void addAllocStats(Component component, String string) {
+        if (!ENABLED) {
+            return;
+        }
+
         final long componentSize = GraphLayout.parseInstance(component).totalSize();
         final long stringSize = GraphLayout.parseInstance(string).totalSize();
 
@@ -88,56 +94,63 @@ public class StatsCollector {
     }
 
     public static void addPacketCount(ScoreboardPacketType packetType) {
+        if (!ENABLED) {
+            return;
+        }
+
         packetCounts.incrementAndGet(packetType.ordinal());
     }
 
     static {
-        GeyserImpl instance = GeyserImpl.getInstance();
-        GeyserLogger logger = instance.getLogger();
+        if (ENABLED) {
+            GeyserImpl instance = GeyserImpl.getInstance();
+            GeyserLogger logger = instance.getLogger();
 
-        long ctm = System.currentTimeMillis();
-        Path allocationStatsPath = instance.configDirectory().resolve("memdiff-alloc-stats-" + ctm + ".txt");
-        logger.info("Writing allocation stats to " + allocationStatsPath);
-        Path scoreStatsPath = instance.configDirectory().resolve("score-stats-" + ctm + ".txt");
-        logger.info("Writing score stats to " + scoreStatsPath);
-        Path packetStatsPath = instance.configDirectory().resolve("packet-stats-" + ctm + ".txt");
-        logger.info("Writing packet stats to " + packetStatsPath);
-
-        try {
-            // Just to be sure, attempt to write to it to see if we have perms. Otherwise, the while loop will just fail indefinitely
-            Files.writeString(allocationStatsPath, "", StandardOpenOption.CREATE);
-            Files.writeString(scoreStatsPath, "", StandardOpenOption.CREATE);
-            Files.writeString(packetStatsPath, "", StandardOpenOption.CREATE);
-        } catch (IOException e) {
-            logger.error("Failed to ensure that the stats files were created!", e);
-            throw new RuntimeException(e);
-        }
-
-        Runtime.getRuntime().addShutdownHook(new Thread(() -> {
-            // Write remaining available stats immediately
-
-            String remainingStats;
-            synchronized (lock) {
-                double percentage = 100.0D - (double) totalStringSize / totalComponentSize * 100.0;
-                remainingStats = String.format("%-15s %-10s %-20s %-20s %-20s %-5.2f (shutdown)%n", System.currentTimeMillis(), count, totalComponentSize, totalStringSize, totalComponentSize - totalStringSize, percentage);
-                allocationLinesToWrite.add(remainingStats);
-            }
+            long ctm = System.currentTimeMillis();
+            Path allocationStatsPath = instance.configDirectory().resolve("memdiff-alloc-stats-" + ctm + ".txt");
+            logger.info("Writing allocation stats to " + allocationStatsPath);
+            Path scoreStatsPath = instance.configDirectory().resolve("score-stats-" + ctm + ".txt");
+            logger.info("Writing score stats to " + scoreStatsPath);
+            Path packetStatsPath = instance.configDirectory().resolve("packet-stats-" + ctm + ".txt");
+            logger.info("Writing packet stats to " + packetStatsPath);
 
             try {
-                writeToDisk(instance, allocationStatsPath, scoreStatsPath, packetStatsPath);
+                // Just to be sure, attempt to write to it to see if we have perms. Otherwise, the while loop will just fail indefinitely
+                Files.writeString(allocationStatsPath, "", StandardOpenOption.CREATE);
+                Files.writeString(scoreStatsPath, "", StandardOpenOption.CREATE);
+                Files.writeString(packetStatsPath, "", StandardOpenOption.CREATE);
             } catch (IOException e) {
+                logger.error("Failed to ensure that the stats files were created!", e);
                 throw new RuntimeException(e);
             }
-        }));
 
-        new Thread(() -> {
-            while (!instance.isShuttingDown()) {
+            Runtime.getRuntime().addShutdownHook(new Thread(() -> {
+                // Write remaining available stats immediately
+
+                String remainingStats;
+                synchronized (lock) {
+                    double percentage = 100.0D - (double) totalStringSize / totalComponentSize * 100.0;
+                    remainingStats = String.format("%-15s %-10s %-20s %-20s %-20s %-5.2f (shutdown)%n", System.currentTimeMillis(), count, totalComponentSize, totalStringSize, totalComponentSize - totalStringSize, percentage);
+                    allocationLinesToWrite.add(remainingStats);
+                }
+
                 try {
-                    Thread.sleep(60_000);
                     writeToDisk(instance, allocationStatsPath, scoreStatsPath, packetStatsPath);
-                } catch (Throwable ignored) {}
-            }
-        }, "Geyser - DebugStatsWriter").start();
+                } catch (IOException e) {
+                    throw new RuntimeException(e);
+                }
+            }));
+
+            new Thread(() -> {
+                while (!instance.isShuttingDown()) {
+                    try {
+                        Thread.sleep(60_000);
+                        writeToDisk(instance, allocationStatsPath, scoreStatsPath, packetStatsPath);
+                    } catch (Throwable ignored) {
+                    }
+                }
+            }, "Geyser - DebugStatsWriter").start();
+        }
     }
 
     private static void writeToDisk(GeyserImpl impl, Path allocationStatsPath, Path scoreStatsPath, Path packetStatsPath) throws IOException {

--- a/core/src/main/java/org/geysermc/geyser/debug/StatsCollector.java
+++ b/core/src/main/java/org/geysermc/geyser/debug/StatsCollector.java
@@ -64,10 +64,10 @@ public class StatsCollector {
                 double percentage = 100.0D - (double) totalStringSize / totalComponentSize * 100.0;
                 allocationLinesToWrite.add(String.format("%-15s %-10s %-20s %-20s %-20s %-5.2f (overflow)%n", System.currentTimeMillis(), count, totalComponentSize, totalStringSize, totalComponentSize - totalStringSize, percentage));
 
+                allocationLastSafeNanos = System.nanoTime();
                 count = 0;
                 totalComponentSize = 0;
                 totalStringSize = 0;
-                allocationLastSafeNanos = System.nanoTime();
             }
 
             count += 1;
@@ -78,6 +78,11 @@ public class StatsCollector {
             if (now - allocationLastSafeNanos > 180_000_000_000L) { // Every 30m
                 double percentage = 100.0D - (double) totalStringSize / totalComponentSize * 100.0;
                 allocationLinesToWrite.add(String.format("%-15s %-10s %-20s %-20s %-20s %.2f%n", System.currentTimeMillis(), count, totalComponentSize, totalStringSize, totalComponentSize - totalStringSize, percentage));
+
+                allocationLastSafeNanos = now;
+                count = 0;
+                totalComponentSize = 0;
+                totalStringSize = 0;
             }
         }
     }

--- a/core/src/main/java/org/geysermc/geyser/debug/StatsCollector.java
+++ b/core/src/main/java/org/geysermc/geyser/debug/StatsCollector.java
@@ -1,0 +1,193 @@
+/*
+ * Copyright (c) 2026 GeyserMC. http://geysermc.org
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ *
+ * @author GeyserMC
+ * @link https://github.com/GeyserMC/Geyser
+ */
+
+package org.geysermc.geyser.debug;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.StandardOpenOption;
+import java.util.ArrayList;
+import java.util.Queue;
+import java.util.concurrent.ConcurrentLinkedQueue;
+import java.util.concurrent.atomic.AtomicLongArray;
+import net.kyori.adventure.text.Component;
+import org.geysermc.geyser.GeyserImpl;
+import org.geysermc.geyser.GeyserLogger;
+import org.geysermc.geyser.scoreboard.Objective;
+import org.geysermc.geyser.scoreboard.Scoreboard;
+import org.geysermc.geyser.scoreboard.display.slot.DisplaySlot;
+import org.geysermc.geyser.session.GeyserSession;
+import org.openjdk.jol.info.GraphLayout;
+
+public class StatsCollector {
+    private static final Queue<String> allocationLinesToWrite = new ConcurrentLinkedQueue<>();
+    private static volatile long allocationLastSafeNanos = System.nanoTime();
+
+    private static volatile long count;
+    private static volatile long totalComponentSize;
+    private static volatile long totalStringSize;
+    private static final Object lock = new Object();
+
+    private static final AtomicLongArray packetCounts = new AtomicLongArray(ScoreboardPacketType.length);
+
+    public static void addAllocStats(Component component, String string) {
+        final long componentSize = GraphLayout.parseInstance(component).totalSize();
+        final long stringSize = GraphLayout.parseInstance(string).totalSize();
+
+        synchronized (lock) {
+            if (totalComponentSize + componentSize < 0 || totalStringSize + stringSize < 0) {
+                // Overflow protection, we have to write to disk now.
+
+                double percentage = 100.0D - (double) totalStringSize / totalComponentSize * 100.0;
+                allocationLinesToWrite.add(String.format("%-15s %-10s %-20s %-20s %-20s %-5.2f (overflow)%n", System.currentTimeMillis(), count, totalComponentSize, totalStringSize, totalComponentSize - totalStringSize, percentage));
+
+                count = 0;
+                totalComponentSize = 0;
+                totalStringSize = 0;
+                allocationLastSafeNanos = System.nanoTime();
+            }
+
+            count += 1;
+            totalComponentSize += componentSize;
+            totalStringSize += stringSize;
+
+            long now = System.nanoTime();
+            if (now - allocationLastSafeNanos > 180_000_000_000L) { // Every 30m
+                double percentage = 100.0D - (double) totalStringSize / totalComponentSize * 100.0;
+                allocationLinesToWrite.add(String.format("%-15s %-10s %-20s %-20s %-20s %.2f%n", System.currentTimeMillis(), count, totalComponentSize, totalStringSize, totalComponentSize - totalStringSize, percentage));
+            }
+        }
+    }
+
+    public static void addPacketCount(ScoreboardPacketType packetType) {
+        packetCounts.incrementAndGet(packetType.ordinal());
+    }
+
+    static {
+        GeyserImpl instance = GeyserImpl.getInstance();
+        GeyserLogger logger = instance.getLogger();
+
+        long ctm = System.currentTimeMillis();
+        Path allocationStatsPath = instance.configDirectory().resolve("memdiff-alloc-stats-" + ctm + ".txt");
+        logger.info("Writing allocation stats to " + allocationStatsPath);
+        Path scoreStatsPath = instance.configDirectory().resolve("score-stats-" + ctm + ".txt");
+        logger.info("Writing score stats to " + scoreStatsPath);
+        Path packetStatsPath = instance.configDirectory().resolve("packet-stats-" + ctm + ".txt");
+        logger.info("Writing packet stats to " + packetStatsPath);
+
+        try {
+            // Just to be sure, attempt to write to it to see if we have perms. Otherwise, the while loop will just fail indefinitely
+            Files.writeString(allocationStatsPath, "", StandardOpenOption.CREATE);
+            Files.writeString(scoreStatsPath, "", StandardOpenOption.CREATE);
+            Files.writeString(packetStatsPath, "", StandardOpenOption.CREATE);
+        } catch (IOException e) {
+            logger.error("Failed to ensure that the stats files were created!", e);
+            throw new RuntimeException(e);
+        }
+
+        Runtime.getRuntime().addShutdownHook(new Thread(() -> {
+            // Write remaining available stats immediately
+
+            String remainingStats;
+            synchronized (lock) {
+                double percentage = 100.0D - (double) totalStringSize / totalComponentSize * 100.0;
+                remainingStats = String.format("%-15s %-10s %-20s %-20s %-20s %-5.2f (shutdown)%n", System.currentTimeMillis(), count, totalComponentSize, totalStringSize, totalComponentSize - totalStringSize, percentage);
+                allocationLinesToWrite.add(remainingStats);
+            }
+
+            try {
+                writeToDisk(instance, allocationStatsPath, scoreStatsPath, packetStatsPath);
+            } catch (IOException e) {
+                throw new RuntimeException(e);
+            }
+        }));
+
+        new Thread(() -> {
+            while (!instance.isShuttingDown()) {
+                try {
+                    Thread.sleep(60_000);
+                    writeToDisk(instance, allocationStatsPath, scoreStatsPath, packetStatsPath);
+                } catch (Throwable ignored) {}
+            }
+        }, "Geyser - DebugStatsWriter").start();
+    }
+
+    private static void writeToDisk(GeyserImpl impl, Path allocationStatsPath, Path scoreStatsPath, Path packetStatsPath) throws IOException {
+        writeAllocLines(allocationStatsPath);
+        writeScoreStats(impl, scoreStatsPath);
+        writePacketStats(packetStatsPath);
+    }
+
+    private static void writeAllocLines(Path path) throws IOException {
+        String line;
+        while ((line = allocationLinesToWrite.poll()) != null) {
+            Files.writeString(path, line, StandardOpenOption.APPEND);
+        }
+    }
+
+    private static void writeScoreStats(GeyserImpl geyser, Path path) throws IOException {
+        long playerCount = 0;
+        long belowNameScoreCount = 0;
+        long sidebarScoreCount = 0;
+        long tabListScoreCount = 0;
+        long unregisteredScoreCount = 0;
+        long teamCount = 0;
+
+        for (GeyserSession connection : geyser.onlineConnections()) {
+            Scoreboard scoreboard = connection.getWorldCache().getScoreboard();
+
+            playerCount += 1;
+
+            for (Objective objective : scoreboard.objectives.values()) {
+                boolean registered = false;
+
+                for (DisplaySlot activeSlot : new ArrayList<>(objective.activeSlots)) {
+                    registered = true;
+                    switch (DisplaySlot.slotCategory(activeSlot.position())) {
+                        case SIDEBAR -> sidebarScoreCount += objective.getScores().size();
+                        case BELOW_NAME -> belowNameScoreCount += objective.getScores().size();
+                        case PLAYER_LIST ->  tabListScoreCount += objective.getScores().size();
+                    }
+                }
+
+                if (!registered) {
+                    unregisteredScoreCount += objective.getScores().size();
+                }
+            }
+            teamCount += scoreboard.teams.size();
+        }
+
+        Files.writeString(path, String.format("%-5s %-7s %-7s %-7s %-7s %-7s%n", playerCount, belowNameScoreCount, sidebarScoreCount, tabListScoreCount, unregisteredScoreCount, teamCount), StandardOpenOption.APPEND);
+    }
+
+    private static void writePacketStats(Path path) throws IOException {
+        Long[] stats = new Long[ScoreboardPacketType.length];
+        for (int i = 0; i < ScoreboardPacketType.length; i++) {
+            stats[i] = packetCounts.getAndSet(i, 0L);
+        }
+        Files.writeString(path, String.format("%-7s".repeat(stats.length) + "%n", (Object[]) stats), StandardOpenOption.APPEND);
+    }
+}

--- a/core/src/main/java/org/geysermc/geyser/entity/type/Entity.java
+++ b/core/src/main/java/org/geysermc/geyser/entity/type/Entity.java
@@ -523,7 +523,7 @@ public class Entity implements GeyserEntity {
         // CustomName is ignored for players, and is always their username.
         Optional<Component> name = entityMetadata.getValue();
         if (name.isPresent()) {
-            this.customName = MessageTranslator.convertMessage(name.get(), session.locale());
+            this.customName = MessageTranslator.convertMessageRaw(name.get(), session.locale());
             setNametag(customName, true);
             return;
         }

--- a/core/src/main/java/org/geysermc/geyser/scoreboard/GlobalScoreboardCache.java
+++ b/core/src/main/java/org/geysermc/geyser/scoreboard/GlobalScoreboardCache.java
@@ -1,0 +1,58 @@
+/*
+ * Copyright (c) 2026 GeyserMC. http://geysermc.org
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ *
+ * @author GeyserMC
+ * @link https://github.com/GeyserMC/Geyser
+ */
+
+package org.geysermc.geyser.scoreboard;
+
+import com.google.common.cache.CacheBuilder;
+import com.google.common.cache.CacheLoader;
+import com.google.common.cache.LoadingCache;
+import it.unimi.dsi.fastutil.Pair;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.TimeUnit;
+import net.kyori.adventure.text.Component;
+import org.geysermc.geyser.translator.text.MessageTranslator;
+import org.jspecify.annotations.NonNull;
+
+public class GlobalScoreboardCache {
+    private static final LoadingCache<Pair<Component, String>, String> fixedNumberFormatToString =
+        CacheBuilder.newBuilder()
+            .expireAfterAccess(10, TimeUnit.MINUTES)
+            .maximumSize(100_000)
+            .build(new CacheLoader<>() {
+                @Override
+                public String load(@NonNull Pair<Component, String> pair) {
+                    return MessageTranslator.convertMessageRaw(pair.first(), pair.second());
+                }
+            });
+
+    public static String fixedNumberFormatToString(Component component, String locale) {
+        try {
+            return fixedNumberFormatToString.get(Pair.of(component, locale));
+        } catch (ExecutionException ignored) {
+            // It can never fail, but: convertMessage will always return an empty string on failure, so we do the same.
+            return "";
+        }
+    }
+}

--- a/core/src/main/java/org/geysermc/geyser/scoreboard/Objective.java
+++ b/core/src/main/java/org/geysermc/geyser/scoreboard/Objective.java
@@ -32,6 +32,8 @@ import java.util.Objects;
 import java.util.concurrent.ConcurrentHashMap;
 import lombok.Getter;
 import net.kyori.adventure.text.Component;
+import org.geysermc.geyser.debug.ScoreboardPacketType;
+import org.geysermc.geyser.debug.StatsCollector;
 import org.geysermc.geyser.scoreboard.display.slot.DisplaySlot;
 import org.geysermc.geyser.translator.text.MessageTranslator;
 import org.geysermc.mcprotocollib.protocol.data.game.chat.numbers.NumberFormat;
@@ -40,7 +42,7 @@ import org.geysermc.mcprotocollib.protocol.data.game.scoreboard.ScoreType;
 @Getter
 public final class Objective {
     private final Scoreboard scoreboard;
-    private final List<DisplaySlot> activeSlots = new ArrayList<>();
+    public final List<DisplaySlot> activeSlots = new ArrayList<>();
 
     private final String objectiveName;
     private final Map<String, ScoreReference> scores = new ConcurrentHashMap<>();
@@ -69,9 +71,11 @@ public final class Objective {
     public void setScore(String id, int score, Component displayName, NumberFormat numberFormat) {
         ScoreReference stored = scores.get(id);
         if (stored != null) {
+            StatsCollector.addPacketCount(ScoreboardPacketType.SCORE_UPDATE);
             stored.updateProperties(scoreboard, score, displayName, numberFormat);
             return;
         }
+        StatsCollector.addPacketCount(ScoreboardPacketType.SCORE_ADD);
         registerScore(id, score, displayName, numberFormat);
     }
 

--- a/core/src/main/java/org/geysermc/geyser/scoreboard/ScoreReference.java
+++ b/core/src/main/java/org/geysermc/geyser/scoreboard/ScoreReference.java
@@ -27,6 +27,7 @@ package org.geysermc.geyser.scoreboard;
 
 import java.util.Objects;
 import net.kyori.adventure.text.Component;
+import org.geysermc.geyser.debug.StatsCollector;
 import org.geysermc.geyser.translator.text.MessageTranslator;
 import org.geysermc.mcprotocollib.protocol.data.game.chat.numbers.NumberFormat;
 
@@ -43,8 +44,7 @@ public final class ScoreReference {
 
     private long lastUpdate;
 
-    public ScoreReference(
-        Scoreboard scoreboard, String name, int score, Component displayName, NumberFormat format) {
+    public ScoreReference(Scoreboard scoreboard, String name, int score, Component displayName, NumberFormat format) {
         this.name = name;
         // hidden is a sidebar exclusive feature
         this.hidden = name.startsWith("#");
@@ -68,6 +68,9 @@ public final class ScoreReference {
     public void displayName(Component displayName, Scoreboard scoreboard) {
         if (this.displayName != null && displayName != null) {
             String convertedDisplayName = MessageTranslator.convertMessage(displayName, scoreboard.session().locale());
+
+            StatsCollector.addAllocStats(displayName, convertedDisplayName);
+
             if (!this.displayName.equals(convertedDisplayName)) {
                 this.displayName = convertedDisplayName;
                 markChanged();
@@ -76,8 +79,11 @@ public final class ScoreReference {
         }
         // simplified from (this.displayName != null && displayName == null) || (this.displayName == null && displayName != null)
         if (this.displayName != null || displayName != null) {
-            this.displayName = MessageTranslator.convertMessage(displayName, scoreboard.session().locale());
+            String convertedDisplayName = MessageTranslator.convertMessage(displayName, scoreboard.session().locale());
+            this.displayName = convertedDisplayName;
             markChanged();
+
+            StatsCollector.addAllocStats(displayName, convertedDisplayName);
         }
     }
 

--- a/core/src/main/java/org/geysermc/geyser/scoreboard/ScoreReference.java
+++ b/core/src/main/java/org/geysermc/geyser/scoreboard/ScoreReference.java
@@ -67,7 +67,7 @@ public final class ScoreReference {
 
     public void displayName(Component displayName, Scoreboard scoreboard) {
         if (this.displayName != null && displayName != null) {
-            String convertedDisplayName = MessageTranslator.convertMessage(displayName, scoreboard.session().locale());
+            String convertedDisplayName = MessageTranslator.convertMessageRaw(displayName, scoreboard.session().locale());
 
             StatsCollector.addAllocStats(displayName, convertedDisplayName);
 
@@ -79,7 +79,7 @@ public final class ScoreReference {
         }
         // simplified from (this.displayName != null && displayName == null) || (this.displayName == null && displayName != null)
         if (this.displayName != null || displayName != null) {
-            String convertedDisplayName = MessageTranslator.convertMessage(displayName, scoreboard.session().locale());
+            String convertedDisplayName = MessageTranslator.convertMessageRaw(displayName, scoreboard.session().locale());
             this.displayName = convertedDisplayName;
             markChanged();
 

--- a/core/src/main/java/org/geysermc/geyser/scoreboard/Scoreboard.java
+++ b/core/src/main/java/org/geysermc/geyser/scoreboard/Scoreboard.java
@@ -88,12 +88,12 @@ public final class Scoreboard {
     private final GeyserLogger logger;
     private final AtomicLong nextId = new AtomicLong(0);
 
-    private final Map<String, Objective> objectives = new ConcurrentHashMap<>();
+    public final Map<String, Objective> objectives = new ConcurrentHashMap<>();
     @Getter
     private final Map<ScoreboardPosition, DisplaySlot> objectiveSlots = Collections.synchronizedMap(new EnumMap<>(ScoreboardPosition.class));
     private final List<DisplaySlot> removedSlots = Collections.synchronizedList(new ArrayList<>());
 
-    private final Map<String, Team> teams = new ConcurrentHashMap<>(); // updated on multiple threads
+    public final Map<String, Team> teams = new ConcurrentHashMap<>();
     /**
      * Required to preserve vanilla behavior, which also uses a map.
      * Otherwise, for example, if TAB has a team for a player and vanilla has a team, "race conditions" that do not

--- a/core/src/main/java/org/geysermc/geyser/scoreboard/ScoreboardUpdater.java
+++ b/core/src/main/java/org/geysermc/geyser/scoreboard/ScoreboardUpdater.java
@@ -60,6 +60,10 @@ public final class ScoreboardUpdater extends Thread {
         new ScoreboardUpdater().start();
     }
 
+    private ScoreboardUpdater() {
+        super("Geyser - Scoreboard Updater");
+    }
+
     @Override
     public void run() {
         while (!geyser.isShuttingDown() && !geyser.isReloading()) {

--- a/core/src/main/java/org/geysermc/geyser/scoreboard/Team.java
+++ b/core/src/main/java/org/geysermc/geyser/scoreboard/Team.java
@@ -122,12 +122,9 @@ public final class Team {
     }
 
     public String displayName(String score) {
-        String chatColor = ChatColor.chatColorFor(color);
         // most sidebar plugins will use the reset color, because they don't want color
         // skip the unneeded double reset color in that case
-        if (ChatColor.RESET.equals(chatColor)) {
-            chatColor = "";
-        }
+        String chatColor = color == TeamColor.RESET ? "" : ChatColor.chatColorFor(color);
         // also add reset because setting the color does not reset the formatting, unlike Java
         return chatColor + prefix + ChatColor.RESET + chatColor + score + ChatColor.RESET + chatColor + suffix;
     }

--- a/core/src/main/java/org/geysermc/geyser/scoreboard/Team.java
+++ b/core/src/main/java/org/geysermc/geyser/scoreboard/Team.java
@@ -46,7 +46,7 @@ public final class Team {
 
     private final Set<String> entities;
     private final Set<Entity> managedEntities;
-    @NonNull private NameTagVisibility nameTagVisibility = NameTagVisibility.ALWAYS;
+    private @NonNull NameTagVisibility nameTagVisibility = NameTagVisibility.ALWAYS;
     private TeamColor color;
 
     private String name;

--- a/core/src/main/java/org/geysermc/geyser/scoreboard/display/score/SidebarDisplayScore.java
+++ b/core/src/main/java/org/geysermc/geyser/scoreboard/display/score/SidebarDisplayScore.java
@@ -27,12 +27,12 @@ package org.geysermc.geyser.scoreboard.display.score;
 
 import java.util.Objects;
 import org.cloudburstmc.protocol.bedrock.data.ScoreInfo;
+import org.geysermc.geyser.scoreboard.GlobalScoreboardCache;
 import org.geysermc.geyser.scoreboard.Objective;
 import org.geysermc.geyser.scoreboard.ScoreReference;
 import org.geysermc.geyser.scoreboard.Team;
 import org.geysermc.geyser.scoreboard.display.slot.DisplaySlot;
 import org.geysermc.geyser.text.ChatColor;
-import org.geysermc.geyser.translator.text.MessageTranslator;
 import org.geysermc.mcprotocollib.protocol.data.game.chat.numbers.FixedFormat;
 import org.geysermc.mcprotocollib.protocol.data.game.chat.numbers.NumberFormat;
 
@@ -77,7 +77,7 @@ public final class SidebarDisplayScore extends DisplayScore {
             numberFormat = objective.getNumberFormat();
         }
         if (numberFormat instanceof FixedFormat fixedFormat) {
-            finalName += " " + ChatColor.RESET + MessageTranslator.convertMessage(fixedFormat.getValue(), objective.getScoreboard().session().locale());
+            finalName += " " + ChatColor.RESET + GlobalScoreboardCache.fixedNumberFormatToString(fixedFormat.getValue(), objective.getScoreboard().session().locale());
         }
 
         if (order != null) {

--- a/core/src/main/java/org/geysermc/geyser/scoreboard/display/slot/BelownameDisplaySlot.java
+++ b/core/src/main/java/org/geysermc/geyser/scoreboard/display/slot/BelownameDisplaySlot.java
@@ -28,10 +28,11 @@ package org.geysermc.geyser.scoreboard.display.slot;
 import it.unimi.dsi.fastutil.longs.Long2ObjectMap;
 import it.unimi.dsi.fastutil.longs.Long2ObjectOpenHashMap;
 import java.util.List;
-import org.cloudburstmc.nbt.NbtMapBuilder;
+import net.kyori.adventure.text.Component;
 import org.cloudburstmc.protocol.bedrock.data.ScoreInfo;
 import org.geysermc.geyser.debug.StatsCollector;
 import org.geysermc.geyser.entity.type.player.PlayerEntity;
+import org.geysermc.geyser.scoreboard.GlobalScoreboardCache;
 import org.geysermc.geyser.scoreboard.Objective;
 import org.geysermc.geyser.scoreboard.ScoreReference;
 import org.geysermc.geyser.scoreboard.UpdateType;
@@ -39,7 +40,6 @@ import org.geysermc.geyser.scoreboard.display.score.BelownameDisplayScore;
 import org.geysermc.geyser.session.GeyserSession;
 import org.geysermc.geyser.text.ChatColor;
 import org.geysermc.geyser.translator.text.MessageTranslator;
-import org.geysermc.mcprotocollib.protocol.codec.NbtComponentSerializer;
 import org.geysermc.mcprotocollib.protocol.data.game.chat.numbers.BlankFormat;
 import org.geysermc.mcprotocollib.protocol.data.game.chat.numbers.FixedFormat;
 import org.geysermc.mcprotocollib.protocol.data.game.chat.numbers.NumberFormat;
@@ -165,14 +165,13 @@ public class BelownameDisplaySlot extends DisplaySlot {
         if (numberFormat instanceof BlankFormat) {
             numberString = "";
         } else if (numberFormat instanceof FixedFormat fixedFormat) {
-            numberString = MessageTranslator.convertMessage(fixedFormat.getValue(), session.locale());
+            numberString = GlobalScoreboardCache.fixedNumberFormatToString(fixedFormat.getValue(), session.locale());
             StatsCollector.addAllocStats(fixedFormat.getValue(), numberString);
         } else if (numberFormat instanceof StyledFormat styledFormat) {
-            NbtMapBuilder styledAmount = styledFormat.getStyle().toBuilder();
-            styledAmount.putString("text", String.valueOf(score));
-
-            numberString = MessageTranslator.convertJsonMessage(
-                NbtComponentSerializer.tagComponentToJson(styledAmount.build()).toString(), session.locale());
+            numberString = MessageTranslator.convertMessage(
+                Component.text(score, MessageTranslator.getStyleFromNbtMap(styledFormat.getStyle())),
+                session.locale()
+            );
         } else {
             numberString = String.valueOf(score);
         }

--- a/core/src/main/java/org/geysermc/geyser/scoreboard/display/slot/BelownameDisplaySlot.java
+++ b/core/src/main/java/org/geysermc/geyser/scoreboard/display/slot/BelownameDisplaySlot.java
@@ -30,6 +30,7 @@ import it.unimi.dsi.fastutil.longs.Long2ObjectOpenHashMap;
 import java.util.List;
 import org.cloudburstmc.nbt.NbtMapBuilder;
 import org.cloudburstmc.protocol.bedrock.data.ScoreInfo;
+import org.geysermc.geyser.debug.StatsCollector;
 import org.geysermc.geyser.entity.type.player.PlayerEntity;
 import org.geysermc.geyser.scoreboard.Objective;
 import org.geysermc.geyser.scoreboard.ScoreReference;
@@ -165,6 +166,7 @@ public class BelownameDisplaySlot extends DisplaySlot {
             numberString = "";
         } else if (numberFormat instanceof FixedFormat fixedFormat) {
             numberString = MessageTranslator.convertMessage(fixedFormat.getValue(), session.locale());
+            StatsCollector.addAllocStats(fixedFormat.getValue(), numberString);
         } else if (numberFormat instanceof StyledFormat styledFormat) {
             NbtMapBuilder styledAmount = styledFormat.getStyle().toBuilder();
             styledAmount.putString("text", String.valueOf(score));

--- a/core/src/main/java/org/geysermc/geyser/translator/protocol/java/scoreboard/JavaResetScorePacket.java
+++ b/core/src/main/java/org/geysermc/geyser/translator/protocol/java/scoreboard/JavaResetScorePacket.java
@@ -27,6 +27,8 @@ package org.geysermc.geyser.translator.protocol.java.scoreboard;
 
 import org.geysermc.geyser.GeyserImpl;
 import org.geysermc.geyser.GeyserLogger;
+import org.geysermc.geyser.debug.ScoreboardPacketType;
+import org.geysermc.geyser.debug.StatsCollector;
 import org.geysermc.geyser.scoreboard.Objective;
 import org.geysermc.geyser.scoreboard.Scoreboard;
 import org.geysermc.geyser.scoreboard.ScoreboardUpdater;
@@ -47,6 +49,8 @@ public class JavaResetScorePacket extends PacketTranslator<ClientboundResetScore
         WorldCache worldCache = session.getWorldCache();
         Scoreboard scoreboard = worldCache.getScoreboard();
         int pps = worldCache.increaseAndGetScoreboardPacketsPerSecond();
+
+        StatsCollector.addPacketCount(ScoreboardPacketType.SCORE_RESET);
 
         if (packet.getObjective() == null) {
             // No objective name means all scores are reset for that player (/scoreboard players reset PLAYERNAME)

--- a/core/src/main/java/org/geysermc/geyser/translator/protocol/java/scoreboard/JavaSetDisplayObjectiveTranslator.java
+++ b/core/src/main/java/org/geysermc/geyser/translator/protocol/java/scoreboard/JavaSetDisplayObjectiveTranslator.java
@@ -25,6 +25,8 @@
 
 package org.geysermc.geyser.translator.protocol.java.scoreboard;
 
+import org.geysermc.geyser.debug.ScoreboardPacketType;
+import org.geysermc.geyser.debug.StatsCollector;
 import org.geysermc.geyser.scoreboard.Scoreboard;
 import org.geysermc.geyser.scoreboard.ScoreboardUpdater;
 import org.geysermc.geyser.session.GeyserSession;
@@ -42,6 +44,7 @@ public class JavaSetDisplayObjectiveTranslator extends PacketTranslator<Clientbo
         Scoreboard scoreboard = worldCache.getScoreboard();
         int pps = worldCache.increaseAndGetScoreboardPacketsPerSecond();
 
+        StatsCollector.addPacketCount(ScoreboardPacketType.OBJECTIVE_DISPLAY);
         scoreboard.displayObjective(packet.getName(), packet.getPosition());
 
         // ScoreboardUpdater will handle it for us if the packets per second

--- a/core/src/main/java/org/geysermc/geyser/translator/protocol/java/scoreboard/JavaSetObjectiveTranslator.java
+++ b/core/src/main/java/org/geysermc/geyser/translator/protocol/java/scoreboard/JavaSetObjectiveTranslator.java
@@ -25,6 +25,8 @@
 
 package org.geysermc.geyser.translator.protocol.java.scoreboard;
 
+import org.geysermc.geyser.debug.ScoreboardPacketType;
+import org.geysermc.geyser.debug.StatsCollector;
 import org.geysermc.geyser.scoreboard.Objective;
 import org.geysermc.geyser.scoreboard.Scoreboard;
 import org.geysermc.geyser.scoreboard.ScoreboardUpdater;
@@ -56,9 +58,14 @@ public class JavaSetObjectiveTranslator extends PacketTranslator<ClientboundSetO
         }
 
         switch (packet.getAction()) {
-            case ADD, UPDATE ->
+            case ADD, UPDATE -> {
+                StatsCollector.addPacketCount(ScoreboardPacketType.OBJECTIVE_CRU);
                 objective.updateProperties(packet.getDisplayName(), packet.getType(), packet.getNumberFormat());
-            case REMOVE -> scoreboard.removeObjective(objective);
+            }
+            case REMOVE -> {
+                StatsCollector.addPacketCount(ScoreboardPacketType.OBJECTIVE_DEL);
+                scoreboard.removeObjective(objective);
+            }
         }
 
         // Scoreboard#removeObjective doesn't touch the display slot(s) that were attached to it.

--- a/core/src/main/java/org/geysermc/geyser/translator/protocol/java/scoreboard/JavaSetPlayerTeamTranslator.java
+++ b/core/src/main/java/org/geysermc/geyser/translator/protocol/java/scoreboard/JavaSetPlayerTeamTranslator.java
@@ -28,6 +28,8 @@ package org.geysermc.geyser.translator.protocol.java.scoreboard;
 import java.util.Arrays;
 import org.geysermc.geyser.GeyserImpl;
 import org.geysermc.geyser.GeyserLogger;
+import org.geysermc.geyser.debug.ScoreboardPacketType;
+import org.geysermc.geyser.debug.StatsCollector;
 import org.geysermc.geyser.scoreboard.Scoreboard;
 import org.geysermc.geyser.scoreboard.ScoreboardUpdater;
 import org.geysermc.geyser.scoreboard.Team;
@@ -56,6 +58,7 @@ public class JavaSetPlayerTeamTranslator extends PacketTranslator<ClientboundSet
         Scoreboard scoreboard = session.getWorldCache().getScoreboard();
 
         if (packet.getAction() == TeamAction.CREATE) {
+            StatsCollector.addPacketCount(ScoreboardPacketType.TEAM_CREATE);
             scoreboard.registerNewTeam(
                 packet.getTeamName(),
                 packet.getPlayers(),
@@ -75,6 +78,14 @@ public class JavaSetPlayerTeamTranslator extends PacketTranslator<ClientboundSet
                 }
                 return;
             }
+
+            StatsCollector.addPacketCount(switch (packet.getAction()) {
+                case REMOVE -> ScoreboardPacketType.TEAM_REMOVE;
+                case UPDATE -> ScoreboardPacketType.TEAM_UPDATE;
+                case ADD_PLAYER -> ScoreboardPacketType.TEAM_PLAYER_ADD;
+                case REMOVE_PLAYER -> ScoreboardPacketType.TEAM_PLAYER_REMOVE;
+                default -> throw new IllegalStateException("Unknown TeamAction " + packet.getAction());
+            });
 
             switch (packet.getAction()) {
                 case UPDATE -> {

--- a/core/src/main/java/org/geysermc/geyser/translator/text/MessageTranslator.java
+++ b/core/src/main/java/org/geysermc/geyser/translator/text/MessageTranslator.java
@@ -25,7 +25,12 @@
 
 package org.geysermc.geyser.translator.text;
 
-import it.unimi.dsi.fastutil.chars.CharConsumer;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Optional;
+import java.util.UUID;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
 import net.kyori.adventure.text.Component;
 import net.kyori.adventure.text.JoinConfiguration;
 import net.kyori.adventure.text.TranslatableComponent;
@@ -56,13 +61,6 @@ import org.geysermc.mcprotocollib.protocol.data.game.Holder;
 import org.geysermc.mcprotocollib.protocol.data.game.chat.ChatType;
 import org.geysermc.mcprotocollib.protocol.data.game.chat.ChatTypeDecoration;
 
-import java.util.ArrayList;
-import java.util.List;
-import java.util.Optional;
-import java.util.UUID;
-import java.util.regex.Matcher;
-import java.util.regex.Pattern;
-
 public class MessageTranslator {
     // These are used for handling the translations of the messages
     // Custom instead of TranslatableComponentRenderer#usingTranslationSource so we don't need to worry about finding a Locale class
@@ -80,7 +78,6 @@ public class MessageTranslator {
 
     // Reset character
     private static final String RESET = BASE + "r";
-    private static final Pattern RESET_PATTERN = Pattern.compile("(" + RESET + "){2,}");
     private static final Pattern LOCALIZATION_PATTERN = Pattern.compile("%(?:(\\d+)\\$)?s");
 
     static {
@@ -175,6 +172,10 @@ public class MessageTranslator {
 
         BEDROCK_COLORS = colorBuilder.toString();
         BEDROCK_DECORATIONS = decorationBuilder.toString();
+
+        if (BEDROCK_COLORS.length() + BEDROCK_DECORATIONS.length() > 32) {
+            throw new AssertionError("Cannot exceed 32 characters due to int-limit on formatting flags");
+        }
     }
 
     /**
@@ -224,11 +225,13 @@ public class MessageTranslator {
             int legacyLength = legacy.length();
 
             // We need to allocate at least the length of the original message, it can only grow
-            StringBuilder finalLegacy = new StringBuilder(legacyLength);
+            StringBuilder finalLegacy = new StringBuilder(legacyLength + (addLeadingResetFormat ? 2 : 0));
+            if (addLeadingResetFormat) finalLegacy.append(RESET);
+
             // A bit for each possible legacy color & formatting, since it's already been converted to legacy colors at this point.
             int appliedFormatting = 0;
 
-            boolean lastFormatReset = !addLeadingResetFormat;
+            boolean lastFormatReset = addLeadingResetFormat;
 
             for (int i = 0; i < legacyLength; i++) {
                 char legacyChar = legacy.charAt(i);
@@ -242,13 +245,18 @@ public class MessageTranslator {
                     if (legacyChar == '\n' && appliedFormatting != 0) {
                         // If there's a new line, then we need to readd the formatting.
                         // Java does continue with the same formatting, but Bedrock doesn't.
-                        applyFormattingFlags(appliedFormatting, formatChar -> finalLegacy.append(BASE).append(formatChar));
+                        applyFormattingFlags(appliedFormatting, finalLegacy);
                     }
                     continue;
                 }
 
                 char next = legacy.charAt(++i);
-                if (!lastFormatReset && BEDROCK_COLORS.indexOf(next) != -1) {
+                if (lastFormatReset && next == 'r') {
+                    // If we have two resets in a row, skip the second one.
+                    continue;
+                }
+
+                if (!lastFormatReset && BEDROCK_COLORS.indexOf(next) != -1 && appliedFormatting != 0) {
                     // Unlike Java Edition, the chat formatting (e.g. bold) is not reset when a ChatColor is added
                     finalLegacy.append(RESET);
                 }
@@ -259,15 +267,11 @@ public class MessageTranslator {
                 appliedFormatting = setFormattingFlag(appliedFormatting, next);
             }
 
-            // Remove duplicate resets and trailing resets
-            String finalLegacyString = RESET_PATTERN.matcher(finalLegacy).replaceAll(RESET);
-
-            //todo does this matter? I don't think so?
-            if (finalLegacyString.endsWith(RESET)) {
-                finalLegacyString = finalLegacyString.substring(0, finalLegacyString.length() - 2);
+            if (endsWith(finalLegacy, RESET)) {
+                return finalLegacy.substring(0, finalLegacy.length() - RESET.length());
             }
 
-            return finalLegacyString;
+            return finalLegacy.toString();
         } catch (Exception e) {
             GeyserImpl.getInstance().getLogger().debug(GSON_SERIALIZER.serialize(message));
             GeyserImpl.getInstance().getLogger().error("Failed to parse message", e);
@@ -299,17 +303,17 @@ public class MessageTranslator {
         return 1 << index;
     }
 
-    private static void applyFormattingFlags(int flags, CharConsumer flagValue) {
+    private static void applyFormattingFlags(int flags, StringBuilder builder) {
         int colorCount = BEDROCK_COLORS.length();
 
         for (int i = 0; i < colorCount; i++) {
             if (((flags >> i) & 0x01) == 0x01) {
-                flagValue.accept(BEDROCK_COLORS.charAt(i));
+                builder.append(BASE).append(BEDROCK_COLORS.charAt(i));
             }
         }
         for (int i = 0; i < BEDROCK_DECORATIONS.length(); i++) {
             if (((flags >> (i + colorCount)) & 0x01) == 0x01) {
-                flagValue.accept(BEDROCK_DECORATIONS.charAt(i));
+                builder.append(BASE).append(BEDROCK_DECORATIONS.charAt(i));
             }
         }
     }
@@ -635,8 +639,8 @@ public class MessageTranslator {
         Style.Builder style = Style.style();
 
         String colorString = map.getString("color", null);
-        if (colorString != null) {
-            if (colorString.startsWith(TextColor.HEX_PREFIX)) {
+        if (colorString != null && !colorString.isEmpty()) {
+            if (colorString.charAt(0) == TextColor.HEX_CHARACTER) {
                 style.color(TextColor.fromHexString(colorString));
             } else {
                 style.color(NamedTextColor.NAMES.value(colorString));
@@ -654,6 +658,13 @@ public class MessageTranslator {
 
     public static Style getStyleFromNbtMap(NbtMap map, Style base) {
         return base.merge(getStyleFromNbtMap(map));
+    }
+
+    private static boolean endsWith(StringBuilder builder, String suffix) {
+        if (builder.length() < suffix.length()) {
+            return false;
+        }
+        return builder.indexOf(suffix, builder.length() - suffix.length() - 1) != -1;
     }
 
     public static void init() {

--- a/core/src/main/java/org/geysermc/geyser/translator/text/MessageTranslator.java
+++ b/core/src/main/java/org/geysermc/geyser/translator/text/MessageTranslator.java
@@ -25,6 +25,7 @@
 
 package org.geysermc.geyser.translator.text;
 
+import it.unimi.dsi.fastutil.chars.CharConsumer;
 import net.kyori.adventure.text.Component;
 import net.kyori.adventure.text.JoinConfiguration;
 import net.kyori.adventure.text.TranslatableComponent;
@@ -72,9 +73,10 @@ public class MessageTranslator {
 
     private static final LegacyComponentSerializer BEDROCK_SERIALIZER;
     private static final String BEDROCK_COLORS;
+    private static final String BEDROCK_DECORATIONS;
 
     // Legacy formatting character
-    private static final String BASE = "\u00a7";
+    private static final String BASE = "§";
 
     // Reset character
     private static final String RESET = BASE + "r";
@@ -157,14 +159,22 @@ public class MessageTranslator {
                 .flattener(flattener)
                 .build();
 
-        // cache all the legacy character codes
+        // Cache all the legacy character codes and formats
+
         StringBuilder colorBuilder = new StringBuilder();
+        StringBuilder decorationBuilder = new StringBuilder();
+
         for (CharacterAndFormat format : formats) {
             if (format.format() instanceof TextColor) {
                 colorBuilder.append(format.character());
             }
+            if (format.format() instanceof TextDecoration) {
+                decorationBuilder.append(format.character());
+            }
         }
+
         BEDROCK_COLORS = colorBuilder.toString();
+        BEDROCK_DECORATIONS = decorationBuilder.toString();
     }
 
     /**
@@ -205,82 +215,102 @@ public class MessageTranslator {
     }
 
     private static String convertMessage(Component message, String locale, boolean addLeadingResetFormat) {
+        // Converting messages is quite a hot path, so the code is a bit less optimized for reading and more optimized for performance.
         try {
             // Translate any components that require it
             message = RENDERER.render(message, locale);
 
             String legacy = BEDROCK_SERIALIZER.serialize(message);
+            int legacyLength = legacy.length();
 
-            StringBuilder finalLegacy = new StringBuilder();
-            char[] legacyChars = legacy.toCharArray();
+            // We need to allocate at least the length of the original message, it can only grow
+            StringBuilder finalLegacy = new StringBuilder(legacyLength);
+            // A bit for each possible legacy color & formatting, since it's already been converted to legacy colors at this point.
+            int appliedFormatting = 0;
+
             boolean lastFormatReset = !addLeadingResetFormat;
-            for (int i = 0; i < legacyChars.length; i++) {
-                char legacyChar = legacyChars[i];
-                if (legacyChar != ChatColor.ESCAPE || i >= legacyChars.length - 1) {
-                    // No special formatting for Bedrock needed
-                    // Or, we're at the end of the string
+
+            for (int i = 0; i < legacyLength; i++) {
+                char legacyChar = legacy.charAt(i);
+                if (legacyChar != ChatColor.ESCAPE || i == legacyLength - 1) {
+                    // No special formatting for Bedrock needed, or we're at the end of the string.
+                    // If the string ends with an escape then Java will silently ignore it. We don't have to remove it.
                     finalLegacy.append(legacyChar);
                     lastFormatReset = false;
+
+                    // However, it can still be a newline.
+                    if (legacyChar == '\n' && appliedFormatting != 0) {
+                        // If there's a new line, then we need to readd the formatting.
+                        // Java does continue with the same formatting, but Bedrock doesn't.
+                        applyFormattingFlags(appliedFormatting, formatChar -> finalLegacy.append(BASE).append(formatChar));
+                    }
                     continue;
                 }
 
-                char next = legacyChars[++i];
-                if (BEDROCK_COLORS.indexOf(next) != -1) {
-                    // Unlike Java Edition, the ChatFormatting is not reset when a ChatColor is added
-                    if (!lastFormatReset) {
-                        finalLegacy.append(RESET);
-                    }
+                char next = legacy.charAt(++i);
+                if (!lastFormatReset && BEDROCK_COLORS.indexOf(next) != -1) {
+                    // Unlike Java Edition, the chat formatting (e.g. bold) is not reset when a ChatColor is added
+                    finalLegacy.append(RESET);
                 }
                 finalLegacy.append(BASE).append(next);
                 lastFormatReset = next == 'r';
+
+                // Store formatting so we can restore it if there are newlines.
+                appliedFormatting = setFormattingFlag(appliedFormatting, next);
             }
 
-            String finalLegacyString = finalLegacy.toString();
-
             // Remove duplicate resets and trailing resets
-            finalLegacyString = RESET_PATTERN.matcher(finalLegacyString).replaceAll(RESET);
+            String finalLegacyString = RESET_PATTERN.matcher(finalLegacy).replaceAll(RESET);
+
+            //todo does this matter? I don't think so?
             if (finalLegacyString.endsWith(RESET)) {
                 finalLegacyString = finalLegacyString.substring(0, finalLegacyString.length() - 2);
             }
 
-            // If the message contains \n then go through and re-set the color after each by caching the last color
-            // Bedrock is dumb and resets the color after a newline
-            if (finalLegacyString.contains("\n")) {
-                StringBuilder output = new StringBuilder();
-
-                StringBuilder lastColors = new StringBuilder();
-                for (int i = 0; i < finalLegacyString.length(); i++) {
-                    char c = finalLegacyString.charAt(i);
-
-                    output.append(c);
-
-                    if (c == ChatColor.ESCAPE) {
-                        // If the string ends with a formatting character, remove and skip
-                        if (i >= finalLegacyString.length() - 1) {
-                            output = output.deleteCharAt(output.length() - 1);
-                            continue;
-                        }
-
-                        char newColor = finalLegacyString.charAt(i + 1);
-                        if (newColor == 'r') {
-                            lastColors = new StringBuilder();
-                        } else {
-                            lastColors.append(ChatColor.ESCAPE).append(newColor);
-                        }
-                    } else if (c == '\n' && !lastColors.isEmpty()) {
-                        output.append(lastColors);
-                    }
-                }
-
-                return output.toString();
-            } else {
-                return finalLegacyString;
-            }
+            return finalLegacyString;
         } catch (Exception e) {
             GeyserImpl.getInstance().getLogger().debug(GSON_SERIALIZER.serialize(message));
             GeyserImpl.getInstance().getLogger().error("Failed to parse message", e);
 
             return "";
+        }
+    }
+
+    private static int setFormattingFlag(int flags, char format) {
+        // Reset resets all formatting, and is registered as neither a color nor decoration.
+        if (format == 'r') {
+            return 0;
+        }
+
+        int index = BEDROCK_COLORS.indexOf(format);
+        if (index == -1) {
+            index = BEDROCK_DECORATIONS.indexOf(format);
+            if (index == -1) {
+                // Just silently ignore if it's an unknown format
+                return flags;
+            }
+
+            // You can have multiple decorations.
+            return flags | (1 << (BEDROCK_COLORS.length() + index));
+        }
+
+        // Colors reset all formatting on Java Edition. Note that Bedrock Edition doesn't do this,
+        // but the method callee makes sure that a reset is added.
+        return 1 << index;
+    }
+
+    private static void applyFormattingFlags(int flags, CharConsumer flagValue) {
+        int colorCount = BEDROCK_COLORS.length();
+
+        for (int i = 0; i < colorCount; i++) {
+            if (((flags >> i) & 0x01) == 0x01) {
+                flagValue.accept(BEDROCK_COLORS.charAt(i));
+            }
+        }
+        for (int i = 0; i < BEDROCK_DECORATIONS.length(); i++) {
+            if (((flags >> (i + colorCount)) & 0x01) == 0x01) {
+                flagValue.accept(BEDROCK_DECORATIONS.charAt(i));
+            }
         }
     }
 

--- a/core/src/test/java/org/geysermc/geyser/network/translators/chat/MessageTranslatorTest.java
+++ b/core/src/test/java/org/geysermc/geyser/network/translators/chat/MessageTranslatorTest.java
@@ -63,9 +63,22 @@ public class MessageTranslatorTest {
         //        "Gave 1 §r§e[Camotoy's Head]§r to DoctorMad9952");
 
         // Newline color restore
-        messages.put("{\"color\":\"#F7DC77\",\"text\":\" Contribute to a weekly community goal.\\n All participants will receive a reward\\n and the top 3 will get extra bonus prizes!\"}", "§r§e Contribute to a weekly community goal.\n" +
-            "§e All participants will receive a reward\n" +
-            "§e and the top 3 will get extra bonus prizes!");
+        messages.put(
+            """
+                {"color":"#F7DC77","text":" Contribute to a weekly community goal.\\n All participants will receive a reward\\n and the top 3 will get extra bonus prizes!"}""",
+            """
+                §r§e Contribute to a weekly community goal.
+                §e All participants will receive a reward
+                §e and the top 3 will get extra bonus prizes!"""
+        );
+        messages.put(
+            """
+                {"text":"","extra":[{"text":"§cContribute to a weekly community goal.\\nAll ","color":"yellow"},{"text":"participants will receive a reward\\nand ","color":"green"},{"text":"the top 3 will get extra bonus prizes!"}]}""",
+            """
+                §r§e§r§cContribute to a weekly community goal.
+                §cAll §r§aparticipants will receive a reward
+                §aand §rthe top 3 will get extra bonus prizes!"""
+        );
 
         // Escape curly braces in translatable strings (make MessageFormat ignore them)
         messages.put("{\"translate\":\"tt{tt%stt}tt\",\"with\":[\"AA\"]}", "tt{ttAAtt}tt");
@@ -74,7 +87,7 @@ public class MessageTranslatorTest {
         messages.put("{\"translate\":\"tt{{''}}tt\"}", "tt{{''}}tt");
 
         messages.put("{\"text\":\"\",\"extra\":[{\"text\":\"Testing end of string\n formatting character§\",\"color\":\"yellow\"}]}",
-            "§r§eTesting end of string\n§e formatting character");
+            "§r§eTesting end of string\n§e formatting character§");
 
         MessageTranslator.init();
     }

--- a/core/src/test/java/org/geysermc/geyser/network/translators/chat/MessageTranslatorTest.java
+++ b/core/src/test/java/org/geysermc/geyser/network/translators/chat/MessageTranslatorTest.java
@@ -39,19 +39,27 @@ public class MessageTranslatorTest {
     private final Map<String, String> messages = new HashMap<>();
 
     @BeforeAll
-    public void setUp() throws Exception {
-        messages.put("{\"text\":\"\",\"extra\":[{\"text\":\"DoctorMad9952 joined the game\",\"color\":\"yellow\"}]}",
+    public void setUp() {
+        messages.put("""
+                {"text":"","extra":[{"text":"DoctorMad9952 joined the game","color":"yellow"}]}""",
                 "§r§eDoctorMad9952 joined the game");
 
-        messages.put("{\"text\":\"\",\"extra\":[\"Plugins (3): \",{\"text\":\"WorldEdit\",\"color\":\"green\"},{\"text\":\", \",\"color\":\"white\"},{\"text\":\"ViaVersion\",\"color\":\"green\"},{\"text\":\", \",\"color\":\"white\"},{\"text\":\"Geyser-Spigot\",\"color\":\"green\"}]}",
-                "Plugins (3): §r§aWorldEdit§r§f, §r§aViaVersion§r§f, §r§aGeyser-Spigot");
+        messages.put("""
+                {"text":"","extra":["Plugins (3): ",{"text":"WorldEdit","color":"green"},{"text":", ","color":"white"},{"text":"ViaVersion","color":"green"},{"text":", ","color":"white"},{"text":"Geyser-Spigot","color":"green"}]}""",
+                "§rPlugins (3): §aWorldEdit§r§f, §r§aViaVersion§r§f, §r§aGeyser-Spigot");
 
         // RGB downgrade test
-        messages.put("{\"extra\":[{\"text\":\"          \"},{\"color\":\"gold\",\"text\":\"The \"},{\"color\":\"#E14248\",\"obfuscated\":true,\"text\":\"||\"},{\"color\":\"#3AA9FF\",\"bold\":true,\"text\":\"CubeCraft\"},{\"color\":\"#E14248\",\"obfuscated\":true,\"text\":\"||\"},{\"color\":\"gold\",\"text\":\" Network \"},{\"color\":\"green\",\"text\":\"[1.8/1.9+]\\n         \"},{\"color\":\"#f5e342\",\"text\":\"✦ \"},{\"color\":\"#b042f5\",\"bold\":true,\"text\":\"N\"},{\"color\":\"#c142f5\",\"bold\":true,\"text\":\"E\"},{\"color\":\"#d342f5\",\"bold\":true,\"text\":\"W\"},{\"color\":\"#e442f5\",\"bold\":true,\"text\":\":\"},{\"color\":\"#f542f5\",\"bold\":true,\"text\":\" \"},{\"color\":\"#bcf542\",\"bold\":true,\"text\":\"A\"},{\"color\":\"#acee3f\",\"bold\":true,\"text\":\"M\"},{\"color\":\"#9ce73c\",\"bold\":true,\"text\":\"O\"},{\"color\":\"#8ce039\",\"bold\":true,\"text\":\"N\"},{\"color\":\"#7cd936\",\"bold\":true,\"text\":\"G\"},{\"color\":\"#6cd233\",\"bold\":true,\"text\":\" \"},{\"color\":\"#5ccb30\",\"bold\":true,\"text\":\"S\"},{\"color\":\"#4cc42d\",\"bold\":true,\"text\":\"L\"},{\"color\":\"#3cbd2a\",\"bold\":true,\"text\":\"I\"},{\"color\":\"#2cb627\",\"bold\":true,\"text\":\"M\"},{\"color\":\"#1caf24\",\"bold\":true,\"text\":\"E\"},{\"color\":\"#0ca821\",\"bold\":true,\"text\":\"S\"},{\"color\":\"#f5e342\",\"text\":\" \"},{\"color\":\"#6d7c87\",\"text\":\"(kinda sus) \"},{\"color\":\"#f5e342\",\"text\":\"✦\"}],\"text\":\"\"}","          §r§6The §r§c§k||§r§b§lCubeCraft§r§c§k||§r§6 Network §r§a[1.8/1.9+]\n§a" +
-                        "         §r§e✦ §r§d§lN§r§d§lE§r§d§lW§r§d§l:§r§d§l §r§e§lA§r§e§lM§r§e§lO§r§a§lN§r§a§lG§r§a§l §r§a§lS§r§2§lL§r§2§lI§r§q§lM§r§q§lE§r§q§lS§r§e §r§t(kinda sus) §r§e✦");
+        messages.put("""
+            {"extra":[{"text":"          "},{"color":"gold","text":"The "},{"color":"#E14248","obfuscated":true,"text":"||"},{"color":"#3AA9FF","bold":true,"text":"CubeCraft"},{"color":"#E14248","obfuscated":true,"text":"||"},{"color":"gold","text":" Network "},{"color":"green","text":"[1.8/1.9+]\\n         "},{"color":"#f5e342","text":"✦ "},{"color":"#b042f5","bold":true,"text":"N"},{"color":"#c142f5","bold":true,"text":"E"},{"color":"#d342f5","bold":true,"text":"W"},{"color":"#e442f5","bold":true,"text":":"},{"color":"#f542f5","bold":true,"text":" "},{"color":"#bcf542","bold":true,"text":"A"},{"color":"#acee3f","bold":true,"text":"M"},{"color":"#9ce73c","bold":true,"text":"O"},{"color":"#8ce039","bold":true,"text":"N"},{"color":"#7cd936","bold":true,"text":"G"},{"color":"#6cd233","bold":true,"text":" "},{"color":"#5ccb30","bold":true,"text":"S"},{"color":"#4cc42d","bold":true,"text":"L"},{"color":"#3cbd2a","bold":true,"text":"I"},{"color":"#2cb627","bold":true,"text":"M"},{"color":"#1caf24","bold":true,"text":"E"},{"color":"#0ca821","bold":true,"text":"S"},{"color":"#f5e342","text":" "},{"color":"#6d7c87","text":"(kinda sus) "},{"color":"#f5e342","text":"✦"}],"text":""}""",
+            """
+                §r          §6The §r§c§k||§r§b§lCubeCraft§r§c§k||§r§6 Network §r§a[1.8/1.9+]
+                §a\
+                         §r§e✦ §r§d§lN§r§d§lE§r§d§lW§r§d§l:§r§d§l §r§e§lA§r§e§lM§r§e§lO§r§a§lN§r§a§lG§r§a§l §r§a§lS§r§2§lL§r§2§lI§r§q§lM§r§q§lE§r§q§lS§r§e §r§t(kinda sus) §r§e✦""");
 
         // Color code format resetting
-        messages.put("{\"text\":\"\",\"extra\":[{\"text\":\"\",\"extra\":[{\"text\":\"[\",\"color\":\"gray\"},{\"text\":\"H\",\"color\":\"yellow\"},{\"text\":\"]\",\"color\":\"gray\"},{\"text\":\" \",\"color\":\"white\"},{\"text\":\"GUEST\",\"color\":\"#b7b7b7\",\"bold\":true}]},{\"text\":\"\",\"extra\":[{\"text\":\" \",\"bold\":true},{\"text\":\"»\",\"color\":\"blue\"},{\"text\":\" \",\"color\":\"gray\"}]},{\"text\":\"\",\"extra\":[{\"text\":\"rtm516\",\"color\":\"white\"},{\"text\":\": \",\"color\":\"gray\"},{\"text\":\"\",\"color\":\"white\"}]},{\"text\":\"\",\"extra\":[{\"text\":\"This is an amazing bedrock test message\",\"color\":\"white\"}]}]}\n",
+        messages.put("""
+                {"text":"","extra":[{"text":"","extra":[{"text":"[","color":"gray"},{"text":"H","color":"yellow"},{"text":"]","color":"gray"},{"text":" ","color":"white"},{"text":"GUEST","color":"#b7b7b7","bold":true}]},{"text":"","extra":[{"text":" ","bold":true},{"text":"»","color":"blue"},{"text":" ","color":"gray"}]},{"text":"","extra":[{"text":"rtm516","color":"white"},{"text":": ","color":"gray"},{"text":"","color":"white"}]},{"text":"","extra":[{"text":"This is an amazing bedrock test message","color":"white"}]}]}
+                """,
                 "§r§7[§r§eH§r§7]§r§f §r§7§lGUEST§r§l §r§9»§r§7 §r§frtm516§r§7: §r§fThis is an amazing bedrock test message");
 
         // Test translation and positional arguments
@@ -81,12 +89,14 @@ public class MessageTranslatorTest {
         );
 
         // Escape curly braces in translatable strings (make MessageFormat ignore them)
-        messages.put("{\"translate\":\"tt{tt%stt}tt\",\"with\":[\"AA\"]}", "tt{ttAAtt}tt");
-        messages.put("{\"translate\":\"tt{'tt%stt'{tt\",\"with\":[\"AA\"]}", "tt{'ttAAtt'{tt");
-        messages.put("{\"translate\":\"tt{''{tt\"}", "tt{''{tt");
-        messages.put("{\"translate\":\"tt{{''}}tt\"}", "tt{{''}}tt");
+        messages.put("{\"translate\":\"tt{tt%stt}tt\",\"with\":[\"AA\"]}", "§rtt{ttAAtt}tt");
+        messages.put("{\"translate\":\"tt{'tt%stt'{tt\",\"with\":[\"AA\"]}", "§rtt{'ttAAtt'{tt");
+        messages.put("{\"translate\":\"tt{''{tt\"}", "§rtt{''{tt");
+        messages.put("{\"translate\":\"tt{{''}}tt\"}", "§rtt{{''}}tt");
 
-        messages.put("{\"text\":\"\",\"extra\":[{\"text\":\"Testing end of string\n formatting character§\",\"color\":\"yellow\"}]}",
+        messages.put("""
+                {"text":"","extra":[{"text":"Testing end of string
+                 formatting character§","color":"yellow"}]}""",
             "§r§eTesting end of string\n§e formatting character§");
 
         MessageTranslator.init();
@@ -105,7 +115,7 @@ public class MessageTranslatorTest {
         Assertions.assertEquals("\n\n\n\n", MessageTranslator.convertMessageLenient("\n\n\n\n"), "All newline message is not handled properly");
         Assertions.assertEquals("", MessageTranslator.convertMessageLenient(""), "Empty message is not handled properly");
         Assertions.assertEquals("§r§eGame Selector", MessageTranslator.convertMessageLenient("§r§eGame Selector"), "Reset before message is not handled properly");
-        Assertions.assertEquals("Bold Underline", MessageTranslator.convertMessageLenient("§m§nBold Underline"), "Unimplemented formatting chars not stripped");
+        Assertions.assertEquals("§rBold Underline", MessageTranslator.convertMessageLenient("§m§nBold Underline"), "Unimplemented formatting chars not stripped");
         Assertions.assertEquals("§r§d[Test]", MessageTranslator.convertMessageLenient("§r§r§d[Test]§r"), "Duplicate and redundant reset removal");
     }
 

--- a/core/src/test/java/org/geysermc/geyser/scoreboard/network/belowname/BasicBelownameScoreboardTests.java
+++ b/core/src/test/java/org/geysermc/geyser/scoreboard/network/belowname/BasicBelownameScoreboardTests.java
@@ -27,15 +27,15 @@ package org.geysermc.geyser.scoreboard.network.belowname;
 
 import static org.geysermc.geyser.scoreboard.network.util.AssertUtils.assertNextPacket;
 import static org.geysermc.geyser.scoreboard.network.util.AssertUtils.assertNoNextPacket;
-import static org.geysermc.geyser.scoreboard.network.util.GeyserMockContextScoreboard.spawnPlayerSilently;
 import static org.geysermc.geyser.scoreboard.network.util.GeyserMockContextScoreboard.mockContextScoreboard;
-
+import static org.geysermc.geyser.scoreboard.network.util.GeyserMockContextScoreboard.spawnPlayerSilently;
 import net.kyori.adventure.text.Component;
 import net.kyori.adventure.text.format.NamedTextColor;
 import org.cloudburstmc.protocol.bedrock.data.entity.EntityDataTypes;
 import org.cloudburstmc.protocol.bedrock.packet.SetEntityDataPacket;
 import org.geysermc.geyser.translator.protocol.java.scoreboard.JavaSetDisplayObjectiveTranslator;
 import org.geysermc.geyser.translator.protocol.java.scoreboard.JavaSetObjectiveTranslator;
+import org.geysermc.mcprotocollib.protocol.data.game.chat.numbers.FixedFormat;
 import org.geysermc.mcprotocollib.protocol.data.game.scoreboard.ObjectiveAction;
 import org.geysermc.mcprotocollib.protocol.data.game.scoreboard.ScoreType;
 import org.geysermc.mcprotocollib.protocol.data.game.scoreboard.ScoreboardPosition;
@@ -135,6 +135,51 @@ public class BasicBelownameScoreboardTests {
                 var packet = new SetEntityDataPacket();
                 packet.setRuntimeEntityId(2);
                 packet.getMetadata().put(EntityDataTypes.SCORE, "0 §robjective");
+                return packet;
+            });
+            assertNoNextPacket(context);
+
+            context.translate(
+                setDisplayObjectiveTranslator,
+                new ClientboundSetDisplayObjectivePacket(ScoreboardPosition.BELOW_NAME, "")
+            );
+            assertNextPacket(context, () -> {
+                var packet = new SetEntityDataPacket();
+                packet.setRuntimeEntityId(2);
+                packet.getMetadata().put(EntityDataTypes.SCORE, "");
+                return packet;
+            });
+        });
+    }
+
+    @Test
+    void numberFormatFixed() {
+        mockContextScoreboard(context -> {
+            var setObjectiveTranslator = new JavaSetObjectiveTranslator();
+            var setDisplayObjectiveTranslator = new JavaSetDisplayObjectiveTranslator();
+
+            spawnPlayerSilently(context, "player1", 2);
+
+            context.translate(
+                setObjectiveTranslator,
+                new ClientboundSetObjectivePacket(
+                    "objective",
+                    ObjectiveAction.ADD,
+                    Component.text("objective"),
+                    ScoreType.INTEGER,
+                    new FixedFormat(Component.text("yes", NamedTextColor.GREEN))
+                )
+            );
+            assertNoNextPacket(context);
+
+            context.translate(
+                setDisplayObjectiveTranslator,
+                new ClientboundSetDisplayObjectivePacket(ScoreboardPosition.BELOW_NAME, "objective")
+            );
+            assertNextPacket(context, () -> {
+                var packet = new SetEntityDataPacket();
+                packet.setRuntimeEntityId(2);
+                packet.getMetadata().put(EntityDataTypes.SCORE, "§ayes §robjective");
                 return packet;
             });
             assertNoNextPacket(context);

--- a/core/src/test/java/org/geysermc/geyser/scoreboard/network/sidebar/BasicSidebarScoreboardTests.java
+++ b/core/src/test/java/org/geysermc/geyser/scoreboard/network/sidebar/BasicSidebarScoreboardTests.java
@@ -40,6 +40,7 @@ import org.cloudburstmc.protocol.bedrock.packet.SetScorePacket;
 import org.geysermc.geyser.translator.protocol.java.scoreboard.JavaSetDisplayObjectiveTranslator;
 import org.geysermc.geyser.translator.protocol.java.scoreboard.JavaSetObjectiveTranslator;
 import org.geysermc.geyser.translator.protocol.java.scoreboard.JavaSetScoreTranslator;
+import org.geysermc.mcprotocollib.protocol.data.game.chat.numbers.FixedFormat;
 import org.geysermc.mcprotocollib.protocol.data.game.scoreboard.ObjectiveAction;
 import org.geysermc.mcprotocollib.protocol.data.game.scoreboard.ScoreType;
 import org.geysermc.mcprotocollib.protocol.data.game.scoreboard.ScoreboardPosition;
@@ -72,21 +73,21 @@ public class BasicSidebarScoreboardTests {
 
             context.translate(
                 setDisplayObjectiveTranslator,
-                new ClientboundSetDisplayObjectivePacket(ScoreboardPosition.PLAYER_LIST, "objective")
+                new ClientboundSetDisplayObjectivePacket(ScoreboardPosition.SIDEBAR, "objective")
             );
             assertNextPacket(context, () -> {
                 var packet = new SetDisplayObjectivePacket();
                 packet.setObjectiveId("0");
                 packet.setDisplayName("objective");
                 packet.setCriteria("dummy");
-                packet.setDisplaySlot("list");
+                packet.setDisplaySlot("sidebar");
                 packet.setSortOrder(1);
                 return packet;
             });
 
             context.translate(
                 setDisplayObjectiveTranslator,
-                new ClientboundSetDisplayObjectivePacket(ScoreboardPosition.PLAYER_LIST, "")
+                new ClientboundSetDisplayObjectivePacket(ScoreboardPosition.SIDEBAR, "")
             );
             assertNextPacket(context, () -> {
                 var packet = new RemoveObjectivePacket();
@@ -125,6 +126,49 @@ public class BasicSidebarScoreboardTests {
                 packet.setCriteria("dummy");
                 packet.setDisplaySlot("sidebar");
                 packet.setSortOrder(1);
+                return packet;
+            });
+        });
+    }
+
+    @Test
+    void numberFormatFixed() {
+        mockContextScoreboard(context -> {
+            var setObjectiveTranslator = new JavaSetObjectiveTranslator();
+            var setDisplayObjectiveTranslator = new JavaSetDisplayObjectiveTranslator();
+            var setScoreTranslator = new JavaSetScoreTranslator();
+
+            context.translate(
+                setObjectiveTranslator,
+                new ClientboundSetObjectivePacket(
+                    "objective",
+                    ObjectiveAction.ADD,
+                    Component.text("objective", NamedTextColor.AQUA, TextDecoration.BOLD),
+                    ScoreType.INTEGER,
+                    new FixedFormat(Component.text("format", NamedTextColor.AQUA))
+                )
+            );
+            assertNoNextPacket(context);
+
+            context.translate(
+                setDisplayObjectiveTranslator,
+                new ClientboundSetDisplayObjectivePacket(ScoreboardPosition.SIDEBAR, "objective")
+            );
+            assertNextPacket(context, () -> {
+                var packet = new SetDisplayObjectivePacket();
+                packet.setObjectiveId("0");
+                packet.setDisplayName("§b§lobjective");
+                packet.setCriteria("dummy");
+                packet.setDisplaySlot("sidebar");
+                packet.setSortOrder(1);
+                return packet;
+            });
+
+            context.translate(setScoreTranslator, new ClientboundSetScorePacket("Tim203", "objective", 3));
+            assertNextPacket(context, () -> {
+                var packet = new SetScorePacket();
+                packet.setAction(SetScorePacket.Action.SET);
+                packet.setInfos(List.of(new ScoreInfo(1, "0", 3, "Tim203 §r§bformat")));
                 return packet;
             });
         });

--- a/core/src/test/java/org/geysermc/geyser/scoreboard/network/util/GeyserMockContext.java
+++ b/core/src/test/java/org/geysermc/geyser/scoreboard/network/util/GeyserMockContext.java
@@ -25,6 +25,7 @@
 
 package org.geysermc.geyser.scoreboard.network.util;
 
+import java.nio.file.Paths;
 import org.cloudburstmc.protocol.bedrock.packet.BedrockPacket;
 import org.geysermc.geyser.GeyserImpl;
 import org.geysermc.geyser.configuration.GeyserConfig;
@@ -57,6 +58,8 @@ public class GeyserMockContext {
 
         var logger = context.storeObject(new EmptyGeyserLogger());
         when(geyserImpl.getLogger()).thenReturn(logger);
+        // Copied from standalone bootstrap
+        when(geyserImpl.configDirectory()).thenReturn(Paths.get(System.getProperty("user.dir")));
 
         try (var geyserImplMock = mockStatic(GeyserImpl.class)) {
             geyserImplMock.when(GeyserImpl::getInstance).thenReturn(geyserImpl);

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -46,6 +46,7 @@ mixin = "0.8.5"
 mixinextras = "0.5.3"
 minecraft = "26.1.2"
 mockito = "5.+"
+jol = "0.17"
 
 # plugin versions
 indra = "4.0.0"
@@ -162,6 +163,8 @@ math = { group = "org.cloudburstmc.math", name = "immutable", version = "2.0" }
 bstats = { group = "org.bstats", name = "bstats-base", version.ref = "bstats"}
 
 mockito = { module = "org.mockito:mockito-core", version.ref = "mockito" }
+
+jol = { module = "org.openjdk.jol:jol-core", version.ref = "jol" }
 
 # plugins
 lombok = { group = "io.freefair.gradle", name = "lombok-plugin", version.ref = "lombok" }


### PR DESCRIPTION
Received a memory alloc report recently that indiciated quite a lot of memory allocations for converting messages, mainly caused by scoreboard stuff.
WIP. Includes some debug stats for now, while in draft mode