### PR TITLE
Change logger to a static reference and add some debugging commands

### DIFF
--- a/bootstrap/bungeecord/src/main/java/org/geysermc/geyser/platform/bungeecord/GeyserBungeeLogger.java
+++ b/bootstrap/bungeecord/src/main/java/org/geysermc/geyser/platform/bungeecord/GeyserBungeeLogger.java
@@ -77,6 +77,13 @@ public class GeyserBungeeLogger implements GeyserLogger {
     }
 
     @Override
+    public void debug(String message, Throwable t) {
+        if (debug) {
+            logger.log(Level.INFO, message, t);
+        }
+    }
+
+    @Override
     public void debug(String message, Object... arguments) {
         if (debug) {
             info(String.format(message, arguments));

--- a/bootstrap/bungeecord/src/main/java/org/geysermc/geyser/platform/bungeecord/GeyserBungeePingPassthrough.java
+++ b/bootstrap/bungeecord/src/main/java/org/geysermc/geyser/platform/bungeecord/GeyserBungeePingPassthrough.java
@@ -39,6 +39,7 @@ import net.md_5.bungee.api.plugin.Listener;
 import net.md_5.bungee.protocol.ProtocolConstants;
 import org.checkerframework.checker.nullness.qual.Nullable;
 import org.geysermc.geyser.GeyserImpl;
+import org.geysermc.geyser.GeyserLogger;
 import org.geysermc.geyser.ping.GeyserPingInfo;
 import org.geysermc.geyser.ping.IGeyserPingPassthrough;
 
@@ -70,7 +71,7 @@ public class GeyserBungeePingPassthrough implements IGeyserPingPassthrough, List
             event = future.get(100, TimeUnit.MILLISECONDS);
         } catch (Throwable cause) {
             String address = GeyserImpl.getInstance().config().logPlayerIpAddresses() ? inetSocketAddress.toString() : "<IP address withheld>";
-            GeyserImpl.getInstance().getLogger().error("Failed to get ping information for " + address, cause);
+            GeyserLogger.get().error("Failed to get ping information for " + address, cause);
             return null;
         }
 

--- a/bootstrap/bungeecord/src/main/java/org/geysermc/geyser/platform/bungeecord/GeyserBungeePlugin.java
+++ b/bootstrap/bungeecord/src/main/java/org/geysermc/geyser/platform/bungeecord/GeyserBungeePlugin.java
@@ -310,10 +310,7 @@ public class GeyserBungeePlugin extends Plugin implements GeyserBootstrap {
         try {
             return new BungeeMetrics(this);
         } catch (IOException e) {
-            this.geyserLogger.debug("Integrated bStats support failed to load.");
-            if (this.config().debugMode()) {
-                e.printStackTrace();
-            }
+            this.geyserLogger.debug("Integrated bStats support failed to load.", e);
             return null;
         }
     }

--- a/bootstrap/mod/gametest/src/main/java/org/geysermc/geyser/gametest/tests/ComponentHashTestInstance.java
+++ b/bootstrap/mod/gametest/src/main/java/org/geysermc/geyser/gametest/tests/ComponentHashTestInstance.java
@@ -43,6 +43,7 @@ import net.minecraft.resources.RegistryOps;
 import net.minecraft.util.ExtraCodecs;
 import net.minecraft.util.HashOps;
 import org.geysermc.geyser.GeyserImpl;
+import org.geysermc.geyser.GeyserLogger;
 import org.geysermc.geyser.gametest.registries.GameTestJavaRegistryProvider;
 import org.geysermc.geyser.item.hashing.DataComponentHashers;
 import org.geysermc.geyser.item.hashing.MapHasher;
@@ -114,11 +115,11 @@ public class ComponentHashTestInstance extends GeyserTestInstance {
             try {
                 helper.assertValueEqual(expected, geyser, "hash for component " + encodedJavaValue);
             } catch (GameTestAssertException assertException) {
-                GeyserImpl.getInstance().getLogger().warning("Hash failed for component " + testCase.type() + " (" + testCase.value() + "), printing values of MapHasher");
+                GeyserLogger.get().warning("Hash failed for component " + testCase.type() + " (" + testCase.value() + "), printing values of MapHasher");
                 MapHasher.debug = true;
                 DataComponentHashers.hash(registries, mcplComponent);
                 MapHasher.debug = false;
-                GeyserImpl.getInstance().getLogger().warning("The Mojang encoded/expected value is printed in the exception message");
+                GeyserLogger.get().warning("The Mojang encoded/expected value is printed in the exception message");
                 throw assertException;
             }
         }

--- a/bootstrap/mod/gametest/src/main/java/org/geysermc/geyser/gametest/tests/EntityMetadataTest.java
+++ b/bootstrap/mod/gametest/src/main/java/org/geysermc/geyser/gametest/tests/EntityMetadataTest.java
@@ -42,6 +42,7 @@ import net.minecraft.world.entity.EntitySpawnReason;
 import net.minecraft.world.entity.EntityType;
 import net.minecraft.world.level.GameType;
 import org.geysermc.geyser.GeyserImpl;
+import org.geysermc.geyser.GeyserLogger;
 import org.geysermc.geyser.entity.EntityDefinition;
 import org.geysermc.geyser.gametest.mixin.SynchedEntityDataAccessor;
 import org.geysermc.geyser.gametest.util.SynchedEntityDataDebugger;
@@ -101,7 +102,7 @@ public class EntityMetadataTest extends GeyserTestInstance {
                         + SynchedEntityDataDebugger.findNameOfSerializer(dataItems[i].getAccessor().serializer()) + ")");
                 }
             } catch (GameTestAssertException exception) {
-                GeyserImpl.getInstance().getLogger().warning("Metadata for entity type " + entityType + " are as follows:\n" + SynchedEntityDataDebugger.prettyPrintEntityDataAccessors(javaEntity.getClass(), dataItems));
+                GeyserLogger.get().warning("Metadata for entity type " + entityType + " are as follows:\n" + SynchedEntityDataDebugger.prettyPrintEntityDataAccessors(javaEntity.getClass(), dataItems));
                 throw exception;
             } finally {
                 javaEntity.discard();

--- a/bootstrap/mod/src/main/java/org/geysermc/geyser/platform/mod/GeyserModInjector.java
+++ b/bootstrap/mod/src/main/java/org/geysermc/geyser/platform/mod/GeyserModInjector.java
@@ -38,6 +38,7 @@ import net.minecraft.server.network.ServerConnectionListener;
 import org.checkerframework.checker.nullness.qual.NonNull;
 import org.geysermc.geyser.GeyserBootstrap;
 import org.geysermc.geyser.GeyserImpl;
+import org.geysermc.geyser.GeyserLogger;
 import org.geysermc.geyser.network.netty.GeyserInjector;
 import org.geysermc.geyser.network.netty.LocalServerChannelWrapper;
 import org.geysermc.geyser.platform.mod.platform.GeyserModPlatform;
@@ -125,10 +126,7 @@ public class GeyserModInjector extends GeyserInjector {
                 childHandler = (ChannelInitializer<Channel>) childHandlerField.get(handler);
                 break;
             } catch (Exception e) {
-                if (bootstrap.config().debugMode()) {
-                    bootstrap.getGeyserLogger().debug("The handler " + name + " isn't a ChannelInitializer. THIS ERROR IS SAFE TO IGNORE!");
-                    e.printStackTrace();
-                }
+                bootstrap.getGeyserLogger().debug("The handler " + name + " isn't a ChannelInitializer. THIS ERROR IS SAFE TO IGNORE!", e);
             }
         }
         if (childHandler == null) {
@@ -149,8 +147,7 @@ public class GeyserModInjector extends GeyserInjector {
                 eventLoopGroup.shutdownGracefully().sync();
                 eventLoopGroup = null;
             } catch (Exception e) {
-                GeyserImpl.getInstance().getLogger().error("Unable to shut down injector! " + e.getMessage());
-                e.printStackTrace();
+                GeyserLogger.get().error("Unable to shut down injector!", e);
             }
         }
 

--- a/bootstrap/mod/src/main/java/org/geysermc/geyser/platform/mod/GeyserModLogger.java
+++ b/bootstrap/mod/src/main/java/org/geysermc/geyser/platform/mod/GeyserModLogger.java
@@ -85,6 +85,13 @@ public class GeyserModLogger implements GeyserLogger {
     }
 
     @Override
+    public void debug(String message, Throwable t) {
+        if (debug) {
+            logger.info(message, t);
+        }
+    }
+
+    @Override
     public void debug(String message, Object... arguments) {
         if (debug) {
             logger.info(String.format(message, arguments));

--- a/bootstrap/mod/src/main/java/org/geysermc/geyser/platform/mod/command/ModCommandSource.java
+++ b/bootstrap/mod/src/main/java/org/geysermc/geyser/platform/mod/command/ModCommandSource.java
@@ -36,6 +36,7 @@ import net.minecraft.server.level.ServerPlayer;
 import org.checkerframework.checker.nullness.qual.NonNull;
 import org.checkerframework.checker.nullness.qual.Nullable;
 import org.geysermc.geyser.GeyserImpl;
+import org.geysermc.geyser.GeyserLogger;
 import org.geysermc.geyser.command.GeyserCommandSource;
 import org.geysermc.geyser.text.ChatColor;
 
@@ -60,7 +61,7 @@ public class ModCommandSource implements GeyserCommandSource {
         if (source.getEntity() instanceof ServerPlayer) {
             ((ServerPlayer) source.getEntity()).sendSystemMessage(Component.literal(message), false);
         } else {
-            GeyserImpl.getInstance().getLogger().info(ChatColor.toANSI(message + ChatColor.RESET));
+            GeyserLogger.get().info(ChatColor.toANSI(message + ChatColor.RESET));
         }
     }
 

--- a/bootstrap/spigot/src/main/java/org/geysermc/geyser/platform/spigot/GeyserSpigotCompressionDisabler.java
+++ b/bootstrap/spigot/src/main/java/org/geysermc/geyser/platform/spigot/GeyserSpigotCompressionDisabler.java
@@ -30,6 +30,7 @@ import io.netty.channel.ChannelOutboundHandlerAdapter;
 import io.netty.channel.ChannelPromise;
 import org.bukkit.Bukkit;
 import org.geysermc.geyser.GeyserImpl;
+import org.geysermc.geyser.GeyserLogger;
 
 /**
  * Disables the compression packet (and the compression handlers from being added to the pipeline) for Geyser clients
@@ -56,7 +57,7 @@ public class GeyserSpigotCompressionDisabler extends ChannelOutboundHandlerAdapt
             loginSuccessPacketClass = findLoginSuccessPacket();
             enabled = true;
         } catch (Exception e) {
-            GeyserImpl.getInstance().getLogger().error("Could not initialize compression disabler!", e);
+            GeyserLogger.get().error("Could not initialize compression disabler!", e);
         }
         COMPRESSION_PACKET_CLASS = compressionPacketClass;
         LOGIN_SUCCESS_PACKET_CLASS = loginSuccessPacketClass;

--- a/bootstrap/spigot/src/main/java/org/geysermc/geyser/platform/spigot/GeyserSpigotInjector.java
+++ b/bootstrap/spigot/src/main/java/org/geysermc/geyser/platform/spigot/GeyserSpigotInjector.java
@@ -162,10 +162,7 @@ public class GeyserSpigotInjector extends GeyserInjector {
                 }
                 break;
             } catch (Exception e) {
-                if (bootstrap.config().debugMode()) {
-                    bootstrap.getGeyserLogger().debug("The handler " + name + " isn't a ChannelInitializer. THIS ERROR IS SAFE TO IGNORE!");
-                    e.printStackTrace();
-                }
+                bootstrap.getGeyserLogger().debug("The handler " + name + " isn't a ChannelInitializer. THIS ERROR IS SAFE TO IGNORE!", e);
             }
         }
         if (childHandler == null) {

--- a/bootstrap/spigot/src/main/java/org/geysermc/geyser/platform/spigot/GeyserSpigotLogger.java
+++ b/bootstrap/spigot/src/main/java/org/geysermc/geyser/platform/spigot/GeyserSpigotLogger.java
@@ -77,6 +77,13 @@ public class GeyserSpigotLogger implements GeyserLogger {
     }
 
     @Override
+    public void debug(String message, Throwable t) {
+        if (debug) {
+            logger.log(Level.INFO, message, t);
+        }
+    }
+
+    @Override
     public void debug(String message, Object... arguments) {
         if (debug) {
             info(String.format(message, arguments));

--- a/bootstrap/spigot/src/main/java/org/geysermc/geyser/platform/spigot/GeyserSpigotPlugin.java
+++ b/bootstrap/spigot/src/main/java/org/geysermc/geyser/platform/spigot/GeyserSpigotPlugin.java
@@ -288,10 +288,7 @@ public class GeyserSpigotPlugin extends JavaPlugin implements GeyserBootstrap {
                 }
                 geyserLogger.debug("Using world manager of type: " + this.geyserWorldManager.getClass().getSimpleName());
             } catch (Throwable e) {
-                if (geyserConfig.debugMode()) {
-                    geyserLogger.debug("Error while attempting to find NMS adapter. Most likely, this can be safely ignored. :)");
-                    e.printStackTrace();
-                }
+                geyserLogger.debug("Error while attempting to find NMS adapter. Most likely, this can be safely ignored. :)", e);
             }
         } else {
             geyserLogger.debug("Not using NMS adapter as it is disabled via system property.");

--- a/bootstrap/spigot/src/main/java/org/geysermc/geyser/platform/spigot/PaperAdventure.java
+++ b/bootstrap/spigot/src/main/java/org/geysermc/geyser/platform/spigot/PaperAdventure.java
@@ -25,6 +25,7 @@
 
 package org.geysermc.geyser.platform.spigot;
 
+import org.geysermc.geyser.GeyserLogger;
 import org.geysermc.mcprotocollib.protocol.data.DefaultComponentSerializer;
 import net.kyori.adventure.text.Component;
 import org.bukkit.command.CommandSender;
@@ -79,7 +80,7 @@ public final class PaperAdventure {
                         nativeGsonComponentSerializerDeserializeMethodBound = nativeGsonComponentSerializerDeserializeMethod
                                 .bindTo(nativeGsonComponentSerializerGsonGetter.invoke());
                     } catch (final Throwable throwable) {
-                        GeyserImpl.getInstance().getLogger().error("Failed to access native GsonComponentSerializer", throwable);
+                        GeyserLogger.get().error("Failed to access native GsonComponentSerializer", throwable);
                     }
                 }
             }
@@ -94,9 +95,7 @@ public final class PaperAdventure {
             try {
                 playerComponentSendMessage = CommandSender.class.getMethod("sendMessage", nativeComponentClass);
             } catch (final NoSuchMethodException e) {
-                if (GeyserImpl.getInstance().getLogger().isDebug()) {
-                    e.printStackTrace();
-                }
+                GeyserLogger.get().debug("No Paper Adventure component method was found.", e);
             }
         }
         SEND_MESSAGE_COMPONENT = playerComponentSendMessage;
@@ -104,21 +103,21 @@ public final class PaperAdventure {
 
     public static @Nullable Object toNativeComponent(final Component component) {
         if (NATIVE_GSON_COMPONENT_SERIALIZER_DESERIALIZE_METHOD_BOUND == null) {
-            GeyserImpl.getInstance().getLogger().error("Illegal state where Component serialization was called when it wasn't available!");
+            GeyserLogger.get().error("Illegal state where Component serialization was called when it wasn't available!");
             return null;
         }
 
         try {
             return NATIVE_GSON_COMPONENT_SERIALIZER_DESERIALIZE_METHOD_BOUND.invoke(DefaultComponentSerializer.get().serialize(component));
         } catch (final Throwable throwable) {
-            GeyserImpl.getInstance().getLogger().error("Failed to create native Component message", throwable);
+            GeyserLogger.get().error("Failed to create native Component message", throwable);
             return null;
         }
     }
 
     public static void sendMessage(final CommandSender sender, final Component component) {
         if (SEND_MESSAGE_COMPONENT == null) {
-            GeyserImpl.getInstance().getLogger().error("Illegal state where Component sendMessage was called when it wasn't available!");
+            GeyserLogger.get().error("Illegal state where Component sendMessage was called when it wasn't available!");
             return;
         }
 
@@ -127,7 +126,7 @@ public final class PaperAdventure {
             try {
                 SEND_MESSAGE_COMPONENT.invoke(sender, nativeComponent);
             } catch (final InvocationTargetException | IllegalAccessException e) {
-                GeyserImpl.getInstance().getLogger().error("Failed to send native Component message", e);
+                GeyserLogger.get().error("Failed to send native Component message", e);
             }
         }
     }

--- a/bootstrap/spigot/src/main/java/org/geysermc/geyser/platform/spigot/command/SpigotCommandRegistry.java
+++ b/bootstrap/spigot/src/main/java/org/geysermc/geyser/platform/spigot/command/SpigotCommandRegistry.java
@@ -31,6 +31,7 @@ import org.bukkit.command.Command;
 import org.bukkit.command.CommandMap;
 import org.checkerframework.checker.nullness.qual.NonNull;
 import org.geysermc.geyser.GeyserImpl;
+import org.geysermc.geyser.GeyserLogger;
 import org.geysermc.geyser.command.CommandRegistry;
 import org.geysermc.geyser.command.GeyserCommandSource;
 import org.incendo.cloud.CommandManager;
@@ -55,7 +56,7 @@ public class SpigotCommandRegistry extends CommandRegistry {
                 cmdMapField.setAccessible(true);
                 commandMap = (CommandMap) cmdMapField.get(Bukkit.getServer());
             } catch (Exception ex) {
-                geyser.getLogger().error("Failed to get Spigot's CommandMap", ex);
+                GeyserLogger.get().error("Failed to get Spigot's CommandMap", ex);
             }
         }
         this.commandMap = commandMap;

--- a/bootstrap/standalone/src/main/java/org/geysermc/geyser/platform/standalone/GeyserStandaloneBootstrap.java
+++ b/bootstrap/standalone/src/main/java/org/geysermc/geyser/platform/standalone/GeyserStandaloneBootstrap.java
@@ -66,6 +66,7 @@ public class GeyserStandaloneBootstrap implements GeyserBootstrap {
     private GeyserStandaloneGUI gui;
     @Getter
     private boolean useGui = System.console() == null && !isHeadless();
+    @Getter
     private Logger log4jLogger;
     private String configFilename = "config.yml";
 

--- a/bootstrap/standalone/src/main/java/org/geysermc/geyser/platform/standalone/GeyserStandaloneLogger.java
+++ b/bootstrap/standalone/src/main/java/org/geysermc/geyser/platform/standalone/GeyserStandaloneLogger.java
@@ -122,6 +122,11 @@ public class GeyserStandaloneLogger extends SimpleTerminalConsole implements Gey
     }
 
     @Override
+    public void debug(String message, Throwable t) {
+        log.debug(ChatColor.GRAY + "{}", message, t);
+    }
+
+    @Override
     public void debug(String message, Object... arguments) {
         // We can't use the debug call that would format for us as we're using Java's string formatting
         log.debug(ChatColor.GRAY + String.format(message, arguments));
@@ -130,6 +135,8 @@ public class GeyserStandaloneLogger extends SimpleTerminalConsole implements Gey
     @Override
     public void setDebug(boolean debug) {
         Configurator.setLevel(log.getName(), debug ? Level.DEBUG : Level.INFO);
+        // Hacky, yes, does it work? Also yes.
+        ((GeyserStandaloneBootstrap) GeyserImpl.getInstance().getBootstrap()).getLog4jLogger().get().setLevel(debug ? Level.DEBUG : Level.INFO);
     }
 
     @Override

--- a/bootstrap/velocity/src/main/java/org/geysermc/geyser/platform/velocity/GeyserVelocityCompressionDisabler.java
+++ b/bootstrap/velocity/src/main/java/org/geysermc/geyser/platform/velocity/GeyserVelocityCompressionDisabler.java
@@ -29,6 +29,7 @@ import io.netty.channel.ChannelDuplexHandler;
 import io.netty.channel.ChannelHandlerContext;
 import io.netty.channel.ChannelPromise;
 import org.geysermc.geyser.GeyserImpl;
+import org.geysermc.geyser.GeyserLogger;
 
 import java.lang.reflect.Method;
 
@@ -61,7 +62,7 @@ public class GeyserVelocityCompressionDisabler extends ChannelDuplexHandler {
                     .getMethod("setCompressionThreshold", int.class);
             enabled = true;
         } catch (Exception e) {
-            GeyserImpl.getInstance().getLogger().error("Could not initialize compression disabler!", e);
+            GeyserLogger.get().error("Could not initialize compression disabler!", e);
         }
 
         ENABLED = enabled;

--- a/bootstrap/velocity/src/main/java/org/geysermc/geyser/platform/velocity/GeyserVelocityLogger.java
+++ b/bootstrap/velocity/src/main/java/org/geysermc/geyser/platform/velocity/GeyserVelocityLogger.java
@@ -75,6 +75,13 @@ public class GeyserVelocityLogger implements GeyserLogger {
     }
 
     @Override
+    public void debug(String message, Throwable t) {
+        if (debug) {
+            logger.info(message, t);
+        }
+    }
+
+    @Override
     public void debug(String message, Object... arguments) {
         if (debug) {
             logger.info(String.format(message, arguments));

--- a/bootstrap/velocity/src/main/java/org/geysermc/geyser/platform/velocity/GeyserVelocityPlugin.java
+++ b/bootstrap/velocity/src/main/java/org/geysermc/geyser/platform/velocity/GeyserVelocityPlugin.java
@@ -271,10 +271,7 @@ public class GeyserVelocityPlugin implements GeyserBootstrap {
         try {
             return new VelocityMetrics(this.configFolder);
         } catch (IOException e) {
-            this.geyserLogger.debug("Integrated bStats support failed to load.");
-            if (this.config().debugMode()) {
-                e.printStackTrace();
-            }
+            this.geyserLogger.debug("Integrated bStats support failed to load.", e);
             return null;
         }
     }

--- a/bootstrap/viaproxy/src/main/java/org/geysermc/geyser/platform/viaproxy/GeyserViaProxyLogger.java
+++ b/bootstrap/viaproxy/src/main/java/org/geysermc/geyser/platform/viaproxy/GeyserViaProxyLogger.java
@@ -84,6 +84,13 @@ public class GeyserViaProxyLogger implements GeyserLogger, GeyserCommandSource {
     }
 
     @Override
+    public void debug(String message, Throwable t) {
+        if (this.debug) {
+            this.logger.debug(ConsoleFormatter.convert(message), t);
+        }
+    }
+
+    @Override
     public void debug(String message, Object... arguments) {
         if (this.debug) {
             this.debug(String.format(message, arguments));

--- a/core/src/main/java/org/geysermc/geyser/GeyserImpl.java
+++ b/core/src/main/java/org/geysermc/geyser/GeyserImpl.java
@@ -73,6 +73,7 @@ import org.geysermc.geyser.api.util.PlatformType;
 import org.geysermc.geyser.command.CommandRegistry;
 import org.geysermc.geyser.configuration.GeyserConfig;
 import org.geysermc.geyser.configuration.GeyserPluginConfig;
+import org.geysermc.geyser.debug.GeyserDebugSessionMap;
 import org.geysermc.geyser.entity.EntityDefinitions;
 import org.geysermc.geyser.erosion.UnixSocketClientListener;
 import org.geysermc.geyser.event.GeyserEventBus;
@@ -157,6 +158,7 @@ public class GeyserImpl implements GeyserApi, EventRegistrar {
     private static final Pattern IP_REGEX = Pattern.compile("\\b\\d{1,3}\\.\\d{1,3}\\.\\d{1,3}\\.\\d{1,3}\\b");
 
     private final SessionManager sessionManager = new SessionManager();
+    private final GeyserDebugSessionMap debugSessionMap = new GeyserDebugSessionMap();
 
     private FloodgateCipher cipher;
     private @Nullable FloodgateSkinUploader skinUploader;
@@ -223,7 +225,7 @@ public class GeyserImpl implements GeyserApi, EventRegistrar {
             try {
                 EncryptionUtils.getMojangPublicKey();
             } catch (Throwable t) {
-                GeyserImpl.getInstance().getLogger().error("Unable to set up encryption! This can be caused by your internet connection or the Minecraft api being unreachable. ", t);
+                GeyserLogger.get().error("Unable to set up encryption! This can be caused by your internet connection or the Minecraft api being unreachable. ", t);
             }
         }
 
@@ -361,10 +363,7 @@ public class GeyserImpl implements GeyserApi, EventRegistrar {
                 try {
                     config.java().address(InetAddress.getLocalHost().getHostAddress());
                 } catch (UnknownHostException ex) {
-                    logger.debug("Unknown host when trying to find localhost.");
-                    if (config.debugMode()) {
-                        ex.printStackTrace();
-                    }
+                    logger.debug("Unknown host when trying to find localhost.", ex);
                     config.java().address(InetAddress.getLoopbackAddress().getHostAddress());
                 }
             }
@@ -520,7 +519,7 @@ public class GeyserImpl implements GeyserApi, EventRegistrar {
         }
 
         if (config.notifyOnNewBedrockUpdate()) {
-            VersionCheckUtils.checkForGeyserUpdate(this::getLogger);
+            VersionCheckUtils.checkForGeyserUpdate(GeyserLogger::get);
         }
     }
 
@@ -712,7 +711,7 @@ public class GeyserImpl implements GeyserApi, EventRegistrar {
 
     @Override
     public @NonNull CommandSource consoleCommandSource() {
-        return getLogger();
+        return GeyserLogger.get();
     }
 
     public int buildNumber() {
@@ -745,6 +744,10 @@ public class GeyserImpl implements GeyserApi, EventRegistrar {
         instance.setEnabled(true);
     }
 
+    /**
+     * @deprecated Use {@link GeyserLogger#get()} instead.
+     */
+    @Deprecated
     public GeyserLogger getLogger() {
         return bootstrap.getGeyserLogger();
     }
@@ -789,7 +792,7 @@ public class GeyserImpl implements GeyserApi, EventRegistrar {
             try (FileWriter writer = new FileWriter(savedAuthChains)) {
                 GSON.toJson(this.savedAuthChains, type, writer);
             } catch (IOException e) {
-                getLogger().error("Unable to write saved refresh tokens!", e);
+                GeyserLogger.get().error("Unable to write saved refresh tokens!", e);
             }
         });
     }

--- a/core/src/main/java/org/geysermc/geyser/GeyserLogger.java
+++ b/core/src/main/java/org/geysermc/geyser/GeyserLogger.java
@@ -108,6 +108,14 @@ public interface GeyserLogger extends GeyserCommandSource {
     }
 
     /**
+     * Logs a debug message with an attached stacktrace
+     *
+     * @param message the message to log
+     * @param t the exception to print
+     */
+    void debug(String message, Throwable t);
+
+    /**
      * Logs and formats a message to console if debug mode is enabled,
      * with the provided arguments.
      *
@@ -160,5 +168,9 @@ public interface GeyserLogger extends GeyserCommandSource {
     @Override
     default boolean hasPermission(String permission) {
         return true;
+    }
+
+    static GeyserLogger get() {
+        return GeyserImpl.getInstance().getBootstrap().getGeyserLogger();
     }
 }

--- a/core/src/main/java/org/geysermc/geyser/command/CommandRegistry.java
+++ b/core/src/main/java/org/geysermc/geyser/command/CommandRegistry.java
@@ -35,6 +35,7 @@ import org.cloudburstmc.protocol.bedrock.data.command.CommandParam;
 import org.cloudburstmc.protocol.bedrock.data.command.CommandParamData;
 import org.cloudburstmc.protocol.bedrock.data.command.CommandPermission;
 import org.geysermc.geyser.GeyserImpl;
+import org.geysermc.geyser.GeyserLogger;
 import org.geysermc.geyser.api.command.Command;
 import org.geysermc.geyser.api.event.EventRegistrar;
 import org.geysermc.geyser.api.event.lifecycle.GeyserDefineCommandsEvent;
@@ -46,6 +47,7 @@ import org.geysermc.geyser.command.defaults.AdvancedTooltipsCommand;
 import org.geysermc.geyser.command.defaults.AdvancementsCommand;
 import org.geysermc.geyser.command.defaults.ConnectionTestCommand;
 import org.geysermc.geyser.command.defaults.CustomOptionsCommand;
+import org.geysermc.geyser.command.defaults.DebugCommand;
 import org.geysermc.geyser.command.defaults.DumpCommand;
 import org.geysermc.geyser.command.defaults.ExtensionsCommand;
 import org.geysermc.geyser.command.defaults.GameruleCommand;
@@ -172,6 +174,7 @@ public class CommandRegistry implements EventRegistrar {
         registerBuiltInCommand(new CustomOptionsCommand("options", "geyser.commands.options.desc", "geyser.command.options"));
         registerBuiltInCommand(new QuickActionsCommand("quickactions", "geyser.commands.quickactions.desc", "geyser.command.quickactions"));
         registerBuiltInCommand(new GameruleCommand("gamerules", "geyser.commands.gamerules.desc", "geyser.command.gamerules"));
+        registerBuiltInCommand(new DebugCommand(geyser, "debug", "geyser.commands.debug.desc", "geyser.command.debug"));
 
         if (this.geyser.platformType() == PlatformType.STANDALONE) {
             registerBuiltInCommand(new StopCommand(geyser, "stop", "geyser.commands.stop.desc", "geyser.command.stop"));
@@ -246,7 +249,7 @@ public class CommandRegistry implements EventRegistrar {
 
         command.register(cloud);
         commands.put(name, command);
-        geyser.getLogger().debug(GeyserLocale.getLocaleStringLog("geyser.commands.registered", root + " " + name));
+        GeyserLogger.get().debug(GeyserLocale.getLocaleStringLog("geyser.commands.registered", root + " " + name));
 
         for (String alias : command.aliases()) {
             commands.put(alias, command);
@@ -259,7 +262,7 @@ public class CommandRegistry implements EventRegistrar {
             TriState existingDefault = permissionDefaults.get(permission);
             // Extensions might be using the same permission for two different commands
             if (existingDefault != null && existingDefault != defaultValue) {
-                geyser.getLogger().debug("Overriding permission default %s:%s with %s".formatted(permission, existingDefault, defaultValue));
+                GeyserLogger.get().debug("Overriding permission default %s:%s with %s".formatted(permission, existingDefault, defaultValue));
             }
 
             permissionDefaults.put(permission, defaultValue);

--- a/core/src/main/java/org/geysermc/geyser/command/CommandSourceConverter.java
+++ b/core/src/main/java/org/geysermc/geyser/command/CommandSourceConverter.java
@@ -95,9 +95,8 @@ public record CommandSourceConverter<S>(Class<S> senderType,
         }
 
         if (!(source instanceof GeyserSession)) {
-            GeyserLogger logger = GeyserImpl.getInstance().getLogger();
-            if (logger.isDebug()) {
-                logger.debug("Falling back to UUID for command sender lookup for a command source that is not a GeyserSession: " + source);
+            if (GeyserLogger.get().isDebug()) {
+                GeyserLogger.get().debug("Falling back to UUID for command sender lookup for a command source that is not a GeyserSession: " + source);
                 Thread.dumpStack();
             }
         }

--- a/core/src/main/java/org/geysermc/geyser/command/ExceptionHandlers.java
+++ b/core/src/main/java/org/geysermc/geyser/command/ExceptionHandlers.java
@@ -129,10 +129,7 @@ final class ExceptionHandlers {
                 return;
             }
         } else {
-            GeyserLogger logger = GeyserImpl.getInstance().getLogger();
-            if (logger.isDebug()) {
-                logger.debug("Expected a GeyserPermission.Result for %s but instead got %s from %s".formatted(exception.currentChain(), exception.permissionResult(), exception.missingPermission()));
-            }
+            GeyserLogger.get().debug("Expected a GeyserPermission.Result for %s but instead got %s from %s".formatted(exception.currentChain(), exception.permissionResult(), exception.missingPermission()));
         }
 
         // Result.NO_PERMISSION or generic permission failure
@@ -141,6 +138,6 @@ final class ExceptionHandlers {
 
     private static void handleUnexpectedThrowable(GeyserCommandSource source, Throwable throwable) {
         source.sendMessage(MinecraftLocale.getLocaleString("command.failed", source.locale())); // java edition translation key
-        GeyserImpl.getInstance().getLogger().error("Exception while executing command handler", throwable);
+        GeyserLogger.get().error("Exception while executing command handler", throwable);
     }
 }

--- a/core/src/main/java/org/geysermc/geyser/command/GeyserPermission.java
+++ b/core/src/main/java/org/geysermc/geyser/command/GeyserPermission.java
@@ -27,6 +27,7 @@ package org.geysermc.geyser.command;
 
 import lombok.AllArgsConstructor;
 import org.checkerframework.checker.nullness.qual.NonNull;
+import org.geysermc.geyser.GeyserLogger;
 import org.incendo.cloud.CommandManager;
 import org.incendo.cloud.key.CloudKey;
 import org.incendo.cloud.permission.Permission;
@@ -62,11 +63,13 @@ public class GeyserPermission implements PredicatePermission<GeyserCommandSource
     public @NonNull Result testPermission(@NonNull GeyserCommandSource source) {
         if (bedrockOnly) {
             if (source.connection() == null) {
+                GeyserLogger.get().warning("Command not executed because not bedrock!");
                 return new Result(Meta.NOT_BEDROCK);
             }
             // connection is present -> it is a player -> playerOnly is irrelevant
         } else if (playerOnly) {
             if (source.isConsole()) {
+                GeyserLogger.get().warning("Command not executed because not player!");
                 return new Result(Meta.NOT_PLAYER); // must be a player but is console
             }
         }
@@ -74,6 +77,7 @@ public class GeyserPermission implements PredicatePermission<GeyserCommandSource
         if (permission.isBlank() || manager.hasPermission(source, permission)) {
             return new Result(Meta.ALLOWED);
         }
+        GeyserLogger.get().warning("Command not executed because no permission!");
         return new Result(Meta.NO_PERMISSION);
     }
 

--- a/core/src/main/java/org/geysermc/geyser/command/GeyserPermission.java
+++ b/core/src/main/java/org/geysermc/geyser/command/GeyserPermission.java
@@ -63,13 +63,11 @@ public class GeyserPermission implements PredicatePermission<GeyserCommandSource
     public @NonNull Result testPermission(@NonNull GeyserCommandSource source) {
         if (bedrockOnly) {
             if (source.connection() == null) {
-                GeyserLogger.get().warning("Command not executed because not bedrock!");
                 return new Result(Meta.NOT_BEDROCK);
             }
             // connection is present -> it is a player -> playerOnly is irrelevant
         } else if (playerOnly) {
             if (source.isConsole()) {
-                GeyserLogger.get().warning("Command not executed because not player!");
                 return new Result(Meta.NOT_PLAYER); // must be a player but is console
             }
         }
@@ -77,7 +75,6 @@ public class GeyserPermission implements PredicatePermission<GeyserCommandSource
         if (permission.isBlank() || manager.hasPermission(source, permission)) {
             return new Result(Meta.ALLOWED);
         }
-        GeyserLogger.get().warning("Command not executed because no permission!");
         return new Result(Meta.NO_PERMISSION);
     }
 

--- a/core/src/main/java/org/geysermc/geyser/command/defaults/ConnectionTestCommand.java
+++ b/core/src/main/java/org/geysermc/geyser/command/defaults/ConnectionTestCommand.java
@@ -28,6 +28,7 @@ package org.geysermc.geyser.command.defaults;
 import com.google.gson.JsonElement;
 import com.google.gson.JsonObject;
 import org.geysermc.geyser.GeyserImpl;
+import org.geysermc.geyser.GeyserLogger;
 import org.geysermc.geyser.api.util.TriState;
 import org.geysermc.geyser.command.GeyserCommand;
 import org.geysermc.geyser.command.GeyserCommandSource;
@@ -211,7 +212,7 @@ public class ConnectionTestCommand extends GeyserCommand {
                 sendLinks(source);
             } catch (Exception e) {
                 source.sendMessage("An error occurred while trying to check your connection! Check the console for more information.");
-                geyser.getLogger().error("Error while trying to check your connection!", e);
+                GeyserLogger.get().error("Error while trying to check your connection!", e);
             }
         });
     }

--- a/core/src/main/java/org/geysermc/geyser/command/defaults/DebugCommand.java
+++ b/core/src/main/java/org/geysermc/geyser/command/defaults/DebugCommand.java
@@ -60,8 +60,8 @@ public class DebugCommand extends GeyserCommand {
         manager.command(baseBuilder(manager)
             .literal("player")
             .literal("options")
-            .required("xuid", longParser(0))
             .required("option", enumParser(SessionDebugOption.class))
+            .required("xuid", longParser(0))
             .handler(this::execute));
 
         manager.command(baseBuilder(manager)
@@ -92,6 +92,8 @@ public class DebugCommand extends GeyserCommand {
             } else {
                 context.sender().sendMessage("Remove debug option, the player may need to relog in order for the option to apply.");
             }
+
+            return;
         }
 
         if (newVal) {
@@ -102,6 +104,7 @@ public class DebugCommand extends GeyserCommand {
     }
 
     private void executeLogging(CommandContext<GeyserCommandSource> context) {
+        GeyserLogger.get().warning("e");
         boolean enabled = context.get("enabled");
         GeyserLogger.get().setDebug(enabled);
 

--- a/core/src/main/java/org/geysermc/geyser/command/defaults/DebugCommand.java
+++ b/core/src/main/java/org/geysermc/geyser/command/defaults/DebugCommand.java
@@ -51,7 +51,7 @@ public class DebugCommand extends GeyserCommand {
     private final GeyserImpl geyser;
 
     public DebugCommand(GeyserImpl geyser, String name, String description, String permission) {
-        super(name, description, permission, TriState.FALSE, false, false);
+        super(name, description, permission, TriState.NOT_SET, false, false);
         this.geyser = geyser;
     }
 

--- a/core/src/main/java/org/geysermc/geyser/command/defaults/DebugCommand.java
+++ b/core/src/main/java/org/geysermc/geyser/command/defaults/DebugCommand.java
@@ -1,0 +1,126 @@
+/*
+ * Copyright (c) 2026 GeyserMC. http://geysermc.org
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ *
+ * @author GeyserMC
+ * @link https://github.com/GeyserMC/Geyser
+ */
+
+package org.geysermc.geyser.command.defaults;
+
+import com.sun.management.HotSpotDiagnosticMXBean;
+import org.geysermc.geyser.GeyserImpl;
+import org.geysermc.geyser.GeyserLogger;
+import org.geysermc.geyser.api.util.TriState;
+import org.geysermc.geyser.command.GeyserCommand;
+import org.geysermc.geyser.command.GeyserCommandSource;
+import org.geysermc.geyser.debug.SessionDebugOption;
+import org.geysermc.geyser.session.GeyserSession;
+import org.incendo.cloud.CommandManager;
+import org.incendo.cloud.context.CommandContext;
+
+import javax.management.MBeanServer;
+
+import java.io.IOException;
+import java.lang.management.ManagementFactory;
+import java.nio.file.Files;
+import java.nio.file.Path;
+
+import static org.incendo.cloud.parser.standard.BooleanParser.booleanParser;
+import static org.incendo.cloud.parser.standard.EnumParser.enumParser;
+import static org.incendo.cloud.parser.standard.LongParser.longParser;
+
+public class DebugCommand extends GeyserCommand {
+    private final GeyserImpl geyser;
+
+    public DebugCommand(GeyserImpl geyser, String name, String description, String permission) {
+        super(name, description, permission, TriState.FALSE, false, false);
+        this.geyser = geyser;
+    }
+
+    @Override
+    public void register(CommandManager<GeyserCommandSource> manager) {
+        manager.command(baseBuilder(manager)
+            .literal("player")
+            .literal("options")
+            .required("xuid", longParser(0))
+            .required("option", enumParser(SessionDebugOption.class))
+            .handler(this::execute));
+
+        manager.command(baseBuilder(manager)
+            .literal("logging")
+            .required("enabled", booleanParser())
+            .handler(this::executeLogging));
+
+        manager.command(baseBuilder(manager)
+            .literal("heapdump")
+            .optional("live", booleanParser())
+            .handler(this::executeHeapDump));
+    }
+
+    @Override
+    public void execute(CommandContext<GeyserCommandSource> context) {
+        long xuid = context.get("xuid");
+        SessionDebugOption option = context.get("option");
+
+        boolean newVal = this.geyser.getDebugSessionMap().toggleDebugOption(xuid, option);
+
+        GeyserSession session = this.geyser.connectionByXuid(String.valueOf(xuid));
+        if (session != null) {
+            if (session.getDebugOptions().contains(option)) session.getDebugOptions().remove(option);
+            else session.getDebugOptions().add(option);
+
+            if (newVal) {
+                context.sender().sendMessage("Applied debug option, the player may need to relog in order for the option to apply.");
+            } else {
+                context.sender().sendMessage("Remove debug option, the player may need to relog in order for the option to apply.");
+            }
+        }
+
+        if (newVal) {
+            context.sender().sendMessage("Applied debug option, the option will apply when the player logs on.");
+        } else {
+            context.sender().sendMessage("Remove debug option, the option will apply when the player logs on.");
+        }
+    }
+
+    private void executeLogging(CommandContext<GeyserCommandSource> context) {
+        boolean enabled = context.get("enabled");
+        GeyserLogger.get().setDebug(enabled);
+
+        for (GeyserSession session : this.geyser.onlineConnections()) {
+            session.getUpstream().getSession().setLogging(enabled);
+        }
+    }
+
+    private void executeHeapDump(CommandContext<GeyserCommandSource> context) {
+        try {
+            Path path = this.geyser.configDirectory().resolve("debug_heapdump.hprof");
+            Files.deleteIfExists(path);
+            MBeanServer server = ManagementFactory.getPlatformMBeanServer();
+            HotSpotDiagnosticMXBean mxBean = ManagementFactory.newPlatformMXBeanProxy(
+                server, "com.sun.management:type=HotSpotDiagnostic", HotSpotDiagnosticMXBean.class);
+            mxBean.dumpHeap(path.toString(), (Boolean) context.optional("live").orElse(true));
+        } catch (IOException e) {
+            GeyserLogger.get().error("Failed to create heapdump!", e);
+            context.sender().sendMessage("Failed to create heapdump.");
+        }
+    }
+}

--- a/core/src/main/java/org/geysermc/geyser/command/defaults/DumpCommand.java
+++ b/core/src/main/java/org/geysermc/geyser/command/defaults/DumpCommand.java
@@ -34,6 +34,7 @@ import java.io.IOException;
 import java.util.ArrayList;
 import java.util.List;
 import org.geysermc.geyser.GeyserImpl;
+import org.geysermc.geyser.GeyserLogger;
 import org.geysermc.geyser.api.util.TriState;
 import org.geysermc.geyser.command.GeyserCommand;
 import org.geysermc.geyser.command.GeyserCommandSource;
@@ -118,7 +119,7 @@ public class DumpCommand extends GeyserCommand {
             dumpData = gson.toJson(dump);
         } catch (Exception e) {
             source.sendMessage(ChatColor.RED + GeyserLocale.getPlayerLocaleString("geyser.commands.dump.collect_error", source.locale()));
-            geyser.getLogger().error(GeyserLocale.getLocaleStringLog("geyser.commands.dump.collect_error_short"), e);
+            GeyserLogger.get().error(GeyserLocale.getLocaleStringLog("geyser.commands.dump.collect_error_short"), e);
             return;
         }
 
@@ -133,7 +134,7 @@ public class DumpCommand extends GeyserCommand {
                 outputStream.close();
             } catch (IOException e) {
                 source.sendMessage(ChatColor.RED + GeyserLocale.getPlayerLocaleString("geyser.commands.dump.write_error", source.locale()));
-                geyser.getLogger().error(GeyserLocale.getLocaleStringLog("geyser.commands.dump.write_error_short"), e);
+                GeyserLogger.get().error(GeyserLocale.getLocaleStringLog("geyser.commands.dump.write_error_short"), e);
                 return;
             }
 
@@ -148,9 +149,9 @@ public class DumpCommand extends GeyserCommand {
                 responseNode = JsonUtils.parseJson(response);
             } catch (Throwable e) {
                 source.sendMessage(ChatColor.RED + GeyserLocale.getPlayerLocaleString("geyser.commands.dump.upload_error", source.locale()));
-                geyser.getLogger().error(GeyserLocale.getLocaleStringLog("geyser.commands.dump.upload_error_short"), e);
+                GeyserLogger.get().error(GeyserLocale.getLocaleStringLog("geyser.commands.dump.upload_error_short"), e);
                 if (e instanceof JsonParseException && response != null) {
-                    geyser.getLogger().error("Failed to parse dump response! got: " + response);
+                    GeyserLogger.get().error("Failed to parse dump response! got: " + response);
                 }
                 return;
             }
@@ -165,7 +166,7 @@ public class DumpCommand extends GeyserCommand {
 
         source.sendMessage(GeyserLocale.getPlayerLocaleString("geyser.commands.dump.message", source.locale()) + " " + ChatColor.DARK_AQUA + uploadedDumpUrl);
         if (!source.isConsole()) {
-            geyser.getLogger().info(GeyserLocale.getLocaleStringLog("geyser.commands.dump.created", source.name(), uploadedDumpUrl));
+            GeyserLogger.get().info(GeyserLocale.getLocaleStringLog("geyser.commands.dump.created", source.name(), uploadedDumpUrl));
         }
     }
 }

--- a/core/src/main/java/org/geysermc/geyser/command/defaults/VersionCommand.java
+++ b/core/src/main/java/org/geysermc/geyser/command/defaults/VersionCommand.java
@@ -27,6 +27,7 @@ package org.geysermc.geyser.command.defaults;
 
 import com.google.gson.JsonObject;
 import org.geysermc.geyser.GeyserImpl;
+import org.geysermc.geyser.GeyserLogger;
 import org.geysermc.geyser.api.util.MinecraftVersion;
 import org.geysermc.geyser.api.util.PlatformType;
 import org.geysermc.geyser.api.util.TriState;
@@ -102,7 +103,7 @@ public class VersionCommand extends GeyserCommand {
                     source.locale(), (latestBuildNumber - buildNumber), "https://geysermc.org/download"
             ));
         } catch (IOException e) {
-            GeyserImpl.getInstance().getLogger().error(GeyserLocale.getLocaleStringLog("geyser.commands.version.failed"), e);
+            GeyserLogger.get().error(GeyserLocale.getLocaleStringLog("geyser.commands.version.failed"), e);
             source.sendMessage(ChatColor.RED + GeyserLocale.getPlayerLocaleString("geyser.commands.version.failed", source.locale()));
         }
     }

--- a/core/src/main/java/org/geysermc/geyser/command/standalone/StandaloneCloudCommandManager.java
+++ b/core/src/main/java/org/geysermc/geyser/command/standalone/StandaloneCloudCommandManager.java
@@ -28,6 +28,7 @@ package org.geysermc.geyser.command.standalone;
 import it.unimi.dsi.fastutil.objects.ObjectOpenHashSet;
 import org.checkerframework.checker.nullness.qual.NonNull;
 import org.geysermc.geyser.GeyserImpl;
+import org.geysermc.geyser.GeyserLogger;
 import org.geysermc.geyser.api.event.lifecycle.GeyserRegisterPermissionCheckersEvent;
 import org.geysermc.geyser.api.event.lifecycle.GeyserRegisterPermissionsEvent;
 import org.geysermc.geyser.api.permission.PermissionChecker;
@@ -81,7 +82,7 @@ public class StandaloneCloudCommandManager extends CommandManager<GeyserCommandS
             basePermissions.addAll(config.getDefaultPermissions());
             baseDeniedPermissions.addAll(config.getDefaultDeniedPermissions());
         } catch (Exception e) {
-            geyser.getLogger().error("Failed to load permissions.yml - proceeding without it", e);
+            GeyserLogger.get().error("Failed to load permissions.yml - proceeding without it", e);
         }
     }
 
@@ -98,7 +99,7 @@ public class StandaloneCloudCommandManager extends CommandManager<GeyserCommandS
                 return;
             }
 
-            GeyserImpl.getInstance().getLogger().debug("Registering permission %s with permission default %s", permission, def);
+            GeyserLogger.get().debug("Registering permission %s with permission default %s", permission, def);
 
             if (def == TriState.TRUE) {
                 // The last caller gets to override earlier set defaults

--- a/core/src/main/java/org/geysermc/geyser/configuration/ConfigLoader.java
+++ b/core/src/main/java/org/geysermc/geyser/configuration/ConfigLoader.java
@@ -30,6 +30,7 @@ import org.checkerframework.checker.nullness.qual.Nullable;
 import org.checkerframework.common.returnsreceiver.qual.This;
 import org.geysermc.geyser.GeyserBootstrap;
 import org.geysermc.geyser.GeyserImpl;
+import org.geysermc.geyser.GeyserLogger;
 import org.geysermc.geyser.api.util.PlatformType;
 import org.geysermc.geyser.text.GeyserLocale;
 import org.spongepowered.configurate.CommentedConfigurationNode;
@@ -95,7 +96,7 @@ public final class ConfigLoader {
         Path dataFolder = this.bootstrap.getConfigFolder();
         if (!dataFolder.toFile().exists()) {
             if (!dataFolder.toFile().mkdir()) {
-                GeyserImpl.getInstance().getLogger().warning("Failed to create config folder: " + dataFolder);
+                GeyserLogger.get().warning("Failed to create config folder: " + dataFolder);
             }
         }
         return this;

--- a/core/src/main/java/org/geysermc/geyser/debug/GeyserDebugSessionMap.java
+++ b/core/src/main/java/org/geysermc/geyser/debug/GeyserDebugSessionMap.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2025 GeyserMC. http://geysermc.org
+ * Copyright (c) 2026 GeyserMC. http://geysermc.org
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -23,33 +23,38 @@
  * @link https://github.com/GeyserMC/Geyser
  */
 
-package org.geysermc.geyser.session.cache.waypoint;
+package org.geysermc.geyser.debug;
 
-import net.kyori.adventure.key.Key;
-import org.cloudburstmc.math.vector.Vector3f;
-import org.geysermc.geyser.GeyserLogger;
-import org.geysermc.geyser.entity.type.Entity;
 import org.geysermc.geyser.session.GeyserSession;
-import org.geysermc.mcprotocollib.protocol.data.game.level.waypoint.ChunkWaypointData;
-import org.geysermc.mcprotocollib.protocol.data.game.level.waypoint.WaypointData;
 
-import java.awt.Color;
-import java.util.Optional;
-import java.util.UUID;
+import java.util.EnumSet;
+import java.util.HashMap;
+import java.util.Map;
 
-public class ChunkWaypoint extends GeyserWaypoint {
+public class GeyserDebugSessionMap {
+    private final Map<Long, EnumSet<SessionDebugOption>> debugOptionsHolder = new HashMap<>();
 
-    public ChunkWaypoint(GeyserSession session, UUID uuid, Key style, Color color, Optional<Entity> entity) {
-        super(session, uuid, style, color, entity);
+    public boolean toggleDebugOption(long xuid, SessionDebugOption option) {
+        if (debugOptionsHolder.containsKey(xuid)) {
+            EnumSet<SessionDebugOption> set = debugOptionsHolder.get(xuid);
+            if (set.contains(option)) {
+                set.remove(option);
+                return false;
+            } else {
+                set.add(option);
+                return true;
+            }
+        } else {
+            debugOptionsHolder.put(xuid, EnumSet.of(option));
+            return true;
+        }
     }
 
-    @Override
-    public void setData(WaypointData data) {
-        if (data instanceof ChunkWaypointData(int chunkX, int chunkZ)) {
-            // Set position in centre of chunk
-            setPosition(Vector3f.from(chunkX * 16.0F + 8.0F, session.getPlayerEntity().position().getY(), chunkZ * 16.0F + 8.0F));
-        } else {
-            GeyserLogger.get().warning("Received incorrect waypoint data " + data.getClass() + " for chunk waypoint");
-        }
+    public void setFor(GeyserSession session) {
+        session.setDebugOptions(debugOptionsHolder.getOrDefault(session.xuid(), EnumSet.noneOf(SessionDebugOption.class)));
+    }
+
+    public EnumSet<SessionDebugOption> getFor(long xuid) {
+        return debugOptionsHolder.getOrDefault(xuid, EnumSet.noneOf(SessionDebugOption.class));
     }
 }

--- a/core/src/main/java/org/geysermc/geyser/debug/GeyserDebugSessionMap.java
+++ b/core/src/main/java/org/geysermc/geyser/debug/GeyserDebugSessionMap.java
@@ -51,10 +51,6 @@ public class GeyserDebugSessionMap {
     }
 
     public void setFor(GeyserSession session) {
-        session.setDebugOptions(debugOptionsHolder.getOrDefault(session.xuid(), EnumSet.noneOf(SessionDebugOption.class)));
-    }
-
-    public EnumSet<SessionDebugOption> getFor(long xuid) {
-        return debugOptionsHolder.getOrDefault(xuid, EnumSet.noneOf(SessionDebugOption.class));
+        session.setDebugOptions(debugOptionsHolder.getOrDefault(Long.parseLong(session.xuid()), EnumSet.noneOf(SessionDebugOption.class)));
     }
 }

--- a/core/src/main/java/org/geysermc/geyser/debug/SessionDebugOption.java
+++ b/core/src/main/java/org/geysermc/geyser/debug/SessionDebugOption.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024 GeyserMC. http://geysermc.org
+ * Copyright (c) 2026 GeyserMC. http://geysermc.org
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -23,35 +23,11 @@
  * @link https://github.com/GeyserMC/Geyser
  */
 
-package org.geysermc.geyser.util.metrics;
+package org.geysermc.geyser.debug;
 
-import org.geysermc.geyser.GeyserImpl;
-import org.geysermc.geyser.GeyserLogger;
-
-public final class ProvidedMetricsPlatform implements MetricsPlatform {
-
-    @Override
-    public boolean enabled() {
-        return GeyserImpl.getInstance().config().enableMetrics();
-    }
-
-    @Override
-    public String serverUuid() {
-        return GeyserImpl.getInstance().config().metricsUuid().toString();
-    }
-
-    @Override
-    public boolean logFailedRequests() {
-        return GeyserLogger.get().isDebug();
-    }
-
-    @Override
-    public boolean logSentData() {
-        return GeyserLogger.get().isDebug();
-    }
-
-    @Override
-    public boolean logResponseStatusText() {
-        return GeyserLogger.get().isDebug();
-    }
+public enum SessionDebugOption {
+    // Pack
+    FORCE_OPTIONAL_PACKS,
+    FORCE_DISABLE_PACKS,
+    FORCE_VIBRANT_VISUALS
 }

--- a/core/src/main/java/org/geysermc/geyser/dump/DumpInfo.java
+++ b/core/src/main/java/org/geysermc/geyser/dump/DumpInfo.java
@@ -41,6 +41,7 @@ import lombok.Getter;
 import org.checkerframework.checker.nullness.qual.Nullable;
 import org.geysermc.floodgate.util.DeviceOs;
 import org.geysermc.geyser.GeyserImpl;
+import org.geysermc.geyser.GeyserLogger;
 import org.geysermc.geyser.api.GeyserApi;
 import org.geysermc.geyser.api.extension.Extension;
 import org.geysermc.geyser.api.util.MinecraftVersion;
@@ -117,10 +118,7 @@ public class DumpInfo {
             configNode.set(geyser.config());
             this.config = toGson(configNode);
         } catch (SerializationException e) {
-            e.printStackTrace();
-            if (geyser.config().debugMode()) {
-                e.printStackTrace();
-            }
+            GeyserLogger.get().error("Error serializing config. Dump will contain null config.", e);
         }
 
         String sha256Hash = "unknown";
@@ -131,9 +129,7 @@ public class DumpInfo {
             //noinspection UnstableApiUsage
             sha256Hash = byteSource.hash(Hashing.sha256()).toString();
         } catch (Exception e) {
-            if (geyser.config().debugMode()) {
-                e.printStackTrace();
-            }
+            GeyserLogger.get().debug("Error obtaining JAR SHA256 hash.", e);
         }
         this.hash = sha256Hash;
 

--- a/core/src/main/java/org/geysermc/geyser/entity/EntityDefinition.java
+++ b/core/src/main/java/org/geysermc/geyser/entity/EntityDefinition.java
@@ -28,7 +28,7 @@ package org.geysermc.geyser.entity;
 import it.unimi.dsi.fastutil.objects.ObjectArrayList;
 import lombok.Setter;
 import lombok.experimental.Accessors;
-import org.geysermc.geyser.GeyserImpl;
+import org.geysermc.geyser.GeyserLogger;
 import org.geysermc.geyser.entity.factory.EntityFactory;
 import org.geysermc.geyser.entity.properties.GeyserEntityProperties;
 import org.geysermc.geyser.entity.properties.type.PropertyType;

--- a/core/src/main/java/org/geysermc/geyser/entity/EntityDefinition.java
+++ b/core/src/main/java/org/geysermc/geyser/entity/EntityDefinition.java
@@ -71,10 +71,8 @@ public record EntityDefinition<T extends Entity>(EntityFactory<T> factory, Entit
         }
 
         if (translator.acceptedType() != metadata.getType()) {
-            GeyserImpl.getInstance().getLogger().warning("Metadata ID " + metadata.getId() + " was received with type " + metadata.getType() + " but we expected " + translator.acceptedType() + " for " + entity.getDefinition().entityType());
-            if (GeyserImpl.getInstance().config().debugMode()) {
-                GeyserImpl.getInstance().getLogger().debug(metadata.toString());
-            }
+            GeyserLogger.get().warning("Metadata ID " + metadata.getId() + " was received with type " + metadata.getType() + " but we expected " + translator.acceptedType() + " for " + entity.getDefinition().entityType());
+            GeyserLogger.get().debug(metadata.toString());
             return;
         }
 

--- a/core/src/main/java/org/geysermc/geyser/entity/properties/type/IntProperty.java
+++ b/core/src/main/java/org/geysermc/geyser/entity/properties/type/IntProperty.java
@@ -29,6 +29,7 @@ import org.checkerframework.checker.nullness.qual.Nullable;
 import org.cloudburstmc.nbt.NbtMap;
 import org.cloudburstmc.protocol.bedrock.data.entity.IntEntityProperty;
 import org.geysermc.geyser.GeyserImpl;
+import org.geysermc.geyser.GeyserLogger;
 import org.geysermc.geyser.api.entity.property.type.GeyserIntEntityProperty;
 import org.geysermc.geyser.api.util.Identifier;
 
@@ -50,7 +51,7 @@ public record IntProperty(
         }
         if (min < -1000000 || max > 1000000) {
             // https://learn.microsoft.com/en-us/minecraft/creator/documents/introductiontoentityproperties?view=minecraft-bedrock-stable#a-note-on-large-integer-entity-property-values
-            GeyserImpl.getInstance().getLogger().warning("Using int entity properties with min / max values larger than +- 1 million is not recommended!");
+            GeyserLogger.get().warning("Using int entity properties with min / max values larger than +- 1 million is not recommended!");
         }
     }
 

--- a/core/src/main/java/org/geysermc/geyser/entity/type/Entity.java
+++ b/core/src/main/java/org/geysermc/geyser/entity/type/Entity.java
@@ -43,6 +43,7 @@ import org.cloudburstmc.protocol.bedrock.packet.MoveEntityAbsolutePacket;
 import org.cloudburstmc.protocol.bedrock.packet.MoveEntityDeltaPacket;
 import org.cloudburstmc.protocol.bedrock.packet.RemoveEntityPacket;
 import org.cloudburstmc.protocol.bedrock.packet.SetEntityDataPacket;
+import org.geysermc.geyser.GeyserLogger;
 import org.geysermc.geyser.api.entity.property.BatchPropertyUpdater;
 import org.geysermc.geyser.api.entity.property.GeyserEntityProperty;
 import org.geysermc.geyser.api.entity.type.GeyserEntity;
@@ -227,10 +228,10 @@ public class Entity implements GeyserEntity {
 
         flagsDirty = false;
 
-        if (session.getGeyser().config().debugMode() && PRINT_ENTITY_SPAWN_DEBUG) {
+        if (GeyserLogger.get().isDebug() && PRINT_ENTITY_SPAWN_DEBUG) {
             EntityType type = definition.entityType();
             String name = type != null ? type.name() : getClass().getSimpleName();
-            session.getGeyser().getLogger().debug("Spawned entity " + name + " at location " + position + " with id " + geyserId + " (java id " + entityId + ")");
+            GeyserLogger.get().debug("Spawned entity " + name + " at location " + position + " with id " + geyserId + " (java id " + entityId + ")");
         }
     }
 

--- a/core/src/main/java/org/geysermc/geyser/entity/type/ItemFrameEntity.java
+++ b/core/src/main/java/org/geysermc/geyser/entity/type/ItemFrameEntity.java
@@ -33,6 +33,7 @@ import org.cloudburstmc.protocol.bedrock.data.definitions.BlockDefinition;
 import org.cloudburstmc.protocol.bedrock.data.inventory.ItemData;
 import org.cloudburstmc.protocol.bedrock.packet.BlockEntityDataPacket;
 import org.cloudburstmc.protocol.bedrock.packet.UpdateBlockPacket;
+import org.geysermc.geyser.GeyserLogger;
 import org.geysermc.geyser.entity.spawn.EntitySpawnContext;
 import org.geysermc.geyser.session.GeyserSession;
 import org.geysermc.geyser.translator.item.ItemTranslator;
@@ -94,7 +95,7 @@ public class ItemFrameEntity extends HangingEntity {
     @Override
     public void spawnEntity() {
         updateBlock(true);
-        session.getGeyser().getLogger().debug("Spawned item frame at location " + bedrockPosition + " with java id " + entityId);
+        GeyserLogger.get().debug("Spawned item frame at location " + bedrockPosition + " with java id " + entityId);
         valid = true;
     }
 

--- a/core/src/main/java/org/geysermc/geyser/entity/type/LivingEntity.java
+++ b/core/src/main/java/org/geysermc/geyser/entity/type/LivingEntity.java
@@ -42,6 +42,7 @@ import org.cloudburstmc.protocol.bedrock.packet.MobEquipmentPacket;
 import org.cloudburstmc.protocol.bedrock.packet.MoveEntityDeltaPacket;
 import org.cloudburstmc.protocol.bedrock.packet.UpdateAttributesPacket;
 import org.geysermc.geyser.GeyserImpl;
+import org.geysermc.geyser.GeyserLogger;
 import org.geysermc.geyser.entity.attribute.GeyserAttributeType;
 import org.geysermc.geyser.entity.spawn.EntitySpawnContext;
 import org.geysermc.geyser.entity.type.living.animal.HappyGhastEntity;
@@ -295,7 +296,7 @@ public class LivingEntity extends Entity implements Tickable {
 
             // If we couldn't map it, skip it
             if (effectType == null) {
-                GeyserImpl.getInstance().getLogger().debug("Could not map particle " + particle.getType() + " to an effect for entity " + this.entityId);
+                GeyserLogger.get().debug("Could not map particle " + particle.getType() + " to an effect for entity " + this.entityId);
                 continue;
             }
 

--- a/core/src/main/java/org/geysermc/geyser/entity/type/PaintingEntity.java
+++ b/core/src/main/java/org/geysermc/geyser/entity/type/PaintingEntity.java
@@ -27,6 +27,7 @@ package org.geysermc.geyser.entity.type;
 
 import org.cloudburstmc.math.vector.Vector3f;
 import org.cloudburstmc.protocol.bedrock.packet.AddPaintingPacket;
+import org.geysermc.geyser.GeyserLogger;
 import org.geysermc.geyser.entity.spawn.EntitySpawnContext;
 import org.geysermc.geyser.level.PaintingType;
 import org.geysermc.geyser.session.cache.registry.JavaRegistries;
@@ -92,7 +93,7 @@ public class PaintingEntity extends HangingEntity {
 
         valid = true;
 
-        session.getGeyser().getLogger().debug("Spawned painting on " + position);
+        GeyserLogger.get().debug("Spawned painting on " + position);
     }
 
     @Override

--- a/core/src/main/java/org/geysermc/geyser/entity/type/ThrownPotionEntity.java
+++ b/core/src/main/java/org/geysermc/geyser/entity/type/ThrownPotionEntity.java
@@ -28,6 +28,7 @@ package org.geysermc.geyser.entity.type;
 import org.cloudburstmc.protocol.bedrock.data.entity.EntityDataTypes;
 import org.cloudburstmc.protocol.bedrock.data.entity.EntityFlag;
 import org.geysermc.geyser.GeyserImpl;
+import org.geysermc.geyser.GeyserLogger;
 import org.geysermc.geyser.entity.spawn.EntitySpawnContext;
 import org.geysermc.geyser.inventory.item.Potion;
 import org.geysermc.mcprotocollib.protocol.data.game.entity.metadata.EntityMetadata;
@@ -65,7 +66,7 @@ public class ThrownPotionEntity extends ThrowableItemEntity {
                         setFlag(EntityFlag.ENCHANTED, !NON_ENCHANTED_POTIONS.contains(potion));
                     } else {
                         dirtyMetadata.put(EntityDataTypes.AUX_VALUE_DATA, (short) 0);
-                        GeyserImpl.getInstance().getLogger().debug("Unknown java potion: " + potionContents.getPotionId());
+                        GeyserLogger.get().debug("Unknown java potion: " + potionContents.getPotionId());
                     }
                 }
 

--- a/core/src/main/java/org/geysermc/geyser/entity/type/player/AvatarEntity.java
+++ b/core/src/main/java/org/geysermc/geyser/entity/type/player/AvatarEntity.java
@@ -41,6 +41,7 @@ import org.cloudburstmc.protocol.bedrock.data.entity.EntityFlag;
 import org.cloudburstmc.protocol.bedrock.packet.AddPlayerPacket;
 import org.cloudburstmc.protocol.bedrock.packet.MovePlayerPacket;
 import org.geysermc.geyser.GeyserImpl;
+import org.geysermc.geyser.GeyserLogger;
 import org.geysermc.geyser.api.skin.SkinData;
 import org.geysermc.geyser.entity.spawn.EntitySpawnContext;
 import org.geysermc.geyser.entity.type.LivingEntity;
@@ -212,7 +213,7 @@ public abstract class AvatarEntity extends LivingEntity {
         try {
             textures = profile.getTextures(false);
         } catch (IllegalStateException e) {
-            GeyserImpl.getInstance().getLogger().debug("Error loading textures for profile (%s)! Got: %s", profile, e);
+            GeyserLogger.get().debug("Error loading textures for profile (%s)! Got: %s", profile, e);
             textures = null;
         }
         setSkin(textures, after);

--- a/core/src/main/java/org/geysermc/geyser/entity/type/player/PlayerEntity.java
+++ b/core/src/main/java/org/geysermc/geyser/entity/type/player/PlayerEntity.java
@@ -36,6 +36,7 @@ import org.cloudburstmc.protocol.bedrock.packet.PlayerListPacket;
 import org.cloudburstmc.protocol.bedrock.packet.SetEntityLinkPacket;
 import org.cloudburstmc.protocol.bedrock.packet.UpdateAttributesPacket;
 import org.geysermc.geyser.GeyserImpl;
+import org.geysermc.geyser.GeyserLogger;
 import org.geysermc.geyser.api.entity.type.player.GeyserPlayerEntity;
 import org.geysermc.geyser.entity.EntityDefinitions;
 import org.geysermc.geyser.entity.attribute.GeyserAttributeType;
@@ -80,7 +81,7 @@ public class PlayerEntity extends AvatarEntity implements GeyserPlayerEntity {
         try {
             this.textures = profile.getTextures(true);
         } catch (Exception e) {
-            GeyserImpl.getInstance().getLogger().debug("Error loading textures for player!" + profile, e);
+            GeyserLogger.get().debug("Error loading textures for player!" + profile, e);
             this.textures = null;
         }
     }

--- a/core/src/main/java/org/geysermc/geyser/entity/vehicle/VehicleComponent.java
+++ b/core/src/main/java/org/geysermc/geyser/entity/vehicle/VehicleComponent.java
@@ -37,6 +37,7 @@ import org.cloudburstmc.math.vector.Vector3i;
 import org.cloudburstmc.protocol.bedrock.data.entity.EntityFlag;
 import org.cloudburstmc.protocol.bedrock.packet.MoveEntityDeltaPacket;
 import org.geysermc.erosion.util.BlockPositionIterator;
+import org.geysermc.geyser.GeyserLogger;
 import org.geysermc.geyser.entity.type.Entity;
 import org.geysermc.geyser.entity.type.LivingEntity;
 import org.geysermc.geyser.level.block.BlockStateValues;
@@ -1005,7 +1006,7 @@ public class VehicleComponent<T extends Entity & ClientVehicle> {
         protected int getBlockId(int x, int y, int z) {
             int index = this.blockIter.getIndex(x, y, z);
             if (index == -1) {
-                vehicle.getSession().getGeyser().getLogger().debug("[client-vehicle] Block cache miss");
+                GeyserLogger.get().debug("[client-vehicle] Block cache miss");
                 return vehicle.getSession().getGeyser().getWorldManager().getBlockAt(vehicle.getSession(), x, y, z);
             }
 

--- a/core/src/main/java/org/geysermc/geyser/erosion/AbstractGeyserboundPacketHandler.java
+++ b/core/src/main/java/org/geysermc/geyser/erosion/AbstractGeyserboundPacketHandler.java
@@ -27,6 +27,7 @@ package org.geysermc.geyser.erosion;
 
 import org.checkerframework.checker.nullness.qual.Nullable;
 import org.geysermc.erosion.packet.geyserbound.*;
+import org.geysermc.geyser.GeyserLogger;
 import org.geysermc.geyser.session.GeyserSession;
 
 public abstract class AbstractGeyserboundPacketHandler implements GeyserboundPacketHandler {
@@ -83,6 +84,6 @@ public abstract class AbstractGeyserboundPacketHandler implements GeyserboundPac
     }
 
     protected final void illegalPacket(GeyserboundPacket packet) {
-        session.getGeyser().getLogger().warning("Illegal packet sent from backend server! " + packet);
+        GeyserLogger.get().warning("Illegal packet sent from backend server! " + packet);
     }
 }

--- a/core/src/main/java/org/geysermc/geyser/erosion/GeyserboundPacketHandlerImpl.java
+++ b/core/src/main/java/org/geysermc/geyser/erosion/GeyserboundPacketHandlerImpl.java
@@ -43,6 +43,7 @@ import org.geysermc.erosion.packet.ErosionPacketSender;
 import org.geysermc.erosion.packet.backendbound.BackendboundInitializePacket;
 import org.geysermc.erosion.packet.backendbound.BackendboundPacket;
 import org.geysermc.erosion.packet.geyserbound.*;
+import org.geysermc.geyser.GeyserLogger;
 import org.geysermc.geyser.level.block.BlockStateValues;
 import org.geysermc.geyser.level.block.property.Properties;
 import org.geysermc.geyser.level.block.type.Block;
@@ -81,7 +82,7 @@ public final class GeyserboundPacketHandlerImpl extends AbstractGeyserboundPacke
         if (this.pendingBatchLookup != null) {
             this.pendingBatchLookup.complete(packet.getBlocks());
         } else {
-            session.getGeyser().getLogger().warning("Batch block ID packet received with no future to complete.");
+            GeyserLogger.get().warning("Batch block ID packet received with no future to complete.");
         }
     }
 
@@ -104,7 +105,7 @@ public final class GeyserboundPacketHandlerImpl extends AbstractGeyserboundPacke
             future.complete(packet.getBlockId());
             return;
         }
-        session.getGeyser().getLogger().warning("Block ID packet received with no future to complete.");
+        GeyserLogger.get().warning("Block ID packet received with no future to complete.");
     }
 
     @Override

--- a/core/src/main/java/org/geysermc/geyser/event/type/GeyserDefineCustomItemsEventImpl.java
+++ b/core/src/main/java/org/geysermc/geyser/event/type/GeyserDefineCustomItemsEventImpl.java
@@ -29,6 +29,7 @@ import com.google.common.collect.Multimap;
 import com.google.common.collect.MultimapBuilder;
 import org.checkerframework.checker.nullness.qual.NonNull;
 import org.geysermc.geyser.GeyserImpl;
+import org.geysermc.geyser.GeyserLogger;
 import org.geysermc.geyser.api.event.lifecycle.GeyserDefineCustomItemsEvent;
 import org.geysermc.geyser.api.item.custom.CustomItemData;
 import org.geysermc.geyser.api.item.custom.NonVanillaCustomItemData;
@@ -89,7 +90,7 @@ public abstract class GeyserDefineCustomItemsEventImpl implements GeyserDefineCu
             deprecatedCustomItems.put(identifier, customItemData);
             return true;
         } catch (CustomItemDefinitionRegisterException exception) {
-            GeyserImpl.getInstance().getLogger().error("Not registering deprecated custom item: " + customItemData, exception);
+            GeyserLogger.get().error("Not registering deprecated custom item: " + customItemData, exception);
             return false;
         }
     }
@@ -102,7 +103,7 @@ public abstract class GeyserDefineCustomItemsEventImpl implements GeyserDefineCu
             deprecatedNonVanillaCustomItems.add(customItemData);
             return true;
         } catch (CustomItemDefinitionRegisterException exception) {
-            GeyserImpl.getInstance().getLogger().error("Not registering deprecated non-vanilla custom item: " + customItemData, exception);
+            GeyserLogger.get().error("Not registering deprecated non-vanilla custom item: " + customItemData, exception);
             return false;
         }
     }

--- a/core/src/main/java/org/geysermc/geyser/event/type/SessionLoadResourcePacksEventImpl.java
+++ b/core/src/main/java/org/geysermc/geyser/event/type/SessionLoadResourcePacksEventImpl.java
@@ -33,6 +33,7 @@ import org.checkerframework.checker.nullness.qual.Nullable;
 import org.cloudburstmc.protocol.bedrock.packet.ResourcePackStackPacket;
 import org.cloudburstmc.protocol.bedrock.packet.ResourcePacksInfoPacket;
 import org.geysermc.geyser.GeyserImpl;
+import org.geysermc.geyser.GeyserLogger;
 import org.geysermc.geyser.api.event.bedrock.SessionLoadResourcePacksEvent;
 import org.geysermc.geyser.api.pack.ResourcePack;
 import org.geysermc.geyser.api.pack.ResourcePackManifest;
@@ -91,7 +92,7 @@ public class SessionLoadResourcePacksEventImpl extends SessionLoadResourcePacksE
         try {
             register(resourcePack, PriorityOption.NORMAL);
         } catch (ResourcePackException e) {
-            GeyserImpl.getInstance().getLogger().error("An exception occurred while registering resource pack: " + e.getMessage(), e);
+            GeyserLogger.get().error("An exception occurred while registering resource pack: " + e.getMessage(), e);
             return false;
         }
         return true;
@@ -219,7 +220,7 @@ public class SessionLoadResourcePacksEventImpl extends SessionLoadResourcePacksE
 
         for (ResourcePackHolder holder : packs.values()) {
             if (!warned && anyCdn && !(holder.codec() instanceof UrlPackCodec)) {
-                GeyserImpl.getInstance().getLogger().warning("Mixing pack codecs will result in all UrlPackCodec delivered packs to fall back to non-cdn delivery!");
+                GeyserLogger.get().warning("Mixing pack codecs will result in all UrlPackCodec delivered packs to fall back to non-cdn delivery!");
                 warned = true;
             }
             GeyserResourcePack pack = holder.pack();
@@ -231,6 +232,13 @@ public class SessionLoadResourcePacksEventImpl extends SessionLoadResourcePacksE
         }
 
         return entries;
+    }
+
+    // Helper method for debugging
+
+    public void unregisterAll() {
+        this.packs.clear();
+        this.sessionPackOptionOverrides.clear();
     }
 
     // Helper methods to get the options for a ResourcePack

--- a/core/src/main/java/org/geysermc/geyser/extension/GeyserExtensionClassLoader.java
+++ b/core/src/main/java/org/geysermc/geyser/extension/GeyserExtensionClassLoader.java
@@ -28,6 +28,7 @@ package org.geysermc.geyser.extension;
 import it.unimi.dsi.fastutil.objects.Object2ObjectMap;
 import it.unimi.dsi.fastutil.objects.Object2ObjectOpenHashMap;
 import org.geysermc.geyser.GeyserImpl;
+import org.geysermc.geyser.GeyserLogger;
 import org.geysermc.geyser.api.extension.Extension;
 import org.geysermc.geyser.api.extension.ExtensionDescription;
 import org.geysermc.geyser.api.extension.exception.InvalidExtensionException;
@@ -90,7 +91,7 @@ public class GeyserExtensionClassLoader extends URLClassLoader {
                 // This is used for classes that are not in the extension, but are in other extensions
                 if (checkGlobal) {
                     if (!warnedForExternalClassAccess && this.description.dependencies().isEmpty()) { // Don't warn when the extension has dependencies, it is probably using it's dependencies!
-                        GeyserImpl.getInstance().getLogger().warning("Extension " + this.description.name() + " loads class " + name + " from an external source. " +
+                        GeyserLogger.get().warning("Extension " + this.description.name() + " loads class " + name + " from an external source. " +
                                 "This can change at any time and break the extension, additionally to potentially causing unexpected behaviour!");
                         warnedForExternalClassAccess = true;
                     }

--- a/core/src/main/java/org/geysermc/geyser/extension/GeyserExtensionLoader.java
+++ b/core/src/main/java/org/geysermc/geyser/extension/GeyserExtensionLoader.java
@@ -122,7 +122,7 @@ public class GeyserExtensionLoader extends ExtensionLoader {
     }
 
     private GeyserExtensionContainer setup(Extension extension, GeyserExtensionDescription description, Path dataFolder, ExtensionEventBus eventBus) {
-        GeyserExtensionLogger logger = new GeyserExtensionLogger(GeyserImpl.getInstance().getLogger(), description.id());
+        GeyserExtensionLogger logger = new GeyserExtensionLogger(GeyserLogger.get(), description.id());
         return new GeyserExtensionContainer(extension, dataFolder, description, this, logger, eventBus);
     }
 
@@ -164,7 +164,7 @@ public class GeyserExtensionLoader extends ExtensionLoader {
 
     @Override
     protected void loadAllExtensions(@NonNull ExtensionManager extensionManager) {
-        GeyserLogger logger = GeyserImpl.getInstance().getLogger();
+        GeyserLogger logger = GeyserLogger.get();
         try {
             if (Files.notExists(extensionsDirectory)) {
                 Files.createDirectory(extensionsDirectory);

--- a/core/src/main/java/org/geysermc/geyser/extension/GeyserExtensionManager.java
+++ b/core/src/main/java/org/geysermc/geyser/extension/GeyserExtensionManager.java
@@ -28,6 +28,7 @@ package org.geysermc.geyser.extension;
 import org.checkerframework.checker.nullness.qual.NonNull;
 import org.checkerframework.checker.nullness.qual.Nullable;
 import org.geysermc.geyser.GeyserImpl;
+import org.geysermc.geyser.GeyserLogger;
 import org.geysermc.geyser.api.extension.Extension;
 import org.geysermc.geyser.api.extension.ExtensionLoader;
 import org.geysermc.geyser.api.extension.ExtensionManager;
@@ -43,12 +44,12 @@ public class GeyserExtensionManager extends ExtensionManager {
     private final Map<String, Extension> extensions = new LinkedHashMap<>();
 
     public void init() {
-        GeyserImpl.getInstance().getLogger().info(GeyserLocale.getLocaleStringLog("geyser.extensions.load.loading"));
+        GeyserLogger.get().info(GeyserLocale.getLocaleStringLog("geyser.extensions.load.loading"));
 
         loadAllExtensions(this.extensionLoader);
         enableExtensions();
 
-        GeyserImpl.getInstance().getLogger().info(GeyserLocale.getLocaleStringLog("geyser.extensions.load.done", this.extensions.size()));
+        GeyserLogger.get().info(GeyserLocale.getLocaleStringLog("geyser.extensions.load.done", this.extensions.size()));
     }
 
     @Override
@@ -62,7 +63,7 @@ public class GeyserExtensionManager extends ExtensionManager {
             try {
                 this.enableExtension(extension);
             } catch (Exception e) {
-                GeyserImpl.getInstance().getLogger().error(GeyserLocale.getLocaleStringLog("geyser.extensions.enable.failed", extension.name()), e);
+                GeyserLogger.get().error(GeyserLocale.getLocaleStringLog("geyser.extensions.enable.failed", extension.name()), e);
                 this.disable(extension);
             }
         }
@@ -74,7 +75,7 @@ public class GeyserExtensionManager extends ExtensionManager {
             try {
                 this.disableExtension(extension);
             } catch (Exception e) {
-                GeyserImpl.getInstance().getLogger().error(GeyserLocale.getLocaleStringLog("geyser.extensions.disable.failed", extension.name()), e);
+                GeyserLogger.get().error(GeyserLocale.getLocaleStringLog("geyser.extensions.disable.failed", extension.name()), e);
             }
         }
     }
@@ -83,7 +84,7 @@ public class GeyserExtensionManager extends ExtensionManager {
         if (!extension.isEnabled()) {
             extension.setEnabled(true);
             GeyserImpl.getInstance().eventBus().register(extension, extension);
-            GeyserImpl.getInstance().getLogger().info(GeyserLocale.getLocaleStringLog("geyser.extensions.enable.success", extension.name()));
+            GeyserLogger.get().info(GeyserLocale.getLocaleStringLog("geyser.extensions.enable.success", extension.name()));
         }
     }
 
@@ -98,7 +99,7 @@ public class GeyserExtensionManager extends ExtensionManager {
             GeyserImpl.getInstance().eventBus().unregisterAll(extension);
 
             extension.setEnabled(false);
-            GeyserImpl.getInstance().getLogger().info(GeyserLocale.getLocaleStringLog("geyser.extensions.disable.success", extension.name()));
+            GeyserLogger.get().info(GeyserLocale.getLocaleStringLog("geyser.extensions.disable.success", extension.name()));
         }
     }
 

--- a/core/src/main/java/org/geysermc/geyser/inventory/CrafterContainer.java
+++ b/core/src/main/java/org/geysermc/geyser/inventory/CrafterContainer.java
@@ -26,6 +26,7 @@
 package org.geysermc.geyser.inventory;
 
 import org.checkerframework.checker.nullness.qual.NonNull;
+import org.geysermc.geyser.GeyserLogger;
 import org.geysermc.geyser.session.GeyserSession;
 import org.geysermc.geyser.translator.inventory.CrafterInventoryTranslator;
 import org.geysermc.geyser.translator.inventory.InventoryTranslator;
@@ -82,7 +83,7 @@ public class CrafterContainer extends Container {
 
     public void setSlot(int slot, boolean enabled) {
         if (!isCraftingGrid(slot)) {
-            GeyserImpl.getInstance().getLogger().warning("Crafter slot out of bounds: " + slot);
+            GeyserLogger.get().warning("Crafter slot out of bounds: " + slot);
             return;
         }
 

--- a/core/src/main/java/org/geysermc/geyser/inventory/GeyserItemStack.java
+++ b/core/src/main/java/org/geysermc/geyser/inventory/GeyserItemStack.java
@@ -35,6 +35,7 @@ import org.checkerframework.checker.nullness.qual.NonNull;
 import org.checkerframework.checker.nullness.qual.Nullable;
 import org.cloudburstmc.protocol.bedrock.data.inventory.ItemData;
 import org.geysermc.geyser.GeyserImpl;
+import org.geysermc.geyser.GeyserLogger;
 import org.geysermc.geyser.inventory.item.DyeColor;
 import org.geysermc.geyser.inventory.item.Potion;
 import org.geysermc.geyser.item.Items;
@@ -151,7 +152,7 @@ public class GeyserItemStack {
                 yield stack;
             }
             default -> {
-                GeyserImpl.getInstance().getLogger().warning("Unsure how to convert to ItemStack: " + slotDisplay);
+                GeyserLogger.get().warning("Unsure how to convert to ItemStack: " + slotDisplay);
                 yield GeyserItemStack.EMPTY;
             }
         };

--- a/core/src/main/java/org/geysermc/geyser/inventory/Inventory.java
+++ b/core/src/main/java/org/geysermc/geyser/inventory/Inventory.java
@@ -33,6 +33,7 @@ import org.checkerframework.checker.nullness.qual.Nullable;
 import org.cloudburstmc.math.vector.Vector3i;
 import org.cloudburstmc.protocol.bedrock.data.definitions.ItemDefinition;
 import org.geysermc.geyser.GeyserImpl;
+import org.geysermc.geyser.GeyserLogger;
 import org.geysermc.geyser.inventory.click.ClickPlan;
 import org.geysermc.geyser.item.Items;
 import org.geysermc.geyser.session.GeyserSession;
@@ -131,7 +132,7 @@ public abstract class Inventory {
 
     public GeyserItemStack getItem(int slot) {
         if (slot > this.size) {
-            GeyserImpl.getInstance().getLogger().debug("Tried to get an item out of bounds! " + this);
+            GeyserLogger.get().debug("Tried to get an item out of bounds! " + this);
             return GeyserItemStack.EMPTY;
         }
         return items[slot];
@@ -141,7 +142,7 @@ public abstract class Inventory {
 
     public void setItem(int slot, @NonNull GeyserItemStack newItem, GeyserSession session) {
         if (slot < 0 || slot >= this.size) {
-            session.getGeyser().getLogger().debug("Tried to set an item out of bounds (slot was " + slot + ")! " + this);
+            GeyserLogger.get().debug("Tried to set an item out of bounds (slot was " + slot + ")! " + this);
             return;
         }
         GeyserItemStack oldItem = items[slot];

--- a/core/src/main/java/org/geysermc/geyser/inventory/PlayerInventory.java
+++ b/core/src/main/java/org/geysermc/geyser/inventory/PlayerInventory.java
@@ -30,6 +30,7 @@ import lombok.Setter;
 import org.checkerframework.checker.nullness.qual.NonNull;
 import org.cloudburstmc.protocol.bedrock.data.entity.EntityFlag;
 import org.geysermc.geyser.GeyserImpl;
+import org.geysermc.geyser.GeyserLogger;
 import org.geysermc.geyser.entity.type.player.PlayerEntity;
 import org.geysermc.geyser.item.Items;
 import org.geysermc.geyser.item.type.Item;
@@ -86,7 +87,7 @@ public class PlayerInventory extends Inventory {
 
     public GeyserItemStack getItemInHand() {
         if (36 + heldItemSlot > this.size) {
-            GeyserImpl.getInstance().getLogger().debug("Held item slot was larger than expected!");
+            GeyserLogger.get().debug("Held item slot was larger than expected!");
             return GeyserItemStack.EMPTY;
         }
         return items[36 + heldItemSlot];
@@ -106,7 +107,7 @@ public class PlayerInventory extends Inventory {
 
     public void setItemInHand(@NonNull GeyserItemStack item) {
         if (36 + heldItemSlot > this.size) {
-            GeyserImpl.getInstance().getLogger().debug("Held item slot was larger than expected!");
+            GeyserLogger.get().debug("Held item slot was larger than expected!");
             return;
         }
         items[36 + heldItemSlot] = item;

--- a/core/src/main/java/org/geysermc/geyser/inventory/click/ClickPlan.java
+++ b/core/src/main/java/org/geysermc/geyser/inventory/click/ClickPlan.java
@@ -29,6 +29,7 @@ import it.unimi.dsi.fastutil.ints.Int2ObjectMap;
 import it.unimi.dsi.fastutil.ints.Int2ObjectOpenHashMap;
 import it.unimi.dsi.fastutil.ints.IntOpenHashSet;
 import it.unimi.dsi.fastutil.ints.IntSet;
+import org.geysermc.geyser.GeyserLogger;
 import org.geysermc.geyser.inventory.GeyserItemStack;
 import org.geysermc.geyser.inventory.Inventory;
 import org.geysermc.geyser.inventory.SlotType;
@@ -493,9 +494,7 @@ public final class ClickPlan {
             } else if (action.click.actionType == ContainerActionType.MOVE_TO_HOTBAR_SLOT) {
                 stateIdIncrements = 1;
             } else {
-                if (session.getGeyser().config().debugMode()) {
-                    session.getGeyser().getLogger().debug("Not sure how to handle state ID hack in crafting table: " + plan);
-                }
+                GeyserLogger.get().debug("Not sure how to handle state ID hack in crafting table: " + plan);
                 stateIdIncrements = 1;
             }
             inventory.incrementStateId(stateIdIncrements);

--- a/core/src/main/java/org/geysermc/geyser/inventory/holder/BlockInventoryHolder.java
+++ b/core/src/main/java/org/geysermc/geyser/inventory/holder/BlockInventoryHolder.java
@@ -34,6 +34,7 @@ import org.cloudburstmc.protocol.bedrock.packet.ContainerClosePacket;
 import org.cloudburstmc.protocol.bedrock.packet.ContainerOpenPacket;
 import org.cloudburstmc.protocol.bedrock.packet.UpdateBlockPacket;
 import org.geysermc.geyser.GeyserImpl;
+import org.geysermc.geyser.GeyserLogger;
 import org.geysermc.geyser.inventory.Container;
 import org.geysermc.geyser.inventory.Inventory;
 import org.geysermc.geyser.inventory.LecternContainer;
@@ -102,7 +103,7 @@ public class BlockInventoryHolder extends InventoryHolder {
         if (Objects.equals(position, previous.getHolderPosition())) {
             return true;
         } else {
-            GeyserImpl.getInstance().getLogger().debug(session, "Not reusing inventory due to virtual block holder changing (%s -> %s)!",
+            GeyserLogger.get().debug(session, "Not reusing inventory due to virtual block holder changing (%s -> %s)!",
                 previous.getHolderPosition(), position);
             return false;
         }
@@ -196,7 +197,7 @@ public class BlockInventoryHolder extends InventoryHolder {
         containerOpenPacket.setUniqueEntityId(container.getHolderId());
         session.sendUpstreamPacket(containerOpenPacket);
 
-        GeyserImpl.getInstance().getLogger().debug(session, containerOpenPacket.toString());
+        GeyserLogger.get().debug(session, containerOpenPacket.toString());
     }
 
     @Override

--- a/core/src/main/java/org/geysermc/geyser/inventory/recipe/RecipeUtil.java
+++ b/core/src/main/java/org/geysermc/geyser/inventory/recipe/RecipeUtil.java
@@ -39,6 +39,7 @@ import org.cloudburstmc.protocol.bedrock.data.inventory.crafting.recipe.RecipeDa
 import org.cloudburstmc.protocol.bedrock.data.inventory.descriptor.DefaultDescriptor;
 import org.cloudburstmc.protocol.bedrock.data.inventory.descriptor.ItemDescriptorWithCount;
 import org.cloudburstmc.protocol.bedrock.data.inventory.descriptor.ItemTagDescriptor;
+import org.geysermc.geyser.GeyserLogger;
 import org.geysermc.geyser.inventory.GeyserItemStack;
 import org.geysermc.geyser.inventory.item.Potion;
 import org.geysermc.geyser.item.Items;
@@ -193,7 +194,7 @@ public class RecipeUtil {
             }
             return Collections.unmodifiableList(itemDescriptors);
         }
-        session.getGeyser().getLogger().warning("Unimplemented slot display type for input: " + slotDisplay);
+        GeyserLogger.get().warning("Unimplemented slot display type for input: " + slotDisplay);
         return null;
     }
 
@@ -212,7 +213,7 @@ public class RecipeUtil {
             GeyserItemStack stack = GeyserItemStack.from(session, slotDisplay);
             return stack.isEmpty() ? null : Pair.of(stack.asItem(), ItemTranslator.translateToBedrock(session, stack));
         }
-        session.getGeyser().getLogger().warning("Unimplemented slot display type for output: " + slotDisplay);
+        GeyserLogger.get().warning("Unimplemented slot display type for output: " + slotDisplay);
         return null;
     }
 

--- a/core/src/main/java/org/geysermc/geyser/inventory/recipe/TrimRecipe.java
+++ b/core/src/main/java/org/geysermc/geyser/inventory/recipe/TrimRecipe.java
@@ -31,6 +31,7 @@ import org.cloudburstmc.protocol.bedrock.data.TrimPattern;
 import org.cloudburstmc.protocol.bedrock.data.inventory.descriptor.ItemDescriptorWithCount;
 import org.cloudburstmc.protocol.bedrock.data.inventory.descriptor.ItemTagDescriptor;
 import org.geysermc.geyser.GeyserImpl;
+import org.geysermc.geyser.GeyserLogger;
 import org.geysermc.geyser.item.type.Item;
 import org.geysermc.geyser.registry.Registries;
 import org.geysermc.geyser.registry.type.ItemMapping;
@@ -74,7 +75,7 @@ public final class TrimRecipe {
                     if (javaItem != null) {
                         trimItem = context.session().get().getItemMappings().getMapping(javaItem);
                     } else {
-                        GeyserImpl.getInstance().getLogger().debug("Could not find trim material provider! Network: %s, Provider: %s".formatted(context.id(), provider));
+                        GeyserLogger.get().debug("Could not find trim material provider! Network: %s, Provider: %s".formatted(context.id(), provider));
                     }
                     break;
                 }
@@ -83,7 +84,7 @@ public final class TrimRecipe {
 
         if (trimItem == null) {
             // This happens in testing and for custom trim materials, not sure what to do for the latter.
-            GeyserImpl.getInstance().getLogger().debug("Unable to found trim material item for material " + context.id());
+            GeyserLogger.get().debug("Unable to found trim material item for material " + context.id());
             trimItem = ItemMapping.AIR;
         }
 
@@ -101,7 +102,7 @@ public final class TrimRecipe {
             itemMapping = context.session().get().getItemMappings().getMapping(identifier);
             if (itemMapping == null) {
                 // This should never happen so not sure what to do here.
-                GeyserImpl.getInstance().getLogger().debug("Unable to found trim pattern item for pattern " + context.id());
+                GeyserLogger.get().debug("Unable to found trim pattern item for pattern " + context.id());
                 itemMapping = ItemMapping.AIR;
             }
         }

--- a/core/src/main/java/org/geysermc/geyser/inventory/updater/AnvilInventoryUpdater.java
+++ b/core/src/main/java/org/geysermc/geyser/inventory/updater/AnvilInventoryUpdater.java
@@ -34,6 +34,7 @@ import org.cloudburstmc.protocol.bedrock.data.inventory.ContainerId;
 import org.cloudburstmc.protocol.bedrock.data.inventory.ItemData;
 import org.cloudburstmc.protocol.bedrock.packet.InventorySlotPacket;
 import org.geysermc.geyser.GeyserImpl;
+import org.geysermc.geyser.GeyserLogger;
 import org.geysermc.geyser.inventory.AnvilContainer;
 import org.geysermc.geyser.inventory.GeyserItemStack;
 import org.geysermc.geyser.inventory.Inventory;
@@ -377,7 +378,7 @@ public class AnvilInventoryUpdater extends InventoryUpdater {
             for (Map.Entry<Integer, Integer> entry : enchantmentComponent.getEnchantments().entrySet()) {
                 Enchantment enchantment = session.getRegistryCache().registry(JavaRegistries.ENCHANTMENT).byId(entry.getKey());
                 if (enchantment == null) {
-                    GeyserImpl.getInstance().getLogger().debug("Unknown Java enchantment in anvil: " + entry.getKey());
+                    GeyserLogger.get().debug("Unknown Java enchantment in anvil: " + entry.getKey());
                     continue;
                 }
                 enchantments.put(enchantment, entry.getValue().intValue());

--- a/core/src/main/java/org/geysermc/geyser/item/GeyserCustomItemData.java
+++ b/core/src/main/java/org/geysermc/geyser/item/GeyserCustomItemData.java
@@ -30,6 +30,7 @@ import lombok.ToString;
 import org.checkerframework.checker.nullness.qual.NonNull;
 import org.checkerframework.checker.nullness.qual.Nullable;
 import org.geysermc.geyser.GeyserImpl;
+import org.geysermc.geyser.GeyserLogger;
 import org.geysermc.geyser.api.item.custom.CustomItemData;
 import org.geysermc.geyser.api.item.custom.CustomItemOptions;
 import org.geysermc.geyser.api.item.custom.CustomRenderOffsets;
@@ -276,12 +277,12 @@ public class GeyserCustomItemData implements CustomItemData {
             }
 
             if (textureSize != 16) {
-                GeyserImpl.getInstance().getLogger().warning("The custom item %s is using a non-standard texture size! ".formatted(name) +
+                GeyserLogger.get().warning("The custom item %s is using a non-standard texture size! ".formatted(name) +
                     "This feature is deprecated and will be removed in a future version! Please migrate to attachables for texture resizing.");
             }
 
             if (renderOffsets != null) {
-                GeyserImpl.getInstance().getLogger().warning("The custom item %s is using render offsets! ".formatted(name) +
+                GeyserLogger.get().warning("The custom item %s is using render offsets! ".formatted(name) +
                     "These are deprecated and will be removed in a future version! Please migrate to attachables.");
             }
 

--- a/core/src/main/java/org/geysermc/geyser/item/hashing/DataComponentHashers.java
+++ b/core/src/main/java/org/geysermc/geyser/item/hashing/DataComponentHashers.java
@@ -27,6 +27,7 @@ package org.geysermc.geyser.item.hashing;
 
 import com.google.common.hash.HashCode;
 import org.geysermc.geyser.GeyserImpl;
+import org.geysermc.geyser.GeyserLogger;
 import org.geysermc.geyser.session.GeyserSession;
 import org.geysermc.geyser.session.cache.registry.JavaRegistryProvider;
 import org.geysermc.mcprotocollib.protocol.data.game.Holder;
@@ -329,8 +330,8 @@ public class DataComponentHashers {
         try {
             return hasher(component).hash(value, new MinecraftHashEncoder(registries));
         } catch (Exception exception) {
-            GeyserImpl.getInstance().getLogger().error("Failed to hash item data component " + component.getKey() + " with value " + value + "!");
-            GeyserImpl.getInstance().getLogger().error("This is a Geyser bug, please report this!");
+            GeyserLogger.get().error("Failed to hash item data component " + component.getKey() + " with value " + value + "!");
+            GeyserLogger.get().error("This is a Geyser bug, please report this!");
             throw exception;
         }
     }
@@ -353,7 +354,7 @@ public class DataComponentHashers {
         Set<DataComponentType<?>> removals = new HashSet<>();
         for (Map.Entry<DataComponentType<?>, DataComponent<?, ?>> component : components.entrySet()) {
             if (NOT_HASHED.contains(component.getKey())) {
-                GeyserImpl.getInstance().getLogger().debug("Not hashing component " + component.getKey() + " on stack " + stack);
+                GeyserLogger.get().debug("Not hashing component " + component.getKey() + " on stack " + stack);
             } else if (component.getValue().getValue() == null) {
                 removals.add(component.getKey());
             } else {

--- a/core/src/main/java/org/geysermc/geyser/item/hashing/MapHasher.java
+++ b/core/src/main/java/org/geysermc/geyser/item/hashing/MapHasher.java
@@ -27,6 +27,7 @@ package org.geysermc.geyser.item.hashing;
 
 import com.google.common.hash.HashCode;
 import org.geysermc.geyser.GeyserImpl;
+import org.geysermc.geyser.GeyserLogger;
 import org.jetbrains.annotations.VisibleForTesting;
 
 import java.util.HashMap;
@@ -249,7 +250,7 @@ public class MapHasher<Type> {
 
     public HashCode build() {
         if (debug) {
-            GeyserImpl.getInstance().getLogger().info("Building MapHasher with unhashed map: " + unhashed);
+            GeyserLogger.get().info("Building MapHasher with unhashed map: " + unhashed);
         }
         return encoder.map(map);
     }

--- a/core/src/main/java/org/geysermc/geyser/item/parser/ItemStackParser.java
+++ b/core/src/main/java/org/geysermc/geyser/item/parser/ItemStackParser.java
@@ -35,6 +35,7 @@ import org.cloudburstmc.nbt.NbtMapBuilder;
 import org.cloudburstmc.nbt.NbtType;
 import org.cloudburstmc.protocol.bedrock.data.inventory.ItemData;
 import org.geysermc.geyser.GeyserImpl;
+import org.geysermc.geyser.GeyserLogger;
 import org.geysermc.geyser.inventory.item.DyeColor;
 import org.geysermc.geyser.inventory.item.Potion;
 import org.geysermc.geyser.item.Items;
@@ -100,7 +101,7 @@ public final class ItemStackParser {
 
         Item item = Registries.JAVA_ITEM_IDENTIFIERS.get(identifier);
         if (item == null) {
-            GeyserImpl.getInstance().getLogger().warning("Received unknown item ID " + identifier + " whilst parsing NBT item stack!");
+            GeyserLogger.get().warning("Received unknown item ID " + identifier + " whilst parsing NBT item stack!");
             return Items.AIR_ID;
         }
         return item.javaId();
@@ -191,9 +192,9 @@ public final class ItemStackParser {
         try {
             patch.put((DataComponentType<Parsed>) type, parser.parse(session, (Raw) raw));
         } catch (ClassCastException exception) {
-            GeyserImpl.getInstance().getLogger().debug("Received incorrect object type for component " + type + "! Exception: %s", exception);
+            GeyserLogger.get().debug("Received incorrect object type for component " + type + "! Exception: %s", exception);
         } catch (Exception exception) {
-            GeyserImpl.getInstance().getLogger().debug("Failed to parse component" + type + " from " + raw + "! Exception: %s", exception);
+            GeyserLogger.get().debug("Failed to parse component" + type + " from " + raw + "! Exception: %s", exception);
         }
     }
 
@@ -214,7 +215,7 @@ public final class ItemStackParser {
 
                 DataComponentType<?> type = DataComponentTypes.fromKey(MinecraftKey.key(rawType));
                 if (type == null) {
-                    GeyserImpl.getInstance().getLogger().warning("Received unknown data component " + rawType + " in NBT data component patch: " + map);
+                    GeyserLogger.get().warning("Received unknown data component " + rawType + " in NBT data component patch: " + map);
                 } else if (removal) {
                     // Removals are easy, we don't have to parse anything
                     patch.put(type, null);
@@ -223,12 +224,12 @@ public final class ItemStackParser {
                     if (parser != null) {
                         parseDataComponent(session, patch, type, parser, patchEntry.getValue());
                     } else {
-                        GeyserImpl.getInstance().getLogger().debug("Ignoring data component " + type + " whilst parsing NBT patch because there is no parser registered for it");
+                        GeyserLogger.get().debug("Ignoring data component " + type + " whilst parsing NBT patch because there is no parser registered for it");
                     }
                 }
             }
         } catch (Exception exception) {
-            GeyserImpl.getInstance().getLogger().error("Failed to parse data component patch from NBT data!", exception);
+            GeyserLogger.get().error("Failed to parse data component patch from NBT data!", exception);
         }
 
         return patch;
@@ -245,7 +246,7 @@ public final class ItemStackParser {
             DataComponents patch = parseDataComponentPatch(session, map.getCompound("components"));
             return new ItemStack(id, count, patch);
         } catch (Exception exception) {
-            GeyserImpl.getInstance().getLogger().error("Failed to parse item stack from NBT data!", exception);
+            GeyserLogger.get().error("Failed to parse item stack from NBT data!", exception);
         }
         return new ItemStack(Items.AIR_ID);
     }

--- a/core/src/main/java/org/geysermc/geyser/item/type/ArmorItem.java
+++ b/core/src/main/java/org/geysermc/geyser/item/type/ArmorItem.java
@@ -31,6 +31,7 @@ import org.cloudburstmc.nbt.NbtMapBuilder;
 import org.cloudburstmc.protocol.bedrock.data.TrimMaterial;
 import org.cloudburstmc.protocol.bedrock.data.TrimPattern;
 import org.geysermc.geyser.GeyserImpl;
+import org.geysermc.geyser.GeyserLogger;
 import org.geysermc.geyser.item.TooltipOptions;
 import org.geysermc.geyser.session.GeyserSession;
 import org.geysermc.geyser.session.cache.registry.JavaRegistries;
@@ -56,7 +57,7 @@ public class ArmorItem extends Item {
             if (trim.material().isId()) {
                 material = session.getRegistryCache().registry(JavaRegistries.TRIM_MATERIAL).byId(trim.material().id());
             } else {
-                GeyserImpl.getInstance().getLogger().debug("Unable to translate non-id trim material: " + trim);
+                GeyserLogger.get().debug("Unable to translate non-id trim material: " + trim);
                 return;
             }
 
@@ -64,7 +65,7 @@ public class ArmorItem extends Item {
             if (trim.pattern().isId()) {
                 pattern = session.getRegistryCache().registry(JavaRegistries.TRIM_PATTERN).byId(trim.pattern().id());
             } else {
-                GeyserImpl.getInstance().getLogger().debug("Unable to translate non-id trim pattern: " + trim);
+                GeyserLogger.get().debug("Unable to translate non-id trim pattern: " + trim);
                 return;
             }
 
@@ -85,7 +86,7 @@ public class ArmorItem extends Item {
                 trimBuilder.put("Pattern", patternId);
                 builder.putCompound("Trim", trimBuilder.build());
             } else {
-                GeyserImpl.getInstance().getLogger().debug("Unknown trim material/pattern: ", trim);
+                GeyserLogger.get().debug("Unknown trim material/pattern: ", trim);
             }
         }
     }

--- a/core/src/main/java/org/geysermc/geyser/item/type/EnchantedBookItem.java
+++ b/core/src/main/java/org/geysermc/geyser/item/type/EnchantedBookItem.java
@@ -31,6 +31,7 @@ import org.checkerframework.checker.nullness.qual.NonNull;
 import org.cloudburstmc.nbt.NbtMap;
 import org.cloudburstmc.nbt.NbtType;
 import org.geysermc.geyser.GeyserImpl;
+import org.geysermc.geyser.GeyserLogger;
 import org.geysermc.geyser.inventory.item.BedrockEnchantment;
 import org.geysermc.geyser.item.TooltipOptions;
 import org.geysermc.geyser.item.enchantment.Enchantment;
@@ -92,7 +93,7 @@ public class EnchantedBookItem extends Item {
                         }
                     }
                 } else {
-                    GeyserImpl.getInstance().getLogger().debug("Unknown bedrock enchantment: " + bedrockId);
+                    GeyserLogger.get().debug("Unknown bedrock enchantment: " + bedrockId);
                 }
             }
             if (!javaEnchantments.isEmpty()) {

--- a/core/src/main/java/org/geysermc/geyser/item/type/Item.java
+++ b/core/src/main/java/org/geysermc/geyser/item/type/Item.java
@@ -34,6 +34,7 @@ import org.cloudburstmc.nbt.NbtMap;
 import org.cloudburstmc.nbt.NbtType;
 import org.cloudburstmc.protocol.bedrock.data.inventory.ItemData;
 import org.geysermc.geyser.GeyserImpl;
+import org.geysermc.geyser.GeyserLogger;
 import org.geysermc.geyser.inventory.GeyserItemStack;
 import org.geysermc.geyser.inventory.item.BedrockEnchantment;
 import org.geysermc.geyser.item.Items;
@@ -264,7 +265,7 @@ public class Item {
     protected final @Nullable NbtMap remapEnchantment(GeyserSession session, int enchantId, int level, BedrockItemBuilder builder) {
         Enchantment enchantment = session.getRegistryCache().registry(JavaRegistries.ENCHANTMENT).byId(enchantId);
         if (enchantment == null) {
-            GeyserImpl.getInstance().getLogger().debug("Unknown Java enchantment while NBT item translating: " + enchantId);
+            GeyserLogger.get().debug("Unknown Java enchantment while NBT item translating: " + enchantId);
             return null;
         }
 

--- a/core/src/main/java/org/geysermc/geyser/item/type/NonVanillaItem.java
+++ b/core/src/main/java/org/geysermc/geyser/item/type/NonVanillaItem.java
@@ -30,6 +30,7 @@ import lombok.experimental.Accessors;
 import org.checkerframework.checker.nullness.qual.NonNull;
 import org.checkerframework.checker.nullness.qual.Nullable;
 import org.geysermc.geyser.GeyserImpl;
+import org.geysermc.geyser.GeyserLogger;
 import org.geysermc.geyser.item.components.resolvable.ResolvableComponent;
 import org.geysermc.geyser.session.cache.ComponentCache;
 import org.geysermc.mcprotocollib.protocol.data.game.item.component.DataComponentType;
@@ -61,7 +62,7 @@ public class NonVanillaItem extends Item {
         if (resolvableComponents.isEmpty()) {
             return super.gatherComponents(componentCache, others);
         } else if (componentCache == null) {
-            GeyserImpl.getInstance().getLogger().debug("Unable to resolve components for non-vanilla item because componentCache is null");
+            GeyserLogger.get().debug("Unable to resolve components for non-vanilla item because componentCache is null");
             return super.gatherComponents(null, others);
         }
         DataComponents resolvedAndOthers = componentCache.getResolvedComponents(this).clone();
@@ -75,7 +76,7 @@ public class NonVanillaItem extends Item {
     public <T> @Nullable T getComponent(@Nullable ComponentCache componentCache, @NonNull DataComponentType<T> type) {
         if (resolvableComponentTypes.contains(type)) {
             if (componentCache == null) {
-                GeyserImpl.getInstance().getLogger().debug("Unable to resolve components for non-vanilla item because componentCache is null");
+                GeyserLogger.get().debug("Unable to resolve components for non-vanilla item because componentCache is null");
                 return super.getComponent(null, type);
             }
             return componentCache.getResolvedComponents(this).get(type);

--- a/core/src/main/java/org/geysermc/geyser/item/type/PotionItem.java
+++ b/core/src/main/java/org/geysermc/geyser/item/type/PotionItem.java
@@ -29,6 +29,7 @@ import org.checkerframework.checker.nullness.qual.NonNull;
 import org.cloudburstmc.protocol.bedrock.data.definitions.ItemDefinition;
 import org.cloudburstmc.protocol.bedrock.data.inventory.ItemData;
 import org.geysermc.geyser.GeyserImpl;
+import org.geysermc.geyser.GeyserLogger;
 import org.geysermc.geyser.inventory.GeyserItemStack;
 import org.geysermc.geyser.inventory.item.Potion;
 import org.geysermc.geyser.registry.type.ItemMapping;
@@ -58,7 +59,7 @@ public class PotionItem extends Item {
                             .damage(potion.getBedrockId())
                             .count(Math.min(count, BEDROCK_MAX_STACK_SIZE));
                 }
-                GeyserImpl.getInstance().getLogger().debug("Unknown Java potion: " + potionContents.getPotionId());
+                GeyserLogger.get().debug("Unknown Java potion: " + potionContents.getPotionId());
             } else {
                 return ItemData.builder()
                         .definition(customItemDefinition)

--- a/core/src/main/java/org/geysermc/geyser/item/type/TippedArrowItem.java
+++ b/core/src/main/java/org/geysermc/geyser/item/type/TippedArrowItem.java
@@ -27,6 +27,7 @@ package org.geysermc.geyser.item.type;
 
 import org.cloudburstmc.protocol.bedrock.data.inventory.ItemData;
 import org.geysermc.geyser.GeyserImpl;
+import org.geysermc.geyser.GeyserLogger;
 import org.geysermc.geyser.inventory.item.Potion;
 import org.geysermc.geyser.registry.type.ItemMapping;
 import org.geysermc.geyser.registry.type.ItemMappings;
@@ -52,7 +53,7 @@ public class TippedArrowItem extends ArrowItem {
                             .damage(potion.tippedArrowId())
                             .count(Math.min(count, BEDROCK_MAX_STACK_SIZE));
                 }
-                GeyserImpl.getInstance().getLogger().debug("Unknown Java potion (tipped arrow): " + potionContents.getPotionId());
+                GeyserLogger.get().debug("Unknown Java potion (tipped arrow): " + potionContents.getPotionId());
             }
         }
         return super.translateToBedrock(session, count, components, mapping, mappings);

--- a/core/src/main/java/org/geysermc/geyser/level/block/GeyserCustomBlockData.java
+++ b/core/src/main/java/org/geysermc/geyser/level/block/GeyserCustomBlockData.java
@@ -31,6 +31,7 @@ import org.checkerframework.checker.nullness.qual.NonNull;
 import org.checkerframework.checker.nullness.qual.Nullable;
 import org.geysermc.geyser.Constants;
 import org.geysermc.geyser.GeyserImpl;
+import org.geysermc.geyser.GeyserLogger;
 import org.geysermc.geyser.api.block.custom.CustomBlockData;
 import org.geysermc.geyser.api.block.custom.CustomBlockPermutation;
 import org.geysermc.geyser.api.block.custom.CustomBlockState;
@@ -71,7 +72,7 @@ public class GeyserCustomBlockData implements CustomBlockData {
             Object2ObjectMap<String, Object> defaultProperties = new Object2ObjectOpenHashMap<>(this.properties.size());
             for (CustomBlockProperty<?> property : properties.values()) {
                 if (property.values().size() > 16) {
-                    GeyserImpl.getInstance().getLogger().warning(property.name() + " contains more than 16 values, but BDS specifies it should not. This may break in future versions.");
+                    GeyserLogger.get().warning(property.name() + " contains more than 16 values, but BDS specifies it should not. This may break in future versions.");
                 }
                 if (property.values().stream().distinct().count() != property.values().size()) {
                     throw new IllegalStateException(property.name() + " has duplicate values.");

--- a/core/src/main/java/org/geysermc/geyser/level/gamerule/GameRuleHandler.java
+++ b/core/src/main/java/org/geysermc/geyser/level/gamerule/GameRuleHandler.java
@@ -31,6 +31,7 @@ import net.kyori.adventure.key.Key;
 import net.kyori.adventure.text.Component;
 import org.geysermc.cumulus.form.CustomForm;
 import org.geysermc.geyser.GeyserImpl;
+import org.geysermc.geyser.GeyserLogger;
 import org.geysermc.geyser.registry.Registries;
 import org.geysermc.geyser.session.GeyserSession;
 import org.geysermc.geyser.text.MinecraftLocale;
@@ -75,7 +76,7 @@ public class GameRuleHandler {
             for (Map.Entry<Key, String> entry : packet.getValues().entrySet()) {
                 GameRule<?> gameRule = Registries.GAME_RULES.get(entry.getKey());
                 if (gameRule == null) {
-                    GeyserImpl.getInstance().getLogger().debug("Unknown gamerule: " + entry.getKey());
+                    GeyserLogger.get().debug("Unknown gamerule: " + entry.getKey());
                     continue;
                 }
                 values.computeIfAbsent(gameRule.category(), (category) -> new Object2ObjectArrayMap<>()).put(gameRule, entry.getValue());
@@ -138,12 +139,12 @@ public class GameRuleHandler {
         try {
             value = gameRule.adapter().parser().apply(newValue);
         } catch (Throwable e) {
-            GeyserImpl.getInstance().getLogger().debug("Failed to parse value for gamerule %s (old value: %s, new value: %s)", gameRule.key(), previous, newValue);
+            GeyserLogger.get().debug("Failed to parse value for gamerule %s (old value: %s, new value: %s)", gameRule.key(), previous, newValue);
             return;
         }
 
         if (!gameRule.validate(value)) {
-            GeyserImpl.getInstance().getLogger().debug("Got invalid value for gamerule %s (old value: %s, new value: %s)", gameRule.key(), previous, newValue);
+            GeyserLogger.get().debug("Got invalid value for gamerule %s (old value: %s, new value: %s)", gameRule.key(), previous, newValue);
             return;
         }
 

--- a/core/src/main/java/org/geysermc/geyser/level/physics/Direction.java
+++ b/core/src/main/java/org/geysermc/geyser/level/physics/Direction.java
@@ -30,6 +30,7 @@ import lombok.experimental.Accessors;
 import org.checkerframework.checker.nullness.qual.NonNull;
 import org.cloudburstmc.math.vector.Vector3i;
 import org.geysermc.geyser.GeyserImpl;
+import org.geysermc.geyser.GeyserLogger;
 
 import java.util.function.ToIntFunction;
 
@@ -104,7 +105,7 @@ public enum Direction {
     public static <T> Direction getUntrusted(T source, ToIntFunction<T> idExtractor) {
         int id = idExtractor.applyAsInt(source);
         if (id < 0 || id >= VALUES.length) {
-            GeyserImpl.getInstance().getLogger().warning("Received invalid direction from " + source + " (ID was " + id + ")");
+            GeyserLogger.get().warning("Received invalid direction from " + source + " (ID was " + id + ")");
             return DOWN; // Default to DOWN when receiving an invalid ID
         }
         return Direction.VALUES[id];

--- a/core/src/main/java/org/geysermc/geyser/network/GeyserServerInitializer.java
+++ b/core/src/main/java/org/geysermc/geyser/network/GeyserServerInitializer.java
@@ -36,6 +36,7 @@ import org.cloudburstmc.protocol.bedrock.BedrockServerSession;
 import org.cloudburstmc.protocol.bedrock.netty.codec.packet.BedrockPacketCodec;
 import org.cloudburstmc.protocol.bedrock.netty.initializer.BedrockServerInitializer;
 import org.geysermc.geyser.GeyserImpl;
+import org.geysermc.geyser.GeyserLogger;
 import org.geysermc.geyser.session.GeyserSession;
 
 public class GeyserServerInitializer extends BedrockServerInitializer {
@@ -61,7 +62,7 @@ public class GeyserServerInitializer extends BedrockServerInitializer {
     @Override
     public void initSession(@NonNull BedrockServerSession bedrockServerSession) {
         try {
-            bedrockServerSession.setLogging(this.geyser.config().debugMode());
+            bedrockServerSession.setLogging(GeyserLogger.get().isDebug());
             GeyserSession session = new GeyserSession(this.geyser, bedrockServerSession, this.eventLoopGroup.next());
 
             if (!bedrockServerSession.isSubClient()) {
@@ -72,7 +73,7 @@ public class GeyserServerInitializer extends BedrockServerInitializer {
             bedrockServerSession.setPacketHandler(new UpstreamPacketHandler(this.geyser, session));
         } catch (Throwable e) {
             // Error must be caught or it will be swallowed
-            this.geyser.getLogger().error("Error occurred while initializing player!", e);
+            GeyserLogger.get().error("Error occurred while initializing player!", e);
             bedrockServerSession.disconnect(e.getMessage());
         }
     }

--- a/core/src/main/java/org/geysermc/geyser/network/InvalidPacketHandler.java
+++ b/core/src/main/java/org/geysermc/geyser/network/InvalidPacketHandler.java
@@ -47,7 +47,7 @@ public class InvalidPacketHandler extends ChannelInboundHandlerAdapter {
                 .findFirst()
                 .orElse(cause);
 
-        GeyserLogger logger = GeyserImpl.getInstance().getLogger();
+        GeyserLogger logger = GeyserLogger.get();
 
         if (!(rootCause instanceof IllegalArgumentException)) {
             // Kick users that cause exceptions

--- a/core/src/main/java/org/geysermc/geyser/network/LoggingPacketHandler.java
+++ b/core/src/main/java/org/geysermc/geyser/network/LoggingPacketHandler.java
@@ -28,6 +28,7 @@ package org.geysermc.geyser.network;
 import org.cloudburstmc.protocol.bedrock.packet.*;
 import org.cloudburstmc.protocol.common.PacketSignal;
 import org.geysermc.geyser.GeyserImpl;
+import org.geysermc.geyser.GeyserLogger;
 import org.geysermc.geyser.session.GeyserSession;
 
 /**
@@ -46,7 +47,7 @@ public class LoggingPacketHandler implements BedrockPacketHandler {
     }
 
     PacketSignal defaultHandler(BedrockPacket packet) {
-        geyser.getLogger().debug("Handled packet: " + packet.getClass().getSimpleName());
+        GeyserLogger.get().debug("Handled packet: " + packet.getClass().getSimpleName());
         return PacketSignal.HANDLED;
     }
 

--- a/core/src/main/java/org/geysermc/geyser/network/UpstreamPacketHandler.java
+++ b/core/src/main/java/org/geysermc/geyser/network/UpstreamPacketHandler.java
@@ -54,12 +54,14 @@ import org.cloudburstmc.protocol.common.util.Zlib;
 import org.geysermc.api.util.BedrockPlatform;
 import org.geysermc.geyser.Constants;
 import org.geysermc.geyser.GeyserImpl;
+import org.geysermc.geyser.GeyserLogger;
 import org.geysermc.geyser.api.event.bedrock.SessionInitializeEvent;
 import org.geysermc.geyser.api.network.AuthType;
 import org.geysermc.geyser.api.pack.PackCodec;
 import org.geysermc.geyser.api.pack.ResourcePack;
 import org.geysermc.geyser.api.pack.ResourcePackManifest;
 import org.geysermc.geyser.api.pack.option.ResourcePackOption;
+import org.geysermc.geyser.debug.SessionDebugOption;
 import org.geysermc.geyser.event.type.SessionLoadResourcePacksEventImpl;
 import org.geysermc.geyser.pack.GeyserResourcePack;
 import org.geysermc.geyser.pack.ResourcePackHolder;
@@ -80,8 +82,11 @@ import java.nio.channels.SeekableByteChannel;
 import java.util.ArrayDeque;
 import java.util.Arrays;
 import java.util.Deque;
+import java.util.HashSet;
+import java.util.List;
 import java.util.OptionalInt;
 import java.util.Queue;
+import java.util.Set;
 import java.util.UUID;
 import java.util.concurrent.ConcurrentLinkedQueue;
 import java.util.concurrent.TimeUnit;
@@ -232,14 +237,21 @@ public class UpstreamPacketHandler extends LoggingPacketHandler {
             // Can happen if an error occurs in the resource pack event; that'll disconnect the player
             return PacketSignal.HANDLED;
         }
+        if (session.getDebugOptions().contains(SessionDebugOption.FORCE_DISABLE_PACKS)) {
+            this.resourcePackLoadEvent.unregisterAll();
+        }
         session.integratedPackActive(resourcePackLoadEvent.isIntegratedPackActive());
 
         ResourcePacksInfoPacket resourcePacksInfo = new ResourcePacksInfoPacket();
         resourcePacksInfo.getResourcePackInfos().addAll(this.resourcePackLoadEvent.infoPacketEntries());
-        resourcePacksInfo.setVibrantVisualsForceDisabled(!session.isAllowVibrantVisuals());
+        if (!session.getDebugOptions().contains(SessionDebugOption.FORCE_VIBRANT_VISUALS)) {
+            resourcePacksInfo.setVibrantVisualsForceDisabled(!session.isAllowVibrantVisuals());
+        }
 
-        resourcePacksInfo.setForcedToAccept(GeyserImpl.getInstance().config().gameplay().forceResourcePacks() ||
-            resourcePackLoadEvent.isIntegratedPackActive());
+        if (!session.getDebugOptions().contains(SessionDebugOption.FORCE_OPTIONAL_PACKS)) {
+            resourcePacksInfo.setForcedToAccept(GeyserImpl.getInstance().config().gameplay().forceResourcePacks() ||
+                resourcePackLoadEvent.isIntegratedPackActive());
+        }
         resourcePacksInfo.setWorldTemplateId(UUID.randomUUID());
         resourcePacksInfo.setWorldTemplateVersion("*");
 
@@ -269,7 +281,7 @@ public class UpstreamPacketHandler extends LoggingPacketHandler {
                     // We must spawn the white world
                     session.connect();
                 }
-                geyser.getLogger().info(GeyserLocale.getLocaleStringLog("geyser.network.connect", session.getAuthData().name() +
+                GeyserLogger.get().info(GeyserLocale.getLocaleStringLog("geyser.network.connect", session.getAuthData().name() +
                     " (" + session.protocolVersion() + ")"));
             }
             case SEND_PACKS -> {
@@ -291,7 +303,7 @@ public class UpstreamPacketHandler extends LoggingPacketHandler {
             }
             case REFUSED -> session.disconnect("disconnectionScreen.resourcePack");
             default -> {
-                GeyserImpl.getInstance().getLogger().debug("received unknown status packet: " + packet);
+                GeyserLogger.get().debug("received unknown status packet: " + packet);
                 session.disconnect("disconnectionScreen.resourcePack");
             }
         }
@@ -312,7 +324,7 @@ public class UpstreamPacketHandler extends LoggingPacketHandler {
         if (geyser.config().savedUserLogins().contains(bedrockUsername)) {
             String authChain = geyser.authChainFor(bedrockUsername);
             if (authChain != null) {
-                geyser.getLogger().info(GeyserLocale.getLocaleStringLog("geyser.auth.stored_credentials", session.getAuthData().name()));
+                GeyserLogger.get().info(GeyserLocale.getLocaleStringLog("geyser.auth.stored_credentials", session.getAuthData().name()));
                 session.authenticateWithAuthChain(authChain);
                 return true;
             }
@@ -365,7 +377,7 @@ public class UpstreamPacketHandler extends LoggingPacketHandler {
 
         ResourcePackHolder holder = this.resourcePackLoadEvent.getPacks().get(packet.getPackId());
         if (holder == null) {
-            GeyserImpl.getInstance().getLogger().debug("Client %s tried to request pack id %s not sent to it!",
+            GeyserLogger.get().debug("Client %s tried to request pack id %s not sent to it!",
                 session.bedrockUsername(), packet.getPackId());
             chunkRequestQueue.clear();
             session.disconnect("disconnectionScreen.resourcePack");
@@ -382,7 +394,7 @@ public class UpstreamPacketHandler extends LoggingPacketHandler {
                 return;
             }
         } else if (finishedResourcePackSending) {
-            GeyserImpl.getInstance().getLogger().warning("Received resource pack chunk packet after stage completed! " + packet);
+            GeyserLogger.get().warning("Received resource pack chunk packet after stage completed! " + packet);
             session.disconnect("Duplicate resource pack packet received!");
             chunkRequestQueue.clear();
             return;
@@ -424,7 +436,7 @@ public class UpstreamPacketHandler extends LoggingPacketHandler {
         String[] packID = id.split("_");
 
         if (packID.length < 2) {
-            GeyserImpl.getInstance().getLogger().debug("Client %s tried to request invalid pack id %s!",
+            GeyserLogger.get().debug("Client %s tried to request invalid pack id %s!",
                 session.bedrockUsername(), Arrays.toString(packID));
             session.disconnect("disconnectionScreen.resourcePack");
             return;
@@ -434,7 +446,7 @@ public class UpstreamPacketHandler extends LoggingPacketHandler {
         try {
             packId = UUID.fromString(packID[0]);
         } catch (IllegalArgumentException e) {
-            GeyserImpl.getInstance().getLogger().debug("Client %s tried to request pack with an invalid id %s)",
+            GeyserLogger.get().debug("Client %s tried to request pack with an invalid id %s)",
                 session.bedrockUsername(), id);
             session.disconnect("disconnectionScreen.resourcePack");
             return;
@@ -442,7 +454,7 @@ public class UpstreamPacketHandler extends LoggingPacketHandler {
 
         ResourcePackHolder holder = this.resourcePackLoadEvent.getPacks().get(packId);
         if (holder == null) {
-            GeyserImpl.getInstance().getLogger().debug("Client %s tried to request pack id %s not sent to it!",
+            GeyserLogger.get().debug("Client %s tried to request pack id %s not sent to it!",
                 session.bedrockUsername(), id);
             session.disconnect("disconnectionScreen.resourcePack");
             return;

--- a/core/src/main/java/org/geysermc/geyser/network/netty/Bootstraps.java
+++ b/core/src/main/java/org/geysermc/geyser/network/netty/Bootstraps.java
@@ -33,6 +33,7 @@ import io.netty.channel.socket.nio.NioChannelOption;
 import io.netty.channel.unix.UnixChannelOption;
 import lombok.experimental.UtilityClass;
 import org.geysermc.geyser.GeyserImpl;
+import org.geysermc.geyser.GeyserLogger;
 import org.geysermc.mcprotocollib.network.helper.TransportHelper;
 
 import java.net.StandardSocketOptions;
@@ -53,9 +54,9 @@ public final class Bootstraps {
         String kernelVersion;
         try {
             kernelVersion = Native.KERNEL_VERSION;
-            GeyserImpl.getInstance().getLogger().debug("Kernel version: " + kernelVersion);
+            GeyserLogger.get().debug("Kernel version: " + kernelVersion);
         } catch (Throwable e) {
-            GeyserImpl.getInstance().getLogger().debug("Could not determine kernel version! " + e.getMessage());
+            GeyserLogger.get().debug("Could not determine kernel version! " + e.getMessage());
             kernelVersion = null;
         }
 
@@ -77,13 +78,13 @@ public final class Bootstraps {
         try {
             ChannelFuture future = bootstrap.register();
             if (!future.awaitUninterruptibly(3, TimeUnit.SECONDS)) {
-                GeyserImpl.getInstance().getLogger().debug("Not able to test so_reuseport availability within 3 seconds.");
+                GeyserLogger.get().debug("Not able to test so_reuseport availability within 3 seconds.");
                 future.cancel(true);
                 return false;
             }
 
             if (!future.isSuccess()) {
-                GeyserImpl.getInstance().getLogger().warning("Could not register bootstrap channel for so_reuseport test: " + future.cause());
+                GeyserLogger.get().warning("Could not register bootstrap channel for so_reuseport test: " + future.cause());
                 return false;
             }
 
@@ -93,7 +94,7 @@ public final class Bootstraps {
                     if (channel.config().setOption(NioChannelOption.of(StandardSocketOptions.SO_REUSEPORT), true)) {
                         bootstrap.option(NioChannelOption.of(StandardSocketOptions.SO_REUSEPORT), true);
                     } else {
-                        GeyserImpl.getInstance().getLogger().debug("NIO SO_REUSEPORT not supported");
+                        GeyserLogger.get().debug("NIO SO_REUSEPORT not supported");
                         success = false;
                     }
                 } else {
@@ -101,7 +102,7 @@ public final class Bootstraps {
                         bootstrap.option(UnixChannelOption.SO_REUSEPORT, true);
                     } else {
                         // If this occurs, we guessed wrong and reuseport is not available
-                        GeyserImpl.getInstance().getLogger().debug("so_reuseport is not available despite version being " + Native.KERNEL_VERSION);
+                        GeyserLogger.get().debug("so_reuseport is not available despite version being " + Native.KERNEL_VERSION);
                         success = false;
                     }
                 }
@@ -110,7 +111,7 @@ public final class Bootstraps {
                 channel.close().awaitUninterruptibly(3, TimeUnit.SECONDS);
             }
         } catch (Throwable e) {
-            GeyserImpl.getInstance().getLogger().debug("Could not set up reuseport check! %s", e);
+            GeyserLogger.get().debug("Could not set up reuseport check! %s", e);
             return false;
         }
         return success;

--- a/core/src/main/java/org/geysermc/geyser/network/netty/GeyserServer.java
+++ b/core/src/main/java/org/geysermc/geyser/network/netty/GeyserServer.java
@@ -45,6 +45,7 @@ import org.cloudburstmc.netty.handler.codec.raknet.server.RakServerOfflineHandle
 import org.cloudburstmc.netty.handler.codec.raknet.server.RakServerRateLimiter;
 import org.cloudburstmc.protocol.bedrock.BedrockPong;
 import org.geysermc.geyser.GeyserImpl;
+import org.geysermc.geyser.GeyserLogger;
 import org.geysermc.geyser.api.event.connection.ConnectionRequestEvent;
 import org.geysermc.geyser.command.defaults.ConnectionTestCommand;
 import org.geysermc.geyser.configuration.GeyserConfig;
@@ -120,7 +121,7 @@ public final class GeyserServer {
     public GeyserServer(GeyserImpl geyser, int threadCount) {
         this.geyser = geyser;
         this.listenCount = Bootstraps.isReusePortAvailable() ?  Integer.getInteger("Geyser.ListenCount", 1) : 1;
-        GeyserImpl.getInstance().getLogger().debug("Listen thread count: " + listenCount);
+        GeyserLogger.get().debug("Listen thread count: " + listenCount);
         this.group = TRANSPORT.eventLoopGroupFactory().apply(listenCount, new DefaultThreadFactory("GeyserServer", true));
         this.childGroup = TRANSPORT.eventLoopGroupFactory().apply(threadCount, new DefaultThreadFactory("GeyserServerChild", true));
 
@@ -148,7 +149,7 @@ public final class GeyserServer {
     private void modifyHandlers(ChannelFuture future) {
         future.addListener((ChannelFutureListener) f -> {
             if (!f.isSuccess()) {
-                GeyserImpl.getInstance().getLogger().warning("Not modifying handlers due to exception: " + f.cause());
+                GeyserLogger.get().warning("Not modifying handlers due to exception: " + f.cause());
                 return;
             }
 
@@ -175,7 +176,7 @@ public final class GeyserServer {
 
             SkinProvider.shutdown();
         } catch (InterruptedException e) {
-            GeyserImpl.getInstance().getLogger().severe("Exception in shutdown process", e);
+            GeyserLogger.get().severe("Exception in shutdown process", e);
         }
         for (ChannelFuture f : bootstrapFutures) {
             f.channel().closeFuture().syncUninterruptibly();
@@ -184,39 +185,37 @@ public final class GeyserServer {
 
     @SuppressWarnings("Convert2MethodRef")
     private ServerBootstrap createBootstrap() {
-        if (this.geyser.config().debugMode()) {
-            this.geyser.getLogger().debug("Transport type: " + TRANSPORT.method().name());
-            if (TRANSPORT.datagramChannelClass() == NioDatagramChannel.class) {
-                if (System.getProperties().contains("disableNativeEventLoop")) {
-                    this.geyser.getLogger().debug("EventLoop type is NIO because native event loops are disabled.");
-                } else {
-                    // Use lambda here, not method reference, or else NoClassDefFoundError for Epoll/KQueue will not be caught
-                    this.geyser.getLogger().debug("Reason for no Epoll: " + throwableOrCaught(() -> Epoll.unavailabilityCause()));
-                    this.geyser.getLogger().debug("Reason for no KQueue: " + throwableOrCaught(() -> KQueue.unavailabilityCause()));
-                    this.geyser.getLogger().debug("Reason for no IoUring: " + throwableOrCaught(() -> IoUring.unavailabilityCause()));
-                }
+        GeyserLogger.get().debug("Transport type: " + TRANSPORT.method().name());
+        if (TRANSPORT.datagramChannelClass() == NioDatagramChannel.class) {
+            if (System.getProperties().contains("disableNativeEventLoop")) {
+                GeyserLogger.get().debug("EventLoop type is NIO because native event loops are disabled.");
+            } else {
+                // Use lambda here, not method reference, or else NoClassDefFoundError for Epoll/KQueue will not be caught
+                GeyserLogger.get().debug("Reason for no Epoll: " + throwableOrCaught(() -> Epoll.unavailabilityCause()));
+                GeyserLogger.get().debug("Reason for no KQueue: " + throwableOrCaught(() -> KQueue.unavailabilityCause()));
+                GeyserLogger.get().debug("Reason for no IoUring: " + throwableOrCaught(() -> IoUring.unavailabilityCause()));
             }
         }
 
-        this.geyser.getLogger().debug("Setting MTU to " + this.geyser.config().advanced().bedrock().mtu());
+        GeyserLogger.get().debug("Setting MTU to " + this.geyser.config().advanced().bedrock().mtu());
 
         int rakPacketLimit = positivePropOrDefault("Geyser.RakPacketLimit", DEFAULT_PACKET_LIMIT);
-        this.geyser.getLogger().debug("Setting RakNet packet limit to " + rakPacketLimit);
+        GeyserLogger.get().debug("Setting RakNet packet limit to " + rakPacketLimit);
 
         int rakGlobalPacketLimit = positivePropOrDefault("Geyser.RakGlobalPacketLimit", DEFAULT_GLOBAL_PACKET_LIMIT);
-        this.geyser.getLogger().debug("Setting RakNet global packet limit to " + rakGlobalPacketLimit);
+        GeyserLogger.get().debug("Setting RakNet global packet limit to " + rakGlobalPacketLimit);
 
         boolean rakSendCookie = Boolean.parseBoolean(System.getProperty("Geyser.RakSendCookie", "true"));
-        this.geyser.getLogger().debug("Setting RakNet send cookie to " + rakSendCookie);
+        GeyserLogger.get().debug("Setting RakNet send cookie to " + rakSendCookie);
 
         int maxConnectionsPerAddress =  positivePropOrDefault("Geyser.MaxConnectionsPerAddress", 10);
-        this.geyser.getLogger().debug("Setting max connections per address to " + maxConnectionsPerAddress);
+        GeyserLogger.get().debug("Setting max connections per address to " + maxConnectionsPerAddress);
 
         boolean rakRateLimitingDisabled = Boolean.parseBoolean(System.getProperty(
             "Geyser.RakRateLimitingDisabled",
             Boolean.toString(this.geyser.config().advanced().bedrock().useWaterdogpeForwarding())
         ));
-        this.geyser.getLogger().debug("Disabling RakNet rate limiting " + rakRateLimitingDisabled);
+        GeyserLogger.get().debug("Disabling RakNet rate limiting " + rakRateLimitingDisabled);
 
         GeyserServerInitializer serverInitializer = new GeyserServerInitializer(this.geyser, rakSendCookie);
         playerGroup = serverInitializer.getEventLoopGroup();
@@ -259,20 +258,20 @@ public final class GeyserServer {
         );
         geyser.eventBus().fire(requestEvent);
         if (requestEvent.isCancelled()) {
-            geyser.getLogger().debug("Connection request from " + ip + " was cancelled using the API!");
+            GeyserLogger.get().debug("Connection request from " + ip + " was cancelled using the API!");
             connectionAttempts++;
             return false;
         }
 
-        geyser.getLogger().debug(GeyserLocale.getLocaleStringLog("geyser.network.attempt_connect", ip));
+        GeyserLogger.get().debug(GeyserLocale.getLocaleStringLog("geyser.network.attempt_connect", ip));
         connectionAttempts++;
         return true;
     }
 
     public BedrockPong onQuery(Channel channel, InetSocketAddress inetSocketAddress) {
-        if (geyser.config().debugMode() && PRINT_DEBUG_PINGS) {
+        if (GeyserLogger.get().isDebug() && PRINT_DEBUG_PINGS) {
             String ip = geyser.config().logPlayerIpAddresses() ? inetSocketAddress.toString() : "<IP address withheld>";
-            geyser.getLogger().debug(GeyserLocale.getLocaleStringLog("geyser.network.pinged", ip));
+            GeyserLogger.get().debug(GeyserLocale.getLocaleStringLog("geyser.network.pinged", ip));
         }
 
         GeyserConfig config = geyser.config();
@@ -410,7 +409,7 @@ public final class GeyserServer {
             int parsed = value != null ? Integer.parseInt(value) : defaultValue;
 
             if (parsed < 1) {
-                GeyserImpl.getInstance().getLogger().warning(
+                GeyserLogger.get().warning(
                     "Non-postive integer value for " + property + ": " + value + ". Using default value: " + defaultValue
                 );
                 return defaultValue;
@@ -418,7 +417,7 @@ public final class GeyserServer {
 
             return parsed;
         } catch (NumberFormatException e) {
-            GeyserImpl.getInstance().getLogger().warning(
+            GeyserLogger.get().warning(
                 "Invalid integer value for " + property + ": " + value + ". Using default value: " + defaultValue
             );
             return defaultValue;

--- a/core/src/main/java/org/geysermc/geyser/pack/SkullResourcePackManager.java
+++ b/core/src/main/java/org/geysermc/geyser/pack/SkullResourcePackManager.java
@@ -30,6 +30,7 @@ import it.unimi.dsi.fastutil.objects.Object2ObjectOpenHashMap;
 import org.checkerframework.checker.nullness.qual.Nullable;
 import org.geysermc.geyser.Constants;
 import org.geysermc.geyser.GeyserImpl;
+import org.geysermc.geyser.GeyserLogger;
 import org.geysermc.geyser.api.pack.ResourcePackManifest;
 import org.geysermc.geyser.registry.BlockRegistries;
 import org.geysermc.geyser.registry.type.CustomSkull;
@@ -71,7 +72,7 @@ public class SkullResourcePackManager {
         try {
             Files.createDirectories(cachePath);
         } catch (IOException e) {
-            GeyserImpl.getInstance().getLogger().severe("Unable to create directories for player skull resource pack!", e);
+            GeyserLogger.get().severe("Unable to create directories for player skull resource pack!", e);
             return null;
         }
         cleanSkullSkinCache();
@@ -83,22 +84,22 @@ public class SkullResourcePackManager {
             return null;
         }
         if (packFile.exists() && canReusePack(packFile)) {
-            GeyserImpl.getInstance().getLogger().info("Reusing cached player skull resource pack.");
+            GeyserLogger.get().info("Reusing cached player skull resource pack.");
             return packPath;
         }
 
         // We need to create the resource pack from scratch
-        GeyserImpl.getInstance().getLogger().info("Creating skull resource pack.");
+        GeyserLogger.get().info("Creating skull resource pack.");
         packFile.delete();
         try (ZipOutputStream zipOS = new ZipOutputStream(Files.newOutputStream(packPath, StandardOpenOption.WRITE, StandardOpenOption.CREATE))) {
             addBaseResources(zipOS);
             addSkinTextures(zipOS);
             addAttachables(zipOS);
-            GeyserImpl.getInstance().getLogger().info("Finished creating skull resource pack.");
+            GeyserLogger.get().info("Finished creating skull resource pack.");
             return packPath;
         } catch (IOException e) {
-            GeyserImpl.getInstance().getLogger().severe("Unable to create player skull resource pack!", e);
-            GeyserImpl.getInstance().getLogger().severe("Bedrock players will see dirt blocks instead of custom skull blocks.");
+            GeyserLogger.get().severe("Unable to create player skull resource pack!", e);
+            GeyserLogger.get().severe("Bedrock players will see dirt blocks instead of custom skull blocks.");
             packFile.delete();
         }
         return null;
@@ -138,7 +139,7 @@ public class SkullResourcePackManager {
 
         ImageIO.write(skullTexture, "png", skinPath.toFile());
         SKULL_SKINS.put(skinHash, skinPath);
-        GeyserImpl.getInstance().getLogger().debug("Cached player skull to " + skinPath + " for " + skinHash);
+        GeyserLogger.get().debug("Cached player skull to " + skinPath + " for " + skinHash);
     }
 
     public static void cleanSkullSkinCache() {
@@ -157,13 +158,10 @@ public class SkullResourcePackManager {
                 }
             }
             if (removeCount != 0) {
-                GeyserImpl.getInstance().getLogger().debug("Removed " + removeCount + " unnecessary skull skins.");
+                GeyserLogger.get().debug("Removed " + removeCount + " unnecessary skull skins.");
             }
         } catch (IOException e) {
-            GeyserImpl.getInstance().getLogger().debug("Unable to clean up skull skin cache.");
-            if (GeyserImpl.getInstance().config().debugMode()) {
-                e.printStackTrace();
-            }
+            GeyserLogger.get().debug("Unable to clean up skull skin cache.", e);
         }
     }
 
@@ -279,7 +277,7 @@ public class SkullResourcePackManager {
             uuid1 = new UUID(skinHashes.getLong(), skinHashes.getLong());
             uuid2 = new UUID(skinHashes.getLong(), skinHashes.getLong());
         } catch (NoSuchAlgorithmException e) {
-            GeyserImpl.getInstance().getLogger().severe("Unable to get SHA-256 Message Digest instance! Bedrock players will have to re-downloaded the player skull resource pack after each server restart.", e);
+            GeyserLogger.get().severe("Unable to get SHA-256 Message Digest instance! Bedrock players will have to re-downloaded the player skull resource pack after each server restart.", e);
         }
 
         return Pair.of(uuid1, uuid2);
@@ -303,7 +301,7 @@ public class SkullResourcePackManager {
                 return resourceUUID.isPresent() && uuids.second().equals(resourceUUID.get());
             }
         } catch (IOException e) {
-            GeyserImpl.getInstance().getLogger().debug("Cached player skull resource pack was invalid! The pack will be recreated.");
+            GeyserLogger.get().debug("Cached player skull resource pack was invalid! The pack will be recreated.");
         }
         return false;
     }

--- a/core/src/main/java/org/geysermc/geyser/pack/path/GeyserPathPackCodec.java
+++ b/core/src/main/java/org/geysermc/geyser/pack/path/GeyserPathPackCodec.java
@@ -28,6 +28,7 @@ package org.geysermc.geyser.pack.path;
 import lombok.RequiredArgsConstructor;
 import org.checkerframework.checker.nullness.qual.NonNull;
 import org.geysermc.geyser.GeyserImpl;
+import org.geysermc.geyser.GeyserLogger;
 import org.geysermc.geyser.api.pack.PathPackCodec;
 import org.geysermc.geyser.api.pack.ResourcePack;
 import org.geysermc.geyser.registry.loader.ResourcePackLoader;
@@ -102,7 +103,7 @@ public class GeyserPathPackCodec extends PathPackCodec {
             }
 
             if (lastModified.toInstant().isAfter(this.lastModified.toInstant())) {
-                GeyserImpl.getInstance().getLogger().warning("Detected a change in the resource pack " + path + ". This is likely to cause undefined behavior for new clients joining. It is suggested you restart Geyser.");
+                GeyserLogger.get().warning("Detected a change in the resource pack " + path + ". This is likely to cause undefined behavior for new clients joining. It is suggested you restart Geyser.");
                 this.lastModified = lastModified;
                 this.sha256 = null;
                 this.size = -1;

--- a/core/src/main/java/org/geysermc/geyser/pack/url/GeyserUrlPackCodec.java
+++ b/core/src/main/java/org/geysermc/geyser/pack/url/GeyserUrlPackCodec.java
@@ -31,6 +31,7 @@ import java.util.Objects;
 import lombok.Getter;
 import org.checkerframework.checker.nullness.qual.NonNull;
 import org.geysermc.geyser.GeyserImpl;
+import org.geysermc.geyser.GeyserLogger;
 import org.geysermc.geyser.api.pack.PathPackCodec;
 import org.geysermc.geyser.api.pack.UrlPackCodec;
 import org.geysermc.geyser.pack.GeyserResourcePack;
@@ -112,14 +113,14 @@ public class GeyserUrlPackCodec extends UrlPackCodec {
                     var currentVersion = holder.version().toString();
                     var updatedVersion = updatedPack.manifest().header().version().toString();
                     if (currentVersion.equals(updatedVersion)) {
-                        GeyserImpl.getInstance().getLogger().info("No version or pack change detected: Was the resource pack server down?");
+                        GeyserLogger.get().info("No version or pack change detected: Was the resource pack server down?");
                         return;
                     } else {
-                        GeyserImpl.getInstance().getLogger().info("Detected a new resource pack version (%s, old version %s) for pack at %s!"
+                        GeyserLogger.get().info("Detected a new resource pack version (%s, old version %s) for pack at %s!"
                             .formatted(currentVersion, updatedVersion, url));
                     }
                 } else {
-                    GeyserImpl.getInstance().getLogger().info("Detected a new resource pack at the url %s!".formatted(url));
+                    GeyserLogger.get().info("Detected a new resource pack at the url %s!".formatted(url));
                     Registries.RESOURCE_PACKS.get().remove(holder.uuid());
                 }
 
@@ -131,7 +132,7 @@ public class GeyserUrlPackCodec extends UrlPackCodec {
             })
             .whenComplete((result, throwable) -> {
                 if (throwable != null) {
-                    GeyserImpl.getInstance().getLogger().error(GeyserLocale.getLocaleStringLog("geyser.resource_pack.broken", url), throwable);
+                    GeyserLogger.get().error(GeyserLocale.getLocaleStringLog("geyser.resource_pack.broken", url), throwable);
                     Registries.RESOURCE_PACKS.get().remove(holder.uuid());
                 }
             });

--- a/core/src/main/java/org/geysermc/geyser/ping/GeyserLegacyPingPassthrough.java
+++ b/core/src/main/java/org/geysermc/geyser/ping/GeyserLegacyPingPassthrough.java
@@ -32,6 +32,7 @@ import io.netty.util.NetUtil;
 import org.checkerframework.checker.nullness.qual.Nullable;
 import org.cloudburstmc.nbt.util.VarInts;
 import org.geysermc.geyser.GeyserImpl;
+import org.geysermc.geyser.GeyserLogger;
 import org.geysermc.geyser.network.GameProtocol;
 import org.geysermc.geyser.util.JsonUtils;
 
@@ -69,7 +70,7 @@ public class GeyserLegacyPingPassthrough extends Thread implements IGeyserPingPa
         if (geyser.config().motd().passthroughMotd() || geyser.config().motd().passthroughPlayerCounts()) {
             // Ensure delay is not zero
             int interval = (geyser.config().motd().pingPassthroughInterval() == 0) ? 1 : geyser.config().motd().pingPassthroughInterval();
-            geyser.getLogger().debug("Scheduling ping passthrough at an interval of " + interval + " second(s).");
+            GeyserLogger.get().debug("Scheduling ping passthrough at an interval of " + interval + " second(s).");
             GeyserLegacyPingPassthrough pingPassthrough = new GeyserLegacyPingPassthrough(geyser, interval);
             pingPassthrough.setName("Geyser LegacyPingPassthrough Thread");
             pingPassthrough.setDaemon(true);
@@ -146,17 +147,17 @@ public class GeyserLegacyPingPassthrough extends Thread implements IGeyserPingPa
                 this.pingInfo = JsonUtils.fromJson(buffer, GeyserPingInfo.class);
             } catch (SocketTimeoutException | ConnectException ex) {
                 this.pingInfo = null;
-                this.geyser.getLogger().debug("Connection timeout for ping passthrough.");
+                GeyserLogger.get().debug("Connection timeout for ping passthrough.");
             } catch (JsonSyntaxException ex) {
-                this.geyser.getLogger().error("Failed to parse json when pinging server!", ex);
+                GeyserLogger.get().error("Failed to parse json when pinging server!", ex);
             } catch (EOFException e) {
                 this.pingInfo = null;
-                this.geyser.getLogger().warning("Failed to ping the remote Java server! Is it online and configured in Geyser's config?");
+                GeyserLogger.get().warning("Failed to ping the remote Java server! Is it online and configured in Geyser's config?");
             } catch (UnknownHostException ex) {
                 // Don't reset pingInfo, as we want to keep the last known value
-                this.geyser.getLogger().warning("Unable to resolve remote host! Is the remote server down or invalid?");
+                GeyserLogger.get().warning("Unable to resolve remote host! Is the remote server down or invalid?");
             } catch (IOException e) {
-                this.geyser.getLogger().error("IO error while trying to use legacy ping passthrough", e);
+                GeyserLogger.get().error("IO error while trying to use legacy ping passthrough", e);
             }
 
             try {

--- a/core/src/main/java/org/geysermc/geyser/registry/PacketTranslatorRegistry.java
+++ b/core/src/main/java/org/geysermc/geyser/registry/PacketTranslatorRegistry.java
@@ -26,6 +26,7 @@
 package org.geysermc.geyser.registry;
 
 import org.cloudburstmc.protocol.bedrock.packet.ServerboundDiagnosticsPacket;
+import org.geysermc.geyser.GeyserLogger;
 import org.geysermc.mcprotocollib.protocol.packet.ingame.clientbound.ClientboundDelimiterPacket;
 import org.geysermc.mcprotocollib.protocol.packet.ingame.clientbound.ClientboundTabListPacket;
 import org.geysermc.mcprotocollib.protocol.packet.ingame.clientbound.level.ClientboundChunkBatchStartPacket;
@@ -73,9 +74,9 @@ public class PacketTranslatorRegistry<T> extends AbstractMappedRegistry<Class<? 
             }
             return true;
         } else {
-            if (GeyserImpl.getInstance().config().debugMode()) {
+            if (GeyserLogger.get().isDebug()) {
                 if (!IGNORED_PACKETS.contains(clazz)) {
-                    GeyserImpl.getInstance().getLogger().debug("Could not find packet for " + (packet.toString().length() > 25 ? packet.getClass().getSimpleName() : packet));
+                    GeyserLogger.get().debug("Could not find packet for " + (packet.toString().length() > 25 ? packet.getClass().getSimpleName() : packet));
                 }
             }
 
@@ -91,9 +92,9 @@ public class PacketTranslatorRegistry<T> extends AbstractMappedRegistry<Class<? 
         try {
             translator.translate(session, packet);
         } catch (ErosionCancellationException ex) {
-            GeyserImpl.getInstance().getLogger().debug("Caught ErosionCancellationException");
+            GeyserLogger.get().debug("Caught ErosionCancellationException");
         } catch (Throwable ex) {
-            GeyserImpl.getInstance().getLogger().error(GeyserLocale.getLocaleStringLog("geyser.network.translator.packet.failed", packet.getClass().getSimpleName()), ex);
+            GeyserLogger.get().error(GeyserLocale.getLocaleStringLog("geyser.network.translator.packet.failed", packet.getClass().getSimpleName()), ex);
             ex.printStackTrace();
         }
     }

--- a/core/src/main/java/org/geysermc/geyser/registry/loader/BlockShapeRegistryLoader.java
+++ b/core/src/main/java/org/geysermc/geyser/registry/loader/BlockShapeRegistryLoader.java
@@ -31,6 +31,7 @@ import org.cloudburstmc.nbt.NbtMap;
 import org.cloudburstmc.nbt.NbtType;
 import org.cloudburstmc.nbt.NbtUtils;
 import org.geysermc.geyser.GeyserImpl;
+import org.geysermc.geyser.GeyserLogger;
 import org.geysermc.geyser.level.block.type.BlockState;
 import org.geysermc.geyser.level.physics.BoundingBox;
 import org.geysermc.geyser.registry.BlockRegistries;
@@ -63,7 +64,7 @@ public class BlockShapeRegistryLoader implements RegistryLoader<String, List<Bou
         for (int i = 0; i < blockStates.size(); i++) {
             BlockState state = blockStates.get(i);
             if (state == null) {
-                GeyserImpl.getInstance().getLogger().warning("Missing block state for Java block " + i);
+                GeyserLogger.get().warning("Missing block state for Java block " + i);
                 collisions.add(null);
                 continue;
             }

--- a/core/src/main/java/org/geysermc/geyser/registry/loader/CollisionRegistryLoader.java
+++ b/core/src/main/java/org/geysermc/geyser/registry/loader/CollisionRegistryLoader.java
@@ -35,6 +35,7 @@ import org.cloudburstmc.nbt.NbtMap;
 import org.cloudburstmc.nbt.NbtType;
 import org.cloudburstmc.nbt.NbtUtils;
 import org.geysermc.geyser.GeyserImpl;
+import org.geysermc.geyser.GeyserLogger;
 import org.geysermc.geyser.level.block.type.BlockState;
 import org.geysermc.geyser.level.physics.BoundingBox;
 import org.geysermc.geyser.registry.BlockRegistries;
@@ -62,7 +63,7 @@ public class CollisionRegistryLoader extends MultiResourceRegistryLoader<String,
     public List<BlockCollision> load(Pair<String, String> input) {
         Map<Class<?>, CollisionInfo> annotationMap = new IdentityHashMap<>();
         for (Class<?> clazz : AnnotationUtils.getGeneratedClassesForAnnotation(CollisionRemapper.class.getName())) {
-            GeyserImpl.getInstance().getLogger().debug("Found annotated collision translator: " + clazz.getCanonicalName());
+            GeyserLogger.get().debug("Found annotated collision translator: " + clazz.getCanonicalName());
 
             CollisionRemapper collisionRemapper = clazz.getAnnotation(CollisionRemapper.class);
             annotationMap.put(clazz, new CollisionInfo(collisionRemapper, Pattern.compile(collisionRemapper.regex())));
@@ -88,7 +89,7 @@ public class CollisionRegistryLoader extends MultiResourceRegistryLoader<String,
         for (int i = 0; i < blockStates.size(); i++) {
             BlockState state = blockStates.get(i);
             if (state == null) {
-                GeyserImpl.getInstance().getLogger().warning("Missing block state for Java block " + i);
+                GeyserLogger.get().warning("Missing block state for Java block " + i);
                 continue;
             }
 

--- a/core/src/main/java/org/geysermc/geyser/registry/loader/ParticleTypesRegistryLoader.java
+++ b/core/src/main/java/org/geysermc/geyser/registry/loader/ParticleTypesRegistryLoader.java
@@ -31,6 +31,7 @@ import it.unimi.dsi.fastutil.objects.Object2ObjectOpenHashMap;
 import org.cloudburstmc.protocol.bedrock.data.LevelEvent;
 import org.cloudburstmc.protocol.bedrock.data.LevelEventType;
 import org.geysermc.geyser.GeyserImpl;
+import org.geysermc.geyser.GeyserLogger;
 import org.geysermc.geyser.registry.type.ParticleMapping;
 import org.geysermc.mcprotocollib.protocol.data.game.level.particle.ParticleType;
 
@@ -52,7 +53,7 @@ public class ParticleTypesRegistryLoader extends EffectRegistryLoader<Map<Partic
                 JsonElement bedrockId = entry.getValue().getAsJsonObject().get("bedrockId");
                 JsonElement eventType = entry.getValue().getAsJsonObject().get("eventType");
                 if (eventType == null && bedrockId == null) {
-                    GeyserImpl.getInstance().getLogger().debug("Skipping particle mapping " + key + " because no Bedrock equivalent exists.");
+                    GeyserLogger.get().debug("Skipping particle mapping " + key + " because no Bedrock equivalent exists.");
                     continue;
                 }
 

--- a/core/src/main/java/org/geysermc/geyser/registry/loader/ResourcePackLoader.java
+++ b/core/src/main/java/org/geysermc/geyser/registry/loader/ResourcePackLoader.java
@@ -30,6 +30,7 @@ import com.google.common.cache.CacheBuilder;
 import it.unimi.dsi.fastutil.objects.Object2ObjectOpenHashMap;
 import org.checkerframework.checker.nullness.qual.NonNull;
 import org.geysermc.geyser.GeyserImpl;
+import org.geysermc.geyser.GeyserLogger;
 import org.geysermc.geyser.api.event.lifecycle.GeyserLoadResourcePacksEvent;
 import org.geysermc.geyser.api.pack.PathPackCodec;
 import org.geysermc.geyser.api.pack.ResourcePack;
@@ -97,7 +98,7 @@ public class ResourcePackLoader implements RegistryLoader<Path, Map<UUID, Resour
             try {
                 Files.createDirectory(directory);
             } catch (IOException e) {
-                GeyserImpl.getInstance().getLogger().error("Could not create packs directory", e);
+                GeyserLogger.get().error("Could not create packs directory", e);
             }
         }
 
@@ -106,7 +107,7 @@ public class ResourcePackLoader implements RegistryLoader<Path, Map<UUID, Resour
             resourcePacks = stream.filter(PACK_MATCHER::matches)
                     .collect(Collectors.toCollection(ArrayList::new)); // toList() does not guarantee mutability
         } catch (Exception e) {
-            GeyserImpl.getInstance().getLogger().error("Could not list packs directory", e);
+            GeyserLogger.get().error("Could not list packs directory", e);
 
             // Ensure the event is fired even if there was an issue reading
             // from our own resource pack directory. External projects may have
@@ -130,7 +131,7 @@ public class ResourcePackLoader implements RegistryLoader<Path, Map<UUID, Resour
             try {
                 defineEvent.register(readPack(path).build());
             } catch (Exception e) {
-                GeyserImpl.getInstance().getLogger().error(GeyserLocale.getLocaleStringLog("geyser.resource_pack.broken", path));
+                GeyserLogger.get().error(GeyserLocale.getLocaleStringLog("geyser.resource_pack.broken", path));
                 e.printStackTrace();
             }
         }
@@ -167,7 +168,7 @@ public class ResourcePackLoader implements RegistryLoader<Path, Map<UUID, Resour
             Path keyFile = path.resolveSibling(path.getFileName().toString() + ".key");
             contentKey = Files.exists(keyFile) ? Files.readString(keyFile, StandardCharsets.UTF_8) : "";
         } catch (IOException e) {
-            GeyserImpl.getInstance().getLogger().error("Failed to read content key for resource pack " + path.getFileName(), e);
+            GeyserLogger.get().error("Failed to read content key for resource pack " + path.getFileName(), e);
             contentKey = "";
         }
 
@@ -196,7 +197,7 @@ public class ResourcePackLoader implements RegistryLoader<Path, Map<UUID, Resour
             stream.forEach(x -> {
                 String name = x.getName();
                 if (SHOW_RESOURCE_PACK_LENGTH_WARNING && name.length() >= 80) {
-                    GeyserImpl.getInstance().getLogger().warning("The resource pack " + packLocation
+                    GeyserLogger.get().warning("The resource pack " + packLocation
                             + " has a file in it that meets or exceeds 80 characters in its path (" + name
                             + ", " + name.length() + " characters long). This will cause problems on some Bedrock platforms." +
                             " Please rename it to be shorter, or reduce the amount of folders needed to get to the file.");
@@ -233,7 +234,7 @@ public class ResourcePackLoader implements RegistryLoader<Path, Map<UUID, Resour
             try {
                 Files.createDirectories(cachedDirectory);
             } catch (IOException e) {
-                instance.getLogger().error("Could not create remote pack cache directory", e);
+                GeyserLogger.get().error("Could not create remote pack cache directory", e);
                 return;
             }
         }
@@ -243,9 +244,9 @@ public class ResourcePackLoader implements RegistryLoader<Path, Map<UUID, Resour
             try {
                 event.register(new GeyserUrlPackCodec(url).create());
             } catch (Throwable e) {
-                instance.getLogger().error(GeyserLocale.getLocaleStringLog("geyser.resource_pack.broken", url));
-                instance.getLogger().error(e.getMessage());
-                if (instance.getLogger().isDebug()) {
+                GeyserLogger.get().error(GeyserLocale.getLocaleStringLog("geyser.resource_pack.broken", url));
+                GeyserLogger.get().error(e.getMessage());
+                if (GeyserLogger.get().isDebug()) {
                     e.printStackTrace();
                 }
             }
@@ -262,13 +263,13 @@ public class ResourcePackLoader implements RegistryLoader<Path, Map<UUID, Resour
     public static void testRemotePack(GeyserSession session, GeyserUrlPackCodec codec, ResourcePackHolder holder) {
         if (CACHED_FAILED_PACKS.getIfPresent(codec.url()) == null) {
             CACHED_FAILED_PACKS.put(codec.url(), codec);
-            GeyserImpl.getInstance().getLogger().warning(
+            GeyserLogger.get().warning(
                 "Bedrock client (%s, playing on %s) was not able to download the resource pack at %s!"
                     .formatted(session.bedrockUsername(), session.getClientData().getDeviceOs().name(), codec.url())
             );
 
             if (!Registries.RESOURCE_PACKS.get().containsKey(holder.uuid())) {
-                GeyserImpl.getInstance().getLogger().warning("Skipping remote resource pack check as pack is not present in global resource pack registry.");
+                GeyserLogger.get().warning("Skipping remote resource pack check as pack is not present in global resource pack registry.");
                 return;
             }
 
@@ -299,8 +300,8 @@ public class ResourcePackLoader implements RegistryLoader<Path, Map<UUID, Resour
                     // Check if a "manifest.json" or "pack_manifest.json" file is located directly in the zip... does not work otherwise.
                     // (something like MyZip.zip/manifest.json) will not, but will if it's a subfolder (MyPack.zip/MyPack/manifest.json)
                     if (zip.getEntry("manifest.json") != null || zip.getEntry("pack_manifest.json") != null) {
-                        if (GeyserImpl.getInstance().getLogger().isDebug()) {
-                            GeyserImpl.getInstance().getLogger().info("The remote resource pack from " + url + " contains a manifest.json file at the root of the zip file. " +
+                        if (GeyserLogger.get().isDebug()) {
+                            GeyserLogger.get().info("The remote resource pack from " + url + " contains a manifest.json file at the root of the zip file. " +
                                     "This may not work for remote packs, and could cause Bedrock clients to fall back to request the pack from the server. " +
                                     "Please put the pack file in a subfolder, and provide that zip in the URL.");
                         }
@@ -338,7 +339,7 @@ public class ResourcePackLoader implements RegistryLoader<Path, Map<UUID, Resour
         }
 
         if (count > 0) {
-            GeyserImpl.getInstance().getLogger().debug(String.format("Removed %d cached resource pack files as they are no longer in use!", count));
+            GeyserLogger.get().debug(String.format("Removed %d cached resource pack files as they are no longer in use!", count));
         }
     }
 }

--- a/core/src/main/java/org/geysermc/geyser/registry/loader/SoundEventsRegistryLoader.java
+++ b/core/src/main/java/org/geysermc/geyser/registry/loader/SoundEventsRegistryLoader.java
@@ -30,6 +30,7 @@ import com.google.gson.JsonObject;
 import it.unimi.dsi.fastutil.objects.Object2ObjectOpenHashMap;
 import org.cloudburstmc.protocol.bedrock.data.LevelEventType;
 import org.geysermc.geyser.GeyserImpl;
+import org.geysermc.geyser.GeyserLogger;
 import org.geysermc.geyser.translator.level.event.LevelEventTranslator;
 import org.geysermc.geyser.translator.level.event.PlaySoundEventTranslator;
 import org.geysermc.geyser.translator.level.event.SoundEventEventTranslator;
@@ -84,7 +85,7 @@ public class SoundEventsRegistryLoader extends EffectRegistryLoader<Map<LevelEve
                     soundEffects.put(javaEffect, transformer);
                 }
             } catch (Exception e) {
-                GeyserImpl.getInstance().getLogger().warning("Failed to map sound effect " + entry.getKey() + " : " + e);
+                GeyserLogger.get().warning("Failed to map sound effect " + entry.getKey() + " : " + e);
             }
         }
         return soundEffects;

--- a/core/src/main/java/org/geysermc/geyser/registry/mappings/MappingsConfigReader.java
+++ b/core/src/main/java/org/geysermc/geyser/registry/mappings/MappingsConfigReader.java
@@ -31,6 +31,7 @@ import it.unimi.dsi.fastutil.ints.Int2ObjectMap;
 import it.unimi.dsi.fastutil.ints.Int2ObjectOpenHashMap;
 import org.checkerframework.checker.nullness.qual.Nullable;
 import org.geysermc.geyser.GeyserImpl;
+import org.geysermc.geyser.GeyserLogger;
 import org.geysermc.geyser.api.item.custom.v2.CustomItemDefinition;
 import org.geysermc.geyser.api.util.Identifier;
 import org.geysermc.geyser.registry.mappings.util.CustomBlockMapping;
@@ -71,7 +72,7 @@ public class MappingsConfigReader {
                 Files.createDirectories(mappingsDirectory);
                 return true;
             } catch (IOException e) {
-                GeyserImpl.getInstance().getLogger().error("Failed to create mappings directory", e);
+                GeyserLogger.get().error("Failed to create mappings directory", e);
                 return false;
             }
         }
@@ -105,12 +106,12 @@ public class MappingsConfigReader {
         try (FileReader reader = new FileReader(file.toFile())) {
             mappingsRoot = (JsonObject) new JsonParser().parse(reader);
         } catch (IOException e) {
-            GeyserImpl.getInstance().getLogger().error("Failed to read custom mapping file: " + file, e);
+            GeyserLogger.get().error("Failed to read custom mapping file: " + file, e);
             return null;
         }
 
         if (!mappingsRoot.has("format_version")) {
-            GeyserImpl.getInstance().getLogger().error("Mappings file " + file + " is missing the format version field!");
+            GeyserLogger.get().error("Mappings file " + file + " is missing the format version field!");
             return null;
         }
 
@@ -120,7 +121,7 @@ public class MappingsConfigReader {
     public int getFormatVersion(JsonObject mappingsRoot, Path file) {
         int formatVersion =  mappingsRoot.get("format_version").getAsInt();
         if (!this.mappingReaders.containsKey(formatVersion)) {
-            GeyserImpl.getInstance().getLogger().error("Mappings file " + file + " has an unknown format version: " + formatVersion);
+            GeyserLogger.get().error("Mappings file " + file + " has an unknown format version: " + formatVersion);
             return -1;
         }
         return formatVersion;

--- a/core/src/main/java/org/geysermc/geyser/registry/mappings/versions/MappingsReader_v1.java
+++ b/core/src/main/java/org/geysermc/geyser/registry/mappings/versions/MappingsReader_v1.java
@@ -33,6 +33,7 @@ import it.unimi.dsi.fastutil.objects.Object2ObjectOpenHashMap;
 import it.unimi.dsi.fastutil.objects.ObjectOpenHashSet;
 import org.checkerframework.checker.nullness.qual.Nullable;
 import org.geysermc.geyser.GeyserImpl;
+import org.geysermc.geyser.GeyserLogger;
 import org.geysermc.geyser.api.block.custom.CustomBlockData;
 import org.geysermc.geyser.api.block.custom.CustomBlockPermutation;
 import org.geysermc.geyser.api.block.custom.CustomBlockState;
@@ -115,7 +116,7 @@ public class MappingsReader_v1 extends MappingsReader {
                             CustomItemDefinition customItemData = this.readItemMappingEntry(vanillaItemIdentifier, data);
                             consumer.accept(vanillaItemIdentifier, customItemData);
                         } catch (InvalidCustomMappingsFileException e) {
-                            GeyserImpl.getInstance().getLogger().error("Error in registering items for custom mapping file: " + file.toString(), e);
+                            GeyserLogger.get().error("Error in registering items for custom mapping file: " + file.toString(), e);
                         }
                     });
                 }
@@ -140,8 +141,8 @@ public class MappingsReader_v1 extends MappingsReader {
                         CustomBlockMapping customBlockMapping = this.readBlockMappingEntry(identifier, jsonObject);
                         consumer.accept(identifier, customBlockMapping);
                     } catch (Exception e) {
-                        GeyserImpl.getInstance().getLogger().error("Error in registering blocks for custom mapping file: " + file.toString());
-                        GeyserImpl.getInstance().getLogger().error("due to entry: " + entry, e);
+                        GeyserLogger.get().error("Error in registering blocks for custom mapping file: " + file.toString());
+                        GeyserLogger.get().error("due to entry: " + entry, e);
                     }
                 }
             });
@@ -407,7 +408,7 @@ public class MappingsReader_v1 extends MappingsReader {
         // Deprecated; but we should map it as best we can
         BoxComponent extendedCollisionBox = readBoxComponent(node.get("extended_collision_box"));
         if (extendedCollisionBox != null) {
-            GeyserImpl.getInstance().getLogger().warning("Extended collision boxes are deprecated and will be removed in a future version. Please increase the height using collision boxes instead.");
+            GeyserLogger.get().warning("Extended collision boxes are deprecated and will be removed in a future version. Please increase the height using collision boxes instead.");
 
             // Map extended collision boxes by adding an increased height to the collisions set
             // For that, we increase the height and limit it to extend by 0.5 blocks max

--- a/core/src/main/java/org/geysermc/geyser/registry/mappings/versions/MappingsReader_v2.java
+++ b/core/src/main/java/org/geysermc/geyser/registry/mappings/versions/MappingsReader_v2.java
@@ -29,6 +29,7 @@ import com.google.gson.JsonArray;
 import com.google.gson.JsonElement;
 import com.google.gson.JsonObject;
 import org.geysermc.geyser.GeyserImpl;
+import org.geysermc.geyser.GeyserLogger;
 import org.geysermc.geyser.api.item.custom.v2.CustomItemDefinition;
 import org.geysermc.geyser.api.util.Identifier;
 import org.geysermc.geyser.item.exception.InvalidCustomMappingsFileException;
@@ -57,12 +58,12 @@ public class MappingsReader_v2 extends MappingsReader {
                             ItemDefinitionReaders.readDefinition(definition, vanillaItem, null, consumer,
                                 "item definition(s) for vanilla Java item " + vanillaItem);
                         } catch (InvalidCustomMappingsFileException exception) {
-                            GeyserImpl.getInstance().getLogger().error(
+                            GeyserLogger.get().error(
                                 "Error reading definition(s) for vanilla Java item " + entry.getKey() + " in custom mappings file: " + file.toString(), exception);
                         }
                     });
                 } else {
-                    GeyserImpl.getInstance().getLogger().error("Item definitions key " + entry.getKey() + " was not an array!");
+                    GeyserLogger.get().error("Item definitions key " + entry.getKey() + " was not an array!");
                 }
             });
         }

--- a/core/src/main/java/org/geysermc/geyser/registry/populator/BlockRegistryPopulator.java
+++ b/core/src/main/java/org/geysermc/geyser/registry/populator/BlockRegistryPopulator.java
@@ -167,7 +167,7 @@ public final class BlockRegistryPopulator {
                     CustomBlockRegistryPopulator.generateCustomBlockStates(customBlock, customBlockStates, customExtBlockStates);
                 }
                 blockStates.addAll(customBlockStates);
-                GeyserImpl.getInstance().getLogger().debug("Added " + customBlockStates.size() + " custom block states to v" + protocolVersion + " palette.");
+                GeyserLogger.get().debug("Added " + customBlockStates.size() + " custom block states to v" + protocolVersion + " palette.");
 
                 // The palette is sorted by the FNV1 64-bit hash of the name
                 blockStates.sort((a, b) -> Long.compareUnsigned(fnv164(a.getString("name")), fnv164(b.getString("name"))));
@@ -364,7 +364,7 @@ public final class BlockRegistryPopulator {
                 for (Map.Entry<JavaBlockState, CustomBlockState> entry : nonVanillaStateOverrides.entrySet()) {
                     GeyserBedrockBlock bedrockDefinition = customBlockStateDefinitions.get(entry.getValue());
                     if (bedrockDefinition == null) {
-                        GeyserImpl.getInstance().getLogger().warning("Unable to find custom block for " + entry.getValue());
+                        GeyserLogger.get().warning("Unable to find custom block for " + entry.getValue());
                         continue;
                     }
 

--- a/core/src/main/java/org/geysermc/geyser/registry/populator/BlockRegistryPopulator.java
+++ b/core/src/main/java/org/geysermc/geyser/registry/populator/BlockRegistryPopulator.java
@@ -50,6 +50,7 @@ import org.cloudburstmc.protocol.bedrock.codec.v975.Bedrock_v975;
 import org.cloudburstmc.protocol.bedrock.data.BlockPropertyData;
 import org.cloudburstmc.protocol.bedrock.data.definitions.BlockDefinition;
 import org.geysermc.geyser.GeyserImpl;
+import org.geysermc.geyser.GeyserLogger;
 import org.geysermc.geyser.api.block.custom.CustomBlockData;
 import org.geysermc.geyser.api.block.custom.CustomBlockState;
 import org.geysermc.geyser.api.block.custom.nonvanilla.JavaBlockState;

--- a/core/src/main/java/org/geysermc/geyser/registry/populator/CreativeItemRegistryPopulator.java
+++ b/core/src/main/java/org/geysermc/geyser/registry/populator/CreativeItemRegistryPopulator.java
@@ -39,6 +39,7 @@ import org.cloudburstmc.protocol.bedrock.data.inventory.CreativeItemGroup;
 import org.cloudburstmc.protocol.bedrock.data.inventory.ItemData;
 import org.geysermc.geyser.GeyserBootstrap;
 import org.geysermc.geyser.GeyserImpl;
+import org.geysermc.geyser.GeyserLogger;
 import org.geysermc.geyser.registry.BlockRegistries;
 import org.geysermc.geyser.registry.type.BlockMappings;
 import org.geysermc.geyser.registry.type.GeyserBedrockBlock;
@@ -218,7 +219,7 @@ public class CreativeItemRegistryPopulator {
 
         ItemDefinition definition = definitions.get(identifier);
         if (definition == null) {
-            GeyserImpl.getInstance().getLogger().debug("Unknown item definition with identifier " + identifier + " when loading creative items!");
+            GeyserLogger.get().debug("Unknown item definition with identifier " + identifier + " when loading creative items!");
             return null;
         }
 

--- a/core/src/main/java/org/geysermc/geyser/registry/populator/CustomBlockRegistryPopulator.java
+++ b/core/src/main/java/org/geysermc/geyser/registry/populator/CustomBlockRegistryPopulator.java
@@ -182,14 +182,14 @@ public class CustomBlockRegistryPopulator {
         for(Map.Entry<String, CustomBlockState> entry : BLOCK_STATE_OVERRIDES_QUEUE.entrySet()) {
             int id = BlockRegistries.JAVA_BLOCK_STATE_IDENTIFIER_TO_ID.getOrDefault(entry.getKey(), -1);
             if (id == -1) {
-                GeyserImpl.getInstance().getLogger().warning("Custom block state override for Java Identifier: " +
+                GeyserLogger.get().warning("Custom block state override for Java Identifier: " +
                         entry.getKey() + " could not be registered as it is not a valid block state.");
                 continue;
             }
 
             CustomBlockState oldBlockState = blockStateOverrides.put(id, entry.getValue());
             if (oldBlockState != null) {
-                GeyserImpl.getInstance().getLogger().warning("Duplicate block state override for Java Identifier: " +
+                GeyserLogger.get().warning("Duplicate block state override for Java Identifier: " +
                         entry.getKey() + " Old override: " + oldBlockState.name() + " New override: " + entry.getValue().name());
             }
         }
@@ -209,12 +209,12 @@ public class CustomBlockRegistryPopulator {
 
         BlockRegistries.CUSTOM_BLOCK_STATE_OVERRIDES.set(blockStateOverrides);
         if (!blockStateOverrides.isEmpty()) {
-            GeyserImpl.getInstance().getLogger().info("Registered " + blockStateOverrides.size() + " custom block overrides.");
+            GeyserLogger.get().info("Registered " + blockStateOverrides.size() + " custom block overrides.");
         }
 
         BlockRegistries.CUSTOM_BLOCK_ITEM_OVERRIDES.set(CUSTOM_BLOCK_ITEM_OVERRIDES);
         if (!CUSTOM_BLOCK_ITEM_OVERRIDES.isEmpty()) {
-            GeyserImpl.getInstance().getLogger().info("Registered " + CUSTOM_BLOCK_ITEM_OVERRIDES.size() + " custom block item overrides.");
+            GeyserLogger.get().info("Registered " + CUSTOM_BLOCK_ITEM_OVERRIDES.size() + " custom block item overrides.");
         }
     }
 
@@ -278,7 +278,7 @@ public class CustomBlockRegistryPopulator {
         BlockRegistries.BLOCK_STATES.freeze();
 
         if (!NON_VANILLA_BLOCK_STATE_OVERRIDES.isEmpty()) {
-            GeyserImpl.getInstance().getLogger().info("Registered " + NON_VANILLA_BLOCK_STATE_OVERRIDES.size() + " non-vanilla block overrides.");
+            GeyserLogger.get().info("Registered " + NON_VANILLA_BLOCK_STATE_OVERRIDES.size() + " non-vanilla block overrides.");
         }
     }
 
@@ -288,7 +288,7 @@ public class CustomBlockRegistryPopulator {
     private static void registration() {
         BlockRegistries.CUSTOM_BLOCKS.set(CUSTOM_BLOCKS.toArray(new CustomBlockData[0]));
         if (!CUSTOM_BLOCKS.isEmpty()) {
-            GeyserImpl.getInstance().getLogger().info("Registered " + CUSTOM_BLOCKS.size() + " custom blocks.");
+            GeyserLogger.get().info("Registered " + CUSTOM_BLOCKS.size() + " custom blocks.");
         }
     }
 

--- a/core/src/main/java/org/geysermc/geyser/registry/populator/CustomBlockRegistryPopulator.java
+++ b/core/src/main/java/org/geysermc/geyser/registry/populator/CustomBlockRegistryPopulator.java
@@ -36,6 +36,7 @@ import org.cloudburstmc.nbt.NbtMapBuilder;
 import org.cloudburstmc.nbt.NbtType;
 import org.cloudburstmc.protocol.bedrock.data.BlockPropertyData;
 import org.geysermc.geyser.GeyserImpl;
+import org.geysermc.geyser.GeyserLogger;
 import org.geysermc.geyser.api.block.custom.CustomBlockData;
 import org.geysermc.geyser.api.block.custom.CustomBlockPermutation;
 import org.geysermc.geyser.api.block.custom.CustomBlockState;

--- a/core/src/main/java/org/geysermc/geyser/registry/populator/CustomItemRegistryPopulator.java
+++ b/core/src/main/java/org/geysermc/geyser/registry/populator/CustomItemRegistryPopulator.java
@@ -36,6 +36,7 @@ import org.cloudburstmc.protocol.bedrock.data.definitions.ItemDefinition;
 import org.cloudburstmc.protocol.bedrock.data.definitions.SimpleItemDefinition;
 import org.cloudburstmc.protocol.bedrock.data.inventory.ItemVersion;
 import org.geysermc.geyser.GeyserImpl;
+import org.geysermc.geyser.GeyserLogger;
 import org.geysermc.geyser.api.item.custom.CustomRenderOffsets;
 import org.geysermc.geyser.api.item.custom.v2.CustomItemBedrockOptions;
 import org.geysermc.geyser.api.item.custom.v2.CustomItemDefinition;
@@ -117,7 +118,7 @@ public class CustomItemRegistryPopulator {
                 validateVanillaOverride(identifier, item, customItems, items);
                 customItems.get(identifier).add(item);
             } catch (CustomItemDefinitionRegisterException exception) {
-                GeyserImpl.getInstance().getLogger().error("Not registering custom item definition (bedrock identifier=" + item.bedrockIdentifier() + "): " + exception.getMessage());
+                GeyserLogger.get().error("Not registering custom item definition (bedrock identifier=" + item.bedrockIdentifier() + "): " + exception.getMessage());
             }
         });
 
@@ -155,7 +156,7 @@ public class CustomItemRegistryPopulator {
 
         int customItemCount = customItems.size() + nonVanillaCustomItems.size();
         if (customItemCount > 0) {
-            GeyserImpl.getInstance().getLogger().info("Registered " + customItemCount + " custom items");
+            GeyserLogger.get().info("Registered " + customItemCount + " custom items");
         }
     }
 
@@ -199,7 +200,7 @@ public class CustomItemRegistryPopulator {
         if (bedrockIdentifier.vanilla()) {
             throw new CustomItemDefinitionRegisterException("custom item bedrock identifier namespace can't be minecraft");
         } else if (item.model().equals(vanillaIdentifier) && item.predicates().isEmpty()) {
-            GeyserImpl.getInstance().getLogger().warning("Custom item " + bedrockIdentifier + " overrides the vanilla item model " + vanillaIdentifier + " without additional predicates!");
+            GeyserLogger.get().warning("Custom item " + bedrockIdentifier + " overrides the vanilla item model " + vanillaIdentifier + " without additional predicates!");
         }
 
         for (Map.Entry<Identifier, CustomItemDefinition> entry : registered.entries()) {

--- a/core/src/main/java/org/geysermc/geyser/registry/populator/CustomSkullRegistryPopulator.java
+++ b/core/src/main/java/org/geysermc/geyser/registry/populator/CustomSkullRegistryPopulator.java
@@ -32,6 +32,7 @@ import org.checkerframework.checker.nullness.qual.NonNull;
 import org.checkerframework.checker.nullness.qual.Nullable;
 import org.geysermc.geyser.GeyserBootstrap;
 import org.geysermc.geyser.GeyserImpl;
+import org.geysermc.geyser.GeyserLogger;
 import org.geysermc.geyser.api.event.lifecycle.GeyserDefineCustomSkullsEvent;
 import org.geysermc.geyser.configuration.GeyserCustomSkullConfiguration;
 import org.geysermc.geyser.pack.SkullResourcePackManager;

--- a/core/src/main/java/org/geysermc/geyser/registry/populator/CustomSkullRegistryPopulator.java
+++ b/core/src/main/java/org/geysermc/geyser/registry/populator/CustomSkullRegistryPopulator.java
@@ -77,7 +77,7 @@ public class CustomSkullRegistryPopulator {
             File skullConfigFile = FileUtils.fileOrCopiedFromResource(skullConfigPath.toFile(), "custom-skulls.yml", Function.identity(), bootstrap);
             skullConfig = FileUtils.loadConfig(skullConfigFile, GeyserCustomSkullConfiguration.class);
         } catch (IOException e) {
-            GeyserImpl.getInstance().getLogger().severe(GeyserLocale.getLocaleStringLog("geyser.config.failed"), e);
+            GeyserLogger.get().severe(GeyserLocale.getLocaleStringLog("geyser.config.failed"), e);
             return;
         }
 
@@ -129,7 +129,7 @@ public class CustomSkullRegistryPopulator {
 
         skinHashes.forEach((skinHash) -> {
             if (!SKULL_HASH_PATTERN.matcher(skinHash).matches()) {
-                GeyserImpl.getInstance().getLogger().error("Skin hash " + skinHash + " does not match required format ^[a-fA-F0-9]+$ and will not be added as a custom block.");
+                GeyserLogger.get().error("Skin hash " + skinHash + " does not match required format ^[a-fA-F0-9]+$ and will not be added as a custom block.");
                 return;
             }
 
@@ -137,12 +137,12 @@ public class CustomSkullRegistryPopulator {
                 SkullResourcePackManager.cacheSkullSkin(skinHash);
                 BlockRegistries.CUSTOM_SKULLS.register(skinHash, new CustomSkull(skinHash));
             } catch (IOException e) {
-                GeyserImpl.getInstance().getLogger().error("Failed to cache skin for skull texture " + skinHash + " This skull will not be added as a custom block.", e);
+                GeyserLogger.get().error("Failed to cache skin for skull texture " + skinHash + " This skull will not be added as a custom block.", e);
             }
         });
 
         if (!BlockRegistries.CUSTOM_SKULLS.get().isEmpty()) {
-            GeyserImpl.getInstance().getLogger().info("Registered " + BlockRegistries.CUSTOM_SKULLS.get().size() + " custom skulls as custom blocks.");
+            GeyserLogger.get().info("Registered " + BlockRegistries.CUSTOM_SKULLS.get().size() + " custom skulls as custom blocks.");
         }
     }
 
@@ -154,7 +154,7 @@ public class CustomSkullRegistryPopulator {
     private static @Nullable String getSkinHash(String profile) {
         String hash = loadHashFromJson(profile);
         if (hash == null) {
-            GeyserImpl.getInstance().getLogger().warning("Skull texture " + profile + " contained no valid skins and will not be added as a custom block.");
+            GeyserLogger.get().warning("Skull texture " + profile + " contained no valid skins and will not be added as a custom block.");
             return null;
         }
         return hash;
@@ -169,7 +169,7 @@ public class CustomSkullRegistryPopulator {
         try {
             return SkinProvider.requestTexturesFromUsername(username).get();
         } catch (InterruptedException | ExecutionException e) {
-            GeyserImpl.getInstance().getLogger().error("Unable to request skull textures for " + username + " This skull will not be added as a custom block.", e);
+            GeyserLogger.get().error("Unable to request skull textures for " + username + " This skull will not be added as a custom block.", e);
             return null;
         }
     }
@@ -184,10 +184,10 @@ public class CustomSkullRegistryPopulator {
             UUID parsed = UUID.fromString(uuid);
             return SkinProvider.requestTexturesFromUUID(parsed).get();
         } catch (InterruptedException | ExecutionException e) {
-            GeyserImpl.getInstance().getLogger().error("Unable to request skull textures for " + uuid + " This skull will not be added as a custom block.", e);
+            GeyserLogger.get().error("Unable to request skull textures for " + uuid + " This skull will not be added as a custom block.", e);
             return null;
         } catch (IllegalArgumentException e) {
-            GeyserImpl.getInstance().getLogger().error("Invalid skull uuid " + uuid + " This skull will not be added as a custom block.");
+            GeyserLogger.get().error("Invalid skull uuid " + uuid + " This skull will not be added as a custom block.");
             return null;
         }
     }
@@ -200,7 +200,7 @@ public class CustomSkullRegistryPopulator {
         try {
             skinObject = JsonUtils.parseJson(new String(Base64.getDecoder().decode(encodedJson), StandardCharsets.UTF_8));
         } catch (IllegalArgumentException e) {
-            GeyserImpl.getInstance().getLogger().warning("Invalid base64 encoded profile!");
+            GeyserLogger.get().warning("Invalid base64 encoded profile!");
             return null;
         }
 
@@ -208,7 +208,7 @@ public class CustomSkullRegistryPopulator {
         try {
             result = GeyserImpl.GSON.fromJson(skinObject, MinimalTexturesPayload.class);
         } catch (Exception e) {
-            GeyserImpl.getInstance().getLogger().error("Could not decode texture payload!", e);
+            GeyserLogger.get().error("Could not decode texture payload!", e);
             return null;
         }
 
@@ -218,13 +218,13 @@ public class CustomSkullRegistryPopulator {
                     continue;
                 }
 
-                GeyserImpl.getInstance().getLogger().warning("Textures payload has been tampered with! (non-whitelisted domain)!");
+                GeyserLogger.get().warning("Textures payload has been tampered with! (non-whitelisted domain)!");
                 return null;
             }
 
             Texture skin = result.textures.get(TextureType.SKIN);
             if (skin == null) {
-                GeyserImpl.getInstance().getLogger().warning("Textures payload contains no skin!");
+                GeyserLogger.get().warning("Textures payload contains no skin!");
                 return null;
             }
 

--- a/core/src/main/java/org/geysermc/geyser/registry/populator/ItemRegistryPopulator.java
+++ b/core/src/main/java/org/geysermc/geyser/registry/populator/ItemRegistryPopulator.java
@@ -60,6 +60,7 @@ import org.cloudburstmc.protocol.bedrock.data.inventory.ItemData;
 import org.cloudburstmc.protocol.bedrock.data.inventory.ItemVersion;
 import org.geysermc.geyser.GeyserBootstrap;
 import org.geysermc.geyser.GeyserImpl;
+import org.geysermc.geyser.GeyserLogger;
 import org.geysermc.geyser.api.block.custom.CustomBlockData;
 import org.geysermc.geyser.api.block.custom.CustomBlockState;
 import org.geysermc.geyser.api.block.custom.NonVanillaCustomBlockData;
@@ -510,7 +511,7 @@ public class ItemRegistryPopulator {
                 if (javaOnlyItems.contains(javaItem)) {
                     // These items don't exist on Bedrock, so set up a variable that indicates they should have custom names
                     mappingBuilder = mappingBuilder.translationString((javaItem instanceof BlockItem ? "block." : "item.") + entry.getKey().replace(":", "."));
-                    GeyserImpl.getInstance().getLogger().debug("Adding " + entry.getKey() + " as an item that needs to be translated.");
+                  GeyserLogger.get().debug("Adding " + entry.getKey() + " as an item that needs to be translated.");
                 }
 
                 // Add the custom item properties, if applicable
@@ -526,7 +527,7 @@ public class ItemRegistryPopulator {
                         Identifier customItemIdentifier = customItem.bedrockIdentifier();
                         if (!registeredCustomItems.add(customItemIdentifier)) {
                             if (firstMappingsPass) {
-                                GeyserImpl.getInstance().getLogger().error("Custom item '" + customItemIdentifier + "' already exists and was registered again! Skipping...");
+                              GeyserLogger.get().error("Custom item '" + customItemIdentifier + "' already exists and was registered again! Skipping...");
                             }
                             continue;
                         }
@@ -563,7 +564,7 @@ public class ItemRegistryPopulator {
                             customIdMappings.put(customMapping.integerId(), customItemIdentifier.toString());
                         } catch (InvalidItemComponentsException exception) {
                             if (firstMappingsPass) {
-                                GeyserImpl.getInstance().getLogger().error("Not registering custom item (bedrock identifier=" + customItem.bedrockIdentifier() + ")!", exception);
+                              GeyserLogger.get().error("Not registering custom item (bedrock identifier=" + customItem.bedrockIdentifier() + ")!", exception);
                             }
                         }
                     }
@@ -680,7 +681,7 @@ public class ItemRegistryPopulator {
                             creativeItems.add(creativeItemData);
                         }
                     } catch (InvalidItemComponentsException exception) {
-                        GeyserImpl.getInstance().getLogger().error("Not registering non-vanilla custom item (identifier=" + customItem.identifier() + ")!", exception);
+                      GeyserLogger.get().error("Not registering non-vanilla custom item (identifier=" + customItem.identifier() + ")!", exception);
                     }
                 }
             }

--- a/core/src/main/java/org/geysermc/geyser/registry/populator/PacketRegistryPopulator.java
+++ b/core/src/main/java/org/geysermc/geyser/registry/populator/PacketRegistryPopulator.java
@@ -27,6 +27,7 @@ package org.geysermc.geyser.registry.populator;
 
 import org.cloudburstmc.protocol.bedrock.packet.BedrockPacket;
 import org.geysermc.geyser.GeyserImpl;
+import org.geysermc.geyser.GeyserLogger;
 import org.geysermc.geyser.registry.Registries;
 import org.geysermc.geyser.translator.protocol.PacketTranslator;
 import org.geysermc.geyser.translator.protocol.Translator;
@@ -40,7 +41,7 @@ public class PacketRegistryPopulator {
         for (Class<?> clazz : AnnotationUtils.getGeneratedClassesForAnnotation(Translator.class)) {
             Class<?> packet = clazz.getAnnotation(Translator.class).packet();
 
-            GeyserImpl.getInstance().getLogger().debug("Found annotated translator: " + clazz.getCanonicalName() + " : " + packet.getSimpleName());
+            GeyserLogger.get().debug("Found annotated translator: " + clazz.getCanonicalName() + " : " + packet.getSimpleName());
 
             try {
                 if (Packet.class.isAssignableFrom(packet)) {
@@ -54,10 +55,10 @@ public class PacketRegistryPopulator {
 
                     Registries.BEDROCK_PACKET_TRANSLATORS.register(targetPacket, translator);
                 } else {
-                    GeyserImpl.getInstance().getLogger().error("Class " + clazz.getCanonicalName() + " is annotated as a translator but has an invalid target packet.");
+                  GeyserLogger.get().error("Class " + clazz.getCanonicalName() + " is annotated as a translator but has an invalid target packet.");
                 }
             } catch (Exception e) {
-                GeyserImpl.getInstance().getLogger().error("Could not instantiate annotated translator " + clazz.getCanonicalName());
+              GeyserLogger.get().error("Could not instantiate annotated translator " + clazz.getCanonicalName());
             }
         }
     }

--- a/core/src/main/java/org/geysermc/geyser/registry/populator/custom/CustomItemContext.java
+++ b/core/src/main/java/org/geysermc/geyser/registry/populator/custom/CustomItemContext.java
@@ -27,6 +27,7 @@ package org.geysermc.geyser.registry.populator.custom;
 
 import org.checkerframework.checker.nullness.qual.Nullable;
 import org.geysermc.geyser.GeyserImpl;
+import org.geysermc.geyser.GeyserLogger;
 import org.geysermc.geyser.api.item.custom.v2.CustomItemDefinition;
 import org.geysermc.geyser.api.item.custom.v2.NonVanillaCustomItemDefinition;
 import org.geysermc.geyser.item.components.resolvable.ResolvableComponent;
@@ -103,10 +104,10 @@ public record CustomItemContext(CustomItemDefinition definition, DataComponents 
         Equippable equippable = components.get(DataComponentTypes.EQUIPPABLE);
 
         if (equippable != null && stackSize > 1 && firstPass) {
-            GeyserImpl.getInstance().getLogger().warning("Bedrock doesn't support stackable equippable items! Custom item %s with stack size %s and equippable component for slot %s will not work as expected!"
+            GeyserLogger.get().warning("Bedrock doesn't support stackable equippable items! Custom item %s with stack size %s and equippable component for slot %s will not work as expected!"
                 .formatted(definition.bedrockIdentifier(), stackSize, equippable.slot()));
         } else if (stackSize > Item.BEDROCK_MAX_STACK_SIZE && firstPass) {
-            GeyserImpl.getInstance().getLogger().warning("Bedrock doesn't support stack sizes above %s! Custom item %s with stack size %s will be clamped to %1$s!"
+            GeyserLogger.get().warning("Bedrock doesn't support stack sizes above %s! Custom item %s with stack size %s will be clamped to %1$s!"
                 .formatted(Item.BEDROCK_MAX_STACK_SIZE, definition.bedrockIdentifier(), stackSize));
         } else if (stackSize > 1 && maxDamage > 0) {
             throw new InvalidItemComponentsException("Stack size must be 1 when max damage is above 0");

--- a/core/src/main/java/org/geysermc/geyser/registry/type/ItemMappings.java
+++ b/core/src/main/java/org/geysermc/geyser/registry/type/ItemMappings.java
@@ -39,6 +39,7 @@ import org.cloudburstmc.protocol.bedrock.data.inventory.CreativeItemGroup;
 import org.cloudburstmc.protocol.bedrock.data.inventory.ItemData;
 import org.cloudburstmc.protocol.common.DefinitionRegistry;
 import org.geysermc.geyser.GeyserImpl;
+import org.geysermc.geyser.GeyserLogger;
 import org.geysermc.geyser.api.block.custom.CustomBlockData;
 import org.geysermc.geyser.inventory.GeyserItemStack;
 import org.geysermc.geyser.inventory.item.StoredItemMappings;
@@ -185,7 +186,7 @@ public class ItemMappings implements DefinitionRegistry<ItemDefinition> {
             }
         }
 
-        GeyserImpl.getInstance().getLogger().debug("Missing mapping for bedrock item " + data);
+        GeyserLogger.get().debug("Missing mapping for bedrock item " + data);
         return ItemMapping.AIR;
     }
 

--- a/core/src/main/java/org/geysermc/geyser/scoreboard/Scoreboard.java
+++ b/core/src/main/java/org/geysermc/geyser/scoreboard/Scoreboard.java
@@ -108,7 +108,7 @@ public final class Scoreboard {
 
     public Scoreboard(GeyserSession session) {
         this.session = session;
-        this.logger = GeyserImpl.getInstance().getLogger();
+        this.logger = GeyserLogger.get();
     }
 
     public void removeScoreboard() {

--- a/core/src/main/java/org/geysermc/geyser/scoreboard/ScoreboardUpdater.java
+++ b/core/src/main/java/org/geysermc/geyser/scoreboard/ScoreboardUpdater.java
@@ -28,6 +28,7 @@ package org.geysermc.geyser.scoreboard;
 import lombok.Getter;
 import lombok.RequiredArgsConstructor;
 import org.geysermc.geyser.GeyserImpl;
+import org.geysermc.geyser.GeyserLogger;
 import org.geysermc.geyser.configuration.GeyserConfig;
 import org.geysermc.geyser.session.GeyserSession;
 import org.geysermc.geyser.session.cache.WorldCache;
@@ -43,12 +44,9 @@ public final class ScoreboardUpdater extends Thread {
     private static final int FIRST_MILLIS_BETWEEN_UPDATES = 250; // 4 updates per second
     private static final int SECOND_MILLIS_BETWEEN_UPDATES = 1000; // 1 update per second
 
-    private static final boolean DEBUG_ENABLED;
-
     static {
         GeyserConfig config = GeyserImpl.getInstance().config();
         FIRST_SCORE_PACKETS_PER_SECOND_THRESHOLD = Math.min(config.advanced().scoreboardPacketThreshold(), SECOND_SCORE_PACKETS_PER_SECOND_THRESHOLD);
-        DEBUG_ENABLED = config.debugMode();
     }
 
     private final GeyserImpl geyser = GeyserImpl.getInstance();
@@ -112,12 +110,12 @@ public final class ScoreboardUpdater extends Thread {
                                 worldCache.getScoreboard().onUpdate();
                                 scoreboardSession.lastUpdate = currentTime;
 
-                                if (DEBUG_ENABLED && (currentTime - scoreboardSession.lastLog >= 60000)) { // one minute
+                                if (GeyserLogger.get().isDebug() && (currentTime - scoreboardSession.lastLog >= 60000)) { // one minute
                                     int threshold = reachedSecondThreshold ?
                                             SECOND_SCORE_PACKETS_PER_SECOND_THRESHOLD :
                                             FIRST_SCORE_PACKETS_PER_SECOND_THRESHOLD;
 
-                                    geyser.getLogger().info(
+                                    GeyserLogger.get().info(
                                             GeyserLocale.getLocaleStringLog("geyser.scoreboard.updater.threshold_reached.log", session.bedrockUsername(), threshold, pps) +
                                                     GeyserLocale.getLocaleStringLog("geyser.scoreboard.updater.threshold_reached", (millisBetweenUpdates / 1000.0))
                                     );
@@ -129,10 +127,10 @@ public final class ScoreboardUpdater extends Thread {
                     }
                 }
 
-                if (DEBUG_ENABLED) {
+                if (GeyserLogger.get().isDebug()) {
                     long timeSpent = System.currentTimeMillis() - currentTime;
                     if (timeSpent > 0) {
-                        geyser.getLogger().info(String.format(
+                        GeyserLogger.get().info(String.format(
                                 "Scoreboard updater: took %s ms. Updated %s players",
                                 timeSpent, sessions.size()
                         ));
@@ -142,7 +140,7 @@ public final class ScoreboardUpdater extends Thread {
                 long timeTillNextAction = getTimeTillNextAction();
                 sleepFor(timeTillNextAction);
             } catch (Throwable e) {
-                geyser.getLogger().error("Error while translating scoreboard information!", e);
+                GeyserLogger.get().error("Error while translating scoreboard information!", e);
                 // Wait so we don't try to run the scoreboard immediately after this
                 sleepFor(FIRST_MILLIS_BETWEEN_UPDATES);
             }

--- a/core/src/main/java/org/geysermc/geyser/session/GeyserSession.java
+++ b/core/src/main/java/org/geysermc/geyser/session/GeyserSession.java
@@ -113,6 +113,7 @@ import org.geysermc.api.util.UiProfile;
 import org.geysermc.cumulus.form.Form;
 import org.geysermc.cumulus.form.util.FormBuilder;
 import org.geysermc.geyser.GeyserImpl;
+import org.geysermc.geyser.GeyserLogger;
 import org.geysermc.geyser.api.bedrock.camera.CameraData;
 import org.geysermc.geyser.api.bedrock.camera.CameraShake;
 import org.geysermc.geyser.api.connection.GeyserConnection;
@@ -127,6 +128,7 @@ import org.geysermc.geyser.api.util.PlatformType;
 import org.geysermc.geyser.command.CommandRegistry;
 import org.geysermc.geyser.command.GeyserCommandSource;
 import org.geysermc.geyser.configuration.GeyserConfig;
+import org.geysermc.geyser.debug.SessionDebugOption;
 import org.geysermc.geyser.entity.EntityDefinitions;
 import org.geysermc.geyser.entity.GeyserEntityData;
 import org.geysermc.geyser.entity.attribute.GeyserAttributeType;
@@ -210,6 +212,7 @@ import org.geysermc.mcprotocollib.network.session.ClientNetworkSession;
 import org.geysermc.mcprotocollib.protocol.ClientListener;
 import org.geysermc.mcprotocollib.protocol.MinecraftConstants;
 import org.geysermc.mcprotocollib.protocol.MinecraftProtocol;
+import org.geysermc.mcprotocollib.protocol.codec.MinecraftPacket;
 import org.geysermc.mcprotocollib.protocol.data.ProtocolState;
 import org.geysermc.mcprotocollib.protocol.data.game.ServerLink;
 import org.geysermc.mcprotocollib.protocol.data.game.entity.metadata.Pose;
@@ -289,6 +292,9 @@ public class GeyserSession implements GeyserConnection, GeyserCommandSource {
     @Accessors(fluent = true)
     @Setter
     private RemoteServer remoteServer;
+
+    @Setter
+    private EnumSet<SessionDebugOption> debugOptions = EnumSet.noneOf(SessionDebugOption.class);
 
     private final SessionPlayerEntity playerEntity;
 
@@ -905,7 +911,7 @@ public class GeyserSession implements GeyserConnection, GeyserCommandSource {
             if (isInOverworld) {
                 this.bedrockDimension = this.bedrockOverworldDimension;
             }
-            geyser.getLogger().debug("Extending overworld dimension to " + minY + " - " + maxY);
+            GeyserLogger.get().debug("Extending overworld dimension to " + minY + " - " + maxY);
 
             DimensionDataPacket dimensionDataPacket = new DimensionDataPacket();
             dimensionDataPacket.getDefinitions().add(new DimensionDefinition("minecraft:overworld", maxY, minY, 5, 3));
@@ -1002,7 +1008,7 @@ public class GeyserSession implements GeyserConnection, GeyserCommandSource {
 
     public void authenticate(String username) {
         if (loggedIn) {
-            geyser.getLogger().severe(GeyserLocale.getLocaleStringLog("geyser.auth.already_loggedin", username));
+            GeyserLogger.get().severe(GeyserLocale.getLocaleStringLog("geyser.auth.already_loggedin", username));
             return;
         }
 
@@ -1019,7 +1025,7 @@ public class GeyserSession implements GeyserConnection, GeyserCommandSource {
 
     public void authenticateWithAuthChain(String authChain) {
         if (loggedIn) {
-            geyser.getLogger().severe(GeyserLocale.getLocaleStringLog("geyser.auth.already_loggedin", getAuthData().name()));
+            GeyserLogger.get().severe(GeyserLocale.getLocaleStringLog("geyser.auth.already_loggedin", getAuthData().name()));
             return;
         }
 
@@ -1039,7 +1045,7 @@ public class GeyserSession implements GeyserConnection, GeyserCommandSource {
                 mcProfile = authManager.getMinecraftProfile().getUpToDate();
                 mcToken = authManager.getMinecraftToken().getUpToDate();
             } catch (Exception e) {
-                geyser.getLogger().error("Error while attempting to use auth chain for " + bedrockUsername() + "!", e);
+                GeyserLogger.get().error("Error while attempting to use auth chain for " + bedrockUsername() + "!", e);
                 return Boolean.FALSE;
             }
 
@@ -1078,7 +1084,7 @@ public class GeyserSession implements GeyserConnection, GeyserCommandSource {
      */
     public void authenticateWithMicrosoftCode(boolean offlineAccess) {
         if (loggedIn) {
-            geyser.getLogger().severe(GeyserLocale.getLocaleStringLog("geyser.auth.already_loggedin", getAuthData().name()));
+            GeyserLogger.get().severe(GeyserLocale.getLocaleStringLog("geyser.auth.already_loggedin", getAuthData().name()));
             return;
         }
 
@@ -1114,7 +1120,7 @@ public class GeyserSession implements GeyserConnection, GeyserCommandSource {
         task.cleanup(); // player is online -> remove pending authentication immediately
         return task.getAuthentication().handle((result, ex) -> {
             if (ex != null) {
-                geyser.getLogger().error("Failed to log in with Microsoft code!", ex);
+                GeyserLogger.get().error("Failed to log in with Microsoft code!", ex);
                 if (ex instanceof CompletionException ce && ce.getCause() instanceof MinecraftProfileNotFoundException) {
                     // Player is trying to join with a Microsoft account that doesn't have Java Edition purchased
                     disconnect(GeyserLocale.getPlayerLocaleString("geyser.network.remote.invalid_account", locale()));
@@ -1238,7 +1244,7 @@ public class GeyserSession implements GeyserConnection, GeyserCommandSource {
                 // Downstream's disconnect will fire an event that prints a log message
                 // Otherwise, we print a message here
                 String address = geyser.config().logPlayerIpAddresses() ? upstream.getAddress().getAddress().toString() : "<IP address withheld>";
-                geyser.getLogger().info(GeyserLocale.getLocaleStringLog("geyser.network.disconnect", address, MessageTranslator.convertMessage(reason)));
+                GeyserLogger.get().info(GeyserLocale.getLocaleStringLog("geyser.network.disconnect", address, MessageTranslator.convertMessage(reason)));
             }
 
             // Disconnect upstream if necessary
@@ -1318,9 +1324,9 @@ public class GeyserSession implements GeyserConnection, GeyserCommandSource {
         try {
             runnable.run();
         } catch (ErosionCancellationException e) {
-            geyser.getLogger().debug("Caught ErosionCancellationException");
+            GeyserLogger.get().debug("Caught ErosionCancellationException");
         } catch (Throwable e) {
-            geyser.getLogger().error("Error thrown in " + this.bedrockUsername() + "'s event loop!", e);
+            GeyserLogger.get().error("Error thrown in " + this.bedrockUsername() + "'s event loop!", e);
         }
     }
 
@@ -2073,7 +2079,7 @@ public class GeyserSession implements GeyserConnection, GeyserCommandSource {
         unconfirmedTeleport.incrementUnconfirmedFor();
         if (unconfirmedTeleport.shouldResend()) {
             unconfirmedTeleport.resetUnconfirmedFor();
-            geyser.getLogger().debug("Resending teleport " + unconfirmedTeleport.getTeleportConfirmId());
+            GeyserLogger.get().debug("Resending teleport " + unconfirmedTeleport.getTeleportConfirmId());
             getPlayerEntity().moveAbsolute(unconfirmedTeleport.getPosition(),
                 unconfirmedTeleport.getYaw(), unconfirmedTeleport.getPitch(), playerEntity.isOnGround(), true);
 
@@ -2135,15 +2141,15 @@ public class GeyserSession implements GeyserConnection, GeyserCommandSource {
     public void sendDownstreamPacket(Packet packet, ProtocolState intendedState) {
         // protocol can be null when we're not yet logged in (online auth)
         if (protocol == null) {
-            if (geyser.config().debugMode()) {
-                geyser.getLogger().debug("Tried to send downstream packet with no downstream session!");
+            if (GeyserLogger.get().isDebug()) {
+                GeyserLogger.get().debug("Tried to send downstream packet with no downstream session!");
                 Thread.dumpStack();
             }
             return;
         }
 
         if (protocol.getOutboundState() != intendedState) {
-            geyser.getLogger().debug("Tried to send " + packet.getClass().getSimpleName() + " packet while not in " + intendedState.name() + " outbound state. Current state: " + protocol.getOutboundState().name());
+            GeyserLogger.get().debug("Tried to send " + packet.getClass().getSimpleName() + " packet while not in " + intendedState.name() + " outbound state. Current state: " + protocol.getOutboundState().name());
             return;
         }
 
@@ -2160,8 +2166,8 @@ public class GeyserSession implements GeyserConnection, GeyserCommandSource {
             Channel channel = this.downstream.getSession().getChannel();
             if (channel == null) {
                 // Channel is only null before the connection has initialized
-                geyser.getLogger().warning("Tried to send a packet to the Java server too early!");
-                if (geyser.config().debugMode()) {
+                GeyserLogger.get().warning("Tried to send a packet to the Java server too early!");
+                if (GeyserLogger.get().isDebug()) {
                     Thread.dumpStack();
                 }
                 return;
@@ -2182,7 +2188,7 @@ public class GeyserSession implements GeyserConnection, GeyserCommandSource {
             || packet.getClass() == ServerboundCookieResponsePacket.class) {
             downstream.sendPacket(packet);
         } else {
-            geyser.getLogger().debug("Tried to send downstream packet " + packet.getClass().getSimpleName() + " before connected to the server");
+            GeyserLogger.get().debug("Tried to send downstream packet " + packet.getClass().getSimpleName() + " before connected to the server");
         }
     }
 

--- a/core/src/main/java/org/geysermc/geyser/session/GeyserSessionAdapter.java
+++ b/core/src/main/java/org/geysermc/geyser/session/GeyserSessionAdapter.java
@@ -29,6 +29,7 @@ import org.geysermc.floodgate.crypto.FloodgateCipher;
 import org.geysermc.floodgate.util.BedrockData;
 import org.geysermc.geyser.Constants;
 import org.geysermc.geyser.GeyserImpl;
+import org.geysermc.geyser.GeyserLogger;
 import org.geysermc.geyser.api.network.AuthType;
 import org.geysermc.geyser.api.util.PlatformType;
 import org.geysermc.geyser.network.netty.LocalSession;
@@ -99,7 +100,7 @@ public class GeyserSessionAdapter extends SessionAdapter {
                         skinUploader == null ? null : skinUploader.getVerifyCode()
                     ).toString());
                 } catch (Exception e) {
-                    geyser.getLogger().error(GeyserLocale.getLocaleStringLog("geyser.auth.floodgate.encrypt_fail"), e);
+                    GeyserLogger.get().error(GeyserLocale.getLocaleStringLog("geyser.auth.floodgate.encrypt_fail"), e);
                     session.disconnect(GeyserLocale.getPlayerLocaleString("geyser.auth.floodgate.encrypt_fail", locale));
                     return;
                 }
@@ -127,11 +128,11 @@ public class GeyserSessionAdapter extends SessionAdapter {
 
         if (session.getDownstream().getSession() instanceof LocalSession) {
             // Connected directly to the server
-            geyser.getLogger().info(GeyserLocale.getLocaleStringLog("geyser.network.remote.connect_internal",
+            GeyserLogger.get().info(GeyserLocale.getLocaleStringLog("geyser.network.remote.connect_internal",
                 session.bedrockUsername(), session.getProtocol().getProfile().getName()));
         } else {
             // Connected to an IP address
-            geyser.getLogger().info(GeyserLocale.getLocaleStringLog("geyser.network.remote.connect",
+            GeyserLogger.get().info(GeyserLocale.getLocaleStringLog("geyser.network.remote.connect",
                 session.bedrockUsername(), session.getProtocol().getProfile().getName(), session.remoteServer().address()));
         }
 
@@ -171,7 +172,7 @@ public class GeyserSessionAdapter extends SessionAdapter {
                 // Server expects online mode
                 customDisconnectMessage = GeyserLocale.getPlayerLocaleString("geyser.network.remote.authentication_type_mismatch", locale);
                 // Explain that they may be looking for Floodgate.
-                geyser.getLogger().warning(GeyserLocale.getLocaleStringLog(
+                GeyserLogger.get().warning(GeyserLocale.getLocaleStringLog(
                     geyser.platformType() == PlatformType.STANDALONE ?
                         "geyser.network.remote.floodgate_explanation_standalone"
                         : "geyser.network.remote.floodgate_explanation_plugin",
@@ -181,7 +182,7 @@ public class GeyserSessionAdapter extends SessionAdapter {
                 // Likely that Floodgate is not configured correctly.
                 customDisconnectMessage = GeyserLocale.getPlayerLocaleString("geyser.network.remote.floodgate_login_error", locale);
                 if (geyser.platformType() == PlatformType.STANDALONE) {
-                    geyser.getLogger().warning(GeyserLocale.getLocaleStringLog("geyser.network.remote.floodgate_login_error_standalone"));
+                    GeyserLogger.get().warning(GeyserLocale.getLocaleStringLog("geyser.network.remote.floodgate_login_error_standalone"));
                 }
             }
         } else if (cause instanceof ConnectException) {
@@ -193,15 +194,15 @@ public class GeyserSessionAdapter extends SessionAdapter {
         disconnectMessage = customDisconnectMessage != null ? customDisconnectMessage : MessageTranslator.convertMessage(event.getReason());;
 
         if (session.getDownstream().getSession() instanceof LocalSession) {
-            geyser.getLogger().info(GeyserLocale.getLocaleStringLog("geyser.network.remote.disconnect_internal", session.bedrockUsername(), disconnectMessage));
+            GeyserLogger.get().info(GeyserLocale.getLocaleStringLog("geyser.network.remote.disconnect_internal", session.bedrockUsername(), disconnectMessage));
         } else {
-            geyser.getLogger().info(GeyserLocale.getLocaleStringLog("geyser.network.remote.disconnect", session.bedrockUsername(), session.remoteServer().address(), disconnectMessage));
+            GeyserLogger.get().info(GeyserLocale.getLocaleStringLog("geyser.network.remote.disconnect", session.bedrockUsername(), session.remoteServer().address(), disconnectMessage));
         }
         if (cause != null) {
             if (cause.getMessage() != null) {
-                GeyserImpl.getInstance().getLogger().error(cause.getMessage());
+                GeyserLogger.get().error(cause.getMessage());
             } else {
-                GeyserImpl.getInstance().getLogger().error("An exception occurred: ", cause);
+                GeyserLogger.get().error("An exception occurred: ", cause);
             }
             if (geyser.config().debugMode()) {
                 cause.printStackTrace();
@@ -229,7 +230,7 @@ public class GeyserSessionAdapter extends SessionAdapter {
 
     @Override
     public void packetError(PacketErrorEvent event) {
-        geyser.getLogger().warning(GeyserLocale.getLocaleStringLog("geyser.network.downstream_error",
+        GeyserLogger.get().warning(GeyserLocale.getLocaleStringLog("geyser.network.downstream_error",
             (event.getPacketClass() != null ? "(" + event.getPacketClass().getSimpleName() + ") " : "") +
                 event.getCause().getMessage())
         );

--- a/core/src/main/java/org/geysermc/geyser/session/PendingMicrosoftAuthentication.java
+++ b/core/src/main/java/org/geysermc/geyser/session/PendingMicrosoftAuthentication.java
@@ -110,10 +110,7 @@ public class PendingMicrosoftAuthentication {
         }
 
         public void cleanup() {
-            GeyserLogger logger = GeyserImpl.getInstance().getLogger();
-            if (logger.isDebug()) {
-                logger.debug("Cleaning up authentication task for " + userKey);
-            }
+            GeyserLogger.get().debug("Cleaning up authentication task for " + userKey);
             authentications.invalidate(userKey);
         }
 

--- a/core/src/main/java/org/geysermc/geyser/session/cache/BlockBreakHandler.java
+++ b/core/src/main/java/org/geysermc/geyser/session/cache/BlockBreakHandler.java
@@ -42,6 +42,7 @@ import org.cloudburstmc.protocol.bedrock.data.definitions.ItemDefinition;
 import org.cloudburstmc.protocol.bedrock.packet.LevelEventPacket;
 import org.cloudburstmc.protocol.bedrock.packet.PlayerAuthInputPacket;
 import org.geysermc.geyser.GeyserImpl;
+import org.geysermc.geyser.GeyserLogger;
 import org.geysermc.geyser.api.block.custom.CustomBlockState;
 import org.geysermc.geyser.entity.type.Entity;
 import org.geysermc.geyser.entity.type.ItemFrameEntity;
@@ -272,7 +273,7 @@ public class BlockBreakHandler {
                     boolean valid = currentBlockPos != null && Objects.equals(position, currentBlockPos);
                     if (!canBreak(position, state, actionData.getAction()) || !valid) {
                         if (!valid) {
-                            GeyserImpl.getInstance().getLogger().warning("Player %s tried to break block at %s (%s), without starting to destroy it!"
+                            GeyserLogger.get().warning("Player %s tried to break block at %s (%s), without starting to destroy it!"
                                 .formatted(session.bedrockUsername(), position, currentBlockPos));
                             handleAbortBreaking(currentBlockPos);
                         }
@@ -297,9 +298,9 @@ public class BlockBreakHandler {
                     handleAbortBreaking(position);
                 }
                 default -> {
-                    GeyserImpl.getInstance().getLogger().warning("Unknown block break action (%s) received! (origin: %s)!"
+                    GeyserLogger.get().warning("Unknown block break action (%s) received! (origin: %s)!"
                         .formatted(actionData.getAction(), session.getDebugInfo()));
-                    GeyserImpl.getInstance().getLogger().debug("Odd packet: " + packet);
+                    GeyserLogger.get().debug("Odd packet: " + packet);
                     session.disconnect("Invalid block breaking action received!");
                 }
             }

--- a/core/src/main/java/org/geysermc/geyser/session/cache/BundleCache.java
+++ b/core/src/main/java/org/geysermc/geyser/session/cache/BundleCache.java
@@ -34,6 +34,7 @@ import org.cloudburstmc.protocol.bedrock.data.inventory.ItemData;
 import org.cloudburstmc.protocol.bedrock.packet.ContainerRegistryCleanupPacket;
 import org.cloudburstmc.protocol.bedrock.packet.InventoryContentPacket;
 import org.cloudburstmc.protocol.bedrock.packet.InventorySlotPacket;
+import org.geysermc.geyser.GeyserLogger;
 import org.geysermc.geyser.inventory.GeyserItemStack;
 import org.geysermc.geyser.inventory.Inventory;
 import org.geysermc.geyser.inventory.PlayerInventory;
@@ -67,10 +68,10 @@ public final class BundleCache {
         // Now irrelevant, but keeping as-is for the time being.
         if (itemStack.is(session, ItemTag.BUNDLES)) {
             if (itemStack.getBundleData() != null) {
-                session.getGeyser().getLogger().warning("Stack has bundle data already! It should not!");
-                if (session.getGeyser().getLogger().isDebug()) {
-                    session.getGeyser().getLogger().debug("Player: " + session.javaUsername());
-                    session.getGeyser().getLogger().debug("Stack: " + itemStack);
+                GeyserLogger.get().warning("Stack has bundle data already! It should not!");
+                if (GeyserLogger.get().isDebug()) {
+                    GeyserLogger.get().debug("Player: " + session.javaUsername());
+                    GeyserLogger.get().debug("Stack: " + itemStack);
                 }
             }
 
@@ -113,7 +114,7 @@ public final class BundleCache {
         int containerId = itemStack.getBundleId();
 
         if (containerId == -1) {
-            session.getGeyser().getLogger().warning("Bundle ID should not be -1!");
+            GeyserLogger.get().warning("Bundle ID should not be -1!");
         }
 
         NbtMap nbt = itemData.build().getTag();

--- a/core/src/main/java/org/geysermc/geyser/session/cache/FormCache.java
+++ b/core/src/main/java/org/geysermc/geyser/session/cache/FormCache.java
@@ -37,6 +37,7 @@ import org.geysermc.cumulus.form.Form;
 import org.geysermc.cumulus.form.SimpleForm;
 import org.geysermc.cumulus.form.impl.FormDefinitions;
 import org.geysermc.geyser.GeyserImpl;
+import org.geysermc.geyser.GeyserLogger;
 import org.geysermc.geyser.entity.attribute.GeyserAttributeType;
 import org.geysermc.geyser.session.GeyserSession;
 
@@ -127,7 +128,7 @@ public class FormCache {
             formDefinitions.definitionFor(form)
                     .handleFormResponse(form, response.getFormData());
         } catch (Exception e) {
-            GeyserImpl.getInstance().getLogger().error("Error while processing form response!", e);
+            GeyserLogger.get().error("Error while processing form response!", e);
         }
     }
 
@@ -143,7 +144,7 @@ public class FormCache {
                 try {
                     formDefinitions.definitionFor(form).handleFormResponse(form, "");
                 } catch (Exception e) {
-                    GeyserImpl.getInstance().getLogger().error("Error while closing form!", e);
+                    GeyserLogger.get().error("Error while closing form!", e);
                 }
             }
         }

--- a/core/src/main/java/org/geysermc/geyser/session/cache/PistonCache.java
+++ b/core/src/main/java/org/geysermc/geyser/session/cache/PistonCache.java
@@ -33,6 +33,7 @@ import it.unimi.dsi.fastutil.objects.Object2ObjectOpenHashMap;
 import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.Setter;
+import org.geysermc.geyser.GeyserLogger;
 import org.geysermc.geyser.entity.type.Entity;
 import org.geysermc.geyser.entity.type.player.SessionPlayerEntity;
 import org.geysermc.geyser.entity.vehicle.ClientVehicle;
@@ -102,9 +103,9 @@ public class PistonCache {
             pistons.entrySet().removeIf((entry) -> entry.getValue().canBeRemoved());
 
             if (pistons.isEmpty() && !movingBlocksMap.isEmpty()) {
-                session.getGeyser().getLogger().error("The moving block map has de-synced!");
+                GeyserLogger.get().error("The moving block map has de-synced!");
                 for (Map.Entry<Vector3i, PistonBlockEntity> entry : movingBlocksMap.entrySet()) {
-                    session.getGeyser().getLogger().error("Moving Block at " + entry.getKey() + " was previously owned by the piston at " + entry.getValue().getPosition());
+                    GeyserLogger.get().error("Moving Block at " + entry.getKey() + " was previously owned by the piston at " + entry.getValue().getPosition());
                 }
             }
         }

--- a/core/src/main/java/org/geysermc/geyser/session/cache/RegistryCache.java
+++ b/core/src/main/java/org/geysermc/geyser/session/cache/RegistryCache.java
@@ -33,6 +33,7 @@ import net.kyori.adventure.key.Key;
 import org.cloudburstmc.nbt.NbtMap;
 import org.cloudburstmc.nbt.NbtType;
 import org.geysermc.geyser.GeyserImpl;
+import org.geysermc.geyser.GeyserLogger;
 import org.geysermc.geyser.entity.type.living.animal.FrogEntity;
 import org.geysermc.geyser.entity.type.living.animal.VariantHolder;
 import org.geysermc.geyser.entity.type.living.animal.TemperatureVariantAnimal;
@@ -151,13 +152,13 @@ public final class RegistryCache implements JavaRegistryProvider {
                 try {
                     readRegistry(session, registryKey, registries.get(registryKey), reader, packet.getEntries());
                 } catch (Exception exception) {
-                    GeyserImpl.getInstance().getLogger().error("Failed parsing registry entries for " + registryKey + "!", exception);
+                    GeyserLogger.get().error("Failed parsing registry entries for " + registryKey + "!", exception);
                 }
             } else {
                 throw new IllegalStateException("Expected reader for registry " + registryKey);
             }
         } else {
-            GeyserImpl.getInstance().getLogger().debug("Ignoring registry of type " + packet.getRegistry());
+            GeyserLogger.get().debug("Ignoring registry of type " + packet.getRegistry());
         }
     }
 

--- a/core/src/main/java/org/geysermc/geyser/session/cache/SkullCache.java
+++ b/core/src/main/java/org/geysermc/geyser/session/cache/SkullCache.java
@@ -33,6 +33,7 @@ import org.checkerframework.checker.nullness.qual.Nullable;
 import org.cloudburstmc.math.vector.Vector3f;
 import org.cloudburstmc.math.vector.Vector3i;
 import org.cloudburstmc.protocol.bedrock.data.definitions.BlockDefinition;
+import org.geysermc.geyser.GeyserLogger;
 import org.geysermc.geyser.api.block.custom.CustomBlockState;
 import org.geysermc.geyser.entity.EntityDefinitions;
 import org.geysermc.geyser.entity.spawn.EntitySpawnContext;
@@ -86,7 +87,7 @@ public class SkullCache {
         try {
             texture = resolved.getTexture(TextureType.SKIN, false);
         } catch (IllegalStateException e) {
-            session.getGeyser().getLogger().debug("Player skull with invalid skin found at " + position + " with texture payload " + resolved.getProperty("textures"));
+            GeyserLogger.get().debug("Player skull with invalid skin found at " + position + " with texture payload " + resolved.getProperty("textures"));
             return null;
         }
         if (texture != null) {

--- a/core/src/main/java/org/geysermc/geyser/session/cache/TagCache.java
+++ b/core/src/main/java/org/geysermc/geyser/session/cache/TagCache.java
@@ -71,7 +71,7 @@ public final class TagCache {
 
     public void loadPacket(ClientboundUpdateTagsPacket packet) {
         Map<Key, Map<Key, int[]>> allTags = packet.getTags();
-        GeyserLogger logger = session.getGeyser().getLogger();
+        GeyserLogger logger = GeyserLogger.get();
 
         this.tags.clear();
 

--- a/core/src/main/java/org/geysermc/geyser/session/cache/tags/GeyserHolderSet.java
+++ b/core/src/main/java/org/geysermc/geyser/session/cache/tags/GeyserHolderSet.java
@@ -32,6 +32,7 @@ import org.checkerframework.checker.nullness.qual.NonNull;
 import org.checkerframework.checker.nullness.qual.Nullable;
 import org.cloudburstmc.nbt.NbtMap;
 import org.geysermc.geyser.GeyserImpl;
+import org.geysermc.geyser.GeyserLogger;
 import org.geysermc.geyser.session.GeyserSession;
 import org.geysermc.geyser.session.cache.TagCache;
 import org.geysermc.geyser.session.cache.registry.JavaRegistryKey;
@@ -207,7 +208,7 @@ public final class GeyserHolderSet<T> {
 
         String expected = reader == null ? "either a tag, a string ID, or a list of string IDs"
             : "either a tag, a string ID, an inline registry element, a list of string IDs, or a list of inline registry elements";
-        GeyserImpl.getInstance().getLogger().warning("Failed parsing HolderSet for registry + " + registry + "! Expected " + expected + ", found " + holderSet);
+        GeyserLogger.get().warning("Failed parsing HolderSet for registry + " + registry + "! Expected " + expected + ", found " + holderSet);
         return new GeyserHolderSet<>(registry);
     }
 }

--- a/core/src/main/java/org/geysermc/geyser/session/cache/waypoint/AzimuthWaypoint.java
+++ b/core/src/main/java/org/geysermc/geyser/session/cache/waypoint/AzimuthWaypoint.java
@@ -27,6 +27,7 @@ package org.geysermc.geyser.session.cache.waypoint;
 
 import net.kyori.adventure.key.Key;
 import org.cloudburstmc.math.vector.Vector3f;
+import org.geysermc.geyser.GeyserLogger;
 import org.geysermc.geyser.entity.type.Entity;
 import org.geysermc.geyser.session.GeyserSession;
 import org.geysermc.mcprotocollib.protocol.data.game.level.waypoint.AzimuthWaypointData;
@@ -55,7 +56,7 @@ public class AzimuthWaypoint extends GeyserWaypoint implements TickingWaypoint {
             angle = azimuthAngle;
             updatePosition();
         } else {
-            session.getGeyser().getLogger().warning("Received incorrect waypoint data " + data.getClass() + " for azimuth waypoint");
+            GeyserLogger.get().warning("Received incorrect waypoint data " + data.getClass() + " for azimuth waypoint");
         }
     }
 

--- a/core/src/main/java/org/geysermc/geyser/session/cache/waypoint/CoordinatesWaypoint.java
+++ b/core/src/main/java/org/geysermc/geyser/session/cache/waypoint/CoordinatesWaypoint.java
@@ -27,6 +27,7 @@ package org.geysermc.geyser.session.cache.waypoint;
 
 import net.kyori.adventure.key.Key;
 import org.cloudburstmc.math.vector.Vector3i;
+import org.geysermc.geyser.GeyserLogger;
 import org.geysermc.geyser.entity.type.Entity;
 import org.geysermc.geyser.session.GeyserSession;
 import org.geysermc.mcprotocollib.protocol.data.game.level.waypoint.Vec3iWaypointData;
@@ -47,7 +48,7 @@ public class CoordinatesWaypoint extends GeyserWaypoint {
         if (data instanceof Vec3iWaypointData(Vector3i vector)) {
             setPosition(vector.toFloat());
         } else {
-            session.getGeyser().getLogger().warning("Received incorrect waypoint data " + data.getClass() + " for coordinates waypoint");
+            GeyserLogger.get().warning("Received incorrect waypoint data " + data.getClass() + " for coordinates waypoint");
         }
     }
 }

--- a/core/src/main/java/org/geysermc/geyser/session/cache/waypoint/GeyserWaypoint.java
+++ b/core/src/main/java/org/geysermc/geyser/session/cache/waypoint/GeyserWaypoint.java
@@ -35,6 +35,7 @@ import org.cloudburstmc.protocol.bedrock.packet.LocatorBarPacket;
 import org.cloudburstmc.protocol.bedrock.packet.PlayerListPacket;
 import org.cloudburstmc.protocol.bedrock.packet.PlayerLocationPacket;
 import org.geysermc.geyser.GeyserImpl;
+import org.geysermc.geyser.GeyserLogger;
 import org.geysermc.geyser.entity.type.Entity;
 import org.geysermc.geyser.entity.type.player.PlayerEntity;
 import org.geysermc.geyser.network.GameProtocol;
@@ -142,7 +143,7 @@ public abstract class GeyserWaypoint {
             if (!(entity instanceof PlayerEntity)) {
                 // 26.0 and below does not support non-player entities as waypoint target,
                 // as such, this method should never be called with non-player entities
-                GeyserImpl.getInstance().getLogger().warning("GeyserWaypoint#setEntity called for non-player entity!");
+                GeyserLogger.get().warning("GeyserWaypoint#setEntity called for non-player entity!");
                 entity = null;
             }
 

--- a/core/src/main/java/org/geysermc/geyser/skin/FakeHeadProvider.java
+++ b/core/src/main/java/org/geysermc/geyser/skin/FakeHeadProvider.java
@@ -34,6 +34,7 @@ import lombok.Setter;
 import org.checkerframework.checker.nullness.qual.NonNull;
 import org.checkerframework.checker.nullness.qual.Nullable;
 import org.geysermc.geyser.GeyserImpl;
+import org.geysermc.geyser.GeyserLogger;
 import org.geysermc.geyser.api.skin.Cape;
 import org.geysermc.geyser.api.skin.Skin;
 import org.geysermc.geyser.api.skin.SkinData;
@@ -113,7 +114,7 @@ public class FakeHeadProvider {
 
         SkinManager.resolveProfile(profile).whenCompleteAsync((resolved, throwable) -> {
             if (throwable != null) {
-                GeyserImpl.getInstance().getLogger().error(GeyserLocale.getLocaleStringLog("geyser.skin.fail", entity.uuid()), throwable);
+                GeyserLogger.get().error(GeyserLocale.getLocaleStringLog("geyser.skin.fail", entity.uuid()), throwable);
                 return;
             }
             loadHeadFromProfile(session, entity, profile, resolved);
@@ -129,7 +130,7 @@ public class FakeHeadProvider {
                     SkinData mergedSkinData = MERGED_SKINS_LOADING_CACHE.get(new FakeHeadEntry(entity.getSkinId(), skinTexture.getURL(), entity, session));
                     SkinManager.sendSkinPacket(session, entity, mergedSkinData);
                 } catch (ExecutionException e) {
-                    GeyserImpl.getInstance().getLogger().error("Couldn't merge skin of " + entity.getUsername() + " with head skin " + resolved, e);
+                    GeyserLogger.get().error("Couldn't merge skin of " + entity.getUsername() + " with head skin " + resolved, e);
                 }
             });
         }
@@ -146,7 +147,7 @@ public class FakeHeadProvider {
 
         SkinProvider.requestSkinData(entity, session).whenCompleteAsync((skinData, throwable) -> {
             if (throwable != null) {
-                GeyserImpl.getInstance().getLogger().error(GeyserLocale.getLocaleStringLog("geyser.skin.fail", entity.uuid()), throwable);
+                GeyserLogger.get().error(GeyserLocale.getLocaleStringLog("geyser.skin.fail", entity.uuid()), throwable);
                 return;
             }
 

--- a/core/src/main/java/org/geysermc/geyser/skin/FloodgateSkinUploader.java
+++ b/core/src/main/java/org/geysermc/geyser/skin/FloodgateSkinUploader.java
@@ -73,7 +73,7 @@ public final class FloodgateSkinUploader {
     @Getter private int subscribersCount;
 
     public FloodgateSkinUploader(GeyserImpl geyser) {
-        this.logger = geyser.getLogger();
+        this.logger = GeyserLogger.get();
         this.client = new WebSocketClient(Constants.GLOBAL_API_WS_URI) {
             @Override
             public void onOpen(ServerHandshake handshake) {

--- a/core/src/main/java/org/geysermc/geyser/skin/SkinManager.java
+++ b/core/src/main/java/org/geysermc/geyser/skin/SkinManager.java
@@ -33,6 +33,7 @@ import org.cloudburstmc.protocol.bedrock.data.skin.SerializedSkin;
 import org.cloudburstmc.protocol.bedrock.packet.PlayerListPacket;
 import org.cloudburstmc.protocol.bedrock.packet.PlayerSkinPacket;
 import org.geysermc.geyser.GeyserImpl;
+import org.geysermc.geyser.GeyserLogger;
 import org.geysermc.geyser.api.skin.Cape;
 import org.geysermc.geyser.api.skin.Skin;
 import org.geysermc.geyser.api.skin.SkinData;
@@ -208,7 +209,7 @@ public class SkinManager {
         try {
             textures = profile.getTextures(false);
         } catch (IllegalStateException e) {
-            GeyserImpl.getInstance().getLogger().debug("Could not decode textures from game profile (%s)! Got: %s", profile, e);
+            GeyserLogger.get().debug("Could not decode textures from game profile (%s)! Got: %s", profile, e);
             return null;
         }
 
@@ -232,8 +233,8 @@ public class SkinManager {
 
     public static void handleBedrockSkin(AvatarEntity playerEntity, BedrockClientData clientData) {
         GeyserImpl geyser = GeyserImpl.getInstance();
-        if (geyser.config().debugMode()) {
-            geyser.getLogger().info(GeyserLocale.getLocaleStringLog("geyser.skin.bedrock.register", playerEntity.getUsername(), playerEntity.uuid()));
+        if (GeyserLogger.get().isDebug()) {
+            GeyserLogger.get().debug(GeyserLocale.getLocaleStringLog("geyser.skin.bedrock.register", playerEntity.getUsername(), playerEntity.uuid()));
         }
 
         try {
@@ -246,9 +247,9 @@ public class SkinManager {
             if (skinBytes.length <= (128 * 128 * 4) && !clientData.isPersonaSkin()) {
                 SkinProvider.storeBedrockSkin(playerEntity.uuid(), clientData.getSkinId(), skinBytes);
                 SkinProvider.storeBedrockGeometry(playerEntity.uuid(), geometryNameBytes, geometryBytes);
-            } else if (geyser.config().debugMode()) {
-                geyser.getLogger().info(GeyserLocale.getLocaleStringLog("geyser.skin.bedrock.fail", playerEntity.getUsername()));
-                geyser.getLogger().debug("The size of '" + playerEntity.getUsername() + "' skin is: " + clientData.getSkinImageWidth() + "x" + clientData.getSkinImageHeight());
+            } else if (GeyserLogger.get().isDebug()) {
+                GeyserLogger.get().debug(GeyserLocale.getLocaleStringLog("geyser.skin.bedrock.fail", playerEntity.getUsername()));
+                GeyserLogger.get().debug("The size of '" + playerEntity.getUsername() + "' skin is: " + clientData.getSkinImageWidth() + "x" + clientData.getSkinImageHeight());
             }
 
             if (!clientData.getCapeId().isEmpty()) {

--- a/core/src/main/java/org/geysermc/geyser/skin/SkinProvider.java
+++ b/core/src/main/java/org/geysermc/geyser/skin/SkinProvider.java
@@ -36,6 +36,7 @@ import org.checkerframework.checker.nullness.qual.Nullable;
 import org.cloudburstmc.protocol.bedrock.data.skin.ImageData;
 import org.cloudburstmc.protocol.bedrock.data.skin.SerializedSkin;
 import org.geysermc.geyser.GeyserImpl;
+import org.geysermc.geyser.GeyserLogger;
 import org.geysermc.geyser.api.event.bedrock.SessionSkinApplyEvent;
 import org.geysermc.geyser.api.network.AuthType;
 import org.geysermc.geyser.api.skin.Cape;

--- a/core/src/main/java/org/geysermc/geyser/skin/SkinProvider.java
+++ b/core/src/main/java/org/geysermc/geyser/skin/SkinProvider.java
@@ -188,7 +188,7 @@ public class SkinProvider {
                 }
 
                 if (count > 0) {
-                    GeyserImpl.getInstance().getLogger().debug(String.format("Removed %d cached image files as they have expired", count));
+                    GeyserLogger.get().debug(String.format("Removed %d cached image files as they have expired", count));
                 }
             }, 10, 1, TimeUnit.DAYS);
         }
@@ -309,7 +309,7 @@ public class SkinProvider {
 
                         return eventSkinData.skinData();
                     } catch (Exception e) {
-                        GeyserImpl.getInstance().getLogger().error(GeyserLocale.getLocaleStringLog("geyser.skin.fail", entity.uuid()), e);
+                        GeyserLogger.get().error(GeyserLocale.getLocaleStringLog("geyser.skin.fail", entity.uuid()), e);
                     }
 
                     return new SkinData(skinAndCape.skin(), skinAndCape.cape(), null);
@@ -325,7 +325,7 @@ public class SkinProvider {
                     getOrDefault(requestCape(capeUrl, false), EMPTY_CAPE, 5)
             );
 
-            GeyserImpl.getInstance().getLogger().debug("Took " + (System.currentTimeMillis() - time) + "ms for " + playerId);
+            GeyserLogger.get().debug("Took " + (System.currentTimeMillis() - time) + "ms for " + playerId);
             return skinAndCape;
         }, getExecutorService());
     }
@@ -436,7 +436,7 @@ public class SkinProvider {
         File imageFile = GeyserImpl.getInstance().getBootstrap().getConfigFolder().resolve("cache").resolve("images").resolve(UUID.nameUUIDFromBytes(imageUrl.getBytes()) + ".png").toFile();
         if (imageFile.exists()) {
             try {
-                GeyserImpl.getInstance().getLogger().debug("Reading cached image from file " + imageFile.getPath() + " for " + imageUrl);
+                GeyserLogger.get().debug("Reading cached image from file " + imageFile.getPath() + " for " + imageUrl);
                 imageFile.setLastModified(System.currentTimeMillis());
                 image = ImageIO.read(imageFile);
             } catch (IOException ignored) {}
@@ -445,16 +445,16 @@ public class SkinProvider {
         // If no image we download it
         if (image == null) {
             image = downloadImage(imageUrl);
-            GeyserImpl.getInstance().getLogger().debug("Downloaded " + imageUrl);
+            GeyserLogger.get().debug("Downloaded " + imageUrl);
 
             // Write to cache if we are allowed
             if (GeyserImpl.getInstance().config().advanced().cacheImages() > 0) {
                 imageFile.getParentFile().mkdirs();
                 try {
                     ImageIO.write(image, "png", imageFile);
-                    GeyserImpl.getInstance().getLogger().debug("Writing cached skin to file " + imageFile.getPath() + " for " + imageUrl);
+                    GeyserLogger.get().debug("Writing cached skin to file " + imageFile.getPath() + " for " + imageUrl);
                 } catch (IOException e) {
-                    GeyserImpl.getInstance().getLogger().error("Failed to write cached skin to file " + imageFile.getPath() + " for " + imageUrl);
+                    GeyserLogger.get().error("Failed to write cached skin to file " + imageFile.getPath() + " for " + imageUrl);
                 }
             }
         }
@@ -536,14 +536,12 @@ public class SkinProvider {
                 JsonObject node = WebUtils.getJson("https://api.minecraftservices.com/minecraft/profile/lookup/" + shorthandUUID(uuid));
                 JsonElement name = node.get("name");
                 if (name == null) {
-                    GeyserImpl.getInstance().getLogger().debug("No username found in Mojang response for " + uuid);
+                    GeyserLogger.get().debug("No username found in Mojang response for " + uuid);
                     return null;
                 }
                 return name.getAsString();
             } catch (Exception e) {
-                if (GeyserImpl.getInstance().config().debugMode()) {
-                    e.printStackTrace();
-                }
+                GeyserLogger.get().debug("Unable to get username from UUID.", e);
                 return null;
             }
         }, getExecutorService());
@@ -561,14 +559,12 @@ public class SkinProvider {
                 JsonObject node = WebUtils.getJson("https://api.mojang.com/users/profiles/minecraft/" + username);
                 JsonElement id = node.get("id");
                 if (id == null) {
-                    GeyserImpl.getInstance().getLogger().debug("No UUID found in Mojang response for " + username);
+                    GeyserLogger.get().debug("No UUID found in Mojang response for " + username);
                     return null;
                 }
                 return expandUUID(id.getAsString());
             } catch (Exception e) {
-                if (GeyserImpl.getInstance().config().debugMode()) {
-                    e.printStackTrace();
-                }
+                GeyserLogger.get().debug("Unable to get UUID from username.", e);
                 return null;
             }
         }, getExecutorService());
@@ -586,15 +582,12 @@ public class SkinProvider {
                 JsonObject node = WebUtils.getJson("https://sessionserver.mojang.com/session/minecraft/profile/" + shorthandUUID(uuid));
                 JsonArray properties = node.getAsJsonArray("properties");
                 if (properties == null) {
-                    GeyserImpl.getInstance().getLogger().debug("No properties found in Mojang response for " + uuid);
+                    GeyserLogger.get().debug("No properties found in Mojang response for " + uuid);
                     return null;
                 }
                 return properties.get(0).getAsJsonObject().get("value").getAsString();
             } catch (Exception e) {
-                GeyserImpl.getInstance().getLogger().debug("Unable to request textures for " + uuid);
-                if (GeyserImpl.getInstance().config().debugMode()) {
-                    e.printStackTrace();
-                }
+                GeyserLogger.get().debug("Unable to request textures for " + uuid, e);
                 return null;
             }
         }, getExecutorService());

--- a/core/src/main/java/org/geysermc/geyser/text/GeyserLocale.java
+++ b/core/src/main/java/org/geysermc/geyser/text/GeyserLocale.java
@@ -29,6 +29,7 @@ import it.unimi.dsi.fastutil.objects.ObjectArrays;
 import org.checkerframework.checker.nullness.qual.Nullable;
 import org.geysermc.geyser.GeyserBootstrap;
 import org.geysermc.geyser.GeyserImpl;
+import org.geysermc.geyser.GeyserLogger;
 
 import java.io.*;
 import java.nio.charset.StandardCharsets;
@@ -91,7 +92,7 @@ public class GeyserLocale {
             // The config's locale is valid
             DEFAULT_LOCALE = loadedNewLocale;
         } else if (SYSTEM_LOCALE_INVALID) {
-            geyser.getLogger().warning(Locale.getDefault().toString() + " is not a valid Bedrock language.");
+            GeyserLogger.get().warning(Locale.getDefault().toString() + " is not a valid Bedrock language.");
         }
     }
 

--- a/core/src/main/java/org/geysermc/geyser/text/MinecraftLocale.java
+++ b/core/src/main/java/org/geysermc/geyser/text/MinecraftLocale.java
@@ -29,6 +29,7 @@ import com.google.gson.JsonElement;
 import com.google.gson.JsonObject;
 import org.checkerframework.checker.nullness.qual.Nullable;
 import org.geysermc.geyser.GeyserImpl;
+import org.geysermc.geyser.GeyserLogger;
 import org.geysermc.geyser.util.AssetUtils;
 import org.geysermc.geyser.util.FileUtils;
 import org.geysermc.geyser.util.JsonUtils;
@@ -85,7 +86,7 @@ public class MinecraftLocale {
                 stream -> AssetUtils.saveFile(DEPRECATED, stream),
                 () -> {
                     if (!loadDeprecations()) {
-                        GeyserImpl.getInstance().getLogger().warning("Failed to load deprecated locale file: it doesn't exist?");
+                        GeyserLogger.get().warning("Failed to load deprecated locale file: it doesn't exist?");
                     }
                 }));
         }
@@ -100,7 +101,7 @@ public class MinecraftLocale {
         locale = locale.toLowerCase(Locale.ROOT);
 
         if (isLocaleLoaded(locale)) {
-            GeyserImpl.getInstance().getLogger().debug("Locale already loaded: " + locale);
+            GeyserLogger.get().debug("Locale already loaded: " + locale);
             return;
         }
 
@@ -112,18 +113,18 @@ public class MinecraftLocale {
         // Check the locale isn't already loaded
         if (!AssetUtils.isAssetKnown("minecraft/lang/" + locale + ".json") && !locale.equals("en_us")) {
             if (loadLocale(locale)) {
-                GeyserImpl.getInstance().getLogger().debug("Loaded locale locally while not being in asset map: " + locale);
+                GeyserLogger.get().debug("Loaded locale locally while not being in asset map: " + locale);
             } else {
-                GeyserImpl.getInstance().getLogger().warning(GeyserLocale.getLocaleStringLog("geyser.locale.fail.invalid", locale));
+                GeyserLogger.get().warning(GeyserLocale.getLocaleStringLog("geyser.locale.fail.invalid", locale));
             }
             return;
         }
 
-        GeyserImpl.getInstance().getLogger().debug("Downloading and loading locale: " + locale);
+        GeyserLogger.get().debug("Downloading and loading locale: " + locale);
 
         downloadLocale(locale);
         if (!loadLocale(locale)) {
-            GeyserImpl.getInstance().getLogger().warning(GeyserLocale.getLocaleStringLog("geyser.locale.fail.missing", locale));
+            GeyserLogger.get().warning(GeyserLocale.getLocaleStringLog("geyser.locale.fail.missing", locale));
         }
     }
 
@@ -145,9 +146,9 @@ public class MinecraftLocale {
             String targetHash = AssetUtils.getAsset("minecraft/lang/" + locale + ".json").getHash();
 
             if (!curHash.equals(targetHash)) {
-                GeyserImpl.getInstance().getLogger().debug("Locale out of date; re-downloading: " + locale);
+                GeyserLogger.get().debug("Locale out of date; re-downloading: " + locale);
             } else {
-                GeyserImpl.getInstance().getLogger().debug("Locale already downloaded and up-to date: " + locale);
+                GeyserLogger.get().debug("Locale already downloaded and up-to date: " + locale);
                 return;
             }
         }
@@ -157,7 +158,7 @@ public class MinecraftLocale {
             String hash = AssetUtils.getAsset("minecraft/lang/" + locale + ".json").getHash();
             WebUtils.downloadFile("https://resources.download.minecraft.net/" + hash.substring(0, 2) + "/" + hash, localeFile.toString());
         } catch (Exception e) {
-            GeyserImpl.getInstance().getLogger().error("Unable to download locale file hash", e);
+            GeyserLogger.get().error("Unable to download locale file hash", e);
         }
     }
 
@@ -269,7 +270,7 @@ public class MinecraftLocale {
         String translated = getLocaleStringIfPresent(messageText, locale);
         if (translated == null) {
             // Don't cause a NPE if the string is missing
-            GeyserImpl.getInstance().getLogger().debug("MISSING JAVA TRANSLATION STRING: " + messageText);
+            GeyserLogger.get().debug("MISSING JAVA TRANSLATION STRING: " + messageText);
             return messageText;
         }
         return translated;

--- a/core/src/main/java/org/geysermc/geyser/translator/inventory/InventoryTranslator.java
+++ b/core/src/main/java/org/geysermc/geyser/translator/inventory/InventoryTranslator.java
@@ -55,6 +55,7 @@ import org.cloudburstmc.protocol.bedrock.data.inventory.itemstack.response.ItemS
 import org.cloudburstmc.protocol.bedrock.data.inventory.itemstack.response.ItemStackResponseStatus;
 import org.cloudburstmc.protocol.bedrock.packet.ItemStackResponsePacket;
 import org.geysermc.geyser.GeyserImpl;
+import org.geysermc.geyser.GeyserLogger;
 import org.geysermc.geyser.inventory.BedrockContainerSlot;
 import org.geysermc.geyser.inventory.CartographyContainer;
 import org.geysermc.geyser.inventory.GeyserItemStack;
@@ -306,8 +307,8 @@ public abstract class InventoryTranslator<Type extends Inventory> {
                 case PLACE: {
                     TransferItemStackRequestAction transferAction = (TransferItemStackRequestAction) action;
                     if (!(checkNetId(session, inventory, transferAction.getSource()) && checkNetId(session, inventory, transferAction.getDestination()))) {
-                        if (session.getGeyser().config().debugMode()) {
-                            session.getGeyser().getLogger().error("DEBUG: About to reject TAKE/PLACE request made by " + session.bedrockUsername());
+                        if (GeyserLogger.get().isDebug()) {
+                            GeyserLogger.get().error("DEBUG: About to reject TAKE/PLACE request made by " + session.bedrockUsername());
                             dumpStackRequestDetails(session, inventory, transferAction.getSource(), transferAction.getDestination());
                         }
                         return rejectRequest(request);
@@ -478,7 +479,7 @@ public abstract class InventoryTranslator<Type extends Inventory> {
 
                     if (!(checkNetId(session, inventory, source) && checkNetId(session, inventory, destination))) {
                         if (session.getGeyser().config().debugMode()) {
-                            session.getGeyser().getLogger().error("DEBUG: About to reject SWAP request made by " + session.bedrockUsername());
+                            GeyserLogger.get().error("DEBUG: About to reject SWAP request made by " + session.bedrockUsername());
                             dumpStackRequestDetails(session, inventory, source, destination);
                         }
                         return rejectRequest(request);
@@ -984,7 +985,7 @@ public abstract class InventoryTranslator<Type extends Inventory> {
      *                   as bad (false).
      */
     protected static ItemStackResponse rejectRequest(ItemStackRequest request, boolean throwError) {
-        if (throwError && GeyserImpl.getInstance().config().debugMode()) {
+        if (throwError && GeyserLogger.get().isDebug()) {
             new Throwable("DEBUGGING: ItemStackRequest rejected " + request.toString()).printStackTrace();
         }
         return new ItemStackResponse(ItemStackResponseStatus.ERROR, request.getRequestId(), Collections.emptyList());
@@ -994,10 +995,10 @@ public abstract class InventoryTranslator<Type extends Inventory> {
      * Print out the contents of an ItemStackRequest, should the net ID check fail.
      */
     protected void dumpStackRequestDetails(GeyserSession session, Type inventory, ItemStackRequestSlotData source, ItemStackRequestSlotData destination) {
-        session.getGeyser().getLogger().error("Source: " + source.toString() + " Result: " + checkNetId(session, inventory, source));
-        session.getGeyser().getLogger().error("Destination: " + destination.toString() + " Result: " + checkNetId(session, inventory, destination));
-        session.getGeyser().getLogger().error("Geyser's record of source slot: " + inventory.getItem(bedrockSlotToJava(source)));
-        session.getGeyser().getLogger().error("Geyser's record of destination slot: " + inventory.getItem(bedrockSlotToJava(destination)));
+        GeyserLogger.get().error("Source: " + source.toString() + " Result: " + checkNetId(session, inventory, source));
+        GeyserLogger.get().error("Destination: " + destination.toString() + " Result: " + checkNetId(session, inventory, destination));
+        GeyserLogger.get().error("Geyser's record of source slot: " + inventory.getItem(bedrockSlotToJava(source)));
+        GeyserLogger.get().error("Geyser's record of destination slot: " + inventory.getItem(bedrockSlotToJava(destination)));
     }
 
     public boolean checkNetId(GeyserSession session, Type inventory, ItemStackRequestSlotData slotInfoData) {

--- a/core/src/main/java/org/geysermc/geyser/translator/inventory/LoomInventoryTranslator.java
+++ b/core/src/main/java/org/geysermc/geyser/translator/inventory/LoomInventoryTranslator.java
@@ -39,6 +39,7 @@ import org.cloudburstmc.protocol.bedrock.data.inventory.itemstack.request.action
 import org.cloudburstmc.protocol.bedrock.data.inventory.itemstack.request.action.ItemStackRequestActionType;
 import org.cloudburstmc.protocol.bedrock.data.inventory.itemstack.response.ItemStackResponse;
 import org.geysermc.geyser.GeyserImpl;
+import org.geysermc.geyser.GeyserLogger;
 import org.geysermc.geyser.inventory.BedrockContainerSlot;
 import org.geysermc.geyser.inventory.Container;
 import org.geysermc.geyser.inventory.GeyserItemStack;
@@ -102,7 +103,7 @@ public class LoomInventoryTranslator extends AbstractBlockInventoryTranslator<Co
 
         BannerPattern requestedPattern = BannerPattern.getByBedrockIdentifier(bedrockPattern);
         if (requestedPattern == null) {
-            GeyserImpl.getInstance().getLogger().warning("Unknown Bedrock pattern id: " + bedrockPattern);
+            GeyserLogger.get().warning("Unknown Bedrock pattern id: " + bedrockPattern);
             return rejectRequest(request);
         }
 

--- a/core/src/main/java/org/geysermc/geyser/translator/inventory/PlayerInventoryTranslator.java
+++ b/core/src/main/java/org/geysermc/geyser/translator/inventory/PlayerInventoryTranslator.java
@@ -48,6 +48,7 @@ import org.cloudburstmc.protocol.bedrock.packet.ContainerOpenPacket;
 import org.cloudburstmc.protocol.bedrock.packet.InventoryContentPacket;
 import org.cloudburstmc.protocol.bedrock.packet.InventorySlotPacket;
 import org.cloudburstmc.protocol.bedrock.packet.UpdateBlockPacket;
+import org.geysermc.geyser.GeyserLogger;
 import org.geysermc.geyser.inventory.BedrockContainerSlot;
 import org.geysermc.geyser.inventory.GeyserItemStack;
 import org.geysermc.geyser.inventory.Inventory;
@@ -419,7 +420,7 @@ public class PlayerInventoryTranslator extends InventoryTranslator<PlayerInvento
                     }
                 }
                 default -> {
-                    session.getGeyser().getLogger().error("Unknown crafting state induced by " + session.bedrockUsername());
+                    GeyserLogger.get().error("Unknown crafting state induced by " + session.bedrockUsername());
                     return rejectRequest(request);
                 }
             }

--- a/core/src/main/java/org/geysermc/geyser/translator/inventory/chest/DoubleChestInventoryTranslator.java
+++ b/core/src/main/java/org/geysermc/geyser/translator/inventory/chest/DoubleChestInventoryTranslator.java
@@ -36,6 +36,7 @@ import org.cloudburstmc.protocol.bedrock.packet.ContainerClosePacket;
 import org.cloudburstmc.protocol.bedrock.packet.ContainerOpenPacket;
 import org.cloudburstmc.protocol.bedrock.packet.UpdateBlockPacket;
 import org.geysermc.geyser.GeyserImpl;
+import org.geysermc.geyser.GeyserLogger;
 import org.geysermc.geyser.inventory.Container;
 import org.geysermc.geyser.inventory.Inventory;
 import org.geysermc.geyser.inventory.holder.BlockInventoryHolder;
@@ -92,7 +93,7 @@ public class DoubleChestInventoryTranslator extends ChestInventoryTranslator<Con
         if (Objects.equals(position, previous.getHolderPosition())) {
             return true;
         } else {
-            GeyserImpl.getInstance().getLogger().debug(session, "Not reusing inventory due to virtual block holder changing (%s -> %s)!",
+            GeyserLogger.get().debug(session, "Not reusing inventory due to virtual block holder changing (%s -> %s)!",
                 previous.getHolderPosition(), position);
             return false;
         }
@@ -166,7 +167,7 @@ public class DoubleChestInventoryTranslator extends ChestInventoryTranslator<Con
         containerOpenPacket.setUniqueEntityId(container.getHolderId());
         session.sendUpstreamPacket(containerOpenPacket);
 
-        GeyserImpl.getInstance().getLogger().debug(session, containerOpenPacket.toString());
+        GeyserLogger.get().debug(session, containerOpenPacket.toString());
     }
 
     @Override

--- a/core/src/main/java/org/geysermc/geyser/translator/item/ItemTranslator.java
+++ b/core/src/main/java/org/geysermc/geyser/translator/item/ItemTranslator.java
@@ -38,6 +38,7 @@ import org.cloudburstmc.nbt.NbtMapBuilder;
 import org.cloudburstmc.protocol.bedrock.data.definitions.BlockDefinition;
 import org.cloudburstmc.protocol.bedrock.data.definitions.ItemDefinition;
 import org.cloudburstmc.protocol.bedrock.data.inventory.ItemData;
+import org.geysermc.geyser.GeyserLogger;
 import org.geysermc.geyser.api.block.custom.CustomBlockData;
 import org.geysermc.geyser.entity.attribute.GeyserAttributeType;
 import org.geysermc.geyser.inventory.GeyserItemStack;
@@ -148,7 +149,7 @@ public final class ItemTranslator {
     public static ItemData.@NonNull Builder translateToBedrock(GeyserSession session, int javaId, int count, DataComponents components) {
         ItemMapping bedrockItem = session.getItemMappings().getMapping(javaId);
         if (bedrockItem == ItemMapping.AIR) {
-            session.getGeyser().getLogger().debug("ItemMapping returned air: " + javaId);
+            GeyserLogger.get().debug("ItemMapping returned air: " + javaId);
             return ItemData.builder();
         }
         return translateToBedrock(session, Registries.JAVA_ITEMS.get().get(javaId), bedrockItem, count, components);
@@ -162,7 +163,7 @@ public final class ItemTranslator {
 
         ItemMapping bedrockItem = session.getItemMappings().getMapping(stack);
         if (bedrockItem == ItemMapping.AIR) {
-            session.getGeyser().getLogger().debug("ItemMapping returned air: " + stack);
+            GeyserLogger.get().debug("ItemMapping returned air: " + stack);
             return ItemData.AIR;
         }
         // Java item needs to be loaded separately. The mapping for tipped arrow would
@@ -178,7 +179,7 @@ public final class ItemTranslator {
 
         ItemMapping bedrockItem = session.getItemMappings().getMapping(stack.getJavaId());
         if (bedrockItem == ItemMapping.AIR) {
-            session.getGeyser().getLogger().debug("ItemMapping returned air: " + stack);
+            GeyserLogger.get().debug("ItemMapping returned air: " + stack);
             return ItemData.AIR;
         }
 

--- a/core/src/main/java/org/geysermc/geyser/translator/level/block/entity/SkullBlockEntityTranslator.java
+++ b/core/src/main/java/org/geysermc/geyser/translator/level/block/entity/SkullBlockEntityTranslator.java
@@ -33,6 +33,7 @@ import org.cloudburstmc.nbt.NbtType;
 import org.cloudburstmc.protocol.bedrock.data.definitions.BlockDefinition;
 import org.cloudburstmc.protocol.bedrock.packet.UpdateBlockPacket;
 import org.geysermc.geyser.GeyserImpl;
+import org.geysermc.geyser.GeyserLogger;
 import org.geysermc.geyser.level.block.property.Properties;
 import org.geysermc.geyser.level.block.type.BlockState;
 import org.geysermc.geyser.session.GeyserSession;
@@ -100,15 +101,12 @@ public class SkullBlockEntityTranslator extends BlockEntityTranslator implements
             try {
                 SkullCache.Skull skull = session.getSkullCache().putSkull(blockPosition, resolvedFuture.get(), blockState);
                 if (skull == null) {
-                    session.getGeyser().getLogger().debug("Custom skull with invalid profile: " + blockPosition + " " + resolvedFuture.get());
+                    GeyserLogger.get().debug("Custom skull with invalid profile: " + blockPosition + " " + resolvedFuture.get());
                     return null;
                 }
                 return skull.getBlockDefinition();
             } catch (InterruptedException | ExecutionException e) {
-                session.getGeyser().getLogger().debug("Failed to acquire textures for custom skull: " + blockPosition + " " + javaNbt);
-                if (GeyserImpl.getInstance().config().debugMode()) {
-                    e.printStackTrace();
-                }
+                GeyserLogger.get().debug("Failed to acquire textures for custom skull: " + blockPosition + " " + javaNbt, e);
             }
             return null;
         }
@@ -116,10 +114,7 @@ public class SkullBlockEntityTranslator extends BlockEntityTranslator implements
         // profile contained a username, so we have to wait for it to be retrieved
         resolvedFuture.whenComplete((resolved, throwable) -> {
             if (throwable != null ) {
-                session.getGeyser().getLogger().debug("Failed resolving profile of player head at: " + blockPosition + " " + javaNbt);
-                if (GeyserImpl.getInstance().config().debugMode()) {
-                    throwable.printStackTrace();
-                }
+                GeyserLogger.get().debug("Failed resolving profile of player head at: " + blockPosition + " " + javaNbt, throwable);
                 return;
             }
             session.ensureInEventLoop(() -> putSkull(session, blockPosition, resolved, blockState));

--- a/core/src/main/java/org/geysermc/geyser/translator/protocol/bedrock/BedrockBookEditTranslator.java
+++ b/core/src/main/java/org/geysermc/geyser/translator/protocol/bedrock/BedrockBookEditTranslator.java
@@ -26,6 +26,7 @@
 package org.geysermc.geyser.translator.protocol.bedrock;
 
 import org.cloudburstmc.protocol.bedrock.packet.BookEditPacket;
+import org.geysermc.geyser.GeyserLogger;
 import org.geysermc.geyser.inventory.GeyserItemStack;
 import org.geysermc.geyser.item.type.WrittenBookItem;
 import org.geysermc.geyser.session.GeyserSession;
@@ -50,7 +51,7 @@ public class BedrockBookEditTranslator extends PacketTranslator<BookEditPacket> 
     @Override
     public void translate(GeyserSession session, BookEditPacket packet) {
         if (packet.getText() != null && !packet.getText().isEmpty() && packet.getText().length() > WrittenBookItem.MAXIMUM_PAGE_EDIT_LENGTH) {
-            session.getGeyser().getLogger().warning("Page length greater than server allowed!");
+            GeyserLogger.get().warning("Page length greater than server allowed!");
             return;
         }
 
@@ -69,7 +70,7 @@ public class BedrockBookEditTranslator extends PacketTranslator<BookEditPacket> 
 
             int page = packet.getPageNumber();
             if (page < 0 || WrittenBookItem.MAXIMUM_PAGE_COUNT <= page) {
-                session.getGeyser().getLogger().warning("Edited page is out of acceptable bounds!");
+                GeyserLogger.get().warning("Edited page is out of acceptable bounds!");
                 return;
             }
             switch (packet.getAction()) {
@@ -139,7 +140,7 @@ public class BedrockBookEditTranslator extends PacketTranslator<BookEditPacket> 
                 // Add title to packet so the server knows we're signing
                 title = MessageTranslator.convertIncomingToPlainText(packet.getTitle());
                 if (title.length() > WrittenBookItem.MAXIMUM_TITLE_LENGTH) {
-                    session.getGeyser().getLogger().warning("Book title larger than server allows!");
+                    GeyserLogger.get().warning("Book title larger than server allows!");
                     return;
                 }
             } else {

--- a/core/src/main/java/org/geysermc/geyser/translator/protocol/bedrock/BedrockContainerCloseTranslator.java
+++ b/core/src/main/java/org/geysermc/geyser/translator/protocol/bedrock/BedrockContainerCloseTranslator.java
@@ -28,6 +28,7 @@ package org.geysermc.geyser.translator.protocol.bedrock;
 import java.util.concurrent.TimeUnit;
 import org.cloudburstmc.protocol.bedrock.packet.ContainerClosePacket;
 import org.geysermc.geyser.GeyserImpl;
+import org.geysermc.geyser.GeyserLogger;
 import org.geysermc.geyser.inventory.Inventory;
 import org.geysermc.geyser.inventory.InventoryHolder;
 import org.geysermc.geyser.session.GeyserSession;
@@ -41,7 +42,7 @@ public class BedrockContainerCloseTranslator extends PacketTranslator<ContainerC
 
     @Override
     public void translate(GeyserSession session, ContainerClosePacket packet) {
-        GeyserImpl.getInstance().getLogger().debug(session, packet.toString());
+        GeyserLogger.get().debug(session, packet.toString());
         byte bedrockId = packet.getId();
 
         //Client wants close confirmation
@@ -65,12 +66,12 @@ public class BedrockContainerCloseTranslator extends PacketTranslator<ContainerC
 
                     session.scheduleInEventLoop(() -> {
                         InventoryUtils.scheduleInventoryOpen(session);
-                        GeyserImpl.getInstance().getLogger().debug(session, "Unable to open a virtual inventory, sent another latency packet!");
+                        GeyserLogger.get().debug(session, "Unable to open a virtual inventory, sent another latency packet!");
                     }, 150, TimeUnit.MILLISECONDS);
                     return;
                 } else {
-                    GeyserImpl.getInstance().getLogger().warning(session.bedrockUsername() + " exceeded 7 attempts to open a virtual inventory!");
-                    GeyserImpl.getInstance().getLogger().debug(session, packet + " " + holder.inventory().getClass().getSimpleName());
+                    GeyserLogger.get().warning(session.bedrockUsername() + " exceeded 7 attempts to open a virtual inventory!");
+                    GeyserLogger.get().debug(session, packet + " " + holder.inventory().getClass().getSimpleName());
 
                     // Prevent inventory deadlocks by letting the code below close the inventory
                     bedrockId = (byte) holder.bedrockId();

--- a/core/src/main/java/org/geysermc/geyser/translator/protocol/bedrock/BedrockInventoryTransactionTranslator.java
+++ b/core/src/main/java/org/geysermc/geyser/translator/protocol/bedrock/BedrockInventoryTransactionTranslator.java
@@ -576,8 +576,8 @@ public class BedrockInventoryTransactionTranslator extends PacketTranslator<Inve
         ItemDefinition heldItemId = packet.getItemInHand() == null ? ItemData.AIR.getDefinition() : packet.getItemInHand().getDefinition();
 
         if (!expectedItem.equals(heldItemId)) {
-            session.getGeyser().getLogger().debug(session.bedrockUsername() + "'s held item has desynced! Expected: " + expectedItem + " Received: " + heldItemId);
-            session.getGeyser().getLogger().debug("Packet: " + packet);
+            GeyserLogger.get().debug(session.bedrockUsername() + "'s held item has desynced! Expected: " + expectedItem + " Received: " + heldItemId);
+            GeyserLogger.get().debug("Packet: " + packet);
             return true;
         }
 

--- a/core/src/main/java/org/geysermc/geyser/translator/protocol/bedrock/BedrockInventoryTransactionTranslator.java
+++ b/core/src/main/java/org/geysermc/geyser/translator/protocol/bedrock/BedrockInventoryTransactionTranslator.java
@@ -43,6 +43,7 @@ import org.cloudburstmc.protocol.bedrock.packet.ContainerOpenPacket;
 import org.cloudburstmc.protocol.bedrock.packet.InventoryTransactionPacket;
 import org.cloudburstmc.protocol.bedrock.packet.LevelSoundEventPacket;
 import org.cloudburstmc.protocol.bedrock.packet.PlaySoundPacket;
+import org.geysermc.geyser.GeyserLogger;
 import org.geysermc.geyser.entity.EntityDefinitions;
 import org.geysermc.geyser.entity.type.Entity;
 import org.geysermc.geyser.entity.type.ItemFrameEntity;

--- a/core/src/main/java/org/geysermc/geyser/translator/protocol/bedrock/BedrockLecternUpdateTranslator.java
+++ b/core/src/main/java/org/geysermc/geyser/translator/protocol/bedrock/BedrockLecternUpdateTranslator.java
@@ -26,6 +26,7 @@
 package org.geysermc.geyser.translator.protocol.bedrock;
 
 import org.cloudburstmc.protocol.bedrock.packet.LecternUpdatePacket;
+import org.geysermc.geyser.GeyserLogger;
 import org.geysermc.geyser.inventory.InventoryHolder;
 import org.geysermc.geyser.inventory.LecternContainer;
 import org.geysermc.geyser.session.GeyserSession;
@@ -46,7 +47,7 @@ public class BedrockLecternUpdateTranslator extends PacketTranslator<LecternUpda
         // Bedrock wants to either move a page or exit
         InventoryHolder<?> holder = session.getInventoryHolder();
         if (holder == null || !(holder.inventory() instanceof LecternContainer lecternContainer)) {
-            session.getGeyser().getLogger().debug("Expected lectern but it wasn't open!");
+            GeyserLogger.get().debug("Expected lectern but it wasn't open!");
             return;
         }
 

--- a/core/src/main/java/org/geysermc/geyser/translator/protocol/bedrock/BedrockNetworkStackLatencyTranslator.java
+++ b/core/src/main/java/org/geysermc/geyser/translator/protocol/bedrock/BedrockNetworkStackLatencyTranslator.java
@@ -26,6 +26,7 @@
 package org.geysermc.geyser.translator.protocol.bedrock;
 
 import org.cloudburstmc.protocol.bedrock.packet.NetworkStackLatencyPacket;
+import org.geysermc.geyser.GeyserLogger;
 import org.geysermc.geyser.session.GeyserSession;
 import org.geysermc.geyser.translator.protocol.PacketTranslator;
 import org.geysermc.geyser.translator.protocol.Translator;
@@ -41,7 +42,7 @@ public class BedrockNetworkStackLatencyTranslator extends PacketTranslator<Netwo
         // We should receive these packets in the same order they were sent
         final Runnable latencyPing = session.getLatencyPingCache().poll();
         if (latencyPing == null) {
-            session.getGeyser().getLogger().debug("Received a latency packet that we don't have a ping for: " + packet);
+            GeyserLogger.get().debug("Received a latency packet that we don't have a ping for: " + packet);
             return;
         }
 

--- a/core/src/main/java/org/geysermc/geyser/translator/protocol/bedrock/BedrockPacketViolationWarningTranslator.java
+++ b/core/src/main/java/org/geysermc/geyser/translator/protocol/bedrock/BedrockPacketViolationWarningTranslator.java
@@ -37,7 +37,7 @@ public class BedrockPacketViolationWarningTranslator extends PacketTranslator<Pa
     @Override
     public void translate(GeyserSession session, PacketViolationWarningPacket packet) {
         // Not translated since this is something that the developers need to know
-        GeyserLogger logger = session.getGeyser().getLogger();
+        GeyserLogger logger = GeyserLogger.get();
         if (logger.isDebug()) {
             logger.error("Packet violation warning sent from client (%s): %s".formatted(session.bedrockUsername(), packet));
             return;

--- a/core/src/main/java/org/geysermc/geyser/translator/protocol/bedrock/entity/BedrockEntityEventTranslator.java
+++ b/core/src/main/java/org/geysermc/geyser/translator/protocol/bedrock/entity/BedrockEntityEventTranslator.java
@@ -26,6 +26,7 @@
 package org.geysermc.geyser.translator.protocol.bedrock.entity;
 
 import org.cloudburstmc.protocol.bedrock.packet.EntityEventPacket;
+import org.geysermc.geyser.GeyserLogger;
 import org.geysermc.geyser.inventory.MerchantContainer;
 import org.geysermc.geyser.session.GeyserSession;
 import org.geysermc.geyser.translator.protocol.PacketTranslator;
@@ -58,6 +59,6 @@ public class BedrockEntityEventTranslator extends PacketTranslator<EntityEventPa
                 return;
             }
         }
-        session.getGeyser().getLogger().debug("Did not translate incoming EntityEventPacket: " + packet);
+        GeyserLogger.get().debug("Did not translate incoming EntityEventPacket: " + packet);
     }
 }

--- a/core/src/main/java/org/geysermc/geyser/translator/protocol/bedrock/entity/player/input/BedrockMovePlayer.java
+++ b/core/src/main/java/org/geysermc/geyser/translator/protocol/bedrock/entity/player/input/BedrockMovePlayer.java
@@ -30,6 +30,7 @@ import org.cloudburstmc.math.vector.Vector3f;
 import org.cloudburstmc.protocol.bedrock.data.PlayerAuthInputData;
 import org.cloudburstmc.protocol.bedrock.data.entity.EntityFlag;
 import org.cloudburstmc.protocol.bedrock.packet.PlayerAuthInputPacket;
+import org.geysermc.geyser.GeyserLogger;
 import org.geysermc.geyser.entity.EntityDefinitions;
 import org.geysermc.geyser.entity.type.Entity;
 import org.geysermc.geyser.entity.type.player.SessionPlayerEntity;
@@ -216,7 +217,7 @@ final class BedrockMovePlayer {
                 }
             } else {
                 // Not a valid move
-                session.getGeyser().getLogger().debug("Recalculating position...");
+                GeyserLogger.get().debug("Recalculating position...");
                 session.getCollisionManager().recalculatePosition();
             }
         } else if (horizontalCollision != session.getInputCache().lastHorizontalCollision() || isOnGround != entity.isOnGround()) {
@@ -247,7 +248,7 @@ final class BedrockMovePlayer {
             return false;
         }
         if (currentPosition.distanceSquared(newPosition) > 300) {
-            session.getGeyser().getLogger().debug(ChatColor.RED + session.bedrockUsername() + " moved too quickly." +
+            GeyserLogger.get().debug(ChatColor.RED + session.bedrockUsername() + " moved too quickly." +
                     " current position: " + currentPosition + ", new position: " + newPosition);
 
             return false;

--- a/core/src/main/java/org/geysermc/geyser/translator/protocol/bedrock/entity/player/input/BedrockPlayerAuthInputTranslator.java
+++ b/core/src/main/java/org/geysermc/geyser/translator/protocol/bedrock/entity/player/input/BedrockPlayerAuthInputTranslator.java
@@ -36,6 +36,7 @@ import org.cloudburstmc.protocol.bedrock.data.entity.EntityFlag;
 import org.cloudburstmc.protocol.bedrock.data.inventory.transaction.ItemUseTransaction;
 import org.cloudburstmc.protocol.bedrock.packet.AnimatePacket;
 import org.cloudburstmc.protocol.bedrock.packet.PlayerAuthInputPacket;
+import org.geysermc.geyser.GeyserLogger;
 import org.geysermc.geyser.entity.type.BoatEntity;
 import org.geysermc.geyser.entity.type.Entity;
 import org.geysermc.geyser.entity.type.living.animal.horse.AbstractHorseEntity;
@@ -230,9 +231,9 @@ public final class BedrockPlayerAuthInputTranslator extends PacketTranslator<Pla
             session.setLastBlockPlaced(null);
             session.setLastBlockPlacePosition(null);
         } else {
-            session.getGeyser().getLogger().error("Unhandled item use transaction type!");
-            if (session.getGeyser().getLogger().isDebug()) {
-                session.getGeyser().getLogger().debug(transaction);
+            GeyserLogger.get().error("Unhandled item use transaction type!");
+            if (GeyserLogger.get().isDebug()) {
+                GeyserLogger.get().debug(transaction);
             }
         }
     }

--- a/core/src/main/java/org/geysermc/geyser/translator/protocol/java/JavaCommandsTranslator.java
+++ b/core/src/main/java/org/geysermc/geyser/translator/protocol/java/JavaCommandsTranslator.java
@@ -40,6 +40,7 @@ import org.checkerframework.checker.nullness.qual.MonotonicNonNull;
 import org.cloudburstmc.protocol.bedrock.data.command.*;
 import org.cloudburstmc.protocol.bedrock.packet.AvailableCommandsPacket;
 import org.geysermc.geyser.GeyserImpl;
+import org.geysermc.geyser.GeyserLogger;
 import org.geysermc.geyser.api.event.java.ServerDefineCommandsEvent;
 import org.geysermc.geyser.api.util.PlatformType;
 import org.geysermc.geyser.command.CommandRegistry;
@@ -124,7 +125,7 @@ public class JavaCommandsTranslator extends PacketTranslator<ClientboundCommands
     public void translate(GeyserSession session, ClientboundCommandsPacket packet) {
         // Don't send command suggestions if they are disabled
         if (!session.getGeyser().config().gameplay().commandSuggestions()) {
-            session.getGeyser().getLogger().debug("Not sending translated command suggestions as they are disabled.");
+            GeyserLogger.get().debug("Not sending translated command suggestions as they are disabled.");
 
             // Send a mostly empty packet so Bedrock doesn't override /help with its own, built-in help command.
             AvailableCommandsPacket emptyPacket = new AvailableCommandsPacket();
@@ -249,7 +250,7 @@ public class JavaCommandsTranslator extends PacketTranslator<ClientboundCommands
         AvailableCommandsPacket availableCommandsPacket = new AvailableCommandsPacket();
         availableCommandsPacket.getCommands().addAll(commandData);
 
-        session.getGeyser().getLogger().debug("Sending command packet of " + commandData.size() + " commands");
+        GeyserLogger.get().debug("Sending command packet of " + commandData.size() + " commands");
 
         // Finally, send the commands to the client
         session.sendUpstreamPacket(availableCommandsPacket);
@@ -267,7 +268,7 @@ public class JavaCommandsTranslator extends PacketTranslator<ClientboundCommands
         // Check if the command is an alias and redirect it
         if (commandNode.getRedirectIndex().isPresent()) {
             int redirectIndex = commandNode.getRedirectIndex().getAsInt();
-            GeyserImpl.getInstance().getLogger().debug("Redirecting command " + commandNode.getName() + " to " + allNodes[redirectIndex].getName());
+            GeyserLogger.get().debug("Redirecting command " + commandNode.getName() + " to " + allNodes[redirectIndex].getName());
             commandNode = allNodes[redirectIndex];
         }
 

--- a/core/src/main/java/org/geysermc/geyser/translator/protocol/java/JavaCustomPayloadTranslator.java
+++ b/core/src/main/java/org/geysermc/geyser/translator/protocol/java/JavaCustomPayloadTranslator.java
@@ -51,7 +51,7 @@ import java.nio.charset.StandardCharsets;
 
 @Translator(packet = ClientboundCustomPayloadPacket.class)
 public class JavaCustomPayloadTranslator extends PacketTranslator<ClientboundCustomPayloadPacket> {
-    private final GeyserLogger logger = GeyserImpl.getInstance().getLogger();
+    private final GeyserLogger logger = GeyserLogger.get();
 
     @Override
     public void translate(GeyserSession session, ClientboundCustomPayloadPacket packet) {

--- a/core/src/main/java/org/geysermc/geyser/translator/protocol/java/JavaRecipeBookAddTranslator.java
+++ b/core/src/main/java/org/geysermc/geyser/translator/protocol/java/JavaRecipeBookAddTranslator.java
@@ -30,6 +30,7 @@ import org.cloudburstmc.protocol.bedrock.data.inventory.crafting.recipe.RecipeDa
 import org.cloudburstmc.protocol.bedrock.packet.CraftingDataPacket;
 import org.cloudburstmc.protocol.bedrock.packet.UnlockedRecipesPacket;
 import org.geysermc.geyser.GeyserImpl;
+import org.geysermc.geyser.GeyserLogger;
 import org.geysermc.geyser.inventory.recipe.GeyserRecipe;
 import org.geysermc.geyser.inventory.recipe.GeyserShapedRecipe;
 import org.geysermc.geyser.inventory.recipe.GeyserShapelessRecipe;
@@ -142,7 +143,7 @@ public class JavaRecipeBookAddTranslator extends PacketTranslator<ClientboundRec
                     netId += recipeData.size();
                 }
                 default -> {
-                    GeyserImpl.getInstance().getLogger().debug("Ignoring unknown recipe display type! " + entry);
+                    GeyserLogger.get().debug("Ignoring unknown recipe display type! " + entry);
                 }
             }
         }

--- a/core/src/main/java/org/geysermc/geyser/translator/protocol/java/JavaUpdateRecipesTranslator.java
+++ b/core/src/main/java/org/geysermc/geyser/translator/protocol/java/JavaUpdateRecipesTranslator.java
@@ -39,6 +39,7 @@ import org.cloudburstmc.protocol.bedrock.data.inventory.descriptor.ItemDescripto
 import org.cloudburstmc.protocol.bedrock.packet.CraftingDataPacket;
 import org.cloudburstmc.protocol.bedrock.packet.TrimDataPacket;
 import org.geysermc.geyser.GeyserImpl;
+import org.geysermc.geyser.GeyserLogger;
 import org.geysermc.geyser.inventory.recipe.GeyserRecipe;
 import org.geysermc.geyser.inventory.recipe.GeyserSmithingRecipe;
 import org.geysermc.geyser.inventory.recipe.GeyserStonecutterData;
@@ -145,7 +146,7 @@ public class JavaUpdateRecipesTranslator extends PacketTranslator<ClientboundUpd
             craftingDataPacket.getCraftingData().add(SmithingTrimRecipeData.of(TrimRecipe.ID,
                     TrimRecipe.BASE, TrimRecipe.ADDITION, TrimRecipe.TEMPLATE, "smithing_table", netId++));
         }
-        session.getGeyser().getLogger().debug("Using old smithing table workaround? " + oldSmithingTable);
+        GeyserLogger.get().debug("Using old smithing table workaround? " + oldSmithingTable);
         session.setOldSmithingTable(oldSmithingTable);
 
         Int2ObjectMap<List<SelectableRecipe>> rawStonecutterData = new Int2ObjectOpenHashMap<>();
@@ -154,7 +155,7 @@ public class JavaUpdateRecipesTranslator extends PacketTranslator<ClientboundUpd
         for (SelectableRecipe recipe : stonecutterRecipes) {
             // Hardcoding the heck out of this until we see different examples of how this works.
             if (!(recipe.recipe() instanceof ItemStackSlotDisplay)) {
-                session.getGeyser().getLogger().warning("Ignoring stonecutter recipe for weird output: " + recipe);
+                GeyserLogger.get().warning("Ignoring stonecutter recipe for weird output: " + recipe);
                 continue;
             }
 
@@ -213,7 +214,7 @@ public class JavaUpdateRecipesTranslator extends PacketTranslator<ClientboundUpd
         if (bedrockDefinition != null) {
             return ItemDescriptorWithCount.fromItem(ItemData.builder().definition(bedrockDefinition).count(1).build());
         }
-        GeyserImpl.getInstance().getLogger().debug("Unable to find item with identifier " + bedrockId);
+        GeyserLogger.get().debug("Unable to find item with identifier " + bedrockId);
         return ItemDescriptorWithCount.EMPTY;
     }
 }

--- a/core/src/main/java/org/geysermc/geyser/translator/protocol/java/entity/JavaAddEntityTranslator.java
+++ b/core/src/main/java/org/geysermc/geyser/translator/protocol/java/entity/JavaAddEntityTranslator.java
@@ -27,6 +27,7 @@ package org.geysermc.geyser.translator.protocol.java.entity;
 
 import org.cloudburstmc.math.vector.Vector3f;
 import org.geysermc.geyser.GeyserImpl;
+import org.geysermc.geyser.GeyserLogger;
 import org.geysermc.geyser.entity.EntityDefinition;
 import org.geysermc.geyser.entity.spawn.EntitySpawnContext;
 import org.geysermc.geyser.entity.type.Entity;
@@ -58,7 +59,7 @@ public class JavaAddEntityTranslator extends PacketTranslator<ClientboundAddEnti
     public void translate(GeyserSession session, ClientboundAddEntityPacket packet) {
         EntityDefinition<?> definition = Registries.ENTITY_DEFINITIONS.get(packet.getType());
         if (definition == null) {
-            session.getGeyser().getLogger().debug("Could not find an entity definition with type " + packet.getType());
+            GeyserLogger.get().debug("Could not find an entity definition with type " + packet.getType());
             return;
         }
 
@@ -83,7 +84,7 @@ public class JavaAddEntityTranslator extends PacketTranslator<ClientboundAddEnti
                 entity = session.getEntityCache().getPlayerEntity(packet.getUuid());
                 if (entity == null) {
                     if (SHOW_PLAYER_LIST_LOGS) {
-                        GeyserImpl.getInstance().getLogger().error(GeyserLocale.getLocaleStringLog("geyser.entity.player.failed_list", packet.getUuid()));
+                        GeyserLogger.get().error(GeyserLocale.getLocaleStringLog("geyser.entity.player.failed_list", packet.getUuid()));
                     }
                     return;
                 }

--- a/core/src/main/java/org/geysermc/geyser/translator/protocol/java/entity/JavaAnimateTranslator.java
+++ b/core/src/main/java/org/geysermc/geyser/translator/protocol/java/entity/JavaAnimateTranslator.java
@@ -31,6 +31,7 @@ import org.cloudburstmc.protocol.bedrock.packet.AnimateEntityPacket;
 import org.cloudburstmc.protocol.bedrock.packet.AnimatePacket;
 import org.cloudburstmc.protocol.bedrock.packet.EntityEventPacket;
 import org.cloudburstmc.protocol.bedrock.packet.SpawnParticleEffectPacket;
+import org.geysermc.geyser.GeyserLogger;
 import org.geysermc.geyser.entity.type.Entity;
 import org.geysermc.geyser.entity.type.LivingEntity;
 import org.geysermc.geyser.session.GeyserSession;
@@ -110,7 +111,7 @@ public class JavaAnimateTranslator extends PacketTranslator<ClientboundAnimatePa
                 animatePacket.setAction(AnimatePacket.Action.WAKE_UP);
             }
             default -> {
-                session.getGeyser().getLogger().debug("Unhandled java animation: " + animation);
+                GeyserLogger.get().debug("Unhandled java animation: " + animation);
                 return;
             }
         }

--- a/core/src/main/java/org/geysermc/geyser/translator/protocol/java/entity/JavaEntityEventTranslator.java
+++ b/core/src/main/java/org/geysermc/geyser/translator/protocol/java/entity/JavaEntityEventTranslator.java
@@ -39,6 +39,7 @@ import org.cloudburstmc.protocol.bedrock.packet.PlaySoundPacket;
 import org.cloudburstmc.protocol.bedrock.packet.SetEntityDataPacket;
 import org.cloudburstmc.protocol.bedrock.packet.SetEntityMotionPacket;
 import org.geysermc.geyser.GeyserImpl;
+import org.geysermc.geyser.GeyserLogger;
 import org.geysermc.geyser.entity.EntityDefinitions;
 import org.geysermc.geyser.entity.type.Entity;
 import org.geysermc.geyser.entity.type.EvokerFangsEntity;
@@ -267,7 +268,7 @@ public class JavaEntityEventTranslator extends PacketTranslator<ClientboundEntit
                     livingEntity.updateMainHand();
                     livingEntity.updateOffHand();
                 } else {
-                    session.getGeyser().getLogger().debug("Got status message to swap hands for a non-living entity.");
+                    GeyserLogger.get().debug("Got status message to swap hands for a non-living entity.");
                 }
                 return;
             case GOAT_LOWERING_HEAD:
@@ -311,7 +312,7 @@ public class JavaEntityEventTranslator extends PacketTranslator<ClientboundEntit
                 // unused, but spams a bit
                 break;
             default:
-                GeyserImpl.getInstance().getLogger().debug("unhandled entity event: " + packet);
+                GeyserLogger.get().debug("unhandled entity event: " + packet);
         }
 
         if (entityEventPacket.getType() != null) {

--- a/core/src/main/java/org/geysermc/geyser/translator/protocol/java/entity/JavaSetEntityDataTranslator.java
+++ b/core/src/main/java/org/geysermc/geyser/translator/protocol/java/entity/JavaSetEntityDataTranslator.java
@@ -25,6 +25,7 @@
 
 package org.geysermc.geyser.translator.protocol.java.entity;
 
+import org.geysermc.geyser.GeyserLogger;
 import org.geysermc.geyser.entity.EntityDefinition;
 import org.geysermc.geyser.entity.type.Entity;
 import org.geysermc.geyser.session.GeyserSession;
@@ -45,10 +46,10 @@ public class JavaSetEntityDataTranslator extends PacketTranslator<ClientboundSet
         EntityDefinition<?> definition = entity.getDefinition();
         for (EntityMetadata<?, ?> metadata : packet.getMetadata()) {
             if (metadata.getId() >= definition.translators().size()) {
-                if (session.getGeyser().config().debugMode()) {
+                if (GeyserLogger.get().isDebug()) {
                     // Minecraft client just ignores these
-                    session.getGeyser().getLogger().warning("Metadata ID " + metadata.getId() + " is out of bounds of known entity metadata size " + definition.translators().size() + " for entity type " + entity.getDefinition().entityType());
-                    session.getGeyser().getLogger().debug(metadata.toString());
+                    GeyserLogger.get().warning("Metadata ID " + metadata.getId() + " is out of bounds of known entity metadata size " + definition.translators().size() + " for entity type " + entity.getDefinition().entityType());
+                    GeyserLogger.get().debug(metadata.toString());
                 }
                 continue;
             }

--- a/core/src/main/java/org/geysermc/geyser/translator/protocol/java/entity/JavaSetEquipmentTranslator.java
+++ b/core/src/main/java/org/geysermc/geyser/translator/protocol/java/entity/JavaSetEquipmentTranslator.java
@@ -25,6 +25,7 @@
 
 package org.geysermc.geyser.translator.protocol.java.entity;
 
+import org.geysermc.geyser.GeyserLogger;
 import org.geysermc.geyser.entity.type.Entity;
 import org.geysermc.geyser.entity.type.LivingEntity;
 import org.geysermc.geyser.entity.type.player.PlayerEntity;
@@ -49,7 +50,7 @@ public class JavaSetEquipmentTranslator extends PacketTranslator<ClientboundSetE
             return;
 
         if (!(entity instanceof LivingEntity livingEntity)) {
-            session.getGeyser().getLogger().debug("Attempted to add armor to a non-living entity (" +
+            GeyserLogger.get().debug("Attempted to add armor to a non-living entity (" +
                     entity.getDefinition().identifier() + ").");
             return;
         }

--- a/core/src/main/java/org/geysermc/geyser/translator/protocol/java/entity/player/JavaPlayerInfoUpdateTranslator.java
+++ b/core/src/main/java/org/geysermc/geyser/translator/protocol/java/entity/player/JavaPlayerInfoUpdateTranslator.java
@@ -27,6 +27,7 @@ package org.geysermc.geyser.translator.protocol.java.entity.player;
 
 import org.cloudburstmc.protocol.bedrock.packet.PlayerListPacket;
 import org.geysermc.geyser.GeyserImpl;
+import org.geysermc.geyser.GeyserLogger;
 import org.geysermc.geyser.entity.EntityDefinitions;
 import org.geysermc.geyser.entity.spawn.EntitySpawnContext;
 import org.geysermc.geyser.entity.type.player.PlayerEntity;
@@ -59,7 +60,7 @@ public class JavaPlayerInfoUpdateTranslator extends PacketTranslator<Clientbound
                 if (profile == null) {
                     // Should never be null for the ADD_PLAYER case
                     // 1.21.11 client NPEs here
-                    GeyserImpl.getInstance().getLogger().debug("Received a null profile in a player info update packet!");
+                    GeyserLogger.get().debug("Received a null profile in a player info update packet!");
                     continue;
                 }
 
@@ -71,7 +72,7 @@ public class JavaPlayerInfoUpdateTranslator extends PacketTranslator<Clientbound
                     // Entity is ourself!
                     playerEntity = session.getPlayerEntity();
                     playerEntity.setUsername(profile.getName());
-                    playerEntity.setSkin(profile, () -> GeyserImpl.getInstance().getLogger().debug("Loaded Local Bedrock Java Skin Data for " + session.getClientData().getUsername()));
+                    playerEntity.setSkin(profile, () -> GeyserLogger.get().debug("Loaded Local Bedrock Java Skin Data for " + session.getClientData().getUsername()));
                 } else {
                     // It's a new player
                     playerEntity = new PlayerEntity(EntitySpawnContext.DUMMY_CONTEXT.apply(session, id, EntityDefinitions.PLAYER), profile);
@@ -87,7 +88,7 @@ public class JavaPlayerInfoUpdateTranslator extends PacketTranslator<Clientbound
             for (PlayerListEntry entry : packet.getEntries()) {
                 PlayerEntity entity = session.getEntityCache().getPlayerEntity(entry.getProfileId());
                 if (entity == null) {
-                    session.getGeyser().getLogger().debug("Ignoring player info update for " + entry.getProfileId());
+                    GeyserLogger.get().debug("Ignoring player info update for " + entry.getProfileId());
                     continue;
                 }
 

--- a/core/src/main/java/org/geysermc/geyser/translator/protocol/java/entity/player/JavaPlayerPositionTranslator.java
+++ b/core/src/main/java/org/geysermc/geyser/translator/protocol/java/entity/player/JavaPlayerPositionTranslator.java
@@ -31,6 +31,7 @@ import org.cloudburstmc.protocol.bedrock.packet.ChunkRadiusUpdatedPacket;
 import org.cloudburstmc.protocol.bedrock.packet.MovePlayerPacket;
 import org.cloudburstmc.protocol.bedrock.packet.RespawnPacket;
 import org.cloudburstmc.protocol.bedrock.packet.SetEntityMotionPacket;
+import org.geysermc.geyser.GeyserLogger;
 import org.geysermc.geyser.entity.type.player.SessionPlayerEntity;
 import org.geysermc.geyser.session.GeyserSession;
 import org.geysermc.geyser.session.cache.TeleportCache;
@@ -114,13 +115,11 @@ public class JavaPlayerPositionTranslator extends PacketTranslator<ClientboundPl
 
             ChunkUtils.updateChunkPosition(session, entityPosition.toInt());
 
-            if (session.getGeyser().config().debugMode()) {
-                session.getGeyser().getLogger().debug("Spawned player at " + packet.getPosition());
-            }
+            GeyserLogger.get().debug("Spawned player at " + packet.getPosition());
             return;
         }
 
-        session.getGeyser().getLogger().debug("Teleport (" + teleportId + ") from " + entity.position());
+        GeyserLogger.get().debug("Teleport (" + teleportId + ") from " + entity.position());
 
         Vector3f lastPlayerPosition = entity.position();
         float lastPlayerPitch = entity.getPitch();
@@ -158,7 +157,7 @@ public class JavaPlayerPositionTranslator extends PacketTranslator<ClientboundPl
             session.sendUpstreamPacket(entityMotionPacket);
         }
 
-        session.getGeyser().getLogger().debug("to " + entity.position());
+        GeyserLogger.get().debug("to " + entity.position());
     }
 
     private void acceptTeleport(GeyserSession session, Vector3d position, float yaw, float pitch, int id) {

--- a/core/src/main/java/org/geysermc/geyser/translator/protocol/java/inventory/JavaContainerSetContentTranslator.java
+++ b/core/src/main/java/org/geysermc/geyser/translator/protocol/java/inventory/JavaContainerSetContentTranslator.java
@@ -50,7 +50,7 @@ public class JavaContainerSetContentTranslator extends PacketTranslator<Clientbo
         int inventorySize = inventory.getSize();
         for (int i = 0; i < packet.getItems().length; i++) {
             if (i >= inventorySize) {
-                GeyserLogger logger = session.getGeyser().getLogger();
+                GeyserLogger logger = GeyserLogger.get();
                 logger.warning("ClientboundContainerSetContentPacket sent to " + session.bedrockUsername()
                         + " that exceeds inventory size!");
                 if (logger.isDebug()) {

--- a/core/src/main/java/org/geysermc/geyser/translator/protocol/java/inventory/JavaContainerSetSlotTranslator.java
+++ b/core/src/main/java/org/geysermc/geyser/translator/protocol/java/inventory/JavaContainerSetSlotTranslator.java
@@ -65,7 +65,7 @@ public class JavaContainerSetSlotTranslator extends PacketTranslator<Clientbound
         Inventory inventory = holder.inventory();
         int slot = packet.getSlot();
         if (slot < 0 || slot >= inventory.getSize()) {
-            GeyserLogger logger = session.getGeyser().getLogger();
+            GeyserLogger logger = GeyserLogger.get();
             logger.warning("Slot of ClientboundContainerSetSlotPacket sent to " + session.bedrockUsername()
                     + " is out of bounds! Was: " + slot + " for container: " + packet.getContainerId());
             if (logger.isDebug()) {

--- a/core/src/main/java/org/geysermc/geyser/translator/protocol/java/inventory/JavaOpenScreenTranslator.java
+++ b/core/src/main/java/org/geysermc/geyser/translator/protocol/java/inventory/JavaOpenScreenTranslator.java
@@ -27,6 +27,7 @@ package org.geysermc.geyser.translator.protocol.java.inventory;
 
 import net.kyori.adventure.text.Component;
 import org.geysermc.geyser.GeyserImpl;
+import org.geysermc.geyser.GeyserLogger;
 import org.geysermc.geyser.inventory.Inventory;
 import org.geysermc.geyser.inventory.InventoryHolder;
 import org.geysermc.geyser.session.GeyserSession;
@@ -47,7 +48,7 @@ public class JavaOpenScreenTranslator extends PacketTranslator<ClientboundOpenSc
 
     @Override
     public void translate(GeyserSession session, ClientboundOpenScreenPacket packet) {
-        GeyserImpl.getInstance().getLogger().debug(session, packet.toString());
+        GeyserLogger.get().debug(session, packet.toString());
         if (packet.getContainerId() == 0) {
             return;
         }
@@ -87,7 +88,7 @@ public class JavaOpenScreenTranslator extends PacketTranslator<ClientboundOpenSc
             // Pending inventories are also considered, as a Java server can re-request the same inventory.
             if (newTranslator.canReuseInventory(session, newInventory, currentInventory.inventory())) {
                 newInventoryHolder.inheritFromExisting(currentInventory);
-                GeyserImpl.getInstance().getLogger().debug(session, "Able to reuse current inventory. Is current pending? %s", currentInventory.pending());
+                GeyserLogger.get().debug(session, "Able to reuse current inventory. Is current pending? %s", currentInventory.pending());
 
                 // If the current inventory is still pending, it'll be updated once open
                 if (newInventory.isDisplayed()) {

--- a/core/src/main/java/org/geysermc/geyser/translator/protocol/java/inventory/JavaSetPlayerInventoryTranslator.java
+++ b/core/src/main/java/org/geysermc/geyser/translator/protocol/java/inventory/JavaSetPlayerInventoryTranslator.java
@@ -50,7 +50,7 @@ public class JavaSetPlayerInventoryTranslator extends PacketTranslator<Clientbou
         }
 
         if (slot >= session.getPlayerInventory().getSize()) {
-            GeyserLogger logger = session.getGeyser().getLogger();
+            GeyserLogger logger = GeyserLogger.get();
             logger.warning("ClientboundSetPlayerInventoryPacket sent to " + session.bedrockUsername()
                 + " that exceeds inventory size!");
             if (logger.isDebug()) {

--- a/core/src/main/java/org/geysermc/geyser/translator/protocol/java/level/JavaBlockEventTranslator.java
+++ b/core/src/main/java/org/geysermc/geyser/translator/protocol/java/level/JavaBlockEventTranslator.java
@@ -31,6 +31,7 @@ import org.cloudburstmc.nbt.NbtMapBuilder;
 import org.cloudburstmc.nbt.NbtType;
 import org.cloudburstmc.protocol.bedrock.packet.BlockEntityDataPacket;
 import org.cloudburstmc.protocol.bedrock.packet.BlockEventPacket;
+import org.geysermc.geyser.GeyserLogger;
 import org.geysermc.geyser.api.util.PlatformType;
 import org.geysermc.geyser.level.block.Blocks;
 import org.geysermc.geyser.level.block.property.Properties;
@@ -63,7 +64,7 @@ public class JavaBlockEventTranslator extends PacketTranslator<ClientboundBlockE
         BlockValue value = packet.getValue();
 
         if (value == null) {
-            session.getGeyser().getLogger().debug("Unable to handle packet %s - null value! ".formatted(packet.toString()));
+            GeyserLogger.get().debug("Unable to handle packet %s - null value! ".formatted(packet.toString()));
             return;
         }
 
@@ -164,8 +165,8 @@ public class JavaBlockEventTranslator extends PacketTranslator<ClientboundBlockE
                 blockEntityPacket.setData(builder.build());
                 session.sendUpstreamPacket(blockEntityPacket);
             });
-        } else if (session.getGeyser().getLogger().isDebug()) {
-            session.getGeyser().getLogger().debug("Unhandled block event packet: " + packet);
+        } else if (GeyserLogger.get().isDebug()) {
+            GeyserLogger.get().debug("Unhandled block event packet: " + packet);
         }
     }
 

--- a/core/src/main/java/org/geysermc/geyser/translator/protocol/java/level/JavaLevelChunkWithLightTranslator.java
+++ b/core/src/main/java/org/geysermc/geyser/translator/protocol/java/level/JavaLevelChunkWithLightTranslator.java
@@ -39,6 +39,7 @@ import org.cloudburstmc.nbt.NbtMap;
 import org.cloudburstmc.nbt.NbtUtils;
 import org.cloudburstmc.protocol.bedrock.data.definitions.BlockDefinition;
 import org.cloudburstmc.protocol.bedrock.packet.LevelChunkPacket;
+import org.geysermc.geyser.GeyserLogger;
 import org.geysermc.geyser.entity.type.ItemFrameEntity;
 import org.geysermc.geyser.level.BedrockDimension;
 import org.geysermc.geyser.level.block.type.Block;
@@ -383,7 +384,7 @@ public class JavaLevelChunkWithLightTranslator extends PacketTranslator<Clientbo
             levelChunkPacket.setDimension(session.getBedrockDimension().bedrockId());
             session.sendUpstreamPacket(levelChunkPacket);
         } catch (IOException e) {
-            session.getGeyser().getLogger().error("IO error while encoding chunk", e);
+            GeyserLogger.get().error("IO error while encoding chunk", e);
             return;
         } finally {
             if (byteBuf != null) {

--- a/core/src/main/java/org/geysermc/geyser/translator/protocol/java/level/JavaLevelEventTranslator.java
+++ b/core/src/main/java/org/geysermc/geyser/translator/protocol/java/level/JavaLevelEventTranslator.java
@@ -38,6 +38,7 @@ import org.cloudburstmc.protocol.bedrock.packet.SpawnParticleEffectPacket;
 import org.cloudburstmc.protocol.bedrock.packet.StopSoundPacket;
 import org.cloudburstmc.protocol.bedrock.packet.TextPacket;
 import org.geysermc.geyser.GeyserImpl;
+import org.geysermc.geyser.GeyserLogger;
 import org.geysermc.geyser.level.JukeboxSong;
 import org.geysermc.geyser.registry.Registries;
 import org.geysermc.geyser.registry.type.SoundMapping;
@@ -446,7 +447,7 @@ public class JavaLevelEventTranslator extends PacketTranslator<ClientboundLevelE
                 return;
             }
             default -> {
-                GeyserImpl.getInstance().getLogger().debug("Unhandled level event: " + packet.getEvent());
+                GeyserLogger.get().debug("Unhandled level event: " + packet.getEvent());
                 return;
             }
         }

--- a/core/src/main/java/org/geysermc/geyser/translator/protocol/java/level/JavaLevelParticlesTranslator.java
+++ b/core/src/main/java/org/geysermc/geyser/translator/protocol/java/level/JavaLevelParticlesTranslator.java
@@ -25,6 +25,7 @@
 
 package org.geysermc.geyser.translator.protocol.java.level;
 
+import org.geysermc.geyser.GeyserLogger;
 import org.geysermc.mcprotocollib.protocol.data.game.item.ItemStack;
 import org.geysermc.mcprotocollib.protocol.data.game.level.particle.BlockParticleData;
 import org.geysermc.mcprotocollib.protocol.data.game.level.particle.ColorParticleData;
@@ -85,7 +86,7 @@ public class JavaLevelParticlesTranslator extends PacketTranslator<ClientboundLe
             }
         } else {
             // Null is only returned when no particle of this type is found
-            session.getGeyser().getLogger().debug("Unhandled particle packet: " + packet);
+            GeyserLogger.get().debug("Unhandled particle packet: " + packet);
         }
     }
 
@@ -153,11 +154,11 @@ public class JavaLevelParticlesTranslator extends PacketTranslator<ClientboundLe
                     if (entity != null) {
                         target = entity.bedrockPosition().up(entityPositionSource.getYOffset());
                     } else {
-                        session.getGeyser().getLogger().debug("Unable to find entity with Java Id: " + entityPositionSource.getEntityId() + " for vibration particle.");
+                        GeyserLogger.get().debug("Unable to find entity with Java Id: " + entityPositionSource.getEntityId() + " for vibration particle.");
                         return null;
                     }
                 } else {
-                    session.getGeyser().getLogger().debug("Unknown position source " + data.getPositionSource() + " for vibration particle.");
+                    GeyserLogger.get().debug("Unknown position source " + data.getPositionSource() + " for vibration particle.");
                     return null;
                 }
 

--- a/core/src/main/java/org/geysermc/geyser/translator/protocol/java/level/JavaStopSoundTranslator.java
+++ b/core/src/main/java/org/geysermc/geyser/translator/protocol/java/level/JavaStopSoundTranslator.java
@@ -25,6 +25,7 @@
 
 package org.geysermc.geyser.translator.protocol.java.level;
 
+import org.geysermc.geyser.GeyserLogger;
 import org.geysermc.mcprotocollib.protocol.packet.ingame.clientbound.ClientboundStopSoundPacket;
 import org.cloudburstmc.protocol.bedrock.packet.StopSoundPacket;
 import org.geysermc.geyser.session.GeyserSession;
@@ -51,6 +52,6 @@ public class JavaStopSoundTranslator extends PacketTranslator<ClientboundStopSou
         stopSoundPacket.setStoppingAllSound(false);
 
         session.sendUpstreamPacket(stopSoundPacket);
-        session.getGeyser().getLogger().debug("[StopSound] Stopped " + packet.getSound() + " -> " + stopSoundPacket.getSoundName());
+        GeyserLogger.get().debug("[StopSound] Stopped " + packet.getSound() + " -> " + stopSoundPacket.getSoundName());
     }
 }

--- a/core/src/main/java/org/geysermc/geyser/translator/protocol/java/scoreboard/JavaResetScorePacket.java
+++ b/core/src/main/java/org/geysermc/geyser/translator/protocol/java/scoreboard/JavaResetScorePacket.java
@@ -40,7 +40,7 @@ import org.geysermc.mcprotocollib.protocol.packet.ingame.clientbound.scoreboard.
 public class JavaResetScorePacket extends PacketTranslator<ClientboundResetScorePacket> {
     private static final boolean SHOW_SCOREBOARD_LOGS = Boolean.parseBoolean(System.getProperty("Geyser.ShowScoreboardLogs", "true"));
 
-    private final GeyserLogger logger = GeyserImpl.getInstance().getLogger();
+    private final GeyserLogger logger = GeyserLogger.get();
 
     @Override
     public void translate(GeyserSession session, ClientboundResetScorePacket packet) {

--- a/core/src/main/java/org/geysermc/geyser/translator/protocol/java/scoreboard/JavaSetPlayerTeamTranslator.java
+++ b/core/src/main/java/org/geysermc/geyser/translator/protocol/java/scoreboard/JavaSetPlayerTeamTranslator.java
@@ -39,13 +39,11 @@ import org.geysermc.mcprotocollib.protocol.packet.ingame.clientbound.scoreboard.
 
 @Translator(packet = ClientboundSetPlayerTeamPacket.class)
 public class JavaSetPlayerTeamTranslator extends PacketTranslator<ClientboundSetPlayerTeamPacket> {
-    private final GeyserLogger logger = GeyserImpl.getInstance().getLogger();
+    private final GeyserLogger logger = GeyserLogger.get();
 
     @Override
     public void translate(GeyserSession session, ClientboundSetPlayerTeamPacket packet) {
-        if (logger.isDebug()) {
-            logger.debug("Team packet " + packet.getTeamName() + " " + packet.getAction() + " " + Arrays.toString(packet.getPlayers()));
-        }
+        logger.debug("Team packet " + packet.getTeamName() + " " + packet.getAction() + " " + Arrays.toString(packet.getPlayers()));
 
         if ((packet.getAction() == TeamAction.ADD_PLAYER || packet.getAction() == TeamAction.REMOVE_PLAYER) && packet.getPlayers().length == 0) {
             return;

--- a/core/src/main/java/org/geysermc/geyser/translator/protocol/java/scoreboard/JavaSetScoreTranslator.java
+++ b/core/src/main/java/org/geysermc/geyser/translator/protocol/java/scoreboard/JavaSetScoreTranslator.java
@@ -40,7 +40,7 @@ import org.geysermc.mcprotocollib.protocol.packet.ingame.clientbound.scoreboard.
 public class JavaSetScoreTranslator extends PacketTranslator<ClientboundSetScorePacket> {
     private static final boolean SHOW_SCOREBOARD_LOGS = Boolean.parseBoolean(System.getProperty("Geyser.ShowScoreboardLogs", "true"));
 
-    private final GeyserLogger logger = GeyserImpl.getInstance().getLogger();
+    private final GeyserLogger logger = GeyserLogger.get();
 
     @Override
     public void translate(GeyserSession session, ClientboundSetScorePacket packet) {

--- a/core/src/main/java/org/geysermc/geyser/translator/text/MessageTranslator.java
+++ b/core/src/main/java/org/geysermc/geyser/translator/text/MessageTranslator.java
@@ -43,6 +43,7 @@ import org.checkerframework.checker.nullness.qual.Nullable;
 import org.cloudburstmc.nbt.NbtMap;
 import org.cloudburstmc.protocol.bedrock.packet.TextPacket;
 import org.geysermc.geyser.GeyserImpl;
+import org.geysermc.geyser.GeyserLogger;
 import org.geysermc.geyser.session.GeyserSession;
 import org.geysermc.geyser.session.cache.registry.JavaRegistries;
 import org.geysermc.geyser.text.ChatColor;
@@ -277,8 +278,8 @@ public class MessageTranslator {
                 return finalLegacyString;
             }
         } catch (Exception e) {
-            GeyserImpl.getInstance().getLogger().debug(GSON_SERIALIZER.serialize(message));
-            GeyserImpl.getInstance().getLogger().error("Failed to parse message", e);
+            GeyserLogger.get().debug(GSON_SERIALIZER.serialize(message));
+            GeyserLogger.get().error("Failed to parse message", e);
 
             return "";
         }
@@ -449,8 +450,8 @@ public class MessageTranslator {
             withDecoration.arguments(args);
             textPacket.setMessage(MessageTranslator.convertMessage(withDecoration.build(), session.locale()));
         } else {
-            session.getGeyser().getLogger().debug("Likely illegal chat type detection found.");
-            if (session.getGeyser().config().debugMode()) {
+            GeyserLogger.get().debug("Likely illegal chat type detection found.");
+            if (GeyserLogger.get().isDebug()) {
                 Thread.dumpStack();
             }
             textPacket.setMessage(MessageTranslator.convertMessage(message, session.locale()));
@@ -589,7 +590,7 @@ public class MessageTranslator {
             }
         }
 
-        GeyserImpl.getInstance().getLogger().error("Expected tag to be a literal string, a list of components, or a component object with a text/translate key: " + nbtTag);
+        GeyserLogger.get().error("Expected tag to be a literal string, a list of components, or a component object with a text/translate key: " + nbtTag);
         return Component.empty();
     }
 

--- a/core/src/main/java/org/geysermc/geyser/util/AnnotationUtils.java
+++ b/core/src/main/java/org/geysermc/geyser/util/AnnotationUtils.java
@@ -26,6 +26,7 @@
 package org.geysermc.geyser.util;
 
 import org.geysermc.geyser.GeyserImpl;
+import org.geysermc.geyser.GeyserLogger;
 
 import java.io.BufferedReader;
 import java.io.IOException;
@@ -87,7 +88,7 @@ public class AnnotationUtils {
                 try {
                     return Class.forName(className);
                 } catch (ClassNotFoundException ex) {
-                    GeyserImpl.getInstance().getLogger().error("Failed to find class " + className, ex);
+                    GeyserLogger.get().error("Failed to find class " + className, ex);
                     throw new RuntimeException(ex);
                 }
             }).collect(Collectors.toSet());

--- a/core/src/main/java/org/geysermc/geyser/util/AssetUtils.java
+++ b/core/src/main/java/org/geysermc/geyser/util/AssetUtils.java
@@ -31,6 +31,7 @@ import com.google.gson.JsonParser;
 import com.google.gson.annotations.SerializedName;
 import lombok.Getter;
 import org.geysermc.geyser.GeyserImpl;
+import org.geysermc.geyser.GeyserLogger;
 import org.geysermc.geyser.network.GameProtocol;
 import org.geysermc.geyser.text.GeyserLocale;
 
@@ -114,9 +115,9 @@ public final class AssetUtils {
                 VersionInfo versionInfo = GeyserImpl.GSON.fromJson(WebUtils.getBody(latestInfoURL), VersionInfo.class);
 
                 // Get the client jar for use when downloading the en_us locale
-                GeyserImpl.getInstance().getLogger().debug(versionInfo.getDownloads()); // Was previously a Jackson call for writeValueToString
+                GeyserLogger.get().debug(versionInfo.getDownloads()); // Was previously a Jackson call for writeValueToString
                 CLIENT_JAR_INFO = versionInfo.getDownloads().get("client");
-                GeyserImpl.getInstance().getLogger().debug(CLIENT_JAR_INFO); // Was previously a Jackson call for writeValueToString
+                GeyserLogger.get().debug(CLIENT_JAR_INFO); // Was previously a Jackson call for writeValueToString
 
                 // Get the assets list
                 JsonObject assets = ((JsonObject) new JsonParser().parse(WebUtils.getBody(versionInfo.getAssetIndex().getUrl()))).getAsJsonObject("objects");
@@ -133,7 +134,7 @@ public final class AssetUtils {
                 }
 
             } catch (Exception e) {
-                GeyserImpl.getInstance().getLogger().error(GeyserLocale.getLocaleStringLog("geyser.locale.fail.asset_cache", (!e.getMessage().isEmpty() ? e.getMessage() : e.getStackTrace())));
+                GeyserLogger.get().error(GeyserLocale.getLocaleStringLog("geyser.locale.fail.asset_cache", (!e.getMessage().isEmpty() ? e.getMessage() : e.getStackTrace())));
             }
             return null;
         });
@@ -142,7 +143,7 @@ public final class AssetUtils {
     public static void downloadAndRunClientJarTasks() {
         if (CLIENT_JAR_INFO == null) {
             // Likely failed to download
-            GeyserImpl.getInstance().getLogger().debug("Skipping en_US hash check as client jar is null.");
+            GeyserLogger.get().debug("Skipping en_US hash check as client jar is null.");
             return;
         }
 
@@ -169,8 +170,8 @@ public final class AssetUtils {
 
         try {
             // Let the user know we are downloading the JAR
-            GeyserImpl.getInstance().getLogger().info(GeyserLocale.getLocaleStringLog("geyser.locale.download.en_us"));
-            GeyserImpl.getInstance().getLogger().debug("Download URL: " + CLIENT_JAR_INFO.getUrl());
+            GeyserLogger.get().info(GeyserLocale.getLocaleStringLog("geyser.locale.download.en_us"));
+            GeyserLogger.get().debug("Download URL: " + CLIENT_JAR_INFO.getUrl());
 
             Path tmpFilePath = GeyserImpl.getInstance().getBootstrap().getConfigFolder().resolve("tmp_locale.jar");
             WebUtils.downloadFile(CLIENT_JAR_INFO.getUrl(), tmpFilePath.toString());
@@ -194,9 +195,9 @@ public final class AssetUtils {
             // Delete the nolonger needed client/server jar
             Files.delete(tmpFilePath);
 
-            GeyserImpl.getInstance().getLogger().info(GeyserLocale.getLocaleStringLog("geyser.locale.download.en_us.done"));
+            GeyserLogger.get().info(GeyserLocale.getLocaleStringLog("geyser.locale.download.en_us.done"));
         } catch (Exception e) {
-            GeyserImpl.getInstance().getLogger().error(GeyserLocale.getLocaleStringLog("geyser.locale.fail.en_us"), e);
+            GeyserLogger.get().error(GeyserLocale.getLocaleStringLog("geyser.locale.fail.en_us"), e);
         }
     }
 

--- a/core/src/main/java/org/geysermc/geyser/util/ChunkUtils.java
+++ b/core/src/main/java/org/geysermc/geyser/util/ChunkUtils.java
@@ -35,6 +35,7 @@ import org.cloudburstmc.math.vector.Vector3i;
 import org.cloudburstmc.protocol.bedrock.packet.LevelChunkPacket;
 import org.cloudburstmc.protocol.bedrock.packet.NetworkChunkPublisherUpdatePacket;
 import org.cloudburstmc.protocol.bedrock.packet.UpdateBlockPacket;
+import org.geysermc.geyser.GeyserLogger;
 import org.geysermc.geyser.entity.type.ItemFrameEntity;
 import org.geysermc.geyser.level.BedrockDimension;
 import org.geysermc.geyser.level.JavaDimension;
@@ -223,7 +224,7 @@ public class ChunkUtils {
         // The constraints change depending on if the player is in the overworld or not, and if experimental height is enabled
         // (Ignore this for the Nether. We can't change that at the moment without the workaround. :/ )
         if (SHOW_CHUNK_HEIGHT_WARNING_LOGS && (minY < bedrockDimension.minY() || (bedrockDimension.doUpperHeightWarn() && maxY > bedrockDimension.maxY()))) {
-            session.getGeyser().getLogger().warning(GeyserLocale.getLocaleStringLog("geyser.network.translator.chunk.out_of_bounds",
+            GeyserLogger.get().warning(GeyserLocale.getLocaleStringLog("geyser.network.translator.chunk.out_of_bounds",
                     String.valueOf(bedrockDimension.minY()),
                     String.valueOf(bedrockDimension.maxY()),
                     session.getRegistryCache().registry(JavaRegistries.DIMENSION_TYPE).byValue(session.getDimensionType())));

--- a/core/src/main/java/org/geysermc/geyser/util/CodeOfConductManager.java
+++ b/core/src/main/java/org/geysermc/geyser/util/CodeOfConductManager.java
@@ -31,6 +31,7 @@ import com.google.gson.JsonParser;
 import it.unimi.dsi.fastutil.objects.Object2IntMap;
 import it.unimi.dsi.fastutil.objects.Object2IntOpenHashMap;
 import org.geysermc.geyser.GeyserImpl;
+import org.geysermc.geyser.GeyserLogger;
 import org.geysermc.geyser.api.event.bedrock.SessionAcceptCodeOfConductEvent;
 import org.geysermc.geyser.api.event.java.ServerCodeOfConductEvent;
 import org.geysermc.geyser.session.GeyserSession;
@@ -53,7 +54,7 @@ public class CodeOfConductManager {
     private CodeOfConductManager() {
         Path savePath = getSavePath();
         if (Files.exists(savePath) && Files.isRegularFile(savePath)) {
-            GeyserImpl.getInstance().getLogger().debug("Loading codeofconducts.json");
+            GeyserLogger.get().debug("Loading codeofconducts.json");
 
             try (Reader reader = new FileReader(savePath.toFile())) {
                 //noinspection deprecation - otherwise 1.16.5 doesn't work
@@ -62,10 +63,10 @@ public class CodeOfConductManager {
                     playerAcceptedCodeOfConducts.put(entry.getKey(), entry.getValue().getAsInt());
                 }
             } catch (IOException exception) {
-                GeyserImpl.getInstance().getLogger().error("Failed to read code of conduct cache!", exception);
+                GeyserLogger.get().error("Failed to read code of conduct cache!", exception);
             }
         } else {
-            GeyserImpl.getInstance().getLogger().debug("codeofconducts.json not found, not loading");
+            GeyserLogger.get().debug("codeofconducts.json not found, not loading");
         }
 
         // Save file now and every 5 minutes after
@@ -97,7 +98,7 @@ public class CodeOfConductManager {
 
     public void save() {
         if (dirty) {
-            GeyserImpl.getInstance().getLogger().debug("Saving codeofconducts.json");
+            GeyserLogger.get().debug("Saving codeofconducts.json");
 
             JsonObject saved = new JsonObject();
             playerAcceptedCodeOfConducts.forEach(saved::addProperty);
@@ -105,7 +106,7 @@ public class CodeOfConductManager {
                 Files.writeString(getSavePath(), saved.toString());
                 dirty = false;
             } catch (IOException exception) {
-                GeyserImpl.getInstance().getLogger().error("Failed to write code of conduct cache!", exception);
+                GeyserLogger.get().error("Failed to write code of conduct cache!", exception);
             }
         }
     }

--- a/core/src/main/java/org/geysermc/geyser/util/CpuUtils.java
+++ b/core/src/main/java/org/geysermc/geyser/util/CpuUtils.java
@@ -26,6 +26,7 @@
 package org.geysermc.geyser.util;
 
 import org.geysermc.geyser.GeyserImpl;
+import org.geysermc.geyser.GeyserLogger;
 
 import java.io.File;
 import java.io.InputStream;
@@ -47,11 +48,11 @@ public final class CpuUtils {
             } else if (osName.contains("mac")) {
                 return getMacProcessorName();
             } else {
-                GeyserImpl.getInstance().getLogger().warning("Couldn't determine OS to get processor name! The OS name is " + osName);
+                GeyserLogger.get().warning("Couldn't determine OS to get processor name! The OS name is " + osName);
                 return "unknown";
             }
         } catch (Exception e) {
-            GeyserImpl.getInstance().getLogger().warning("Couldn't get processor name! " + e.getMessage());
+            GeyserLogger.get().warning("Couldn't get processor name! " + e.getMessage());
             return "unknown";
         }
     }
@@ -69,7 +70,7 @@ public final class CpuUtils {
                 return splitLine[1];
             }
         }
-        GeyserImpl.getInstance().getLogger().warning("Couldn't parse processor name!");
+        GeyserLogger.get().warning("Couldn't parse processor name!");
         return "unknown";
     }
 
@@ -93,7 +94,7 @@ public final class CpuUtils {
         int p = result.indexOf(regstrToken);
 
         if (p == -1) {
-            GeyserImpl.getInstance().getLogger().warning("Couldn't parse processor name!");
+            GeyserLogger.get().warning("Couldn't parse processor name!");
             return "unknown";
         }
 
@@ -117,7 +118,7 @@ public final class CpuUtils {
         if (!result.isEmpty()) {
             return result;
         } else {
-            GeyserImpl.getInstance().getLogger().warning("Couldn't parse processor name!");
+            GeyserLogger.get().warning("Couldn't parse processor name!");
             return "unknown";
         }
     }

--- a/core/src/main/java/org/geysermc/geyser/util/DimensionUtils.java
+++ b/core/src/main/java/org/geysermc/geyser/util/DimensionUtils.java
@@ -34,6 +34,7 @@ import org.cloudburstmc.protocol.bedrock.packet.ChunkRadiusUpdatedPacket;
 import org.cloudburstmc.protocol.bedrock.packet.MobEffectPacket;
 import org.cloudburstmc.protocol.bedrock.packet.PlayerActionPacket;
 import org.cloudburstmc.protocol.bedrock.packet.StopSoundPacket;
+import org.geysermc.geyser.GeyserLogger;
 import org.geysermc.geyser.entity.type.Entity;
 import org.geysermc.geyser.level.EffectType;
 import org.geysermc.geyser.level.BedrockDimension;
@@ -113,7 +114,7 @@ public class DimensionUtils {
             // The client locks up when switching dimensions, expecting more chunks than it's getting
             // To solve this, we cap at 32 unless we know that the render distance actually exceeds 32
             // Also, as of 1.19: PS4 crashes with a ChunkRadiusUpdatedPacket too large
-            session.getGeyser().getLogger().debug("Applying dimension switching workaround for Bedrock render distance of "
+            GeyserLogger.get().debug("Applying dimension switching workaround for Bedrock render distance of "
                 + session.getServerRenderDistance());
             ChunkRadiusUpdatedPacket chunkRadiusUpdatedPacket = new ChunkRadiusUpdatedPacket();
             chunkRadiusUpdatedPacket.setRadius(32);

--- a/core/src/main/java/org/geysermc/geyser/util/GeyserIntegratedPackUtil.java
+++ b/core/src/main/java/org/geysermc/geyser/util/GeyserIntegratedPackUtil.java
@@ -26,6 +26,7 @@
 package org.geysermc.geyser.util;
 
 import org.geysermc.geyser.GeyserImpl;
+import org.geysermc.geyser.GeyserLogger;
 import org.geysermc.geyser.api.pack.PackCodec;
 import org.geysermc.geyser.api.pack.PathPackCodec;
 import org.geysermc.geyser.api.pack.ResourcePack;
@@ -65,7 +66,7 @@ public interface GeyserIntegratedPackUtil {
             Files.copy(GeyserImpl.getInstance().getBootstrap().getResourceOrThrow("GeyserIntegratedPack.mcpack"),
                 PACK_PATH, StandardCopyOption.REPLACE_EXISTING);
         } catch (Exception e) {
-            GeyserImpl.getInstance().getLogger().error("Could not copy over Geyser integrated resource pack!", e);
+            GeyserLogger.get().error("Could not copy over Geyser integrated resource pack!", e);
             PACK_ENABLED.set(false);
             return;
         }
@@ -78,7 +79,7 @@ public interface GeyserIntegratedPackUtil {
             event.registerOptions(INTEGRATED_PACK_UUID, PriorityOption.LOW);
             PACK_ENABLED.set(true);
         } catch (Exception e) {
-            GeyserImpl.getInstance().getLogger().error("Could not register GeyserIntegratedPack!", e);
+            GeyserLogger.get().error("Could not register GeyserIntegratedPack!", e);
             PACK_ENABLED.set(false);
         }
     }
@@ -107,9 +108,9 @@ public interface GeyserIntegratedPackUtil {
         ResourcePackManifest.Version version = duplicate.manifest().header().version();
         if (duplicate.codec() instanceof UrlPackCodec) {
             if (Objects.equals(version, INTEGRATED_PACK_VERSION.get())) {
-                GeyserImpl.getInstance().getLogger().debug("Found GeyserIntegratedPack sent via UrlPackCodec (version: %s)!".formatted(version));
+                GeyserLogger.get().debug("Found GeyserIntegratedPack sent via UrlPackCodec (version: %s)!".formatted(version));
             } else {
-                GeyserImpl.getInstance().getLogger().warning("Found GeyserIntegratedPack sent via UrlPackCodec, but the version differs! " +
+                GeyserLogger.get().warning("Found GeyserIntegratedPack sent via UrlPackCodec, but the version differs! " +
                     "(found: %s, expected: %s). Skipping our own, but things may not work as expected!".formatted(duplicate, INTEGRATED_PACK_VERSION.get()));
             }
             unregisterIntegratedPack();
@@ -123,14 +124,14 @@ public interface GeyserIntegratedPackUtil {
     default void handleOptionalPack(ResourcePack pack) {
         // Gracefully handle optional pack presence to avoid issues
         if (pack.codec() instanceof UrlPackCodec) {
-            GeyserImpl.getInstance().getLogger().warning("Detected GeyserOptionalPack sent via the UrlPackCodec! Please migrate to sending the " +
+            GeyserLogger.get().warning("Detected GeyserOptionalPack sent via the UrlPackCodec! Please migrate to sending the " +
                 "GeyserIntegratedPack instead - it will be required in the future for advanced features to work correctly!");
         } else {
-            GeyserImpl.getInstance().getLogger().warning("Detected GeyserOptionalPack! " +
+            GeyserLogger.get().warning("Detected GeyserOptionalPack! " +
                 "It should be removed " + warnMessageLocation(pack.codec()) + ", as Geyser now includes an improved version of this resource pack by default!"
             );
         }
-        GeyserImpl.getInstance().getLogger().warning("Disabling the integrated pack...");
+        GeyserLogger.get().warning("Disabling the integrated pack...");
         unregisterIntegratedPack();
         PACK_ENABLED.set(false);
     }

--- a/core/src/main/java/org/geysermc/geyser/util/InventoryUtils.java
+++ b/core/src/main/java/org/geysermc/geyser/util/InventoryUtils.java
@@ -36,6 +36,7 @@ import org.cloudburstmc.protocol.bedrock.data.inventory.ContainerId;
 import org.cloudburstmc.protocol.bedrock.data.inventory.ItemData;
 import org.cloudburstmc.protocol.bedrock.packet.InventorySlotPacket;
 import org.geysermc.geyser.GeyserImpl;
+import org.geysermc.geyser.GeyserLogger;
 import org.geysermc.geyser.inventory.GeyserItemStack;
 import org.geysermc.geyser.inventory.Inventory;
 import org.geysermc.geyser.inventory.InventoryHolder;
@@ -109,7 +110,7 @@ public class InventoryUtils {
             // Handled in BedrockContainerCloseTranslator
             // or - client hasn't yet loaded in; wait until inventory is shown
             holder.pending(true);
-            GeyserImpl.getInstance().getLogger().debug(holder.session(), "Inventory (%s) set pending: closing inv? %s, pending inv id? %s",
+            GeyserLogger.get().debug(holder.session(), "Inventory (%s) set pending: closing inv? %s, pending inv id? %s",
                 debugInventory(holder), holder.session().isClosingInventory(), holder.session().getPendingOrCurrentBedrockInventoryId());
             return;
         }
@@ -125,7 +126,7 @@ public class InventoryUtils {
         InventoryHolder<?> holder = session.getInventoryHolder();
         if (holder == null) {
             session.setPendingOrCurrentBedrockInventoryId(-1);
-            GeyserImpl.getInstance().getLogger().debug(session, "No pending inventory, not opening an inventory! Current inventory: %s", debugInventory(holder));
+            GeyserLogger.get().debug(session, "No pending inventory, not opening an inventory! Current inventory: %s", debugInventory(holder));
             return;
         }
 
@@ -133,16 +134,16 @@ public class InventoryUtils {
         if (holder.bedrockId() == session.getPendingOrCurrentBedrockInventoryId()) {
             // Don't re-open an inventory that is already open
             if (!holder.pending() && holder.inventory().isDisplayed()) {
-                GeyserImpl.getInstance().getLogger().debug("Container with id %s is not pending and already displayed!".formatted(holder.bedrockId()));
+                GeyserLogger.get().debug("Container with id %s is not pending and already displayed!".formatted(holder.bedrockId()));
                 return;
             }
 
-            GeyserImpl.getInstance().getLogger().debug(session, "Attempting to open currently delayed inventory with matching bedrock id! " + holder.bedrockId());
+            GeyserLogger.get().debug(session, "Attempting to open currently delayed inventory with matching bedrock id! " + holder.bedrockId());
             openAndUpdateInventory(holder);
             return;
         }
 
-        GeyserImpl.getInstance().getLogger().debug(session, "Opening current pending inventory! " + debugInventory(holder));
+        GeyserLogger.get().debug(session, "Opening current pending inventory! " + debugInventory(holder));
         displayInventory(holder);
         if (holder.inventory() instanceof MerchantContainer merchantContainer && merchantContainer.getPendingOffersPacket() != null) {
             JavaMerchantOffersTranslator.openMerchant(session, merchantContainer.getPendingOffersPacket(), merchantContainer);
@@ -159,7 +160,7 @@ public class InventoryUtils {
             if (holder.requiresOpeningDelay()) {
                 holder.pending(true);
                 scheduleInventoryOpen(holder.session());
-                GeyserImpl.getInstance().getLogger().debug(holder.session(), "Queuing virtual inventory (%s)", debugInventory(holder));
+                GeyserLogger.get().debug(holder.session(), "Queuing virtual inventory (%s)", debugInventory(holder));
             } else {
                 openAndUpdateInventory(holder);
             }
@@ -200,7 +201,7 @@ public class InventoryUtils {
             }
             holder.closeInventory(confirm);
             session.getBundleCache().onInventoryClose(holder.inventory());
-            GeyserImpl.getInstance().getLogger().debug(session, "Closed inventory: (java id: %s/bedrock id: %s), waiting on confirm? %s", holder.javaId(), holder.bedrockId(), session.isClosingInventory());
+            GeyserLogger.get().debug(session, "Closed inventory: (java id: %s/bedrock id: %s), waiting on confirm? %s", holder.javaId(), holder.bedrockId(), session.isClosingInventory());
         }
 
         session.setInventoryHolder(null);
@@ -268,7 +269,7 @@ public class InventoryUtils {
     }
 
     public static boolean canStack(GeyserItemStack item1, GeyserItemStack item2) {
-        if (GeyserImpl.getInstance().config().debugMode())
+        if (GeyserLogger.get().isDebug())
             canStackDebug(item1, item2);
         if (item1.isEmpty() || item2.isEmpty())
             return false;
@@ -280,10 +281,10 @@ public class InventoryUtils {
         DataComponents components2 = item2.getComponents();
         if (components1 != null && components2 != null) {
             if (components1.hashCode() == components2.hashCode() && !components1.equals(components2)) {
-                GeyserImpl.getInstance().getLogger().error("DEBUG: DataComponents hash collision");
-                GeyserImpl.getInstance().getLogger().error("hash: " + components1.hashCode());
-                GeyserImpl.getInstance().getLogger().error("components1: " + components1);
-                GeyserImpl.getInstance().getLogger().error("components2: " + components2);
+                GeyserLogger.get().error("DEBUG: DataComponents hash collision");
+                GeyserLogger.get().error("hash: " + components1.hashCode());
+                GeyserLogger.get().error("components1: " + components1);
+                GeyserLogger.get().error("components2: " + components2);
             }
         }
     }
@@ -324,7 +325,7 @@ public class InventoryUtils {
         ItemDefinition itemDefinition = mappings.getDefinition(unusableSpaceBlock);
 
         if (itemDefinition == null) {
-            GeyserImpl.getInstance().getLogger().error("Invalid value " + unusableSpaceBlock + ". Resorting to barrier block.");
+            GeyserLogger.get().error("Invalid value " + unusableSpaceBlock + ". Resorting to barrier block.");
             return mappings.getStoredItems().barrier().getBedrockDefinition();
         } else {
             return itemDefinition;
@@ -408,7 +409,7 @@ public class InventoryUtils {
             }
             return acceptsAsInput(session, display, itemStack);
         }
-        session.getGeyser().getLogger().warning("Unknown slot display type: " + slotDisplay);
+        GeyserLogger.get().warning("Unknown slot display type: " + slotDisplay);
         return false;
     }
 

--- a/core/src/main/java/org/geysermc/geyser/util/LoginEncryptionUtils.java
+++ b/core/src/main/java/org/geysermc/geyser/util/LoginEncryptionUtils.java
@@ -41,6 +41,7 @@ import org.geysermc.cumulus.response.SimpleFormResponse;
 import org.geysermc.cumulus.response.result.FormResponseResult;
 import org.geysermc.cumulus.response.result.ValidFormResponseResult;
 import org.geysermc.geyser.GeyserImpl;
+import org.geysermc.geyser.GeyserLogger;
 import org.geysermc.geyser.session.GeyserSession;
 import org.geysermc.geyser.session.auth.AuthData;
 import org.geysermc.geyser.session.auth.BedrockClientData;
@@ -72,7 +73,7 @@ public class LoginEncryptionUtils {
 
             ChainValidationResult result = EncryptionUtils.validatePayload(authPayload);
 
-            geyser.getLogger().debug(String.format("Is player data signed? %s", result.signed()));
+            GeyserLogger.get().debug(String.format("Is player data signed? %s", result.signed()));
             if (!result.signed() && session.getGeyser().config().advanced().bedrock().validateBedrockLogin()) {
                 session.disconnect(GeyserLocale.getLocaleStringLog("geyser.network.remote.invalid_xbox_account"));
                 return;
@@ -87,7 +88,7 @@ public class LoginEncryptionUtils {
             } else if (authPayload instanceof CertificateChainPayload certificateChainPayload) {
                 session.setCertChainData(certificateChainPayload.getChain());
             } else {
-                GeyserImpl.getInstance().getLogger().warning("Unknown auth payload! Skin uploading will not work");
+                GeyserLogger.get().warning("Unknown auth payload! Skin uploading will not work");
             }
 
             PublicKey identityPublicKey = result.identityClaims().parsedIdentityPublicKey();
@@ -115,14 +116,13 @@ public class LoginEncryptionUtils {
                 }
             }
             session.setAuthData(new AuthData(extraData.displayName, extraData.identity, xuid, issuedAt, extraData.minecraftId));
+            session.getGeyser().getDebugSessionMap().setFor(session);
 
             try {
                 startEncryptionHandshake(session, identityPublicKey);
             } catch (Throwable e) {
                 // An error can be thrown on older Java 8 versions about an invalid key
-                if (geyser.config().debugMode()) {
-                    e.printStackTrace();
-                }
+                GeyserLogger.get().debug("Error while starting encryption handshake.", e);
 
                 sendEncryptionFailedMessage(geyser);
             }
@@ -146,8 +146,8 @@ public class LoginEncryptionUtils {
 
     private static void sendEncryptionFailedMessage(GeyserImpl geyser) {
         if (!HAS_SENT_ENCRYPTION_MESSAGE) {
-            geyser.getLogger().warning(GeyserLocale.getLocaleStringLog("geyser.network.encryption.line_1"));
-            geyser.getLogger().warning(GeyserLocale.getLocaleStringLog("geyser.network.encryption.line_2", "https://geysermc.org/supported_java"));
+            GeyserLogger.get().warning(GeyserLocale.getLocaleStringLog("geyser.network.encryption.line_1"));
+            GeyserLogger.get().warning(GeyserLocale.getLocaleStringLog("geyser.network.encryption.line_2", "https://geysermc.org/supported_java"));
             HAS_SENT_ENCRYPTION_MESSAGE = true;
         }
     }

--- a/core/src/main/java/org/geysermc/geyser/util/NewsHandler.java
+++ b/core/src/main/java/org/geysermc/geyser/util/NewsHandler.java
@@ -48,7 +48,7 @@ import java.util.concurrent.TimeUnit;
 
 public class NewsHandler {
     private final ScheduledExecutorService executorService = Executors.newScheduledThreadPool(1);
-    private final GeyserLogger logger = GeyserImpl.getInstance().getLogger();
+    private final GeyserLogger logger = GeyserLogger.get();
     private final Gson gson = new Gson();
 
     private final Map<Integer, NewsItem> activeNewsItems = new HashMap<>();

--- a/core/src/main/java/org/geysermc/geyser/util/SoundUtils.java
+++ b/core/src/main/java/org/geysermc/geyser/util/SoundUtils.java
@@ -34,6 +34,7 @@ import org.cloudburstmc.protocol.bedrock.packet.LevelEventPacket;
 import org.cloudburstmc.protocol.bedrock.packet.LevelSoundEventPacket;
 import org.cloudburstmc.protocol.bedrock.packet.PlaySoundPacket;
 import org.geysermc.geyser.GeyserImpl;
+import org.geysermc.geyser.GeyserLogger;
 import org.geysermc.geyser.level.block.type.Block;
 import org.geysermc.geyser.registry.BlockRegistries;
 import org.geysermc.geyser.registry.Registries;
@@ -71,7 +72,7 @@ public final class SoundUtils {
         SoundMapping soundMapping = Registries.SOUNDS.get(soundIdentifier);
         if (soundMapping == null || soundMapping.playsound() == null) {
             // no mapping
-            GeyserImpl.getInstance().getLogger().debug("[PlaySound] Defaulting to sound server gave us for " + javaIdentifier);
+            GeyserLogger.get().debug("[PlaySound] Defaulting to sound server gave us for " + javaIdentifier);
             return soundIdentifier;
         }
         return soundMapping.playsound();
@@ -107,7 +108,7 @@ public final class SoundUtils {
 
         SoundMapping soundMapping = Registries.SOUNDS.get(soundIdentifier);
         if (soundMapping == null) {
-            session.getGeyser().getLogger().debug("[Builtin] Sound mapping for " + soundIdentifier + " not found; assuming custom.");
+            GeyserLogger.get().debug("[Builtin] Sound mapping for " + soundIdentifier + " not found; assuming custom.");
             playSound(session, soundIdentifier, position, volume, pitch);
             return;
         }
@@ -133,7 +134,7 @@ public final class SoundUtils {
             sound = SoundUtils.toSoundEvent(soundIdentifier);
         }
         if (sound == null) {
-            session.getGeyser().getLogger().debug("[Builtin] Sound for original '" + soundIdentifier + "' to mappings '" + soundMapping.bedrock()
+            GeyserLogger.get().debug("[Builtin] Sound for original '" + soundIdentifier + "' to mappings '" + soundMapping.bedrock()
                 + "' was not a playable level sound, or has yet to be mapped to an enum in SoundEvent.");
             return;
         }
@@ -151,7 +152,7 @@ public final class SoundUtils {
                 int javaId = BlockRegistries.JAVA_BLOCK_STATE_IDENTIFIER_TO_ID.get().getOrDefault(soundMapping.identifier(), Block.JAVA_AIR_ID);
                 soundPacket.setExtraData(session.getBlockMappings().getBedrockBlockId(javaId));
             } else {
-                session.getGeyser().getLogger().debug("PLACE sound mapping identifier was invalid! Please report: " + soundMapping);
+                GeyserLogger.get().debug("PLACE sound mapping identifier was invalid! Please report: " + soundMapping);
             }
             soundPacket.setIdentifier(":");
         } else {
@@ -172,7 +173,7 @@ public final class SoundUtils {
             soundEvent = string;
         } else {
             soundEvent = "";
-            GeyserImpl.getInstance().getLogger().debug("Sound event for " + context + " was of an unexpected type! Expected string or NBT map, got " + soundEventObject);
+            GeyserLogger.get().debug("Sound event for " + context + " was of an unexpected type! Expected string or NBT map, got " + soundEventObject);
         }
         return soundEvent;
     }

--- a/core/src/main/java/org/geysermc/geyser/util/VersionCheckUtils.java
+++ b/core/src/main/java/org/geysermc/geyser/util/VersionCheckUtils.java
@@ -122,9 +122,9 @@ public final class VersionCheckUtils {
                         .build();
                 sender.sendMessage(message);
             } catch (UnknownHostException e) {
-                GeyserImpl.getInstance().getLogger().error("Unable to resolve Geyser api! Cannot check for Geyser updates.");
+                GeyserLogger.get().error("Unable to resolve Geyser api! Cannot check for Geyser updates.");
             } catch (Exception e) {
-                GeyserImpl.getInstance().getLogger().error("Error whilst checking for Geyser update!", e);
+                GeyserLogger.get().error("Error whilst checking for Geyser update!", e);
             }
         });
     }

--- a/core/src/main/java/org/geysermc/geyser/util/WebUtils.java
+++ b/core/src/main/java/org/geysermc/geyser/util/WebUtils.java
@@ -142,7 +142,7 @@ public class WebUtils {
      */
     @SuppressWarnings("ResultOfMethodCallIgnored")
     public static @NonNull Path downloadRemotePack(String url, boolean force) throws IOException {
-        GeyserLogger logger = GeyserImpl.getInstance().getLogger();
+        GeyserLogger logger = GeyserLogger.get();
         try {
             HttpURLConnection con = (HttpURLConnection) new URL(url).openConnection();
 
@@ -197,7 +197,7 @@ public class WebUtils {
                         Files.deleteIfExists(downloadLocation);
                     }
                 } catch (IOException e) {
-                    GeyserImpl.getInstance().getLogger().error("Failed to read cached pack metadata! " + e);
+                    logger.error("Failed to read cached pack metadata! " + e);
                     packMetadata.toFile().deleteOnExit();
                 }
             }
@@ -377,11 +377,9 @@ public class WebUtils {
             if (attr != null && attr.size() > 0) {
                 return ((String) attr.get(0)).split(" ");
             }
-        } catch (Exception | NoClassDefFoundError ex) { // Check for a NoClassDefFoundError to prevent Android crashes
-            if (geyser.config().debugMode()) {
-                geyser.getLogger().debug("Exception while trying to find an SRV record for the remote host.");
-                ex.printStackTrace(); // Otherwise we can get a stack trace for any domain that doesn't have an SRV record
-            }
+        } catch (Exception ex) {
+            GeyserLogger.get().debug("Exception while trying to find an SRV record for the remote host.", ex);
+            ex.printStackTrace(); // Otherwise we can get a stack trace for any domain that doesn't have an SRV record
         }
         return null;
     }
@@ -403,7 +401,7 @@ public class WebUtils {
 
             return connectionToString(con).lines();
         } catch (Exception e) {
-            GeyserImpl.getInstance().getLogger().error("Error while trying to get a stream from " + reqURL, e);
+            GeyserLogger.get().error("Error while trying to get a stream from " + reqURL, e);
             return Stream.empty();
         }
     }

--- a/core/src/test/java/org/geysermc/geyser/scoreboard/network/util/EmptyGeyserLogger.java
+++ b/core/src/test/java/org/geysermc/geyser/scoreboard/network/util/EmptyGeyserLogger.java
@@ -64,6 +64,11 @@ public class EmptyGeyserLogger implements GeyserLogger {
     }
 
     @Override
+    public void debug(String message, Throwable t) {
+
+    }
+
+    @Override
     public void debug(String message, Object... arguments) {
 
     }

--- a/core/src/test/java/org/geysermc/geyser/scoreboard/network/util/GeyserMockContext.java
+++ b/core/src/test/java/org/geysermc/geyser/scoreboard/network/util/GeyserMockContext.java
@@ -57,10 +57,11 @@ public class GeyserMockContext {
         when(advancedConfig.scoreboardPacketThreshold()).thenReturn(1_000);
 
         var logger = context.storeObject(new EmptyGeyserLogger());
-        when(GeyserLogger.get()).thenReturn(logger);
 
-        try (var geyserImplMock = mockStatic(GeyserImpl.class)) {
+        try (var geyserImplMock = mockStatic(GeyserImpl.class);
+             var geyserLoggerMock = mockStatic(GeyserLogger.class)) {
             geyserImplMock.when(GeyserImpl::getInstance).thenReturn(geyserImpl);
+            geyserLoggerMock.when(GeyserLogger::get).thenReturn(logger);
 
             geyserContext.accept(context);
         }

--- a/core/src/test/java/org/geysermc/geyser/scoreboard/network/util/GeyserMockContext.java
+++ b/core/src/test/java/org/geysermc/geyser/scoreboard/network/util/GeyserMockContext.java
@@ -27,6 +27,7 @@ package org.geysermc.geyser.scoreboard.network.util;
 
 import org.cloudburstmc.protocol.bedrock.packet.BedrockPacket;
 import org.geysermc.geyser.GeyserImpl;
+import org.geysermc.geyser.GeyserLogger;
 import org.geysermc.geyser.configuration.GeyserConfig;
 import org.geysermc.geyser.session.GeyserSession;
 import org.geysermc.geyser.translator.protocol.PacketTranslator;
@@ -56,7 +57,7 @@ public class GeyserMockContext {
         when(advancedConfig.scoreboardPacketThreshold()).thenReturn(1_000);
 
         var logger = context.storeObject(new EmptyGeyserLogger());
-        when(geyserImpl.getLogger()).thenReturn(logger);
+        when(GeyserLogger.get()).thenReturn(logger);
 
         try (var geyserImplMock = mockStatic(GeyserImpl.class)) {
             geyserImplMock.when(GeyserImpl::getInstance).thenReturn(geyserImpl);


### PR DESCRIPTION
TLDR; Any reference to GeyserImpl#getLogger() has been replaced with GeyserLogger#get() (A static method), this prevents the boilerplate of `GeyserImpl.getInstance().getLogger()`, this should help to improve the length of logging line, it also improves debug logging by a bit.

Other than that, this PR introduces some handy debugging commands, allowing you to add session debug flags that will apply when a user joins, currently there is only three:
- FORCE_DISABLE_PACKS
  - Does what it says on the tin, will make sure this user *never* gets a resource pack.
- FORCE_OPTIONAL_PACKS
  - Forces the packs to be optional to the client, this allows for declining if required.
- FORCE_VIBRANT_VISUALS
  - This option allows server owners to force Vibrant Visual support in order to test if it compatible with their server.

These can be enabled via `/geyser debug player options [xuid] [option_name]`.

There are also the following commands:
- `/geyser debug logging [enabled]`
  - Will toggle Geyser debug-mode in real time so getting debug logs is easier
- `/geyser debug heapdump [live]`
  - Will produce a heapdump from Geyser, optionally capturing "live" obejcts