### PR TITLE
Fix beds being invisible on Bedrock when loaded from a chunk

### DIFF
--- a/core/src/main/java/org/geysermc/geyser/level/block/type/BedBlock.java
+++ b/core/src/main/java/org/geysermc/geyser/level/block/type/BedBlock.java
@@ -28,10 +28,13 @@ package org.geysermc.geyser.level.block.type;
 import org.cloudburstmc.math.vector.Vector3i;
 import org.cloudburstmc.nbt.NbtMap;
 import org.geysermc.geyser.session.GeyserSession;
+import org.geysermc.geyser.translator.level.block.entity.BedrockChunkWantsBlockEntityTag;
 import org.geysermc.geyser.translator.level.block.entity.BlockEntityTranslator;
 import org.geysermc.geyser.util.BlockEntityUtils;
 
-public class BedBlock extends Block {
+// Beds are a block on Java, but a block entity on Bedrock, so the block entity (carrying the color) must be sent both
+// when the block is placed (updateBlock) and when a chunk containing it loads (BedrockChunkWantsBlockEntityTag).
+public class BedBlock extends Block implements BedrockChunkWantsBlockEntityTag {
     private final int dyeColor;
 
     public BedBlock(String javaIdentifier, int dyeColor, Builder builder) {
@@ -42,11 +45,11 @@ public class BedBlock extends Block {
     @Override
     public void updateBlock(GeyserSession session, BlockState state, Vector3i position) {
         super.updateBlock(session, state, position);
-        // Block on Java, block entity on bedrock
-        BlockEntityUtils.updateBlockEntity(session, createTag(position), position);
+        BlockEntityUtils.updateBlockEntity(session, createTag(session, position, state), position);
     }
 
-    private NbtMap createTag(Vector3i position) {
+    @Override
+    public NbtMap createTag(GeyserSession session, Vector3i position, BlockState blockState) {
         return BlockEntityTranslator.getConstantBedrockTag("Bed", position)
             .putByte("color", (byte) dyeColor)
             .build();


### PR DESCRIPTION
Beds are a block on Java but a block entity on Bedrock, so Geyser has to send a
Bedrock bed block entity for them to render. `BedBlock` only did this in
`updateBlock` (i.e. when a bed is placed), so beds arriving via chunk load —
after a relog, or when a chunk re-enters render distance — were sent without a
block entity and rendered invisibly.

Implement `BedrockChunkWantsBlockEntityTag` on `BedBlock` (as `LecternBlock` and
the other Bedrock-only block entities do) so the bed block entity, carrying its
color, is also sent on chunk load.

### Testing
Verified on a 26.2 Fabric server with a Bedrock client: a bed that was invisible
after relogging now renders correctly once its chunk reloads.
