### PR TITLE
fix: use Bedrock's spectator gamemode on 26.40 and above

### DIFF
--- a/core/src/main/java/org/geysermc/geyser/session/GeyserSession.java
+++ b/core/src/main/java/org/geysermc/geyser/session/GeyserSession.java
@@ -1988,7 +1988,7 @@ public class GeyserSession implements GeyserConnection, GeyserCommandSource {
         StartGamePacket startGamePacket = new StartGamePacket();
         startGamePacket.setUniqueEntityId(playerEntity.geyserId());
         startGamePacket.setRuntimeEntityId(playerEntity.geyserId());
-        startGamePacket.setPlayerGameType(EntityUtils.toBedrockGamemode(gameMode));
+        startGamePacket.setPlayerGameType(EntityUtils.toBedrockGamemode(gameMode, this));
         startGamePacket.setPlayerPosition(Vector3f.from(0, 69, 0));
         startGamePacket.setRotation(Vector2f.from(1, 1));
 

--- a/core/src/main/java/org/geysermc/geyser/translator/protocol/bedrock/entity/player/BedrockSetDefaultGameTypeTranslator.java
+++ b/core/src/main/java/org/geysermc/geyser/translator/protocol/bedrock/entity/player/BedrockSetDefaultGameTypeTranslator.java
@@ -48,7 +48,7 @@ public class BedrockSetDefaultGameTypeTranslator extends PacketTranslator<SetDef
         // Stop the client from updating their own Gamemode without telling the server
         // Can occur when client Gamemode is set to "default", and default game mode is changed.
         SetPlayerGameTypePacket playerGameTypePacket = new SetPlayerGameTypePacket();
-        playerGameTypePacket.setGamemode(EntityUtils.toBedrockGamemode(session.getGameMode()).ordinal());
+        playerGameTypePacket.setGamemode(EntityUtils.toBedrockGamemode(session.getGameMode(), session).ordinal());
         session.sendUpstreamPacket(playerGameTypePacket);
     }
 }

--- a/core/src/main/java/org/geysermc/geyser/translator/protocol/bedrock/entity/player/BedrockSetPlayerGameTypeTranslator.java
+++ b/core/src/main/java/org/geysermc/geyser/translator/protocol/bedrock/entity/player/BedrockSetPlayerGameTypeTranslator.java
@@ -47,7 +47,7 @@ public class BedrockSetPlayerGameTypeTranslator extends PacketTranslator<SetPlay
     public void translate(GeyserSession session, SetPlayerGameTypePacket packet) {
         // Revert to current game mode first - gamemode sending will be done server-authorative
         SetPlayerGameTypePacket playerGameTypePacket = new SetPlayerGameTypePacket();
-        playerGameTypePacket.setGamemode(EntityUtils.toBedrockGamemode(session.getGameMode()).ordinal());
+        playerGameTypePacket.setGamemode(EntityUtils.toBedrockGamemode(session.getGameMode(), session).ordinal());
         session.sendUpstreamPacket(playerGameTypePacket);
 
         // We will still inform the server that we want to change gamemodes, granted we have the permission to

--- a/core/src/main/java/org/geysermc/geyser/translator/protocol/java/JavaLoginTranslator.java
+++ b/core/src/main/java/org/geysermc/geyser/translator/protocol/java/JavaLoginTranslator.java
@@ -103,7 +103,7 @@ public class JavaLoginTranslator extends PacketTranslator<ClientboundLoginPacket
             session.getUpstream().sendPostStartGamePackets();
         } else {
             SetPlayerGameTypePacket playerGameTypePacket = new SetPlayerGameTypePacket();
-            playerGameTypePacket.setGamemode(EntityUtils.toBedrockGamemode(spawnInfo.getGameMode()).ordinal());
+            playerGameTypePacket.setGamemode(EntityUtils.toBedrockGamemode(spawnInfo.getGameMode(), session).ordinal());
             session.sendUpstreamPacket(playerGameTypePacket);
         }
 

--- a/core/src/main/java/org/geysermc/geyser/translator/protocol/java/JavaRespawnTranslator.java
+++ b/core/src/main/java/org/geysermc/geyser/translator/protocol/java/JavaRespawnTranslator.java
@@ -71,7 +71,7 @@ public class JavaRespawnTranslator extends PacketTranslator<ClientboundRespawnPa
         entity.updateBedrockMetadata();
 
         SetPlayerGameTypePacket playerGameTypePacket = new SetPlayerGameTypePacket();
-        playerGameTypePacket.setGamemode(EntityUtils.toBedrockGamemode(spawnInfo.getGameMode()).ordinal());
+        playerGameTypePacket.setGamemode(EntityUtils.toBedrockGamemode(spawnInfo.getGameMode(), session).ordinal());
         session.sendUpstreamPacket(playerGameTypePacket);
         session.setGameMode(spawnInfo.getGameMode());
 

--- a/core/src/main/java/org/geysermc/geyser/translator/protocol/java/level/JavaGameEventTranslator.java
+++ b/core/src/main/java/org/geysermc/geyser/translator/protocol/java/level/JavaGameEventTranslator.java
@@ -79,7 +79,7 @@ public class JavaGameEventTranslator extends PacketTranslator<ClientboundGameEve
                 GameMode gameMode = (GameMode) packet.getValue();
 
                 SetPlayerGameTypePacket playerGameTypePacket = new SetPlayerGameTypePacket();
