### PR TITLE
Map unknown Java biomes to a dimension-appropriate vanilla biome

### DIFF
--- a/core/src/main/java/org/geysermc/geyser/translator/level/BiomeTranslator.java
+++ b/core/src/main/java/org/geysermc/geyser/translator/level/BiomeTranslator.java
@@ -25,6 +25,9 @@
 
 package org.geysermc.geyser.translator.level;
 
+import org.checkerframework.checker.nullness.qual.Nullable;
+import org.geysermc.geyser.level.BedrockDimension;
+import org.geysermc.geyser.level.JavaDimension;
 import org.geysermc.geyser.session.cache.registry.JavaRegistries;
 import org.geysermc.geyser.session.cache.registry.JavaRegistry;
 import org.geysermc.geyser.session.cache.registry.RegistryEntryContext;
@@ -46,9 +49,45 @@ import org.geysermc.geyser.session.GeyserSession;
 // Array index formula by https://wiki.vg/Chunk_Format
 public class BiomeTranslator {
 
+    /**
+     * Marks a Java biome with no direct Bedrock equivalent; a dimension-appropriate fallback
+     * is selected in {@link #bedrockBiomeId(GeyserSession, JavaRegistry, int)} instead.
+     */
+    private static final int UNKNOWN_BIOME = -1;
+
     public static int loadServerBiome(RegistryEntryContext entry) {
         String javaIdentifier = entry.id().asString();
-        return Registries.BIOME_IDENTIFIERS.get().getOrDefault(javaIdentifier, 0);
+        return Registries.BIOME_IDENTIFIERS.get().getOrDefault(javaIdentifier, UNKNOWN_BIOME);
+    }
+
+    /**
+     * Resolves a Java biome network ID to a Bedrock biome ID, never returning an invalid ID.
+     * Biomes that could not be mapped, along with out-of-range network IDs, resolve to a
+     * vanilla biome fitting the session's current dimension so that sky, fog and weather
+     * render sensibly instead of always defaulting to ocean.
+     */
+    private static int bedrockBiomeId(GeyserSession session, JavaRegistry<Integer> biomeTranslations, int javaId) {
+        Integer bedrockId = javaId < 0 ? null : biomeTranslations.byId(javaId);
+        if (bedrockId == null || bedrockId == UNKNOWN_BIOME) {
+            return fallbackBiomeId(session.getDimensionType());
+        }
+        return bedrockId;
+    }
+
+    private static int fallbackBiomeId(@Nullable JavaDimension dimension) {
+        String identifier;
+        if (dimension == null) {
+            identifier = "minecraft:ocean";
+        } else if (dimension.isNetherLike()) {
+            // Checked before the Bedrock dimension ID, as the Nether-roof workaround maps
+            // Nether-like dimensions to the End's dimension ID
+            identifier = "minecraft:nether_wastes";
+        } else if (dimension.bedrockId() == BedrockDimension.END_ID) {
+            identifier = "minecraft:the_end";
+        } else {
+            identifier = "minecraft:ocean";
+        }
+        return Registries.BIOME_IDENTIFIERS.get().getOrDefault(identifier, 0);
     }
 
     public static BlockStorage toNewBedrockBiome(GeyserSession session, DataPalette biomeData) {
@@ -58,7 +97,7 @@ public class BiomeTranslator {
 
         Palette palette = biomeData.getPalette();
         if (palette instanceof SingletonPalette) {
-            int biomeId = biomeTranslations.byId(palette.idToState(0));
+            int biomeId = bedrockBiomeId(session, biomeTranslations, palette.idToState(0));
             return new BlockStorage(SingletonBitArray.INSTANCE, IntLists.singleton(biomeId));
         } else {
             BlockStorage storage;
@@ -78,7 +117,7 @@ public class BiomeTranslator {
                 }
 
                 if (allSame) {
-                    int biomeId = biomeTranslations.byId(palette.idToState(firstIdx)).intValue();
+                    int biomeId = bedrockBiomeId(session, biomeTranslations, palette.idToState(firstIdx));
                     storage = new BlockStorage(SingletonBitArray.INSTANCE, IntLists.singleton(biomeId));
                 } else {
                     // Prevent resizing by allocating what we can ahead of time
@@ -89,7 +128,7 @@ public class BiomeTranslator {
 
                     for (int i = 0; i < size; i++) {
                         int javaId = palette.idToState(i);
-                        bedrockPalette.add(biomeTranslations.byId(javaId).intValue());
+                        bedrockPalette.add(bedrockBiomeId(session, biomeTranslations, javaId));
                     }
 
                     // Each section of biome corresponding to a chunk section contains 4 * 4 * 4 entries
@@ -115,7 +154,7 @@ public class BiomeTranslator {
                     int y = (i >> 4) & 3;
                     int z = (i >> 2) & 3;
                     // Get the Bedrock biome ID override
-                    int biomeId = biomeTranslations.byId(javaId);
+                    int biomeId = bedrockBiomeId(session, biomeTranslations, javaId);
                     int idx = storage.idFor(biomeId);
                     // Convert biome coordinates into block coordinates
                     // Bedrock expects a full 4096 blocks


### PR DESCRIPTION
Custom biomes from datapacks or mods currently fall back to Bedrock biome 0 (ocean), so a custom Nether biome gets an overworld sky and no Nether fog.

With this PR, unknown biomes resolve to nether wastes in Nether-like dimensions, the end in End dimensions, and ocean everywhere else (unchanged from current behavior). This happens during chunk translation since that's the first point where the session's dimension is known, and the same biome can appear in multiple dimensions. `isNetherLike()` is checked before the Bedrock dimension ID so the Nether roof workaround still picks nether wastes. This also fixes an NPE: `byId` is nullable but was unboxed directly, so an out-of-range biome ID would crash.

Tested with a datapack biome on a Paper server: Custom biome renders the nether fog instead of overworld sky. Vanilla biomes are unaffected.