### PR TITLE
Fix sign line break

### DIFF
--- a/core/src/main/java/org/geysermc/geyser/translator/level/block/entity/SignBlockEntityTranslator.java
+++ b/core/src/main/java/org/geysermc/geyser/translator/level/block/entity/SignBlockEntityTranslator.java
@@ -110,7 +110,7 @@ public class SignBlockEntityTranslator extends BlockEntityTranslator {
                         signWidth += SignUtils.getCharacterWidth(c);
                     }
 
-                    if (signWidth <= signWidthMax()) {
+                    if (signWidth < signWidthMax()) {
                         finalSignLine.append(c);
                     } else {
                         // Adding the character would make Bedrock move to the next line - Java doesn't do that, so we do not want to


### PR DESCRIPTION
Sign line break occurs at 90 chars, break before.