### PR TITLE
Add extensible server-authoritative custom block breaking

### DIFF
--- a/api/src/main/java/org/geysermc/geyser/api/block/custom/CustomBlockBreakProgress.java
+++ b/api/src/main/java/org/geysermc/geyser/api/block/custom/CustomBlockBreakProgress.java
@@ -1,0 +1,38 @@
+/*
+ * Copyright (c) 2019-2026 GeyserMC. http://geysermc.org
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+package org.geysermc.geyser.api.block.custom;
+
+/**
+ * Server-authoritative custom block mining information.
+ *
+ * @param progressPerTick progress added by one Java server tick, in the range {@code [0, 1]}
+ * @param continuousSwing whether Geyser should forward one arm swing per Java tick while mining
+ */
+public record CustomBlockBreakProgress(float progressPerTick, boolean continuousSwing) {
+
+    public CustomBlockBreakProgress {
+        if (!Float.isFinite(progressPerTick) || progressPerTick < 0.0f) {
+            throw new IllegalArgumentException("progressPerTick must be finite and non-negative");
+        }
+    }
+}

--- a/api/src/main/java/org/geysermc/geyser/api/block/custom/CustomBlockBreakProgressProvider.java
+++ b/api/src/main/java/org/geysermc/geyser/api/block/custom/CustomBlockBreakProgressProvider.java
@@ -1,0 +1,36 @@
+/*
+ * Copyright (c) 2019-2026 GeyserMC. http://geysermc.org
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+package org.geysermc.geyser.api.block.custom;
+
+import org.geysermc.geyser.api.connection.GeyserConnection;
+import org.jspecify.annotations.Nullable;
+
+/** Supplies authoritative mining progress for server-managed custom blocks. */
+@FunctionalInterface
+public interface CustomBlockBreakProgressProvider {
+
+    /**
+     * @return mining information, or {@code null} when this provider does not own the block
+     */
+    @Nullable CustomBlockBreakProgress progress(GeyserConnection connection, int x, int y, int z);
+}

--- a/api/src/main/java/org/geysermc/geyser/api/block/custom/CustomBlockStateProvider.java
+++ b/api/src/main/java/org/geysermc/geyser/api/block/custom/CustomBlockStateProvider.java
@@ -1,0 +1,36 @@
+/*
+ * Copyright (c) 2019-2026 GeyserMC. http://geysermc.org
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+package org.geysermc.geyser.api.block.custom;
+
+import org.geysermc.geyser.api.connection.GeyserConnection;
+import org.jspecify.annotations.Nullable;
+
+/** Resolves a server-managed block to the vanilla Java state used by custom mappings. */
+@FunctionalInterface
+public interface CustomBlockStateProvider {
+
+    /**
+     * @return a complete Java block-state identifier, or {@code null} when not handled
+     */
+    @Nullable String javaBlockState(GeyserConnection connection, int x, int y, int z);
+}

--- a/api/src/main/java/org/geysermc/geyser/api/event/lifecycle/GeyserDefineCustomBlocksEvent.java
+++ b/api/src/main/java/org/geysermc/geyser/api/event/lifecycle/GeyserDefineCustomBlocksEvent.java
@@ -26,7 +26,9 @@
 package org.geysermc.geyser.api.event.lifecycle;
 
 import org.geysermc.geyser.api.block.custom.CustomBlockData;
+import org.geysermc.geyser.api.block.custom.CustomBlockBreakProgressProvider;
 import org.geysermc.geyser.api.block.custom.CustomBlockState;
+import org.geysermc.geyser.api.block.custom.CustomBlockStateProvider;
 import org.geysermc.geyser.api.block.custom.nonvanilla.JavaBlockState;
 import org.geysermc.event.Event;
 
