### PR TITLE
Allow for config stage forms

### DIFF
--- a/core/src/main/java/org/geysermc/geyser/session/GeyserSession.java
+++ b/core/src/main/java/org/geysermc/geyser/session/GeyserSession.java
@@ -1859,6 +1859,10 @@ public class GeyserSession implements GeyserConnection, GeyserCommandSource {
 
     @Override
     public boolean sendForm(@NonNull Form form) {
+        // Check if we're in the config stage, if so, prepare the client for forms
+        if (this.downstream != null && this.downstream.getSession().getPacketProtocol().getInboundState().equals(ProtocolState.CONFIGURATION)) {
+            this.prepareForConfigurationForm();
+        }
         // First close any dialogs that are open. This won't execute the dialog's closing action.
         dialogManager.close();
         return doSendForm(form);


### PR DESCRIPTION
This PR allows for forms to be sent during the config stage correctly.

> [!WARNING]
> You, the end-user, must block the config stage **and** unblock it for this to work, we may introduce API for this later in order to improve this.