### PR TITLE
Indicate Minecraft: Bedrock Edition 26.33 support

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ Special thanks to the DragonProxy project for being a trailblazer in protocol tr
 
 | Edition | Supported Versions                                                                                         |
 |---------|------------------------------------------------------------------------------------------------------------|
-| Bedrock | 26.0, 26.1, 26.2, 26.3, 26.10, 26.20, 26.21, 26.22, 26.23, 26.30, 26.31, 26.32                             |
+| Bedrock | 26.0, 26.1, 26.2, 26.3, 26.10, 26.20, 26.21, 26.22, 26.23, 26.30, 26.31, 26.32, 26.33                      |
 | Java    | 26.1 - 26.1.2 (For older versions, [see this guide](https://geysermc.org/wiki/geyser/supported-versions/)) |
 
 ## Setting Up

--- a/core/src/main/java/org/geysermc/geyser/network/GameProtocol.java
+++ b/core/src/main/java/org/geysermc/geyser/network/GameProtocol.java
@@ -85,7 +85,7 @@ public final class GameProtocol {
         register(Bedrock_v924.CODEC, "26.0", "26.1", "26.2", "26.3");
         register(Bedrock_v944.CODEC, "26.10");
         register(Bedrock_v975.CODEC, "26.20", "26.21", "26.22", "26.23");
-        register(Bedrock_v1001.CODEC, "26.30", "26.31", "26.32");
+        register(Bedrock_v1001.CODEC, "26.30", "26.31", "26.32", "26.33");
 
         MinecraftVersion latestBedrock = SUPPORTED_BEDROCK_VERSIONS.getLast();
         DEFAULT_BEDROCK_VERSION = latestBedrock.versionString();


### PR DESCRIPTION
This pull request updates the GameProtocol.java and the README.md file to include Minecraft: Bedrock Edition 26.33.