### PR TITLE
Fix: don't forward movement while entering a bed

### DIFF
--- a/core/src/main/java/org/geysermc/geyser/entity/type/player/AvatarEntity.java
+++ b/core/src/main/java/org/geysermc/geyser/entity/type/player/AvatarEntity.java
@@ -190,6 +190,10 @@ public abstract class AvatarEntity extends LivingEntity {
     @Override
     public @Nullable Vector3i setBedPosition(EntityMetadata<Optional<Vector3i>, ?> entityMetadata) {
         bedPosition = super.setBedPosition(entityMetadata);
+        if (this instanceof SessionPlayerEntity) {
+            // The server has answered the bed click either way.
+            session.stopEnteringBed();
+        }
         if (bedPosition != null) {
             // Indicate that the player should enter the sleep cycle
             // Has to be a byte or it does not work

--- a/core/src/main/java/org/geysermc/geyser/session/GeyserSession.java
+++ b/core/src/main/java/org/geysermc/geyser/session/GeyserSession.java
@@ -325,6 +325,11 @@ public class GeyserSession implements GeyserConnection, GeyserCommandSource {
     @Setter
     private TeleportCache unconfirmedTeleport;
 
+    /**
+     * When a pending bed click stops holding movement back. See {@link #isEnteringBed()}.
+     */
+    private long enteringBedUntil;
+
     @Setter
     private @Nullable Entity spectatedEntity;
 
@@ -2097,6 +2102,29 @@ public class GeyserSession implements GeyserConnection, GeyserCommandSource {
      */
     public int getNextItemNetId() {
         return itemNetId.getAndIncrement();
+    }
+
+    /**
+     * Records that we have asked the Java server to let the player sleep. The server moves the
+     * player onto the bed as soon as it accepts, but still measures any movement we forward
+     * against where they stood before. Forwarding anything before the bed metadata arrives
+     * trips the sleeping-movement check and gets the player bounced back out of the bed.
+     */
+    public void startEnteringBed() {
+        // Has to cover a full round trip to the Java server, which can be remote. A refused
+        // click sends no metadata back, so this also bounds how long it can hold movement.
+        this.enteringBedUntil = System.currentTimeMillis() + 1000L;
+    }
+
+    public void stopEnteringBed() {
+        this.enteringBedUntil = 0L;
+    }
+
+    /**
+     * @return whether a bed click is still waiting on the Java server's answer.
+     */
+    public boolean isEnteringBed() {
+        return System.currentTimeMillis() < this.enteringBedUntil;
     }
 
     public void confirmTeleport(Vector3f position) {

--- a/core/src/main/java/org/geysermc/geyser/translator/protocol/bedrock/BedrockInventoryTransactionTranslator.java
+++ b/core/src/main/java/org/geysermc/geyser/translator/protocol/bedrock/BedrockInventoryTransactionTranslator.java
@@ -58,6 +58,7 @@ import org.geysermc.geyser.item.type.Item;
 import org.geysermc.geyser.item.type.SpawnEggItem;
 import org.geysermc.geyser.level.block.Blocks;
 import org.geysermc.geyser.level.block.property.Properties;
+import org.geysermc.geyser.level.block.type.BedBlock;
 import org.geysermc.geyser.level.block.type.Block;
 import org.geysermc.geyser.level.block.type.BlockState;
 import org.geysermc.geyser.level.block.type.ButtonBlock;
@@ -273,6 +274,12 @@ public class BedrockInventoryTransactionTranslator extends PacketTranslator<Inve
                          */
 
                         BlockState blockState = session.getGeyser().getWorldManager().blockAt(session, packet.getBlockPosition());
+
+                        if (blockState.block() instanceof BedBlock) {
+                            // The server will move us onto the bed before it tells us we are asleep;
+                            // hold back movement until then. See GeyserSession#startEnteringBed.
+                            session.startEnteringBed();
+                        }
 
                         // Buttons on Java Edition cannot be interacted with when they are powered
                         if (blockState.block() instanceof ButtonBlock && blockState.getValue(Properties.POWERED)) {

--- a/core/src/main/java/org/geysermc/geyser/translator/protocol/bedrock/entity/player/input/BedrockMovePlayer.java
+++ b/core/src/main/java/org/geysermc/geyser/translator/protocol/bedrock/entity/player/input/BedrockMovePlayer.java
@@ -71,10 +71,12 @@ final class BedrockMovePlayer {
             session.getBookEditCache().checkForSend();
         }
 
-        if (entity.getBedPosition() != null) {
+        if (entity.getBedPosition() != null || session.isEnteringBed()) {
             // https://github.com/GeyserMC/Geyser/issues/5001
             // Bedrock 1.21.22 started sending a MovePlayerPacket as soon as it got into a bed.
             // This trips up Fabric.
+            // https://github.com/GeyserMC/Geyser/issues/6600
+            // The same applies while a bed click is still pending. See GeyserSession#startEnteringBed.
             return;
         }
 


### PR DESCRIPTION
Movement forwarded between clicking a bed and the sleep metadata arriving trips Java's sleeping-movement check and ejects the player; holding movement back until the click is answered fixes it.

Closes #6600

The issue can only be reproduced on Fabric. Paper tested clean.