### PR TITLE
fix: fallback to overworld clock when ViaVersion strips dimension data

### DIFF
--- a/core/src/main/java/org/geysermc/geyser/level/JavaDimension.java
+++ b/core/src/main/java/org/geysermc/geyser/level/JavaDimension.java
@@ -92,6 +92,12 @@ public record JavaDimension(int minY, int height, boolean piglinSafe, boolean ul
         if (defaultClock == null) {
             defaultClock = COMMON_CLOCKS.get(entry.id());
         }
+        // ViaVersion may strip or rename the dimension key, so COMMON_CLOCKS might not match.
+        // This is a heuristic fallback, not a strict mapping: any non-nether dimension without
+        // a known clock defaults to overworld to avoid a frozen sky for Bedrock players.
+        if (defaultClock == null && !isNetherLike) {
+            defaultClock = MinecraftKey.key("overworld");
+        }
 
         if (minY % 16 != 0) {
             throw new RuntimeException("Minimum Y must be a multiple of 16!");


### PR DESCRIPTION
## What
ViaVersion translating 1.21.11 → 1.26.2 removes the `default_clock` field from dimension data. The existing `COMMON_CLOCKS` map only matched exact `overworld` and `the_end` keys, which fails when ViaVersion changes the dimension namespace. Bedrock players see a frozen sky stuck at daytime.

## Fix
Added a general fallback: if no clock was resolved by either the packet data or the `COMMON_CLOCKS` map, and the dimension is not nether-like, default to the overworld clock. This covers custom Multiverse dimensions and any namespaced keys ViaVersion produces.

## Testing
- 1.21.11 server + Velocity 4.0 + ViaVersion + Geyser
- Multiverse worlds (spawn, pvp, custom) now have proper day/night cycle for Bedrock players
- Nether remains dark (no clock, as expected)
- The End continues to use its own clock

Closes #6449