### PR TITLE
Fix: item use/drop de-sync when swapping item.

### DIFF
--- a/core/src/main/java/org/geysermc/geyser/session/GeyserSession.java
+++ b/core/src/main/java/org/geysermc/geyser/session/GeyserSession.java
@@ -1505,7 +1505,7 @@ public class GeyserSession implements GeyserConnection, GeyserCommandSource {
      * Switch the player currently selected hotbar slot.
      */
     public void switchHeldSlot(int slot) {
-        if (!spawned || slot > 8 || playerInventoryHolder.inventory().getHeldItemSlot() == slot) {
+        if (!spawned || slot < 0 || slot > 8 || playerInventoryHolder.inventory().getHeldItemSlot() == slot) {
             // For the last condition - Don't update the slot if the slot is the same - not Java Edition behavior and messes with plugins such as Grief Prevention
             return;
         }

--- a/core/src/main/java/org/geysermc/geyser/session/GeyserSession.java
+++ b/core/src/main/java/org/geysermc/geyser/session/GeyserSession.java
@@ -232,6 +232,7 @@ import org.geysermc.mcprotocollib.protocol.packet.ingame.serverbound.Serverbound
 import org.geysermc.mcprotocollib.protocol.packet.ingame.serverbound.ServerboundChatPacket;
 import org.geysermc.mcprotocollib.protocol.packet.ingame.serverbound.player.ServerboundPlayerAbilitiesPacket;
 import org.geysermc.mcprotocollib.protocol.packet.ingame.serverbound.player.ServerboundPlayerActionPacket;
+import org.geysermc.mcprotocollib.protocol.packet.ingame.serverbound.player.ServerboundSetCarriedItemPacket;
 import org.geysermc.mcprotocollib.protocol.packet.ingame.serverbound.player.ServerboundUseItemPacket;
 import org.geysermc.mcprotocollib.protocol.packet.login.serverbound.ServerboundCustomQueryAnswerPacket;
 
@@ -1498,6 +1499,44 @@ public class GeyserSession implements GeyserConnection, GeyserCommandSource {
         this.hasFishingRodCast = cast;
         int slot = getPlayerInventory().getOffsetForHotbar(getPlayerInventory().getHeldItemSlot());
         this.playerInventoryHolder.updateSlot(slot);
+    }
+
+    /**
+     * Switch the player currently selected hotbar slot.
+     */
+    public void switchHeldSlot(int slot) {
+        if (!spawned || slot > 8 || playerInventoryHolder.inventory().getHeldItemSlot() == slot) {
+            // For the last condition - Don't update the slot if the slot is the same - not Java Edition behavior and messes with plugins such as Grief Prevention
+            return;
+        }
+
+        // Send book update before switching hotbar slot
+        bookEditCache.checkForSend();
+
+        GeyserItemStack oldItem = playerInventoryHolder.inventory().getItemInHand();
+        playerInventoryHolder.inventory().setHeldItemSlot(slot);
+
+        ServerboundSetCarriedItemPacket setCarriedItemPacket = new ServerboundSetCarriedItemPacket(slot);
+        sendDownstreamGamePacket(setCarriedItemPacket);
+
+        GeyserItemStack newItem = playerInventoryHolder.inventory().getItemInHand();
+
+        if (sneaking && newItem.is(Items.SHIELD)) {
+            // Activate shield since we are already sneaking
+            // (No need to send a release item packet - Java doesn't do this when swapping items)
+            // Required to do it a tick later or else it doesn't register
+            scheduleInEventLoop(() -> useItem(Hand.MAIN_HAND), nanosecondsPerTick, TimeUnit.NANOSECONDS);
+        }
+
+        if (!oldItem.isSameItem(newItem)) {
+            // Java sends a cooldown indicator whenever you switch to a new item type
+            CooldownUtils.setCooldownHitTime(this);
+        }
+
+        // Update the interactive tag, if an entity is present
+        if (mouseoverEntity != null) {
+            mouseoverEntity.updateInteractiveTag();
+        }
     }
 
     /**

--- a/core/src/main/java/org/geysermc/geyser/translator/protocol/bedrock/BedrockInventoryTransactionTranslator.java
+++ b/core/src/main/java/org/geysermc/geyser/translator/protocol/bedrock/BedrockInventoryTransactionTranslator.java
@@ -116,6 +116,14 @@ public class BedrockInventoryTransactionTranslator extends PacketTranslator<Inve
         // Send book updates before opening inventories
         session.getBookEditCache().checkForSend();
 
+        // For some reason bedrock decides to send InventoryTransactionPacket before BedrockMobEquipmentTranslator
+        // which means that if the player quickly switch to an item then drop it/use it within a single tick,
+        // we will receive the use item first, causing Geyser to send use item/drop item for the wrong item.
+        // which is pretty important for thing like attribute swapping, so we have to check if the slot has changed.
+        if (packet.getHotbarSlot() != session.getPlayerInventory().getHeldItemSlot()) {
+            session.switchHeldSlot(packet.getHotbarSlot());
+        }
+
         switch (packet.getTransactionType()) {
             case NORMAL:
                 if (packet.getActions().size() == 2) {

--- a/core/src/main/java/org/geysermc/geyser/translator/protocol/bedrock/BedrockMobEquipmentTranslator.java
+++ b/core/src/main/java/org/geysermc/geyser/translator/protocol/bedrock/BedrockMobEquipmentTranslator.java
@@ -27,56 +27,19 @@ package org.geysermc.geyser.translator.protocol.bedrock;
 
 import org.cloudburstmc.protocol.bedrock.data.inventory.ContainerId;
 import org.cloudburstmc.protocol.bedrock.packet.MobEquipmentPacket;
-import org.geysermc.geyser.inventory.GeyserItemStack;
-import org.geysermc.geyser.item.Items;
 import org.geysermc.geyser.session.GeyserSession;
 import org.geysermc.geyser.translator.protocol.PacketTranslator;
 import org.geysermc.geyser.translator.protocol.Translator;
-import org.geysermc.geyser.util.CooldownUtils;
-import org.geysermc.mcprotocollib.protocol.data.game.entity.player.Hand;
-import org.geysermc.mcprotocollib.protocol.packet.ingame.serverbound.player.ServerboundSetCarriedItemPacket;
-
-import java.util.concurrent.TimeUnit;
 
 @Translator(packet = MobEquipmentPacket.class)
 public class BedrockMobEquipmentTranslator extends PacketTranslator<MobEquipmentPacket> {
 
     @Override
     public void translate(GeyserSession session, MobEquipmentPacket packet) {
-        int newSlot = packet.getHotbarSlot();
-        if (!session.isSpawned() || newSlot > 8 || packet.getContainerId() != ContainerId.INVENTORY
-                || session.getPlayerInventory().getHeldItemSlot() == newSlot) {
-            // For the last condition - Don't update the slot if the slot is the same - not Java Edition behavior and messes with plugins such as Grief Prevention
+        if (packet.getContainerId() != ContainerId.INVENTORY) {
             return;
         }
 
-        // Send book update before switching hotbar slot
-        session.getBookEditCache().checkForSend();
-
-        GeyserItemStack oldItem = session.getPlayerInventory().getItemInHand();
-        session.getPlayerInventory().setHeldItemSlot(newSlot);
-
-        ServerboundSetCarriedItemPacket setCarriedItemPacket = new ServerboundSetCarriedItemPacket(newSlot);
-        session.sendDownstreamGamePacket(setCarriedItemPacket);
-
-        GeyserItemStack newItem = session.getPlayerInventory().getItemInHand();
-
-        if (session.isSneaking() && newItem.is(Items.SHIELD)) {
-            // Activate shield since we are already sneaking
-            // (No need to send a release item packet - Java doesn't do this when swapping items)
-            // Required to do it a tick later or else it doesn't register
-            session.scheduleInEventLoop(() -> session.useItem(Hand.MAIN_HAND),
-                    session.getNanosecondsPerTick(), TimeUnit.NANOSECONDS);
-        }
-
-        if (!oldItem.isSameItem(newItem)) {
-            // Java sends a cooldown indicator whenever you switch to a new item type
-            CooldownUtils.setCooldownHitTime(session);
-        }
-
-        // Update the interactive tag, if an entity is present
-        if (session.getMouseoverEntity() != null) {
-            session.getMouseoverEntity().updateInteractiveTag();
-        }
+        session.switchHeldSlot(packet.getHotbarSlot());
     }
 }


### PR DESCRIPTION
For some reason Bedrock decide to sends item use/drop before item swap packet if you managed to do both in a single tick, which makes attribute swapping or other quick swap actions almost impossible.

This can be easily reproduce by having an elytra equipped and having fireworks rocket and and an armor , if you quickly switch to the fireworks rocket and use it, you will equip the armor instead of using the fireworks.

These two videos below can show the different before and after the changes.

https://github.com/user-attachments/assets/c7380ad1-779b-43b5-8f59-c35667074fcf
https://github.com/user-attachments/assets/73e28e30-a280-413b-94a8-25afd42b9aca