### PR TITLE
Fix: Passenger y-offset when riding a player

### DIFF
--- a/core/src/main/java/org/geysermc/geyser/util/EntityUtils.java
+++ b/core/src/main/java/org/geysermc/geyser/util/EntityUtils.java
@@ -128,6 +128,7 @@ public final class EntityUtils {
             }
             case PIGLIN -> mountedHeightOffset = height * 0.92f;
             case PHANTOM -> mountedHeightOffset = height * 0.35f;
+            case PLAYER, MANNEQUIN -> mountedHeightOffset = height;
             case RAVAGER -> mountedHeightOffset = 2.1f;
             case SKELETON_HORSE -> mountedHeightOffset -= 0.1875f;
             case SNIFFER -> mountedHeightOffset = 1.8f;


### PR DESCRIPTION
`getMountedHeightOffset` has no `PLAYER` case, so a player vehicle falls through to the default `height * 0.75f` = 1.35. Since 1.20.2 Java positions passengers via `EntityAttachments`, and `Avatar` / `EntityType.PLAYER` declare only a `VEHICLE` attachment, so `EntityAttachment.PASSENGER` falls back to `AT_HEIGHT` = the full 1.80.

The `height * 0.75f` default is left over from the pre-1.20.2 `Entity#getPassengersRidingOffset()` that the attachments refactor removed. Nothing in vanilla rides a player (`/ride` even refuses it), so this only shows up with plugins, which is presumably why it went unnoticed.

`MANNEQUIN` shares `avatarEntityBase` and the same dimensions. Tested against a cosmetic plugin that mounts marker armor stands on players.

<img width="2560" height="1600" alt="Snímek obrazovky (1650)" src="https://github.com/user-attachments/assets/89ad3547-93c4-49ae-8731-33cce566ccd2" />
