### PR TITLE
Add dyeable support for custom items (v2)

### DIFF
--- a/api/src/main/java/org/geysermc/geyser/api/item/custom/v2/CustomItemBedrockOptions.java
+++ b/api/src/main/java/org/geysermc/geyser/api/item/custom/v2/CustomItemBedrockOptions.java
@@ -103,6 +103,18 @@ public interface CustomItemBedrockOptions {
     Set<Identifier> tags();
 
     /**
+     * If the item can be dyed, like leather armor. Defaults to false.
+     *
+     * <p>When enabled, the item is registered as dyeable on Bedrock and is tinted according to the
+     * {@code minecraft:dyed_color} data component present on the item server-side. The item's texture
+     * should be designed to be tinted (e.g. grayscale), otherwise the tint may not appear as expected.</p>
+     *
+     * @return true if the item can be dyed, false otherwise
+     * @since 2.11.0
+     */
+    boolean dyeable();
+
+    /**
      * Creates a new builder for custom item bedrock options.
      *
      * @return a new builder
@@ -204,6 +216,17 @@ public interface CustomItemBedrockOptions {
          */
         @This
         Builder tags(@Nullable Set<Identifier> tags);
+
+        /**
+         * Sets if the item can be dyed, like leather armor.
+         *
+         * @param dyeable if the item can be dyed
+         * @see CustomItemBedrockOptions#dyeable()
+         * @return this builder
+         * @since 2.11.0
+         */
+        @This
+        Builder dyeable(boolean dyeable);
 
         /**
          * Creates the custom item bedrock options.

--- a/core/src/main/java/org/geysermc/geyser/item/custom/GeyserCustomItemBedrockOptions.java
+++ b/core/src/main/java/org/geysermc/geyser/item/custom/GeyserCustomItemBedrockOptions.java
@@ -38,7 +38,8 @@ import java.util.Objects;
 import java.util.Set;
 
 public record GeyserCustomItemBedrockOptions(@Nullable String icon, boolean allowOffhand, boolean displayHandheld, int protectionValue,
-                                             @NonNull CreativeCategory creativeCategory, @Nullable String creativeGroup, @NonNull Set<Identifier> tags) implements CustomItemBedrockOptions {
+                                             @NonNull CreativeCategory creativeCategory, @Nullable String creativeGroup, @NonNull Set<Identifier> tags,
+                                             boolean dyeable) implements CustomItemBedrockOptions {
 
     @Override
     public int protectionValue() {
@@ -60,6 +61,7 @@ public record GeyserCustomItemBedrockOptions(@Nullable String icon, boolean allo
         private CreativeCategory creativeCategory = CreativeCategory.NONE;
         private String creativeGroup = null;
         private Set<Identifier> tags = new HashSet<>();
+        private boolean dyeable = false;
 
         @Override
         public Builder icon(@Nullable String icon) {
@@ -112,9 +114,15 @@ public record GeyserCustomItemBedrockOptions(@Nullable String icon, boolean allo
         }
 
         @Override
+        public Builder dyeable(boolean dyeable) {
+            this.dyeable = dyeable;
+            return this;
+        }
+
+        @Override
         public CustomItemBedrockOptions build() {
             return new GeyserCustomItemBedrockOptions(icon, allowOffhand, displayHandheld, protectionValue,
-                creativeCategory, creativeGroup, Set.copyOf(tags));
+                creativeCategory, creativeGroup, Set.copyOf(tags), dyeable);
         }
     }
 }

--- a/core/src/main/java/org/geysermc/geyser/item/type/DyeableArmorItem.java
+++ b/core/src/main/java/org/geysermc/geyser/item/type/DyeableArmorItem.java
@@ -25,23 +25,10 @@
 
 package org.geysermc.geyser.item.type;
 
-import org.checkerframework.checker.nullness.qual.NonNull;
-import org.geysermc.geyser.item.TooltipOptions;
-import org.geysermc.geyser.session.GeyserSession;
-import org.geysermc.geyser.translator.item.BedrockItemBuilder;
-import org.geysermc.mcprotocollib.protocol.data.game.item.component.DataComponents;
-
 public class DyeableArmorItem extends ArmorItem {
     public DyeableArmorItem(String javaIdentifier, Builder builder) {
         super(javaIdentifier, builder);
     }
 
-    @Override
-    public void translateComponentsToBedrock(@NonNull GeyserSession session, @NonNull DataComponents components, @NonNull TooltipOptions tooltip, @NonNull BedrockItemBuilder builder) {
-        super.translateComponentsToBedrock(session, components, tooltip, builder);
-
-        // Note that this is handled as of 1.20.5 in the ItemColors class.
-        // But horse leather armor and body leather armor are now both armor items. So it works!
-        translateDyedColor(components, builder);
-    }
+    // The dyed color component is translated in Item#translateComponentsToBedrock for all items.
 }

--- a/core/src/main/java/org/geysermc/geyser/item/type/Item.java
+++ b/core/src/main/java/org/geysermc/geyser/item/type/Item.java
@@ -262,6 +262,10 @@ public class Item {
             builder.putByte("Unbreakable", (byte) 1);
         }
 
+        // Tints any item that carries a dyed color component (vanilla leather armor, wolf armor, and custom items
+        // marked dyeable via the API). Only has a visible effect on items Bedrock treats as dyeable.
+        translateDyedColor(components, builder);
+
         // Prevents the client from trying to stack items with untranslated components
         // Relies on correct hash code implementation, and some luck
         // However, we should only set a hash when the components differ from the default ones,

--- a/core/src/main/java/org/geysermc/geyser/item/type/WolfArmorItem.java
+++ b/core/src/main/java/org/geysermc/geyser/item/type/WolfArmorItem.java
@@ -25,22 +25,10 @@
 
 package org.geysermc.geyser.item.type;
 
-import org.checkerframework.checker.nullness.qual.NonNull;
-import org.geysermc.geyser.item.TooltipOptions;
-import org.geysermc.geyser.session.GeyserSession;
-import org.geysermc.geyser.translator.item.BedrockItemBuilder;
-import org.geysermc.mcprotocollib.protocol.data.game.item.component.DataComponents;
-
 public class WolfArmorItem extends Item {
     public WolfArmorItem(String javaIdentifier, Builder builder) {
         super(javaIdentifier, builder);
     }
 
-    @Override
-    public void translateComponentsToBedrock(@NonNull GeyserSession session, @NonNull DataComponents components, @NonNull TooltipOptions tooltip, @NonNull BedrockItemBuilder builder) {
-        super.translateComponentsToBedrock(session, components, tooltip, builder);
-
-        // Note that this is handled as of 1.21 in the ItemColors class.
-        translateDyedColor(components, builder);
-    }
+    // The dyed color component is translated in Item#translateComponentsToBedrock for all items.
 }

--- a/core/src/main/java/org/geysermc/geyser/registry/mappings/definition/SingleDefinitionReader.java
+++ b/core/src/main/java/org/geysermc/geyser/registry/mappings/definition/SingleDefinitionReader.java
@@ -147,6 +147,7 @@ public class SingleDefinitionReader implements ItemDefinitionReader {
         MappingsUtil.readIfPresent(bedrockOptions, "creative_category", builder::creativeCategory, NodeReader.CREATIVE_CATEGORY, context);
         MappingsUtil.readIfPresent(bedrockOptions, "creative_group", builder::creativeGroup, NodeReader.NON_EMPTY_STRING, context);
         MappingsUtil.readArrayIfPresent(bedrockOptions, "tags", tags -> builder.tags(new HashSet<>(tags)), NodeReader.IDENTIFIER, context);
+        MappingsUtil.readIfPresent(bedrockOptions, "dyeable", builder::dyeable, NodeReader.BOOLEAN, context);
 
         definitionBuilder.bedrockOptions(builder);
     }

--- a/core/src/main/java/org/geysermc/geyser/registry/populator/CustomItemRegistryPopulator.java
+++ b/core/src/main/java/org/geysermc/geyser/registry/populator/CustomItemRegistryPopulator.java
@@ -297,6 +297,10 @@ public class CustomItemRegistryPopulator {
                 .build());
         }
 
+        if (context.definition().bedrockOptions().dyeable()) {
+            computeDyeableProperties(componentBuilder);
+        }
+
         AttackRange attackRange = context.components().getOrDefault(DataComponentTypes.ATTACK_RANGE, DEFAULT_ATTACK_RANGE);
 
         KineticWeapon kineticWeapon = context.components().get(DataComponentTypes.KINETIC_WEAPON);
@@ -426,10 +430,14 @@ public class CustomItemRegistryPopulator {
         // This makes bedrock use a 3D render of the block this item places as icon
         GeyserBlockPlacer blockPlacer = definition.components().get(GeyserItemDataComponents.BLOCK_PLACER);
         if (blockPlacer == null || !blockPlacer.useBlockIcon()) {
+            NbtMapBuilder textures = NbtMap.builder().putString("default", definition.icon());
+            if (options.dyeable()) {
+                // Bedrock renders (and tints by customColor) the "dyed" icon texture state when the item has a dye color.
+                // Without it, dyed dyeable items render invisibly. Reuse the item's icon - it should be grayscale so the tint shows.
+                textures.putString("dyed", definition.icon());
+            }
             NbtMap iconMap = NbtMap.builder()
-                .putCompound("textures", NbtMap.builder()
-                    .putString("default", definition.icon())
-                    .build())
+                .putCompound("textures", textures.build())
                 .build();
             itemProperties.putCompound("minecraft:icon", iconMap);
         }
@@ -577,6 +585,14 @@ public class CustomItemRegistryPopulator {
         componentBuilder.putCompound("minecraft:enchantable", NbtMap.builder()
             .putString("slot", "all")
             .putByte("value", (byte) enchantmentValue)
+            .build());
+    }
+
+    private static void computeDyeableProperties(NbtMapBuilder componentBuilder) {
+        // Registers the item as dyeable on Bedrock (dyed in a cauldron), tinted by the "customColor" NBT tag
+        // (set at runtime from the Java minecraft:dyed_color component, see Item#translateDyedColor).
+        componentBuilder.putCompound("minecraft:dyeable", NbtMap.builder()
+            .putString("default_color", "#FFFFFF")
             .build());
     }
 


### PR DESCRIPTION
Addresses the "supporting dyeable items" item from the 26.2 checklist (#6452).

Adds the ability to mark a v2 custom item as dyeable, via
`CustomItemBedrockOptions#dyeable` (API) and a `dyeable` option in the JSON
item mappings.

When enabled:
- the item is registered on Bedrock with the `minecraft:dyeable` component, and
- its generated `minecraft:icon` gains a `dyed` texture state so Bedrock
  actually renders the tint (without it, dyed items render invisibly — the
  icon needs both a `default` and a `dyed` state).

A Java `minecraft:dyed_color` component is then translated to Bedrock's
`customColor` tag. That translation is moved into the base
`Item#translateComponentsToBedrock`, so it applies to any item carrying the
component; the now-redundant overrides in `DyeableArmorItem` and
`WolfArmorItem` are removed.

### Testing
Verified end-to-end on a 26.2 Fabric server with a Bedrock client: a dyeable
custom item renders and tints correctly, and existing dyed leather/wolf armor
still tints correctly after the refactor.
