### PR TITLE
Fix spectator gamemode crashing clients when set on join.

### DIFF
--- a/core/src/main/java/org/geysermc/geyser/session/GeyserSession.java
+++ b/core/src/main/java/org/geysermc/geyser/session/GeyserSession.java
@@ -94,6 +94,7 @@ import org.cloudburstmc.protocol.bedrock.packet.NetworkStackLatencyPacket;
 import org.cloudburstmc.protocol.bedrock.packet.PlayStatusPacket;
 import org.cloudburstmc.protocol.bedrock.packet.SetCommandsEnabledPacket;
 import org.cloudburstmc.protocol.bedrock.packet.SetEntityMotionPacket;
+import org.cloudburstmc.protocol.bedrock.packet.SetPlayerGameTypePacket;
 import org.cloudburstmc.protocol.bedrock.packet.SetTimePacket;
 import org.cloudburstmc.protocol.bedrock.packet.StartGamePacket;
 import org.cloudburstmc.protocol.bedrock.packet.SyncEntityPropertyPacket;
@@ -847,6 +848,8 @@ public class GeyserSession implements GeyserConnection, GeyserCommandSource {
     private final Set<InputLocksFlag> inputLocksSet = EnumSet.noneOf(InputLocksFlag.class);
     private boolean inputLockDirty;
 
+    private boolean pendingSpectator = false;
+
     public GeyserSession(GeyserImpl geyser, BedrockServerSession bedrockServerSession, EventLoop tickEventLoop) {
         this.geyser = geyser;
         this.upstream = new UpstreamSession(bedrockServerSession);
@@ -936,6 +939,13 @@ public class GeyserSession implements GeyserConnection, GeyserCommandSource {
         sendInitialPlayerState();
         sendInitialGameRules();
         resetTimeParameters();
+
+        if (pendingSpectator) {
+            pendingSpectator = false;
+            SetPlayerGameTypePacket gameTypePacket = new SetPlayerGameTypePacket();
+            gameTypePacket.setGamemode(GameType.SURVIVAL_VIEWER.ordinal());
+            this.upstream.sendPacket(gameTypePacket);
+        }
     }
 
     /**
@@ -1988,7 +1998,12 @@ public class GeyserSession implements GeyserConnection, GeyserCommandSource {
         StartGamePacket startGamePacket = new StartGamePacket();
         startGamePacket.setUniqueEntityId(playerEntity.geyserId());
         startGamePacket.setRuntimeEntityId(playerEntity.geyserId());
-        startGamePacket.setPlayerGameType(EntityUtils.toBedrockGamemode(gameMode));
+        GameType gameType = EntityUtils.toBedrockGamemode(gameMode);
+        if (gameType == GameType.SURVIVAL_VIEWER && GameProtocol.is26_40orHigher(this.protocolVersion())) {
+            gameType = GameType.SURVIVAL;
+            pendingSpectator = true;
+        }
+        startGamePacket.setPlayerGameType(gameType);
         startGamePacket.setPlayerPosition(Vector3f.from(0, 69, 0));
         startGamePacket.setRotation(Vector2f.from(1, 1));
 


### PR DESCRIPTION
Only sends the proper game type after start game, as `survival_viewer` no longer exists in the start game packet, and will cause a disconnect if sent anyway