-                playerGameTypePacket.setGamemode(EntityUtils.toBedrockGamemode(gameMode).ordinal());
+                playerGameTypePacket.setGamemode(EntityUtils.toBedrockGamemode(gameMode, session).ordinal());
                 session.sendUpstreamPacket(playerGameTypePacket);
                 session.setGameMode(gameMode);
 

--- a/core/src/main/java/org/geysermc/geyser/util/EntityUtils.java
+++ b/core/src/main/java/org/geysermc/geyser/util/EntityUtils.java
@@ -64,6 +64,7 @@ import org.geysermc.geyser.entity.type.living.animal.horse.CamelEntity;
 import org.geysermc.geyser.inventory.GeyserItemStack;
 import org.geysermc.geyser.item.Items;
 import org.geysermc.geyser.registry.Registries;
+import org.geysermc.geyser.network.GameProtocol;
 import org.geysermc.geyser.session.GeyserSession;
 import org.geysermc.geyser.session.cache.registry.JavaRegistries;
 import org.geysermc.geyser.session.cache.tags.GeyserHolderSet;
@@ -322,12 +323,18 @@ public final class EntityUtils {
      * Convert Java GameMode to Bedrock GameType
      * Needed to account for ordinal differences (spectator is 3 in Java, 6 in Bedrock)
      */
-    @SuppressWarnings("deprecation") // Must use survival_viewer due to limitations on Bedrock's spectator gamemode
-    public static GameType toBedrockGamemode(GameMode gamemode) {
+    @SuppressWarnings("deprecation") // survival_viewer is still what pre-26.40 clients need for spectator
+    public static GameType toBedrockGamemode(GameMode gamemode, GeyserSession session) {
         return switch (gamemode) {
             case CREATIVE -> GameType.CREATIVE;
             case ADVENTURE -> GameType.ADVENTURE;
-            case SPECTATOR -> GameType.SURVIVAL_VIEWER;
+            // 26.40 clients hang up on their own when told to apply survival_viewer:
+            // no packet violation warning, nothing logged server side, the client just
+            // reports error code "Block" and drops. Bedrock has a real spectator
+            // gamemode these days, so use it where the client understands it.
+            case SPECTATOR -> GameProtocol.is26_40orHigher(session.protocolVersion())
+                    ? GameType.SPECTATOR
+                    : GameType.SURVIVAL_VIEWER;
             default -> GameType.SURVIVAL;
         };
     }


### PR DESCRIPTION
# Use Bedrock's spectator gamemode on 26.40 and above

## Problem

Bedrock clients on 26.40 drop the connection on their own as soon as they are told to apply spectator mode. The client shows a generic "connection failed" screen with error code `Block`. There is no packet violation warning, no exception, and nothing in the server log beyond the disconnect itself:

```
[INFO] Spawned player at (0.0, 64.0, 0.0)
[INFO] Sending command packet of 5 commands
[INFO] Loaded Local Bedrock Java Skin Data for HereGarlic37777
[INFO] HereGarlic37777 has disconnected from remote Java server because of Bedrock client disconnected
```

Java clients connecting to the same server are unaffected.

## Cause

`EntityUtils.toBedrockGamemode` maps Java `SPECTATOR` to Bedrock's `SURVIVAL_VIEWER`:

```java
@SuppressWarnings("deprecation") // Must use survival_viewer due to limitations on Bedrock's spectator gamemode
case SPECTATOR -> GameType.SURVIVAL_VIEWER;
```

That value has been deprecated for a while, and 26.40 clients no longer accept it. Bedrock has had a working spectator gamemode for several releases, so the workaround is no longer needed on current clients.

## Fix

Pick the real spectator gamemode where the client understands it, keep the legacy value below 26.40:

```java
case SPECTATOR -> GameProtocol.is26_40orHigher(session.protocolVersion())
        ? GameType.SPECTATOR
        : GameType.SURVIVAL_VIEWER;
```

`toBedrockGamemode` gains a `GeyserSession` parameter for the version check. All six call sites already had the session at hand.

## How this was narrowed down

Reproduced with a minimal setup of Geyser 2.11.1-b1208 standalone plus a bare Java server, no proxy, no plugins, no resource packs, no extensions. Against a Paper server the same client joins fine; against a server that puts the player in spectator on join it fails every time.

Varying only the server side game mode:

| Game mode | Result |
|---|---|
| survival | joins |
| creative | joins |
| adventure | joins |
| spectator | client disconnects itself |

With this change spectator joins as well, and the player arrives in Bedrock's spectator mode.

## Scope

This affects any Java server that puts a Bedrock player into spectator during the join sequence. Limbo servers are where it shows up immediately because several of them default to spectator, but hub servers with a spectator lobby or minigames that spectate players after death will hit the same thing.

## Testing

* Bedrock 26.40 (Windows GDK) against a spectator server, before and after the change
* Bedrock 26.40 against Paper 26.2 to confirm the other game modes still behave
* Built and deployed as a Velocity plugin on a live network with Floodgate, spectator limbo, and Bedrock players joining through it