@@ -36,6 +38,16 @@ import org.geysermc.event.Event;
  * This event will not be called if the "add-non-bedrock-items" setting is disabled in the Geyser config.
  */
 public abstract class GeyserDefineCustomBlocksEvent implements Event {
+
+    /**
+     * Registers a provider for resolving server-managed custom blocks to their
+     * mapped Java visual state.
+     */
+    public abstract void registerStateProvider(CustomBlockStateProvider provider);
+
+    /** Registers a provider for server-authoritative custom block mining progress. */
+    public abstract void registerBreakProgressProvider(CustomBlockBreakProgressProvider provider);
+
     /**
      * Registers the given {@link CustomBlockData} as a custom block
      *

--- a/bootstrap/spigot/src/main/java/org/geysermc/geyser/platform/spigot/world/manager/GeyserSpigotLegacyNativeWorldManager.java
+++ b/bootstrap/spigot/src/main/java/org/geysermc/geyser/platform/spigot/world/manager/GeyserSpigotLegacyNativeWorldManager.java
@@ -18,9 +18,6 @@
  * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
  * THE SOFTWARE.
- *
- * @author GeyserMC
- * @link https://github.com/GeyserMC/Geyser
  */
 
 package org.geysermc.geyser.platform.spigot.world.manager;
@@ -32,6 +29,8 @@ import com.viaversion.viaversion.api.protocol.version.ProtocolVersion;
 import it.unimi.dsi.fastutil.ints.Int2IntMap;
 import it.unimi.dsi.fastutil.ints.Int2IntOpenHashMap;
 import it.unimi.dsi.fastutil.ints.IntList;
+import org.bukkit.entity.Player;
+import org.geysermc.geyser.level.block.type.Block;
 import org.geysermc.geyser.network.GameProtocol;
 import org.geysermc.geyser.platform.spigot.GeyserSpigotPlugin;
 import org.geysermc.geyser.session.GeyserSession;
@@ -39,11 +38,8 @@ import org.geysermc.geyser.session.GeyserSession;
 import java.util.List;
 import java.util.Objects;
 
-/**
- * Used when block IDs need to be translated to the latest version
- */
+/** Used when block IDs need to be translated to the latest Java protocol version. */
 public class GeyserSpigotLegacyNativeWorldManager extends GeyserSpigotNativeWorldManager {
-
     private final Int2IntMap oldToNewBlockId;
 
     public GeyserSpigotLegacyNativeWorldManager(GeyserSpigotPlugin plugin, boolean isPaper) {
@@ -51,12 +47,12 @@ public class GeyserSpigotLegacyNativeWorldManager extends GeyserSpigotNativeWorl
         IntList allBlockStates = adapter.getAllBlockStates();
         oldToNewBlockId = new Int2IntOpenHashMap(allBlockStates.size());
         ProtocolVersion serverVersion = plugin.getServerProtocolVersion();
-        List<ProtocolPathEntry> protocolList = Via.getManager().getProtocolManager().getProtocolPath(GameProtocol.getJavaProtocolVersion(),
-                serverVersion.getVersion());
+        List<ProtocolPathEntry> protocolList = Via.getManager().getProtocolManager().getProtocolPath(
+                GameProtocol.getJavaProtocolVersion(), serverVersion.getVersion());
         Objects.requireNonNull(protocolList, "protocolList cannot be null");
+
         for (int oldBlockId : allBlockStates) {
             int newBlockId = oldBlockId;
-            // protocolList should *not* be null; we checked for that before initializing this class
             for (int i = protocolList.size() - 1; i >= 0; i--) {
                 MappingData mappingData = protocolList.get(i).protocol().getMappingData();
                 if (mappingData != null) {
@@ -69,7 +65,19 @@ public class GeyserSpigotLegacyNativeWorldManager extends GeyserSpigotNativeWorl
 
     @Override
     public int getBlockAt(GeyserSession session, int x, int y, int z) {
-        int nativeBlockId = super.getBlockAt(session, x, y, z);
+        Player player = resolvePlayer(session);
+        if (player == null) {
+            return Block.JAVA_AIR_ID;
+        }
+
+        // Provider results are already in current protocol space and must not
+        // be translated through the legacy native-id mapping table.
+        Integer customState = resolveCustomBlockStateId(session, x, y, z);
+        if (customState != null) {
+            return customState;
+        }
+
+        int nativeBlockId = adapter.getBlockAt(player.getWorld(), x, y, z);
         return oldToNewBlockId.getOrDefault(nativeBlockId, nativeBlockId);
     }
 

--- a/bootstrap/spigot/src/main/java/org/geysermc/geyser/platform/spigot/world/manager/GeyserSpigotNativeWorldManager.java
+++ b/bootstrap/spigot/src/main/java/org/geysermc/geyser/platform/spigot/world/manager/GeyserSpigotNativeWorldManager.java
@@ -18,9 +18,6 @@
  * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
  * THE SOFTWARE.
- *
- * @author GeyserMC
- * @link https://github.com/GeyserMC/Geyser
  */
 
 package org.geysermc.geyser.platform.spigot.world.manager;
@@ -41,27 +38,26 @@ public class GeyserSpigotNativeWorldManager extends GeyserSpigotWorldManager {
 
     public GeyserSpigotNativeWorldManager(Plugin plugin, boolean isPaper) {
         super(plugin);
-        if (isPaper) {
-            adapter = PaperAdapters.getWorldAdapter();
-        } else {
-            adapter = SpigotAdapters.getWorldAdapter();
-        }
+        this.adapter = isPaper ? PaperAdapters.getWorldAdapter() : SpigotAdapters.getWorldAdapter();
     }
 
     @Override
     public int getBlockAt(GeyserSession session, int x, int y, int z) {
-        Player player = Bukkit.getPlayer(session.getPlayerEntity().getUsername());
+        Player player = resolvePlayer(session);
         if (player == null) {
             return Block.JAVA_AIR_ID;
         }
-        return adapter.getBlockAt(player.getWorld(), x, y, z);
+
+        Integer customState = resolveCustomBlockStateId(session, x, y, z);
+        return customState != null ? customState : adapter.getBlockAt(player.getWorld(), x, y, z);
     }
 
-    @Nullable
+    protected final @Nullable Player resolvePlayer(GeyserSession session) {
+        return Bukkit.getPlayer(session.getPlayerEntity().getUsername());
+    }
+
     @Override
-    public String[] getBiomeIdentifiers(boolean withTags) {
-        // Biome identifiers will basically always be the same for one server, since you have to re-send the
-        // ClientboundLoginPacket to change the registry. Therefore, don't bother caching for each player.
+    public @Nullable String[] getBiomeIdentifiers(boolean withTags) {
         return adapter.getBiomeSuggestions(withTags);
     }
 }

--- a/bootstrap/spigot/src/main/java/org/geysermc/geyser/platform/spigot/world/manager/GeyserSpigotWorldManager.java
+++ b/bootstrap/spigot/src/main/java/org/geysermc/geyser/platform/spigot/world/manager/GeyserSpigotWorldManager.java
@@ -31,11 +31,13 @@ import org.bukkit.block.Block;
 import org.bukkit.block.DecoratedPot;
 import org.bukkit.entity.Player;
 import org.bukkit.plugin.Plugin;
+import org.checkerframework.checker.nullness.qual.Nullable;
 import org.cloudburstmc.math.vector.Vector3i;
 import org.geysermc.erosion.bukkit.BukkitUtils;
 import org.geysermc.erosion.bukkit.SchedulerUtils;
 import org.geysermc.geyser.level.WorldManager;
 import org.geysermc.geyser.registry.BlockRegistries;
+import org.geysermc.geyser.registry.populator.CustomBlockRegistryPopulator;
 import org.geysermc.geyser.session.GeyserSession;
 import org.geysermc.mcprotocollib.protocol.data.game.entity.player.GameMode;
 
@@ -65,17 +67,37 @@ public class GeyserSpigotWorldManager extends WorldManager {
             return org.geysermc.geyser.level.block.type.Block.JAVA_AIR_ID;
         }
 
-        return getBlockNetworkId(world.getBlockAt(x, y, z));
+        return getBlockNetworkId(session, world.getBlockAt(x, y, z));
     }
 
     public int getBlockNetworkId(Block block) {
+        return getBlockNetworkId(null, block);
+    }
+
+    private int getBlockNetworkId(@Nullable GeyserSession session, Block block) {
         if (SchedulerUtils.FOLIA && !Bukkit.isOwnedByCurrentRegion(block)) {
-            // Terrible behavior, but this is basically what's always been happening behind the scenes anyway.
-            CompletableFuture<String> blockData = new CompletableFuture<>();
-            Bukkit.getRegionScheduler().execute(this.plugin, block.getLocation(), () -> blockData.complete(block.getBlockData().getAsString()));
-            return BlockRegistries.JAVA_BLOCK_STATE_IDENTIFIER_TO_ID.getOrDefault(blockData.join(), org.geysermc.geyser.level.block.type.Block.JAVA_AIR_ID);
+            CompletableFuture<Integer> blockData = new CompletableFuture<>();
+            Bukkit.getRegionScheduler().execute(this.plugin, block.getLocation(),
+                    () -> blockData.complete(resolve(session, block)));
+            return blockData.join();
         }
-        return BlockRegistries.JAVA_BLOCK_STATE_IDENTIFIER_TO_ID.getOrDefault(block.getBlockData().getAsString(), org.geysermc.geyser.level.block.type.Block.JAVA_AIR_ID); // TODO could just make this a BlockState lookup?
+        return resolve(session, block);
+    }
+
+    private int resolve(@Nullable GeyserSession session, Block block) {
+        if (session != null) {
+            Integer customState = resolveCustomBlockStateId(session, block.getX(), block.getY(), block.getZ());
+            if (customState != null) {
+                return customState;
+            }
+        }
+        return BlockRegistries.JAVA_BLOCK_STATE_IDENTIFIER_TO_ID.getOrDefault(block.getBlockData().getAsString(),
+                org.geysermc.geyser.level.block.type.Block.JAVA_AIR_ID);
+    }
+
+    protected final @Nullable Integer resolveCustomBlockStateId(GeyserSession session, int x, int y, int z) {
+        String state = CustomBlockRegistryPopulator.resolveJavaBlockState(session, x, y, z);
+        return state == null ? null : BlockRegistries.JAVA_BLOCK_STATE_IDENTIFIER_TO_ID.get(state);
     }
 
     @Override

--- a/core/src/main/java/org/geysermc/geyser/registry/populator/CustomBlockRegistryPopulator.java
+++ b/core/src/main/java/org/geysermc/geyser/registry/populator/CustomBlockRegistryPopulator.java
@@ -37,8 +37,12 @@ import org.cloudburstmc.nbt.NbtType;
 import org.cloudburstmc.protocol.bedrock.data.BlockPropertyData;
 import org.geysermc.geyser.GeyserImpl;
 import org.geysermc.geyser.api.block.custom.CustomBlockData;
+import org.geysermc.geyser.api.block.custom.CustomBlockBreakProgress;
+import org.geysermc.geyser.api.block.custom.CustomBlockBreakProgressProvider;
 import org.geysermc.geyser.api.block.custom.CustomBlockPermutation;
 import org.geysermc.geyser.api.block.custom.CustomBlockState;
+import org.geysermc.geyser.api.block.custom.CustomBlockStateProvider;
+import org.geysermc.geyser.api.connection.GeyserConnection;
 import org.geysermc.geyser.api.block.custom.component.BoxComponent;
 import org.geysermc.geyser.api.block.custom.component.CustomBlockComponents;
 import org.geysermc.geyser.api.block.custom.component.GeometryComponent;
@@ -63,6 +67,7 @@ import org.geysermc.geyser.registry.type.CustomSkull;
 import org.geysermc.geyser.translator.collision.OtherCollision;
 import org.geysermc.geyser.util.BlockUtils;
 import org.geysermc.geyser.util.MathUtils;
+import org.jspecify.annotations.Nullable;
 
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -117,6 +122,28 @@ public class CustomBlockRegistryPopulator {
     private static Map<String, CustomBlockData> CUSTOM_BLOCK_ITEM_OVERRIDES;
     private static Map<JavaBlockState, CustomBlockState> NON_VANILLA_BLOCK_STATE_OVERRIDES;
     private static Map<String, CustomBlockState> BLOCK_STATE_OVERRIDES_QUEUE;
+    private static List<CustomBlockStateProvider> CUSTOM_BLOCK_STATE_PROVIDERS = List.of();
+    private static List<CustomBlockBreakProgressProvider> CUSTOM_BLOCK_BREAK_PROGRESS_PROVIDERS = List.of();
+
+    public static @Nullable String resolveJavaBlockState(GeyserConnection connection, int x, int y, int z) {
+        for (CustomBlockStateProvider provider : CUSTOM_BLOCK_STATE_PROVIDERS) {
+            String state = provider.javaBlockState(connection, x, y, z);
+            if (state != null) {
+                return state;
+            }
+        }
+        return null;
+    }
+
+    public static @Nullable CustomBlockBreakProgress resolveBreakProgress(GeyserConnection connection, int x, int y, int z) {
+        for (CustomBlockBreakProgressProvider provider : CUSTOM_BLOCK_BREAK_PROGRESS_PROVIDERS) {
+            CustomBlockBreakProgress progress = provider.progress(connection, x, y, z);
+            if (progress != null) {
+                return progress;
+            }
+        }
+        return null;
+    }
 
     /**
      * Initializes custom blocks defined by API
@@ -126,9 +153,21 @@ public class CustomBlockRegistryPopulator {
         CUSTOM_BLOCK_ITEM_OVERRIDES = new HashMap<>();
         NON_VANILLA_BLOCK_STATE_OVERRIDES = new HashMap<>();
         BLOCK_STATE_OVERRIDES_QUEUE = new HashMap<>();
+        List<CustomBlockStateProvider> stateProviders = new ArrayList<>();
+        List<CustomBlockBreakProgressProvider> breakProgressProviders = new ArrayList<>();
 
         Set<String> customBlockIdentifiers = new ObjectOpenHashSet<>();
         GeyserImpl.getInstance().getEventBus().fire(new GeyserDefineCustomBlocksEvent() {
+            @Override
+            public void registerStateProvider(@NonNull CustomBlockStateProvider provider) {
+                stateProviders.add(provider);
+            }
+
+            @Override
+            public void registerBreakProgressProvider(@NonNull CustomBlockBreakProgressProvider provider) {
+                breakProgressProviders.add(provider);
+            }
+
             @Override
             public void register(@NonNull CustomBlockData customBlockData) {
                 if (customBlockData.name().isEmpty()) {
@@ -168,6 +207,8 @@ public class CustomBlockRegistryPopulator {
                 NON_VANILLA_BLOCK_STATE_OVERRIDES.put(javaBlockState, customBlockState);
             }
         });
+        CUSTOM_BLOCK_STATE_PROVIDERS = List.copyOf(stateProviders);
+        CUSTOM_BLOCK_BREAK_PROGRESS_PROVIDERS = List.copyOf(breakProgressProviders);
     }
 
     /**

--- a/core/src/main/java/org/geysermc/geyser/session/cache/BlockBreakHandler.java
+++ b/core/src/main/java/org/geysermc/geyser/session/cache/BlockBreakHandler.java
@@ -42,6 +42,7 @@ import org.cloudburstmc.protocol.bedrock.data.definitions.ItemDefinition;
 import org.cloudburstmc.protocol.bedrock.packet.LevelEventPacket;
 import org.cloudburstmc.protocol.bedrock.packet.PlayerAuthInputPacket;
 import org.geysermc.geyser.GeyserImpl;
+import org.geysermc.geyser.api.block.custom.CustomBlockBreakProgress;
 import org.geysermc.geyser.api.block.custom.CustomBlockState;
 import org.geysermc.geyser.entity.type.Entity;
 import org.geysermc.geyser.entity.type.ItemFrameEntity;
@@ -54,6 +55,7 @@ import org.geysermc.geyser.level.block.type.LecternBlock;
 import org.geysermc.geyser.level.physics.Direction;
 import org.geysermc.geyser.registry.BlockRegistries;
 import org.geysermc.geyser.registry.Registries;
+import org.geysermc.geyser.registry.populator.CustomBlockRegistryPopulator;
 import org.geysermc.geyser.registry.type.ItemMapping;
 import org.geysermc.geyser.session.GeyserSession;
 import org.geysermc.geyser.translator.item.CustomItemTranslator;
@@ -69,6 +71,7 @@ import org.geysermc.mcprotocollib.protocol.data.game.item.component.DataComponen
 import org.geysermc.mcprotocollib.protocol.data.game.item.component.ToolData;
 import org.geysermc.mcprotocollib.protocol.packet.ingame.serverbound.player.ServerboundAttackPacket;
 import org.geysermc.mcprotocollib.protocol.packet.ingame.serverbound.player.ServerboundPlayerActionPacket;
+import org.geysermc.mcprotocollib.protocol.packet.ingame.serverbound.player.ServerboundSwingPacket;
 import org.geysermc.mcprotocollib.protocol.packet.ingame.serverbound.player.ServerboundUseItemOnPacket;
 
 import java.util.HashSet;
@@ -115,6 +118,20 @@ public class BlockBreakHandler {
     protected float currentProgress = 0.0F;
 
     /**
+     * Session tick on which custom-block progress was last accumulated.
+     * PlayerAuthInput packets can arrive more than once per Java game tick;
+     * counting every packet made Bedrock finish while Java observers were
+     * still around crack stage 3-4.
+     */
+    private int lastProgressSessionTick = -1;
+
+    /** Whether the active custom-block provider requires one Java swing per tick. */
+    private boolean continuousSwing = false;
+
+    /** Whether progress for the active block is supplied by a server-authoritative provider. */
+    private boolean authoritativeBreakProgress = false;
+
+    /**
      * The last known face of the block the client was breaking.
      * Only set when keeping track of custom blocks / custom items breaking blocks.
      */
@@ -148,6 +165,13 @@ public class BlockBreakHandler {
      */
     @Getter
     private final Cache<Vector3i, Pair<Long, BlockBreakStage>> destructionStageCache = CacheBuilder.newBuilder()
+        .maximumSize(200)
+        .expireAfterWrite(3, TimeUnit.MINUTES)
+        .build();
+
+    /** Stable Bedrock break speed estimated from Java destruction stages. */
+    @Getter
+    private final Cache<Vector3i, Integer> destructionSpeedCache = CacheBuilder.newBuilder()
         .maximumSize(200)
         .expireAfterWrite(3, TimeUnit.MINUTES)
         .build();
@@ -319,7 +343,12 @@ public class BlockBreakHandler {
         }
 
         // % block breaking progress in this tick
-        float breakProgress = calculateBreakProgress(state, position, item);
+        CustomBlockBreakProgress suppliedProgress = resolveBreakProgress(state, position);
+        this.authoritativeBreakProgress = suppliedProgress != null;
+        this.continuousSwing = suppliedProgress != null && suppliedProgress.continuousSwing();
+        float breakProgress = suppliedProgress != null
+                ? suppliedProgress.progressPerTick()
+                : calculateBreakProgress(state, position, item);
 
         // insta-breaking should be treated differently; don't send STOP_BREAK for these
         if (session.isInstabuild() || breakProgress >= 1.0F) {
@@ -342,7 +371,7 @@ public class BlockBreakHandler {
             LevelEventPacket startBreak = new LevelEventPacket();
             startBreak.setType(LevelEvent.BLOCK_START_BREAK);
             startBreak.setPosition(position.toFloat());
-            startBreak.setData((int) (65535 / BlockUtils.reciprocal(breakProgress)));
+            startBreak.setData(bedrockBreakSpeed(breakProgress));
             session.sendUpstreamPacket(startBreak);
 
             BlockUtils.spawnBlockBreakParticles(session, blockFace, position, state);
@@ -351,9 +380,10 @@ public class BlockBreakHandler {
             this.currentBlockPos = position;
             this.currentBlockState = state;
             this.currentItemStack = item;
-            // The Java client calls MultiPlayerGameMode#startDestroyBlock which would set this to zero,
-            // but also #continueDestroyBlock in the same tick to advance the break progress.
-            this.currentProgress = breakProgress;
+            // Server-authoritative providers start after START_DIGGING reaches the
+            // Java server. Vanilla handling includes the first local tick immediately.
+            this.currentProgress = authoritativeBreakProgress ? 0.0F : breakProgress;
+            this.lastProgressSessionTick = session.getTicks();
 
             session.sendDownstreamGamePacket(new ServerboundPlayerActionPacket(PlayerAction.START_DIGGING, position,
                 blockFace.mcpl(), session.getWorldCache().nextPredictionSequence()));
@@ -368,10 +398,24 @@ public class BlockBreakHandler {
         if (currentBlockState != null && Objects.equals(position, currentBlockPos) && sameItemStack()) {
             this.currentBlockFace = blockFace;
 
-            final float newProgress = calculateBreakProgress(state, position, session.getPlayerInventory().getItemInHand());
-            this.currentProgress = this.currentProgress + newProgress;
-            double totalBreakTime = BlockUtils.reciprocal(newProgress);
-
+            CustomBlockBreakProgress suppliedProgress = resolveBreakProgress(state, position);
+            this.authoritativeBreakProgress = suppliedProgress != null;
+            this.continuousSwing = suppliedProgress != null && suppliedProgress.continuousSwing();
+            final float newProgress = suppliedProgress != null
+                    ? suppliedProgress.progressPerTick()
+                    : calculateBreakProgress(state, position, session.getPlayerInventory().getItemInHand());
+            int sessionTick = session.getTicks();
+            int elapsedTicks = lastProgressSessionTick < 0 ? 0 : sessionTick - lastProgressSessionTick;
+            if (elapsedTicks > 0) {
+                if (continuousSwing) {
+                    session.sendDownstreamGamePacket(new ServerboundSwingPacket(Hand.MAIN_HAND));
+                }
+                // Progress providers and Geyser advance once per Java game tick.
+                // Capping protects against a stale handler after
+                // a long pause without creating a sudden instant break.
+                this.currentProgress += newProgress * Math.min(elapsedTicks, 5);
+                this.lastProgressSessionTick = sessionTick;
+            }
             if (sendParticles || (serverSideBlockBreaking && currentProgress % 4 == 0)) {
                 BlockUtils.spawnBlockBreakParticles(session, blockFace, position, state);
             }
@@ -392,7 +436,7 @@ public class BlockBreakHandler {
             LevelEventPacket updateBreak = new LevelEventPacket();
             updateBreak.setType(LevelEvent.BLOCK_UPDATE_BREAK);
             updateBreak.setPosition(position.toFloat());
-            updateBreak.setData((int) (65535 / totalBreakTime));
+            updateBreak.setData(bedrockBreakSpeed(newProgress));
             session.sendUpstreamPacket(updateBreak);
         } else {
             // Don't store last mined position; we don't want to ignore any actions now that we switched!
@@ -558,7 +602,10 @@ public class BlockBreakHandler {
 
     protected boolean mayBreak(float progress, boolean bedrockDestroyed) {
         // We're tolerant here to account for e.g. obsidian breaking speeds not matching 1:1 :(
-        return (serverSideBlockBreaking && progress >= 1.0F) || (bedrockDestroyed && progress >= 0.65F);
+        if (serverSideBlockBreaking) {
+            return progress >= 1.0F;
+        }
+        return bedrockDestroyed && progress >= 0.65F;
     }
 
     protected void destroyBlock(BlockState state, Vector3i vector, Direction direction, boolean instamine) {
@@ -578,6 +625,22 @@ public class BlockBreakHandler {
 
     protected float calculateBreakProgress(BlockState state, Vector3i vector, GeyserItemStack stack) {
         return BlockUtils.getBlockMiningProgressPerTick(session, state.block(), stack);
+    }
+
+    private @Nullable CustomBlockBreakProgress resolveBreakProgress(BlockState state, Vector3i position) {
+        if (BlockRegistries.CUSTOM_BLOCK_STATE_OVERRIDES.get(state.javaId()) == null
+                && !BlockRegistries.NON_VANILLA_BLOCK_IDS.get().get(state.javaId())) {
+            return null;
+        }
+        return CustomBlockRegistryPopulator.resolveBreakProgress(
+                session, position.getX(), position.getY(), position.getZ());
+    }
+
+    private static int bedrockBreakSpeed(float progressPerTick) {
+        if (!Float.isFinite(progressPerTick) || progressPerTick <= 0.0f) {
+            return 1;
+        }
+        return Math.clamp(Math.round(65535.0f * progressPerTick), 1, 65535);
     }
 
     /**
@@ -633,6 +696,9 @@ public class BlockBreakHandler {
         this.currentBlockState = null;
         this.currentBlockFace = null;
         this.currentProgress = 0.0F;
+        this.lastProgressSessionTick = -1;
+        this.continuousSwing = false;
+        this.authoritativeBreakProgress = false;
         this.currentItemStack = null;
         this.updatedServerBlockStateId = null;
     }
@@ -644,6 +710,18 @@ public class BlockBreakHandler {
         clearCurrentVariables();
         this.lastMinedPosition = null;
         this.destructionStageCache.invalidateAll();
+        this.destructionSpeedCache.invalidateAll();
+    }
+
+    /** Clears a remote Java destruction overlay when the block at its position changes. */
+    public boolean clearDestructionAt(Vector3i position) {
+        if (destructionStageCache.getIfPresent(position) == null) {
+            return false;
+        }
+        destructionStageCache.invalidate(position);
+        destructionSpeedCache.invalidate(position);
+        BlockUtils.sendBedrockStopBlockBreak(session, position.toFloat());
+        return true;
     }
 
     private static class BlockPredicateCache {

--- a/core/src/main/java/org/geysermc/geyser/session/cache/WorldCache.java
+++ b/core/src/main/java/org/geysermc/geyser/session/cache/WorldCache.java
@@ -182,6 +182,11 @@ public final class WorldCache {
     public void updateServerCorrectBlockState(Vector3i position, int blockState) {
         this.unverifiedPredictions.removeInt(position);
 
+        // A Java destruction overlay is independent of the block state itself.
+        // Explicitly clear it before replacing the block so the new state cannot
+        // inherit the previous block's final crack stage.
+        session.getBlockBreakHandler().clearDestructionAt(position);
+
         // Hack to avoid looking up blockstates for the currently broken position each tick
         Vector3i clientBreakPos = session.getBlockBreakHandler().getCurrentBlockPos();
         if (clientBreakPos != null && Objects.equals(clientBreakPos, position)) {

--- a/core/src/main/java/org/geysermc/geyser/translator/protocol/java/level/JavaBlockDestructionTranslator.java
+++ b/core/src/main/java/org/geysermc/geyser/translator/protocol/java/level/JavaBlockDestructionTranslator.java
@@ -41,9 +41,15 @@ public class JavaBlockDestructionTranslator extends PacketTranslator<Clientbound
     @Override
     public void translate(GeyserSession session, ClientboundBlockDestructionPacket packet) {
         if (packet.getStage() == BlockBreakStage.RESET) {
-            // Invalidate the position now that it's not being broken anymore
-            session.getBlockBreakHandler().getDestructionStageCache().invalidate(packet.getPosition());
-            BlockUtils.sendBedrockStopBlockBreak(session, packet.getPosition().toFloat());
+            if (!session.getBlockBreakHandler().clearDestructionAt(packet.getPosition())) {
+                BlockUtils.sendBedrockStopBlockBreak(session, packet.getPosition().toFloat());
+            }
+            return;
+        }
+
+        // Local mining already has a per-tick speed from BlockBreakHandler.
+        // Translating the server echo as well would make two animations compete.
+        if (packet.getPosition().equals(session.getBlockBreakHandler().getCurrentBlockPos())) {
             return;
         }
 
@@ -52,22 +58,42 @@ public class JavaBlockDestructionTranslator extends PacketTranslator<Clientbound
         levelEventPacket.setPosition(packet.getPosition().toFloat());
 
         // First: Check if we know when the last packet for this position was sent - we'll use that for our estimation
+        long currentTick = session.getTicks();
         Pair<Long, BlockBreakStage> lastUpdate = session.getBlockBreakHandler().getDestructionStageCache().getIfPresent(packet.getPosition());
+        if (lastUpdate != null && packet.getStage().compareTo(lastUpdate.second()) < 0) {
+            // A new mining sequence can start at the same position before a
+            // RESET packet arrives. Stop the old overlay instead of treating
+            // every stage of the new sequence as out-of-order.
+            session.getBlockBreakHandler().clearDestructionAt(packet.getPosition());
+            lastUpdate = null;
+        }
         if (lastUpdate == null) {
             levelEventPacket.setType(LevelEvent.BLOCK_START_BREAK);
             levelEventPacket.setData(65535 / 6000); // just a high value (5 mins), we'll update this once we get a new progress update
         } else {
-            // Ticks since last update
-            int ticksSince = (int) (session.getClientTicks() - lastUpdate.first());
+            int ticksSince = (int) (currentTick - lastUpdate.first());
             int stagesSince = packet.getStage().compareTo(lastUpdate.second());
-            int ticksPerStage = stagesSince == 0 ? ticksSince : ticksSince / stagesSince;
-            int remainingStages = 10 - packet.getStage().ordinal();
+            if (ticksSince <= 0 || stagesSince <= 0) {
+                return;
+            }
+
+            Integer stableSpeed = session.getBlockBreakHandler().getDestructionSpeedCache().getIfPresent(packet.getPosition());
+            if (stableSpeed == null) {
+                // The Bedrock animation started close to zero. Estimate the
+                // server's stage rate once, then choose one stable speed that
+                // catches up and reaches 100% at the same time as Java.
+                float serverProgressPerTick = stagesSince / (10.0f * ticksSince);
+                float serverProgress = Math.clamp(packet.getStage().ordinal() / 10.0f, 0.0f, 0.9f);
+                int remainingTicks = Math.max(1, Math.round((1.0f - serverProgress) / serverProgressPerTick));
+                stableSpeed = Math.clamp(Math.round(65535.0f / remainingTicks), 1, 65535);
+                session.getBlockBreakHandler().getDestructionSpeedCache().put(packet.getPosition(), stableSpeed);
+            }
 
             levelEventPacket.setType(LevelEvent.BLOCK_UPDATE_BREAK);
-            levelEventPacket.setData(65535 / Math.max(remainingStages, 1) * Math.max(ticksPerStage, 1));
+            levelEventPacket.setData(stableSpeed);
         }
 
-        session.getBlockBreakHandler().getDestructionStageCache().put(packet.getPosition(), Pair.of(session.getClientTicks(), packet.getStage()));
+        session.getBlockBreakHandler().getDestructionStageCache().put(packet.getPosition(), Pair.of(currentTick, packet.getStage()));
         session.sendUpstreamPacket(levelEventPacket);
     }
 }


### PR DESCRIPTION
## What changed

This PR improves support for custom Java blocks on Bedrock clients.

Some custom block systems use vanilla block states for visual display while storing the real block data separately. Because Geyser only sees the visual state, block breaking speed and crack animations can become incorrect or out of sync.

This change adds an API that allows extensions to provide the real custom block state and current breaking progress to Geyser. It also improves crack animation synchronization between Java and Bedrock players and clears old crack animations when a block is replaced.

The implementation is generic and does not directly depend on CraftEngine or any other custom block plugin.

## Testing

I tested the changes on a Paper 1.21.8 server with Java and Bedrock players.

I tested:

- Custom block breaking time
- Crack animation synchronization
- Interrupted block breaking
- Replacing a broken block
- Breaking blocks with both Java and Bedrock players

The project was also built successfully with:

`./gradlew :spigot:shadowJar --no-daemon`

## AI usage

I used OpenAI Codex to assist with implementing and debugging these changes. I personally reviewed the code and understand how it works.
<img width="1920" height="1080" alt="{966CE570-BF9A-4694-BB6C-A199009C7BF9}" src="https://github.com/user-attachments/assets/45f1e6e7-40b0-49fe-ad63-f561080c1a4b" />

