### PR TITLE
Fix: truncate long boss bar titles before sending to Bedrock

### DIFF
--- a/core/src/main/java/org/geysermc/geyser/session/cache/BossBar.java
+++ b/core/src/main/java/org/geysermc/geyser/session/cache/BossBar.java
@@ -35,10 +35,22 @@ import org.cloudburstmc.protocol.bedrock.packet.AddEntityPacket;
 import org.cloudburstmc.protocol.bedrock.packet.BossEventPacket;
 import org.cloudburstmc.protocol.bedrock.packet.RemoveEntityPacket;
 import org.geysermc.geyser.session.GeyserSession;
+import org.geysermc.geyser.text.ChatColor;
 import org.geysermc.geyser.translator.text.MessageTranslator;
 
 @AllArgsConstructor
 public class BossBar {
+    /**
+     * Maximum length of a boss bar title (after translation to the Bedrock legacy format) that we send to the client.
+     * <p>
+     * Some Bedrock clients (observed on protocol 1001 / MC 26.x) immediately disconnect when they receive a
+     * {@link BossEventPacket} with an excessively long title, so we truncate it here as a safeguard. The value is
+     * chosen below the observed breaking point while still being far longer than any reasonable boss bar title.
+     *
+     * @see <a href="https://github.com/GeyserMC/Geyser/issues/6496">GeyserMC/Geyser#6496</a>
+     */
+    private static final int MAX_BEDROCK_TITLE_LENGTH = 256;
+
     private final GeyserSession session;
 
     private final long entityId;
@@ -59,7 +71,7 @@ public class BossBar {
         BossEventPacket bossEventPacket = new BossEventPacket();
         bossEventPacket.setBossUniqueEntityId(entityId);
         bossEventPacket.setAction(BossEventPacket.Action.CREATE);
-        bossEventPacket.setTitle(MessageTranslator.convertMessage(title, session.locale()).replace("%", "%%%%"));
+        bossEventPacket.setTitle(bedrockTitle());
         bossEventPacket.setHealthPercentage(health);
         bossEventPacket.setColor(color);
         bossEventPacket.setOverlay(overlay);
@@ -73,9 +85,26 @@ public class BossBar {
         BossEventPacket bossEventPacket = new BossEventPacket();
         bossEventPacket.setBossUniqueEntityId(entityId);
         bossEventPacket.setAction(BossEventPacket.Action.UPDATE_NAME);
-        bossEventPacket.setTitle(MessageTranslator.convertMessage(title, session.locale()).replace("%", "%%%%"));
+        bossEventPacket.setTitle(bedrockTitle());
 
         session.sendUpstreamPacket(bossEventPacket);
+    }
+
+    /**
+     * Converts the cached {@link #title} into the legacy string format Bedrock expects, truncating it if needed to
+     * avoid clients disconnecting on overly long titles (see {@link #MAX_BEDROCK_TITLE_LENGTH}).
+     */
+    private String bedrockTitle() {
+        String bedrockTitle = MessageTranslator.convertMessage(title, session.locale());
+        if (bedrockTitle.length() > MAX_BEDROCK_TITLE_LENGTH) {
+            bedrockTitle = bedrockTitle.substring(0, MAX_BEDROCK_TITLE_LENGTH);
+            // Avoid leaving a dangling formatting character (§ without its format code) that would corrupt rendering
+            if (bedrockTitle.charAt(bedrockTitle.length() - 1) == ChatColor.ESCAPE) {
+                bedrockTitle = bedrockTitle.substring(0, bedrockTitle.length() - 1);
+            }
+        }
+        // Escape percent signs after truncating so we never split an escape sequence in half
+        return bedrockTitle.replace("%", "%%%%");
     }
 
     public void updateHealth(float health) {

--- a/core/src/main/java/org/geysermc/geyser/session/cache/BossBar.java
+++ b/core/src/main/java/org/geysermc/geyser/session/cache/BossBar.java
@@ -95,16 +95,31 @@ public class BossBar {
      * avoid clients disconnecting on overly long titles (see {@link #MAX_BEDROCK_TITLE_LENGTH}).
      */
     private String bedrockTitle() {
-        String bedrockTitle = MessageTranslator.convertMessage(title, session.locale());
-        if (bedrockTitle.length() > MAX_BEDROCK_TITLE_LENGTH) {
-            bedrockTitle = bedrockTitle.substring(0, MAX_BEDROCK_TITLE_LENGTH);
-            // Avoid leaving a dangling formatting character (§ without its format code) that would corrupt rendering
-            if (bedrockTitle.charAt(bedrockTitle.length() - 1) == ChatColor.ESCAPE) {
-                bedrockTitle = bedrockTitle.substring(0, bedrockTitle.length() - 1);
+        return truncateForBedrock(MessageTranslator.convertMessage(title, session.locale()));
+    }
+
+    /**
+     * Truncates and escapes a converted title so the string actually sent to Bedrock never exceeds
+     * {@link #MAX_BEDROCK_TITLE_LENGTH}. Escaping a "%" quadruples its length, so the cap has to be enforced on the
+     * escaped output - truncating the raw title to the limit first and escaping after can let a title full of "%"
+     * grow right back past the limit.
+     */
+    static String truncateForBedrock(String rawTitle) {
+        StringBuilder bedrockTitle = new StringBuilder(Math.min(rawTitle.length(), MAX_BEDROCK_TITLE_LENGTH));
+        for (int i = 0; i < rawTitle.length(); i++) {
+            char c = rawTitle.charAt(i);
+            String escaped = c == '%' ? "%%%%" : String.valueOf(c);
+            if (bedrockTitle.length() + escaped.length() > MAX_BEDROCK_TITLE_LENGTH) {
+                break;
             }
+            bedrockTitle.append(escaped);
         }
-        // Escape percent signs after truncating so we never split an escape sequence in half
-        return bedrockTitle.replace("%", "%%%%");
+        // Avoid leaving a dangling formatting character (§ without its format code) that would corrupt rendering
+        int length = bedrockTitle.length();
+        if (length > 0 && bedrockTitle.charAt(length - 1) == ChatColor.ESCAPE) {
+            bedrockTitle.setLength(length - 1);
+        }
+        return bedrockTitle.toString();
     }
 
     public void updateHealth(float health) {

--- a/core/src/test/java/org/geysermc/geyser/session/cache/BossBarTest.java
+++ b/core/src/test/java/org/geysermc/geyser/session/cache/BossBarTest.java
@@ -1,0 +1,69 @@
+/*
+ * Copyright (c) 2019-2022 GeyserMC. http://geysermc.org
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ *
+ * @author GeyserMC
+ * @link https://github.com/GeyserMC/Geyser
+ */
+
+package org.geysermc.geyser.session.cache;
+
+import org.geysermc.geyser.text.ChatColor;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+// https://github.com/GeyserMC/Geyser/issues/6496 - overly long boss bar titles disconnect some Bedrock clients.
+public class BossBarTest {
+
+    private static final int MAX_LENGTH = 256;
+
+    @Test
+    public void shortTitleIsUnchanged() {
+        Assertions.assertEquals("Boss", BossBar.truncateForBedrock("Boss"));
+    }
+
+    @Test
+    public void longTitleIsTruncated() {
+        String title = "a".repeat(300);
+        String result = BossBar.truncateForBedrock(title);
+        Assertions.assertEquals(MAX_LENGTH, result.length());
+        Assertions.assertEquals("a".repeat(MAX_LENGTH), result);
+    }
+
+    @Test
+    public void escapedOutputNeverExceedsMaxLength() {
+        // Every character escapes to 4, so a naive truncate-then-escape would land at 1024 chars.
+        String title = "%".repeat(300);
+        String result = BossBar.truncateForBedrock(title);
+        Assertions.assertTrue(result.length() <= MAX_LENGTH,
+            "Escaped title must not exceed " + MAX_LENGTH + " chars, was " + result.length());
+        // Only whole "%%%%" groups should be present - never a partial escape sequence.
+        Assertions.assertEquals(0, result.length() % 4);
+        Assertions.assertEquals("%".repeat(result.length() / 4), result.replace("%%%%", "%"));
+    }
+
+    @Test
+    public void danglingFormattingCharacterIsDropped() {
+        String title = "a".repeat(MAX_LENGTH - 1) + ChatColor.ESCAPE + "r";
+        String result = BossBar.truncateForBedrock(title);
+        Assertions.assertEquals(MAX_LENGTH - 1, result.length());
+        Assertions.assertFalse(result.endsWith(String.valueOf(ChatColor.ESCAPE)));
+    }
+}


### PR DESCRIPTION
> **AI usage:** I used an AI assistant (Claude Code) to help investigate the bug and write the fix, and to draft this description. I tested the change in-game myself and understand how it works.

### Problem

Newer Bedrock clients (reported on protocol 1001 / MC 26.x) disconnect immediately after joining when they receive a boss bar with a very long title. Testing on the issue showed a 40 character title joins fine while a ~293 character one drops the connection right away. This shows up with plugins like TabTPS whose boss bar text can get very long when translation keys aren't resolved.

Fixes #6496

### Change

`BossBar` now caps the title length before the packet is sent. If the cut would land in the middle of a color code I drop the trailing section sign so we don't send a broken formatting sequence, and the `%` escaping is done after the trim so an escape sequence can't be split.

Both the create and rename paths sent the same title, so I moved that conversion into a small `bedrockTitle()` helper instead of duplicating it.

The limit is set at 256, which is under the point where clients start dropping the connection and still far longer than any normal boss bar title.

### Testing

Tested in-game on Paper with a Bedrock client: creating a boss bar with a 300+ character title (via `/bossbar`) no longer disconnects the client, and the title shows up truncated. `./gradlew :core:compileJava` builds clean.
