### PR TITLE
Generate Bedrock resource-pack visuals for Java biomes

### DIFF
--- a/core/src/main/java/org/geysermc/geyser/pack/BiomeResourcePackManager.java
+++ b/core/src/main/java/org/geysermc/geyser/pack/BiomeResourcePackManager.java
@@ -35,7 +35,6 @@ import net.kyori.adventure.key.InvalidKeyException;
 import org.checkerframework.checker.nullness.qual.Nullable;
 import org.geysermc.geyser.GeyserImpl;
 import org.geysermc.geyser.registry.Registries;
-import org.geysermc.geyser.registry.loader.BiomeIdentifierRegistryLoader;
 import org.geysermc.geyser.util.FileUtils;
 import org.geysermc.geyser.util.MinecraftKey;
 
@@ -47,7 +46,6 @@ import java.nio.file.Path;
 import java.util.Map;
 import java.util.Set;
 import java.util.TreeMap;
-import java.util.TreeSet;
 import java.util.UUID;
 import java.util.zip.ZipEntry;
 import java.util.zip.ZipOutputStream;
@@ -56,11 +54,14 @@ public final class BiomeResourcePackManager {
     private static final String INPUT_FILE = "biome-visuals.json";
     private static final int FORMAT_VERSION = 1;
     private static final int RESOURCE_PACK_VERSION = 1;
+    private static final int CUSTOM_BIOME_ID_START = 30_000;
 
     private BiomeResourcePackManager() {
     }
 
     public static @Nullable Path createResourcePack() {
+        Registries.CUSTOM_BIOME_IDENTIFIERS.get().clear();
+
         GeyserImpl geyser = GeyserImpl.getInstance();
         Path input = geyser.getBootstrap().getConfigFolder().resolve(INPUT_FILE);
         if (!Files.isRegularFile(input)) {
@@ -71,7 +72,7 @@ public final class BiomeResourcePackManager {
         try {
             Set<String> bedrockIdentifiers = Registries.BIOMES.get().getDefinitions().keySet();
             Files.createDirectories(output.getParent());
-            int biomeCount = createResourcePack(input, output, bedrockIdentifiers, Registries.BIOME_IDENTIFIERS.get());
+            int biomeCount = createResourcePack(input, output, bedrockIdentifiers);
             geyser.getLogger()
                     .info("Generated Bedrock biome visuals resource pack with " + biomeCount + " biome appearance(s).");
             return output;
@@ -81,12 +82,11 @@ public final class BiomeResourcePackManager {
         }
     }
 
-    private static int createResourcePack(Path input, Path output, Set<String> bedrockIdentifiers,
-            Object2IntMap<String> biomeIdentifiers) throws IOException {
+    private static int createResourcePack(Path input, Path output, Set<String> bedrockIdentifiers) throws IOException {
         Map<String, BiomeVisuals> biomes = load(input);
         Object2IntMap<String> customMappings = customMappings(biomes.keySet(), bedrockIdentifiers);
         write(output, biomes);
-        biomeIdentifiers.putAll(customMappings);
+        Registries.CUSTOM_BIOME_IDENTIFIERS.set(customMappings);
         return biomes.size();
     }
 
@@ -130,8 +130,8 @@ public final class BiomeResourcePackManager {
 
     private static Object2IntMap<String> customMappings(Set<String> configuredIdentifiers, Set<String> bedrockIdentifiers) {
         Object2IntMap<String> customMappings = new Object2IntOpenHashMap<>();
-        int customId = BiomeIdentifierRegistryLoader.CUSTOM_BIOME_ID_START;
-        for (String identifier : new TreeSet<>(configuredIdentifiers)) {
+        int customId = CUSTOM_BIOME_ID_START;
+        for (String identifier : configuredIdentifiers) {
             if (!bedrockIdentifiers.contains(identifier)) {
                 customMappings.put(identifier, customId++);
             }

--- a/core/src/main/java/org/geysermc/geyser/pack/BiomeResourcePackManager.java
+++ b/core/src/main/java/org/geysermc/geyser/pack/BiomeResourcePackManager.java
@@ -133,6 +133,8 @@ public final class BiomeResourcePackManager {
         @Nullable Integer waterFogColor = attributes == null ? null : optionalColor(attributes.waterFogColor());
         @Nullable Integer fogColor = attributes == null ? null : optionalColor(attributes.fogColor());
         @Nullable Integer skyColor = attributes == null ? null : optionalColor(attributes.skyColor());
+
+        // Since Bedrock only has a single foliage color, we use foliage_color as the default, and fall back to Java's dry_foliage_color.
         @Nullable Integer foliageColor = optionalColor(effects.foliageColor()) != null
             ? optionalColor(effects.foliageColor())
             : optionalColor(effects.dryFoliageColor());
@@ -162,8 +164,7 @@ public final class BiomeResourcePackManager {
         return value == null ? null : color(value);
     }
 
-    private static Object2IntMap<String> customMappings(Set<String> configuredIdentifiers,
-                                                        Set<String> bedrockIdentifiers) {
+    private static Object2IntMap<String> customMappings(Set<String> configuredIdentifiers, Set<String> bedrockIdentifiers) {
         Object2IntMap<String> customMappings = new Object2IntOpenHashMap<>();
         int customId = CUSTOM_BIOME_ID_START;
         for (String identifier : configuredIdentifiers) {

--- a/core/src/main/java/org/geysermc/geyser/pack/BiomeResourcePackManager.java
+++ b/core/src/main/java/org/geysermc/geyser/pack/BiomeResourcePackManager.java
@@ -120,6 +120,7 @@ public final class BiomeResourcePackManager {
                     color(definition.waterColor()),
                     color(definition.waterFogColor()),
                     color(definition.fogColor()),
+                    optionalColor(definition.weatherFogColor()),
                     optionalColor(definition.skyColor()),
                     optionalColor(definition.grassColor()),
                     optionalColor(definition.foliageColor()));
@@ -235,6 +236,7 @@ public final class BiomeResourcePackManager {
             @SerializedName("water_color") String waterColor,
             @SerializedName("water_fog_color") String waterFogColor,
             @SerializedName("fog_color") String fogColor,
+            @SerializedName("weather_fog_color") @Nullable String weatherFogColor,
             @SerializedName("sky_color") @Nullable String skyColor,
             @SerializedName("grass_color") @Nullable String grassColor,
             @SerializedName("foliage_color") @Nullable String foliageColor) {
@@ -244,6 +246,7 @@ public final class BiomeResourcePackManager {
             int waterColor,
             int waterFogColor,
             int fogColor,
+            @Nullable Integer weatherFogColor,
             @Nullable Integer skyColor,
             @Nullable Integer grassColor,
             @Nullable Integer foliageColor) {
@@ -292,8 +295,11 @@ public final class BiomeResourcePackManager {
 
         private JsonObject fog(String fogIdentifier) {
             JsonObject distance = new JsonObject();
-            distance.add("air", fogDistance(fogColor));
-            distance.add("water", fogDistance(waterFogColor));
+            distance.add("air", fogDistance(fogColor, 0.92F, 1.0F, "render"));
+            if (weatherFogColor != null) {
+                distance.add("weather", fogDistance(weatherFogColor, 0.23F, 0.7F, "render"));
+            }
+            distance.add("water", fogDistance(waterFogColor, 0, 60, "fixed"));
 
             JsonObject description = new JsonObject();
             description.addProperty("identifier", fogIdentifier);
@@ -308,12 +314,12 @@ public final class BiomeResourcePackManager {
             return root;
         }
 
-        private static JsonObject fogDistance(int color) {
+        private static JsonObject fogDistance(int color, float start, float end, String distanceType) {
             JsonObject distance = new JsonObject();
-            distance.addProperty("fog_start", 0);
-            distance.addProperty("fog_end", 1);
+            distance.addProperty("fog_start", start);
+            distance.addProperty("fog_end", end);
             distance.addProperty("fog_color", rgb(color));
-            distance.addProperty("render_distance_type", "render");
+            distance.addProperty("render_distance_type", distanceType);
             return distance;
         }
 

--- a/core/src/main/java/org/geysermc/geyser/pack/BiomeResourcePackManager.java
+++ b/core/src/main/java/org/geysermc/geyser/pack/BiomeResourcePackManager.java
@@ -77,7 +77,7 @@ public final class BiomeResourcePackManager {
             Files.createDirectories(output.getParent());
             int biomeCount = createResourcePack(input, output, bedrockIdentifiers);
             geyser.getLogger()
-                    .info("Generated Bedrock biome visuals resource pack with " + biomeCount + " biome appearance(s).");
+                .info("Registered " + biomeCount + " biome visual overrides.");
             return output;
         } catch (Exception e) {
             geyser.getLogger().error("Failed to generate Bedrock biome visuals resource pack!", e);
@@ -121,33 +121,49 @@ public final class BiomeResourcePackManager {
                 throw new IllegalArgumentException("No biome visuals were defined for " + javaIdentifier);
             }
             validateIdentifier(javaIdentifier);
-
-            BiomeVisuals visuals = new BiomeVisuals(
-                    color(definition.waterColor()),
-                    color(definition.waterFogColor()),
-                    color(definition.fogColor()),
-                    optionalColor(definition.weatherFogColor()),
-                    optionalColor(definition.skyColor()),
-                    optionalColor(definition.grassColor()),
-                    optionalColor(definition.foliageColor()));
-            resolved.put(javaIdentifier, visuals);
+            resolved.put(javaIdentifier, resolveBiome(definition));
         }
         return resolved;
     }
 
-    private static int color(@Nullable String color) {
-        if (color == null || !color.matches("#[0-9a-fA-F]{6}")) {
-            throw new IllegalArgumentException("Biome colors must use the #RRGGBB format");
-        }
-        return Integer.parseInt(color.substring(1), 16);
+    private static BiomeVisuals resolveBiome(BiomeDefinition definition) {
+        BiomeAttributes attributes = definition.attributes();
+        BiomeEffects effects = definition.effects();
+
+        @Nullable Integer waterFogColor = attributes == null ? null : optionalColor(attributes.waterFogColor());
+        @Nullable Integer fogColor = attributes == null ? null : optionalColor(attributes.fogColor());
+        @Nullable Integer skyColor = attributes == null ? null : optionalColor(attributes.skyColor());
+        @Nullable Integer foliageColor = optionalColor(effects.foliageColor()) != null
+            ? optionalColor(effects.foliageColor())
+            : optionalColor(effects.dryFoliageColor());
+
+        return new BiomeVisuals(
+            color(effects.waterColor()),
+            optionalColor(effects.grassColor()),
+            foliageColor,
+            waterFogColor,
+            fogColor,
+            skyColor);
     }
 
-    private static @Nullable Integer optionalColor(@Nullable String color) {
-        return color == null ? null : color(color);
+    private static int color(@Nullable Object value) {
+        if (value instanceof Number number) {
+            return number.intValue();
+        }
+
+        if (value instanceof String text && text.matches("#[0-9a-fA-F]{6}")) {
+            return Integer.parseInt(text.substring(1), 16);
+        }
+
+        throw new IllegalArgumentException("Biome colors must be either an integer or a string in the #RRGGBB format");
+    }
+
+    private static @Nullable Integer optionalColor(@Nullable Object value) {
+        return value == null ? null : color(value);
     }
 
     private static Object2IntMap<String> customMappings(Set<String> configuredIdentifiers,
-            Set<String> bedrockIdentifiers) {
+                                                        Set<String> bedrockIdentifiers) {
         Object2IntMap<String> customMappings = new Object2IntOpenHashMap<>();
         int customId = CUSTOM_BIOME_ID_START;
         for (String identifier : configuredIdentifiers) {
@@ -174,7 +190,7 @@ public final class BiomeResourcePackManager {
         // invalidating the cache.
         Map<String, BiomeVisuals> sortedBiomes = new TreeMap<>(biomes);
         UUID packUuid = UUID.nameUUIDFromBytes(
-                (RESOURCE_PACK_VERSION + sortedBiomes.toString()).getBytes(StandardCharsets.UTF_8));
+            (RESOURCE_PACK_VERSION + sortedBiomes.toString()).getBytes(StandardCharsets.UTF_8));
         UUID moduleUuid = UUID.nameUUIDFromBytes((packUuid + "/module").getBytes(StandardCharsets.UTF_8));
 
         try (ZipOutputStream zip = new ZipOutputStream(Files.newOutputStream(output))) {
@@ -185,7 +201,7 @@ public final class BiomeResourcePackManager {
                 String fileIdentifier = fileIdentifier(biomeIdentifier);
                 String fogIdentifier = "geyser:fog_" + fileIdentifier;
                 write(zip, "biomes/" + fileIdentifier + ".client_biome.json",
-                        entry.getValue().clientBiome(biomeIdentifier, fogIdentifier));
+                    entry.getValue().clientBiome(biomeIdentifier, fogIdentifier));
                 write(zip, "fogs/" + fileIdentifier + "_fog_setting.json", entry.getValue().fog(fogIdentifier));
             }
         }
@@ -199,8 +215,8 @@ public final class BiomeResourcePackManager {
 
     private static String fileIdentifier(String identifier) {
         String fileIdentifier = identifier.startsWith("minecraft:")
-                ? identifier.substring("minecraft:".length())
-                : identifier;
+            ? identifier.substring("minecraft:".length())
+            : identifier;
         return fileIdentifier.replace(':', '_').replace('/', '_');
     }
 
@@ -238,28 +254,48 @@ public final class BiomeResourcePackManager {
     }
 
     private record BiomeConfig(
-            @SerializedName("format_version") int formatVersion,
-            Map<String, BiomeDefinition> biomes) {
+        @SerializedName("format_version") int formatVersion,
+        Map<String, BiomeDefinition> biomes) {
     }
 
     private record BiomeDefinition(
-            @SerializedName("water_color") String waterColor,
-            @SerializedName("water_fog_color") String waterFogColor,
-            @SerializedName("fog_color") String fogColor,
-            @SerializedName("weather_fog_color") @Nullable String weatherFogColor,
-            @SerializedName("sky_color") @Nullable String skyColor,
-            @SerializedName("grass_color") @Nullable String grassColor,
-            @SerializedName("foliage_color") @Nullable String foliageColor) {
+        @Nullable BiomeAttributes attributes,
+        BiomeEffects effects) {
+    }
+
+    private record BiomeAttributes(
+        @SerializedName("minecraft:visual/fog_color") @Nullable Object fogColor,
+        @SerializedName("minecraft:visual/sky_color") @Nullable Object skyColor,
+        @SerializedName("minecraft:visual/water_fog_color") @Nullable Object waterFogColor) {
+    }
+
+    private record BiomeEffects(
+        @SerializedName("water_color") Object waterColor,
+        @SerializedName("dry_foliage_color") @Nullable Object dryFoliageColor,
+        @SerializedName("foliage_color") @Nullable Object foliageColor,
+        @SerializedName("grass_color") @Nullable Object grassColor) {
     }
 
     private record BiomeVisuals(
-            int waterColor,
-            int waterFogColor,
-            int fogColor,
-            @Nullable Integer weatherFogColor,
-            @Nullable Integer skyColor,
-            @Nullable Integer grassColor,
-            @Nullable Integer foliageColor) {
+        int waterColor,
+        @Nullable Integer grassColor,
+        @Nullable Integer foliageColor,
+        @Nullable Integer waterFogColor,
+        @Nullable Integer fogColor,
+        @Nullable Integer skyColor) {
+
+        private static String rgb(int color) {
+            return "#%06X".formatted(color & 0xFFFFFF);
+        }
+
+        private static JsonObject fogDistance(int color, float start, float end, String distanceType) {
+            JsonObject distance = new JsonObject();
+            distance.addProperty("fog_start", start);
+            distance.addProperty("fog_end", end);
+            distance.addProperty("fog_color", rgb(color));
+            distance.addProperty("render_distance_type", distanceType);
+            return distance;
+        }
 
         private JsonObject clientBiome(String biomeIdentifier, String fogIdentifier) {
             JsonObject components = new JsonObject();
@@ -309,17 +345,20 @@ public final class BiomeResourcePackManager {
         private JsonObject fog(String fogIdentifier) {
             JsonObject distance = new JsonObject();
 
-            distance.add("air", fogDistance(fogColor, 0.92F, 1.0F, "render"));
-            distance.add("water", fogDistance(waterFogColor, 0, 60, "fixed"));
+            if (fogColor != null) {
+                distance.add("air", fogDistance(fogColor, 0.92F, 1.0F, "render"));
 
-            // Weather fog color falls back to default fog color if not specified. In Java
-            // both of these settings are combined into one setting, but Bedrock separates
-            // the two. One thing to keep in mind is that the weather fog color in Bedrock
-            // does not apply the same darkening effect as in Java. Having the same color
-            // will result in different results (Might also be fixable by playing with the
-            // fog distance values).
-            distance.add("weather",
-                    fogDistance(weatherFogColor != null ? weatherFogColor : fogColor, 0.23F, 0.7F, "render"));
+                // In Java, both air and weather settings are combined into one setting, but
+                // Bedrock separates the two. One thing to keep in mind is that the weather fog
+                // color in Bedrock does not apply the same darkening effect as in Java. Having
+                // the same color will most likely result in (slightly) different results.
+                distance.add("weather", fogDistance(fogColor, 0.23F, 0.7F, "render"));
+            }
+
+            if (waterFogColor != null) {
+                distance.add("water", fogDistance(waterFogColor, 0, 60, "fixed"));
+            }
+
 
             JsonObject description = new JsonObject();
             description.addProperty("identifier", fogIdentifier);
@@ -332,19 +371,6 @@ public final class BiomeResourcePackManager {
             root.addProperty("format_version", "1.16.100");
             root.add("minecraft:fog_settings", settings);
             return root;
-        }
-
-        private static String rgb(int color) {
-            return "#%06X".formatted(color & 0xFFFFFF);
-        }
-
-        private static JsonObject fogDistance(int color, float start, float end, String distanceType) {
-            JsonObject distance = new JsonObject();
-            distance.addProperty("fog_start", start);
-            distance.addProperty("fog_end", end);
-            distance.addProperty("fog_color", rgb(color));
-            distance.addProperty("render_distance_type", distanceType);
-            return distance;
         }
     }
 }

--- a/core/src/main/java/org/geysermc/geyser/pack/BiomeResourcePackManager.java
+++ b/core/src/main/java/org/geysermc/geyser/pack/BiomeResourcePackManager.java
@@ -308,11 +308,18 @@ public final class BiomeResourcePackManager {
         // point.
         private JsonObject fog(String fogIdentifier) {
             JsonObject distance = new JsonObject();
+
             distance.add("air", fogDistance(fogColor, 0.92F, 1.0F, "render"));
-            if (weatherFogColor != null) {
-                distance.add("weather", fogDistance(weatherFogColor, 0.23F, 0.7F, "render"));
-            }
             distance.add("water", fogDistance(waterFogColor, 0, 60, "fixed"));
+
+            // Weather fog color falls back to default fog color if not specified. In Java
+            // both of these settings are combined into one setting, but Bedrock separates
+            // the two. One thing to keep in mind is that the weather fog color in Bedrock
+            // does not apply the same darkening effect as in Java. Having the same color
+            // will result in different results (Might also be fixable by playing with the
+            // fog distance values).
+            distance.add("weather",
+                    fogDistance(weatherFogColor != null ? weatherFogColor : fogColor, 0.23F, 0.7F, "render"));
 
             JsonObject description = new JsonObject();
             description.addProperty("identifier", fogIdentifier);
@@ -327,6 +334,10 @@ public final class BiomeResourcePackManager {
             return root;
         }
 
+        private static String rgb(int color) {
+            return "#%06X".formatted(color & 0xFFFFFF);
+        }
+
         private static JsonObject fogDistance(int color, float start, float end, String distanceType) {
             JsonObject distance = new JsonObject();
             distance.addProperty("fog_start", start);
@@ -334,10 +345,6 @@ public final class BiomeResourcePackManager {
             distance.addProperty("fog_color", rgb(color));
             distance.addProperty("render_distance_type", distanceType);
             return distance;
-        }
-
-        private static String rgb(int color) {
-            return "#%06X".formatted(color & 0xFFFFFF);
         }
     }
 }

--- a/core/src/main/java/org/geysermc/geyser/pack/BiomeResourcePackManager.java
+++ b/core/src/main/java/org/geysermc/geyser/pack/BiomeResourcePackManager.java
@@ -52,8 +52,14 @@ import java.util.zip.ZipOutputStream;
 
 public final class BiomeResourcePackManager {
     private static final String INPUT_FILE = "biome-visuals.json";
+
     private static final int FORMAT_VERSION = 1;
+
     private static final int RESOURCE_PACK_VERSION = 1;
+
+    // Bedrock’s custom-biome runtime ID range begins at 30_000. Any value below
+    // that will serialize just fine, but the client will not treat it as a custom
+    // biome and the definition won't bind properly to the biome ID used by chunks.
     private static final int CUSTOM_BIOME_ID_START = 30_000;
 
     public static @Nullable Path createResourcePack() {
@@ -129,6 +135,17 @@ public final class BiomeResourcePackManager {
         return resolved;
     }
 
+    private static int color(@Nullable String color) {
+        if (color == null || !color.matches("#[0-9a-fA-F]{6}")) {
+            throw new IllegalArgumentException("Biome colors must use the #RRGGBB format");
+        }
+        return Integer.parseInt(color.substring(1), 16);
+    }
+
+    private static @Nullable Integer optionalColor(@Nullable String color) {
+        return color == null ? null : color(color);
+    }
+
     private static Object2IntMap<String> customMappings(Set<String> configuredIdentifiers,
             Set<String> bedrockIdentifiers) {
         Object2IntMap<String> customMappings = new Object2IntOpenHashMap<>();
@@ -152,6 +169,9 @@ public final class BiomeResourcePackManager {
     }
 
     private static void write(Path output, Map<String, BiomeVisuals> biomes) throws IOException {
+        // We sort the biomes to make sure the resource pack is deterministic, and the
+        // UUID is always the same when the visuals remain unchanged to avoid
+        // invalidating the cache.
         Map<String, BiomeVisuals> sortedBiomes = new TreeMap<>(biomes);
         UUID packUuid = UUID.nameUUIDFromBytes(
                 (RESOURCE_PACK_VERSION + sortedBiomes.toString()).getBytes(StandardCharsets.UTF_8));
@@ -171,11 +191,10 @@ public final class BiomeResourcePackManager {
         }
     }
 
-    private static int color(@Nullable String color) {
-        if (color == null || !color.matches("#[0-9a-fA-F]{6}")) {
-            throw new IllegalArgumentException("Biome colors must use the #RRGGBB format");
-        }
-        return Integer.parseInt(color.substring(1), 16);
+    private static void write(ZipOutputStream zip, String name, JsonObject json) throws IOException {
+        zip.putNextEntry(new ZipEntry(name));
+        zip.write(GeyserImpl.GSON.toJson(json).getBytes(StandardCharsets.UTF_8));
+        zip.closeEntry();
     }
 
     private static String fileIdentifier(String identifier) {
@@ -183,10 +202,6 @@ public final class BiomeResourcePackManager {
                 ? identifier.substring("minecraft:".length())
                 : identifier;
         return fileIdentifier.replace(':', '_').replace('/', '_');
-    }
-
-    private static @Nullable Integer optionalColor(@Nullable String color) {
-        return color == null ? null : color(color);
     }
 
     private static JsonObject manifest(UUID packUuid, UUID moduleUuid) {
@@ -220,12 +235,6 @@ public final class BiomeResourcePackManager {
         version.add(minor);
         version.add(patch);
         return version;
-    }
-
-    private static void write(ZipOutputStream zip, String name, JsonObject json) throws IOException {
-        zip.putNextEntry(new ZipEntry(name));
-        zip.write(GeyserImpl.GSON.toJson(json).getBytes(StandardCharsets.UTF_8));
-        zip.closeEntry();
     }
 
     private record BiomeConfig(
@@ -294,6 +303,9 @@ public final class BiomeResourcePackManager {
             return root;
         }
 
+        // The used fog distances are based on the default values used by Bedrock's
+        // default_fog_setting.json, might be worth making it configurable at some
+        // point.
         private JsonObject fog(String fogIdentifier) {
             JsonObject distance = new JsonObject();
             distance.add("air", fogDistance(fogColor, 0.92F, 1.0F, "render"));

--- a/core/src/main/java/org/geysermc/geyser/pack/BiomeResourcePackManager.java
+++ b/core/src/main/java/org/geysermc/geyser/pack/BiomeResourcePackManager.java
@@ -1,0 +1,303 @@
+/*
+ * Copyright (c) 2019-2026 GeyserMC. http://geysermc.org
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ *
+ * @author GeyserMC
+ * @link https://github.com/GeyserMC/Geyser
+ */
+
+package org.geysermc.geyser.pack;
+
+import com.google.gson.JsonArray;
+import com.google.gson.JsonObject;
+import com.google.gson.annotations.SerializedName;
+import it.unimi.dsi.fastutil.objects.Object2ObjectOpenHashMap;
+import org.checkerframework.checker.nullness.qual.Nullable;
+import org.geysermc.geyser.GeyserImpl;
+import org.geysermc.geyser.registry.Registries;
+import org.geysermc.geyser.util.FileUtils;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.Map;
+import java.util.Set;
+import java.util.TreeMap;
+import java.util.UUID;
+import java.util.zip.ZipEntry;
+import java.util.zip.ZipOutputStream;
+
+public final class BiomeResourcePackManager {
+    private static final String INPUT_FILE = "biome-visuals.json";
+    private static final int FORMAT_VERSION = 1;
+    private static final int RESOURCE_PACK_VERSION = 1;
+
+    private BiomeResourcePackManager() {
+    }
+
+    public static @Nullable Path createResourcePack() {
+        GeyserImpl geyser = GeyserImpl.getInstance();
+        Path input = geyser.getBootstrap().getConfigFolder().resolve(INPUT_FILE);
+        if (!Files.isRegularFile(input)) {
+            return null;
+        }
+
+        Path output = geyser.getBootstrap().getConfigFolder().resolve("cache").resolve("GeyserBiomeVisuals.mcpack");
+        try {
+            Set<String> bedrockIdentifiers = Registries.BIOMES.get().getDefinitions().keySet();
+            Files.createDirectories(output.getParent());
+            int biomeCount = createResourcePack(input, output, bedrockIdentifiers);
+            geyser.getLogger()
+                    .info("Generated Bedrock biome visuals resource pack with " + biomeCount + " biome appearance(s).");
+            return output;
+        } catch (Exception e) {
+            geyser.getLogger().error("Failed to generate Bedrock biome visuals resource pack!", e);
+            return null;
+        }
+    }
+
+    static int createResourcePack(Path input, Path output, Set<String> bedrockIdentifiers) throws IOException {
+        Map<String, BiomeVisuals> biomes = load(input, bedrockIdentifiers);
+        write(output, biomes);
+        return biomes.size();
+    }
+
+    private static Map<String, BiomeVisuals> load(Path input, Set<String> bedrockIdentifiers) throws IOException {
+        BiomeConfig config;
+        try (InputStream stream = Files.newInputStream(input)) {
+            config = FileUtils.loadJson(stream, BiomeConfig.class);
+        }
+
+        if (config == null || config.formatVersion() != FORMAT_VERSION) {
+            throw new IllegalArgumentException("Unsupported biome visuals format version");
+        }
+        if (config.biomes() == null) {
+            throw new IllegalArgumentException("No biome visuals were defined");
+        }
+
+        return resolve(config.biomes(), bedrockIdentifiers);
+    }
+
+    private static Map<String, BiomeVisuals> resolve(Map<String, BiomeDefinition> definitions,
+            Set<String> bedrockIdentifiers) {
+        Map<String, BiomeVisuals> resolved = new Object2ObjectOpenHashMap<>();
+        for (Map.Entry<String, BiomeDefinition> biome : definitions.entrySet()) {
+            String javaIdentifier = biome.getKey();
+            BiomeDefinition definition = biome.getValue();
+            String bedrockIdentifier = definition.bedrockIdentifier() != null
+                    ? definition.bedrockIdentifier()
+                    : javaIdentifier;
+
+            if (!bedrockIdentifiers.contains(bedrockIdentifier)) {
+                throw new IllegalArgumentException("Unknown Bedrock biome identifier " + bedrockIdentifier);
+            }
+
+            BiomeVisuals visuals = new BiomeVisuals(
+                    color(definition.waterColor()),
+                    color(definition.waterFogColor()),
+                    color(definition.fogColor()),
+                    optionalColor(definition.skyColor()),
+                    optionalColor(definition.grassColor()),
+                    optionalColor(definition.foliageColor()));
+            BiomeVisuals previous = resolved.putIfAbsent(bedrockIdentifier, visuals);
+            if (previous != null && !previous.equals(visuals)) {
+                throw new IllegalArgumentException("Multiple Java biomes resolve to " + bedrockIdentifier
+                        + " with different appearances");
+            }
+        }
+        return resolved;
+    }
+
+    private static void write(Path output, Map<String, BiomeVisuals> biomes) throws IOException {
+        Map<String, BiomeVisuals> sortedBiomes = new TreeMap<>(biomes);
+        UUID packUuid = UUID.nameUUIDFromBytes(
+                (RESOURCE_PACK_VERSION + sortedBiomes.toString()).getBytes(StandardCharsets.UTF_8));
+        UUID moduleUuid = UUID.nameUUIDFromBytes((packUuid + "/module").getBytes(StandardCharsets.UTF_8));
+
+        try (ZipOutputStream zip = new ZipOutputStream(Files.newOutputStream(output))) {
+            write(zip, "manifest.json", manifest(packUuid, moduleUuid));
+
+            for (Map.Entry<String, BiomeVisuals> entry : sortedBiomes.entrySet()) {
+                String biomeIdentifier = entry.getKey();
+                String fileIdentifier = fileIdentifier(biomeIdentifier);
+                String fogIdentifier = "geyser:fog_" + fileIdentifier;
+                write(zip, "biomes/" + fileIdentifier + ".client_biome.json",
+                        entry.getValue().clientBiome(biomeIdentifier, fogIdentifier));
+                write(zip, "fogs/" + fileIdentifier + "_fog_setting.json", entry.getValue().fog(fogIdentifier));
+            }
+        }
+    }
+
+    private static int color(@Nullable String color) {
+        if (color == null || !color.matches("#[0-9a-fA-F]{6}")) {
+            throw new IllegalArgumentException("Biome colors must use the #RRGGBB format");
+        }
+        return Integer.parseInt(color.substring(1), 16);
+    }
+
+    private static String fileIdentifier(String identifier) {
+        String fileIdentifier = identifier.startsWith("minecraft:")
+                ? identifier.substring("minecraft:".length())
+                : identifier;
+        return fileIdentifier.replace(':', '_').replace('/', '_');
+    }
+
+    private static @Nullable Integer optionalColor(@Nullable String color) {
+        return color == null ? null : color(color);
+    }
+
+    private static JsonObject manifest(UUID packUuid, UUID moduleUuid) {
+        JsonArray version = version(1, 0, 0);
+
+        JsonObject header = new JsonObject();
+        header.addProperty("name", "Geyser Java biome visuals");
+        header.addProperty("description", "Java biome colors converted for Bedrock clients");
+        header.addProperty("uuid", packUuid.toString());
+        header.add("version", version);
+        header.add("min_engine_version", version(1, 21, 40));
+
+        JsonObject module = new JsonObject();
+        module.addProperty("type", "resources");
+        module.addProperty("uuid", moduleUuid.toString());
+        module.add("version", version);
+
+        JsonArray modules = new JsonArray();
+        modules.add(module);
+
+        JsonObject manifest = new JsonObject();
+        manifest.addProperty("format_version", 2);
+        manifest.add("header", header);
+        manifest.add("modules", modules);
+        return manifest;
+    }
+
+    private static JsonArray version(int major, int minor, int patch) {
+        JsonArray version = new JsonArray();
+        version.add(major);
+        version.add(minor);
+        version.add(patch);
+        return version;
+    }
+
+    private static void write(ZipOutputStream zip, String name, JsonObject json) throws IOException {
+        zip.putNextEntry(new ZipEntry(name));
+        zip.write(GeyserImpl.GSON.toJson(json).getBytes(StandardCharsets.UTF_8));
+        zip.closeEntry();
+    }
+
+    private record BiomeConfig(
+            @SerializedName("format_version") int formatVersion,
+            Map<String, BiomeDefinition> biomes) {
+    }
+
+    private record BiomeDefinition(
+            @SerializedName("water_color") String waterColor,
+            @SerializedName("water_fog_color") String waterFogColor,
+            @SerializedName("fog_color") String fogColor,
+            @SerializedName("sky_color") @Nullable String skyColor,
+            @SerializedName("grass_color") @Nullable String grassColor,
+            @SerializedName("foliage_color") @Nullable String foliageColor,
+            @SerializedName("bedrock_identifier") @Nullable String bedrockIdentifier) {
+    }
+
+    private record BiomeVisuals(
+            int waterColor,
+            int waterFogColor,
+            int fogColor,
+            @Nullable Integer skyColor,
+            @Nullable Integer grassColor,
+            @Nullable Integer foliageColor) {
+
+        JsonObject clientBiome(String biomeIdentifier, String fogIdentifier) {
+            JsonObject components = new JsonObject();
+
+            JsonObject water = new JsonObject();
+            water.addProperty("surface_color", rgb(waterColor));
+            components.add("minecraft:water_appearance", water);
+
+            if (skyColor != null) {
+                JsonObject sky = new JsonObject();
+                sky.addProperty("sky_color", rgb(skyColor));
+                components.add("minecraft:sky_color", sky);
+            }
+
+            if (grassColor != null) {
+                JsonObject grass = new JsonObject();
+                grass.addProperty("color", rgb(grassColor));
+                components.add("minecraft:grass_appearance", grass);
+            }
+
+            if (foliageColor != null) {
+                JsonObject foliage = new JsonObject();
+                foliage.addProperty("color", rgb(foliageColor));
+                components.add("minecraft:foliage_appearance", foliage);
+            }
+
+            JsonObject fogAppearance = new JsonObject();
+            fogAppearance.addProperty("fog_identifier", fogIdentifier);
+            components.add("minecraft:fog_appearance", fogAppearance);
+
+            JsonObject description = new JsonObject();
+            description.addProperty("identifier", biomeIdentifier);
+
+            JsonObject clientBiome = new JsonObject();
+            clientBiome.add("description", description);
+            clientBiome.add("components", components);
+
+            JsonObject root = new JsonObject();
+            root.addProperty("format_version", "1.21.120");
+            root.add("minecraft:client_biome", clientBiome);
+            return root;
+        }
+
+        JsonObject fog(String fogIdentifier) {
+            JsonObject distance = new JsonObject();
+            distance.add("air", fogDistance(fogColor));
+            distance.add("water", fogDistance(waterFogColor));
+
+            JsonObject description = new JsonObject();
+            description.addProperty("identifier", fogIdentifier);
+
+            JsonObject settings = new JsonObject();
+            settings.add("description", description);
+            settings.add("distance", distance);
+
+            JsonObject root = new JsonObject();
+            root.addProperty("format_version", "1.16.100");
+            root.add("minecraft:fog_settings", settings);
+            return root;
+        }
+
+        private static JsonObject fogDistance(int color) {
+            JsonObject distance = new JsonObject();
+            distance.addProperty("fog_start", 0);
+            distance.addProperty("fog_end", 1);
+            distance.addProperty("fog_color", rgb(color));
+            distance.addProperty("render_distance_type", "render");
+            return distance;
+        }
+
+        private static String rgb(int color) {
+            return "#%06X".formatted(color & 0xFFFFFF);
+        }
+    }
+}

--- a/core/src/main/java/org/geysermc/geyser/pack/BiomeResourcePackManager.java
+++ b/core/src/main/java/org/geysermc/geyser/pack/BiomeResourcePackManager.java
@@ -56,9 +56,6 @@ public final class BiomeResourcePackManager {
     private static final int RESOURCE_PACK_VERSION = 1;
     private static final int CUSTOM_BIOME_ID_START = 30_000;
 
-    private BiomeResourcePackManager() {
-    }
-
     public static @Nullable Path createResourcePack() {
         Registries.CUSTOM_BIOME_IDENTIFIERS.get().clear();
 
@@ -99,8 +96,9 @@ public final class BiomeResourcePackManager {
         if (config == null || config.formatVersion() != FORMAT_VERSION) {
             throw new IllegalArgumentException("Unsupported biome visuals format version");
         }
+
         if (config.biomes() == null) {
-            throw new IllegalArgumentException("No biome visuals were defined");
+            return resolve(Map.of());
         }
 
         return resolve(config.biomes());
@@ -108,9 +106,11 @@ public final class BiomeResourcePackManager {
 
     private static Map<String, BiomeVisuals> resolve(Map<String, BiomeDefinition> definitions) {
         Map<String, BiomeVisuals> resolved = new Object2ObjectOpenHashMap<>();
+
         for (Map.Entry<String, BiomeDefinition> biome : definitions.entrySet()) {
             String javaIdentifier = biome.getKey();
             BiomeDefinition definition = biome.getValue();
+
             if (definition == null) {
                 throw new IllegalArgumentException("No biome visuals were defined for " + javaIdentifier);
             }
@@ -129,7 +129,8 @@ public final class BiomeResourcePackManager {
         return resolved;
     }
 
-    private static Object2IntMap<String> customMappings(Set<String> configuredIdentifiers, Set<String> bedrockIdentifiers) {
+    private static Object2IntMap<String> customMappings(Set<String> configuredIdentifiers,
+            Set<String> bedrockIdentifiers) {
         Object2IntMap<String> customMappings = new Object2IntOpenHashMap<>();
         int customId = CUSTOM_BIOME_ID_START;
         for (String identifier : configuredIdentifiers) {

--- a/core/src/main/java/org/geysermc/geyser/pack/BiomeResourcePackManager.java
+++ b/core/src/main/java/org/geysermc/geyser/pack/BiomeResourcePackManager.java
@@ -28,11 +28,16 @@ package org.geysermc.geyser.pack;
 import com.google.gson.JsonArray;
 import com.google.gson.JsonObject;
 import com.google.gson.annotations.SerializedName;
+import it.unimi.dsi.fastutil.objects.Object2IntMap;
+import it.unimi.dsi.fastutil.objects.Object2IntOpenHashMap;
 import it.unimi.dsi.fastutil.objects.Object2ObjectOpenHashMap;
+import net.kyori.adventure.key.InvalidKeyException;
 import org.checkerframework.checker.nullness.qual.Nullable;
 import org.geysermc.geyser.GeyserImpl;
 import org.geysermc.geyser.registry.Registries;
+import org.geysermc.geyser.registry.loader.BiomeIdentifierRegistryLoader;
 import org.geysermc.geyser.util.FileUtils;
+import org.geysermc.geyser.util.MinecraftKey;
 
 import java.io.IOException;
 import java.io.InputStream;
@@ -42,6 +47,7 @@ import java.nio.file.Path;
 import java.util.Map;
 import java.util.Set;
 import java.util.TreeMap;
+import java.util.TreeSet;
 import java.util.UUID;
 import java.util.zip.ZipEntry;
 import java.util.zip.ZipOutputStream;
@@ -65,7 +71,7 @@ public final class BiomeResourcePackManager {
         try {
             Set<String> bedrockIdentifiers = Registries.BIOMES.get().getDefinitions().keySet();
             Files.createDirectories(output.getParent());
-            int biomeCount = createResourcePack(input, output, bedrockIdentifiers);
+            int biomeCount = createResourcePack(input, output, bedrockIdentifiers, Registries.BIOME_IDENTIFIERS.get());
             geyser.getLogger()
                     .info("Generated Bedrock biome visuals resource pack with " + biomeCount + " biome appearance(s).");
             return output;
@@ -75,13 +81,16 @@ public final class BiomeResourcePackManager {
         }
     }
 
-    static int createResourcePack(Path input, Path output, Set<String> bedrockIdentifiers) throws IOException {
-        Map<String, BiomeVisuals> biomes = load(input, bedrockIdentifiers);
+    private static int createResourcePack(Path input, Path output, Set<String> bedrockIdentifiers,
+            Object2IntMap<String> biomeIdentifiers) throws IOException {
+        Map<String, BiomeVisuals> biomes = load(input);
+        Object2IntMap<String> customMappings = customMappings(biomes.keySet(), bedrockIdentifiers);
         write(output, biomes);
+        biomeIdentifiers.putAll(customMappings);
         return biomes.size();
     }
 
-    private static Map<String, BiomeVisuals> load(Path input, Set<String> bedrockIdentifiers) throws IOException {
+    private static Map<String, BiomeVisuals> load(Path input) throws IOException {
         BiomeConfig config;
         try (InputStream stream = Files.newInputStream(input)) {
             config = FileUtils.loadJson(stream, BiomeConfig.class);
@@ -94,22 +103,18 @@ public final class BiomeResourcePackManager {
             throw new IllegalArgumentException("No biome visuals were defined");
         }
 
-        return resolve(config.biomes(), bedrockIdentifiers);
+        return resolve(config.biomes());
     }
 
-    private static Map<String, BiomeVisuals> resolve(Map<String, BiomeDefinition> definitions,
-            Set<String> bedrockIdentifiers) {
+    private static Map<String, BiomeVisuals> resolve(Map<String, BiomeDefinition> definitions) {
         Map<String, BiomeVisuals> resolved = new Object2ObjectOpenHashMap<>();
         for (Map.Entry<String, BiomeDefinition> biome : definitions.entrySet()) {
             String javaIdentifier = biome.getKey();
             BiomeDefinition definition = biome.getValue();
-            String bedrockIdentifier = definition.bedrockIdentifier() != null
-                    ? definition.bedrockIdentifier()
-                    : javaIdentifier;
-
-            if (!bedrockIdentifiers.contains(bedrockIdentifier)) {
-                throw new IllegalArgumentException("Unknown Bedrock biome identifier " + bedrockIdentifier);
+            if (definition == null) {
+                throw new IllegalArgumentException("No biome visuals were defined for " + javaIdentifier);
             }
+            validateIdentifier(javaIdentifier);
 
             BiomeVisuals visuals = new BiomeVisuals(
                     color(definition.waterColor()),
@@ -118,13 +123,30 @@ public final class BiomeResourcePackManager {
                     optionalColor(definition.skyColor()),
                     optionalColor(definition.grassColor()),
                     optionalColor(definition.foliageColor()));
-            BiomeVisuals previous = resolved.putIfAbsent(bedrockIdentifier, visuals);
-            if (previous != null && !previous.equals(visuals)) {
-                throw new IllegalArgumentException("Multiple Java biomes resolve to " + bedrockIdentifier
-                        + " with different appearances");
-            }
+            resolved.put(javaIdentifier, visuals);
         }
         return resolved;
+    }
+
+    private static Object2IntMap<String> customMappings(Set<String> configuredIdentifiers, Set<String> bedrockIdentifiers) {
+        Object2IntMap<String> customMappings = new Object2IntOpenHashMap<>();
+        int customId = BiomeIdentifierRegistryLoader.CUSTOM_BIOME_ID_START;
+        for (String identifier : new TreeSet<>(configuredIdentifiers)) {
+            if (!bedrockIdentifiers.contains(identifier)) {
+                customMappings.put(identifier, customId++);
+            }
+        }
+        return customMappings;
+    }
+
+    private static void validateIdentifier(String identifier) {
+        try {
+            if (!MinecraftKey.key(identifier).asString().equals(identifier)) {
+                throw new IllegalArgumentException("Invalid biome identifier " + identifier);
+            }
+        } catch (InvalidKeyException e) {
+            throw new IllegalArgumentException("Invalid biome identifier " + identifier, e);
+        }
     }
 
     private static void write(Path output, Map<String, BiomeVisuals> biomes) throws IOException {
@@ -215,8 +237,7 @@ public final class BiomeResourcePackManager {
             @SerializedName("fog_color") String fogColor,
             @SerializedName("sky_color") @Nullable String skyColor,
             @SerializedName("grass_color") @Nullable String grassColor,
-            @SerializedName("foliage_color") @Nullable String foliageColor,
-            @SerializedName("bedrock_identifier") @Nullable String bedrockIdentifier) {
+            @SerializedName("foliage_color") @Nullable String foliageColor) {
     }
 
     private record BiomeVisuals(
@@ -227,7 +248,7 @@ public final class BiomeResourcePackManager {
             @Nullable Integer grassColor,
             @Nullable Integer foliageColor) {
 
-        JsonObject clientBiome(String biomeIdentifier, String fogIdentifier) {
+        private JsonObject clientBiome(String biomeIdentifier, String fogIdentifier) {
             JsonObject components = new JsonObject();
 
             JsonObject water = new JsonObject();
@@ -269,7 +290,7 @@ public final class BiomeResourcePackManager {
             return root;
         }
 
-        JsonObject fog(String fogIdentifier) {
+        private JsonObject fog(String fogIdentifier) {
             JsonObject distance = new JsonObject();
             distance.add("air", fogDistance(fogColor));
             distance.add("water", fogDistance(waterFogColor));

--- a/core/src/main/java/org/geysermc/geyser/registry/Registries.java
+++ b/core/src/main/java/org/geysermc/geyser/registry/Registries.java
@@ -125,7 +125,7 @@ public final class Registries {
     public static final SimpleDeferredRegistry<Object2IntMap<String>> BIOME_IDENTIFIERS = SimpleDeferredRegistry.create("mappings/biomes.json", BiomeIdentifierRegistryLoader::new);
 
     /**
-     * A mapped registry which stores configured Java biome identifiers and their generated Bedrock biome IDs.
+     * A mapped registry which stores custom Java biome identifiers that have been configured and their generated Bedrock biome IDs.
      */
     public static final SimpleRegistry<Object2IntMap<String>> CUSTOM_BIOME_IDENTIFIERS = SimpleRegistry.create(RegistryLoaders.empty(Object2IntOpenHashMap::new));
 

--- a/core/src/main/java/org/geysermc/geyser/registry/Registries.java
+++ b/core/src/main/java/org/geysermc/geyser/registry/Registries.java
@@ -27,6 +27,7 @@ package org.geysermc.geyser.registry;
 
 import it.unimi.dsi.fastutil.ints.Int2ObjectOpenHashMap;
 import it.unimi.dsi.fastutil.objects.Object2IntMap;
+import it.unimi.dsi.fastutil.objects.Object2IntOpenHashMap;
 import it.unimi.dsi.fastutil.objects.Object2ObjectMap;
 import it.unimi.dsi.fastutil.objects.Object2ObjectOpenHashMap;
 import it.unimi.dsi.fastutil.objects.Reference2ObjectOpenHashMap;
@@ -122,6 +123,11 @@ public final class Registries {
      * A mapped registry which stores Java biome identifiers and their Bedrock biome identifier.
      */
     public static final SimpleDeferredRegistry<Object2IntMap<String>> BIOME_IDENTIFIERS = SimpleDeferredRegistry.create("mappings/biomes.json", BiomeIdentifierRegistryLoader::new);
+
+    /**
+     * A mapped registry which stores configured Java biome identifiers and their generated Bedrock biome IDs.
+     */
+    public static final SimpleRegistry<Object2IntMap<String>> CUSTOM_BIOME_IDENTIFIERS = SimpleRegistry.create(RegistryLoaders.empty(Object2IntOpenHashMap::new));
 
     /**
      * A mapped registry which stores a block entity identifier to its {@link BlockEntityTranslator}.

--- a/core/src/main/java/org/geysermc/geyser/registry/loader/BiomeIdentifierRegistryLoader.java
+++ b/core/src/main/java/org/geysermc/geyser/registry/loader/BiomeIdentifierRegistryLoader.java
@@ -38,6 +38,7 @@ import java.lang.reflect.Type;
 import java.util.Map;
 
 public class BiomeIdentifierRegistryLoader implements RegistryLoader<String, Object2IntMap<String>> {
+    public static final int CUSTOM_BIOME_ID_START = 10_000;
 
     @Override
     public Object2IntMap<String> load(String input) {

--- a/core/src/main/java/org/geysermc/geyser/registry/loader/BiomeIdentifierRegistryLoader.java
+++ b/core/src/main/java/org/geysermc/geyser/registry/loader/BiomeIdentifierRegistryLoader.java
@@ -38,7 +38,6 @@ import java.lang.reflect.Type;
 import java.util.Map;
 
 public class BiomeIdentifierRegistryLoader implements RegistryLoader<String, Object2IntMap<String>> {
-    public static final int CUSTOM_BIOME_ID_START = 10_000;
 
     @Override
     public Object2IntMap<String> load(String input) {

--- a/core/src/main/java/org/geysermc/geyser/registry/loader/ResourcePackLoader.java
+++ b/core/src/main/java/org/geysermc/geyser/registry/loader/ResourcePackLoader.java
@@ -36,6 +36,7 @@ import org.geysermc.geyser.api.pack.ResourcePack;
 import org.geysermc.geyser.api.pack.ResourcePackManifest;
 import org.geysermc.geyser.api.pack.UrlPackCodec;
 import org.geysermc.geyser.event.type.GeyserDefineResourcePacksEventImpl;
+import org.geysermc.geyser.pack.BiomeResourcePackManager;
 import org.geysermc.geyser.pack.GeyserResourcePack;
 import org.geysermc.geyser.pack.GeyserResourcePackManifest;
 import org.geysermc.geyser.pack.ResourcePackHolder;
@@ -118,6 +119,11 @@ public class ResourcePackLoader implements RegistryLoader<Path, Map<UUID, Resour
         Path skullResourcePack = SkullResourcePackManager.createResourcePack();
         if (skullResourcePack != null) {
             resourcePacks.add(skullResourcePack);
+        }
+
+        Path biomeVisualsPack = BiomeResourcePackManager.createResourcePack();
+        if (biomeVisualsPack != null) {
+            resourcePacks.add(biomeVisualsPack);
         }
 
         //noinspection deprecation - we know

--- a/core/src/main/java/org/geysermc/geyser/session/GeyserSession.java
+++ b/core/src/main/java/org/geysermc/geyser/session/GeyserSession.java
@@ -195,6 +195,7 @@ import org.geysermc.geyser.session.dialog.Dialog;
 import org.geysermc.geyser.session.dialog.DialogManager;
 import org.geysermc.geyser.skin.SkinManager;
 import org.geysermc.geyser.text.GeyserLocale;
+import org.geysermc.geyser.translator.level.BiomeTranslator;
 import org.geysermc.geyser.translator.inventory.InventoryTranslator;
 import org.geysermc.geyser.translator.text.MessageTranslator;
 import org.geysermc.geyser.util.ChunkUtils;
@@ -953,7 +954,8 @@ public class GeyserSession implements GeyserConnection, GeyserCommandSource {
      */
     private void sendRegistryDefinitions() {
         BiomeDefinitionListPacket biomeDefinitionListPacket = new BiomeDefinitionListPacket();
-        biomeDefinitionListPacket.setBiomes(Registries.BIOMES.get());
+        biomeDefinitionListPacket.setBiomes(BiomeTranslator.bedrockBiomeDefinitions(
+                registryCache.registry(JavaRegistries.BIOME)));
         upstream.sendPacket(biomeDefinitionListPacket);
 
         AvailableEntityIdentifiersPacket entityPacket = new AvailableEntityIdentifiersPacket();

--- a/core/src/main/java/org/geysermc/geyser/session/cache/registry/JavaRegistries.java
+++ b/core/src/main/java/org/geysermc/geyser/session/cache/registry/JavaRegistries.java
@@ -46,6 +46,7 @@ import org.geysermc.geyser.registry.BlockRegistries;
 import org.geysermc.geyser.registry.ListRegistry;
 import org.geysermc.geyser.registry.Registries;
 import org.geysermc.geyser.session.dialog.Dialog;
+import org.geysermc.geyser.translator.level.BiomeTranslator.BiomeMapping;
 import org.geysermc.geyser.util.MinecraftKey;
 import org.geysermc.mcprotocollib.protocol.data.game.chat.ChatType;
 import org.geysermc.mcprotocollib.protocol.data.game.item.component.ArmorTrim;
@@ -72,7 +73,7 @@ public class JavaRegistries {
 
     public static final JavaRegistryKey<ChatType> CHAT_TYPE = create("chat_type");
     public static final JavaRegistryKey<JavaDimension> DIMENSION_TYPE = create("dimension_type");
-    public static final JavaRegistryKey<Integer> BIOME = create("worldgen/biome");
+    public static final JavaRegistryKey<BiomeMapping> BIOME = create("worldgen/biome");
     public static final JavaRegistryKey<Enchantment> ENCHANTMENT = create("enchantment");
     public static final JavaRegistryKey<BannerPattern> BANNER_PATTERN = create("banner_pattern");
     public static final JavaRegistryKey<GeyserInstrument> INSTRUMENT = create("instrument");

--- a/core/src/main/java/org/geysermc/geyser/translator/level/BiomeTranslator.java
+++ b/core/src/main/java/org/geysermc/geyser/translator/level/BiomeTranslator.java
@@ -31,7 +31,6 @@ import org.cloudburstmc.protocol.bedrock.data.biome.BiomeDefinitionData;
 import org.cloudburstmc.protocol.bedrock.data.biome.BiomeDefinitions;
 import org.geysermc.geyser.level.BedrockDimension;
 import org.geysermc.geyser.level.JavaDimension;
-import org.geysermc.geyser.registry.loader.BiomeIdentifierRegistryLoader;
 import org.geysermc.geyser.session.cache.registry.JavaRegistries;
 import org.geysermc.geyser.session.cache.registry.JavaRegistry;
 import org.geysermc.geyser.session.cache.registry.RegistryEntryContext;
@@ -66,15 +65,17 @@ public class BiomeTranslator {
     private static final int UNKNOWN_BIOME = -1;
 
     public static BiomeMapping loadServerBiome(RegistryEntryContext entry) {
-        int bedrockId = Registries.BIOME_IDENTIFIERS.get().getOrDefault(entry.id().asString(), UNKNOWN_BIOME);
-        return loadServerBiome(entry, bedrockId);
-    }
-
-    private static BiomeMapping loadServerBiome(RegistryEntryContext entry, int bedrockId) {
-        if (bedrockId < BiomeIdentifierRegistryLoader.CUSTOM_BIOME_ID_START) {
-            return new BiomeMapping(bedrockId, null);
+        String identifier = entry.id().asString();
+        int customId = Registries.CUSTOM_BIOME_IDENTIFIERS.get().getOrDefault(identifier, UNKNOWN_BIOME);
+        if (customId != UNKNOWN_BIOME) {
+            return customBiome(entry, customId);
         }
 
+        int bedrockId = Registries.BIOME_IDENTIFIERS.get().getOrDefault(identifier, UNKNOWN_BIOME);
+        return new BiomeMapping(bedrockId, null);
+    }
+
+    private static BiomeMapping customBiome(RegistryEntryContext entry, int bedrockId) {
         NbtMap data = entry.data();
         return new BiomeMapping(bedrockId, new BiomeDefinitionData(
                 bedrockId,

--- a/core/src/main/java/org/geysermc/geyser/translator/level/BiomeTranslator.java
+++ b/core/src/main/java/org/geysermc/geyser/translator/level/BiomeTranslator.java
@@ -26,11 +26,16 @@
 package org.geysermc.geyser.translator.level;
 
 import org.checkerframework.checker.nullness.qual.Nullable;
+import org.cloudburstmc.nbt.NbtMap;
+import org.cloudburstmc.protocol.bedrock.data.biome.BiomeDefinitionData;
+import org.cloudburstmc.protocol.bedrock.data.biome.BiomeDefinitions;
 import org.geysermc.geyser.level.BedrockDimension;
 import org.geysermc.geyser.level.JavaDimension;
+import org.geysermc.geyser.registry.loader.BiomeIdentifierRegistryLoader;
 import org.geysermc.geyser.session.cache.registry.JavaRegistries;
 import org.geysermc.geyser.session.cache.registry.JavaRegistry;
 import org.geysermc.geyser.session.cache.registry.RegistryEntryContext;
+import org.geysermc.geyser.session.cache.registry.RegistryEntryData;
 import org.geysermc.mcprotocollib.protocol.data.game.chunk.BitStorage;
 import org.geysermc.mcprotocollib.protocol.data.game.chunk.DataPalette;
 import org.geysermc.mcprotocollib.protocol.data.game.chunk.palette.GlobalPalette;
@@ -39,6 +44,7 @@ import org.geysermc.mcprotocollib.protocol.data.game.chunk.palette.SingletonPale
 import it.unimi.dsi.fastutil.ints.IntArrayList;
 import it.unimi.dsi.fastutil.ints.IntList;
 import it.unimi.dsi.fastutil.ints.IntLists;
+import it.unimi.dsi.fastutil.objects.Object2ObjectLinkedOpenHashMap;
 import org.geysermc.geyser.level.chunk.BlockStorage;
 import org.geysermc.geyser.level.chunk.bitarray.BitArray;
 import org.geysermc.geyser.level.chunk.bitarray.BitArrayVersion;
@@ -46,18 +52,41 @@ import org.geysermc.geyser.level.chunk.bitarray.SingletonBitArray;
 import org.geysermc.geyser.registry.Registries;
 import org.geysermc.geyser.session.GeyserSession;
 
+import java.awt.Color;
+import java.util.List;
+import java.util.Map;
+
 // Array index formula by https://wiki.vg/Chunk_Format
 public class BiomeTranslator {
 
     /**
      * Marks a Java biome with no direct Bedrock equivalent; a dimension-appropriate fallback
-     * is selected in {@link #bedrockBiomeId(GeyserSession, JavaRegistry, int)} instead.
+     * is selected in {@link #bedrockBiomeId(JavaDimension, JavaRegistry, int)} instead.
      */
     private static final int UNKNOWN_BIOME = -1;
 
-    public static int loadServerBiome(RegistryEntryContext entry) {
-        String javaIdentifier = entry.id().asString();
-        return Registries.BIOME_IDENTIFIERS.get().getOrDefault(javaIdentifier, UNKNOWN_BIOME);
+    public static BiomeMapping loadServerBiome(RegistryEntryContext entry) {
+        int bedrockId = Registries.BIOME_IDENTIFIERS.get().getOrDefault(entry.id().asString(), UNKNOWN_BIOME);
+        return loadServerBiome(entry, bedrockId);
+    }
+
+    private static BiomeMapping loadServerBiome(RegistryEntryContext entry, int bedrockId) {
+        if (bedrockId < BiomeIdentifierRegistryLoader.CUSTOM_BIOME_ID_START) {
+            return new BiomeMapping(bedrockId, null);
+        }
+
+        NbtMap data = entry.data();
+        return new BiomeMapping(bedrockId, new BiomeDefinitionData(
+                bedrockId,
+                data.getFloat("temperature"),
+                data.getFloat("downfall"),
+                0,
+                0,
+                0,
+                new Color(data.getCompound("effects").getInt("water_color")),
+                data.getBoolean("has_precipitation"),
+                List.of(),
+                null));
     }
 
     /**
@@ -66,12 +95,12 @@ public class BiomeTranslator {
      * vanilla biome fitting the session's current dimension so that sky, fog and weather
      * render sensibly instead of always defaulting to ocean.
      */
-    private static int bedrockBiomeId(GeyserSession session, JavaRegistry<Integer> biomeTranslations, int javaId) {
-        Integer bedrockId = javaId < 0 ? null : biomeTranslations.byId(javaId);
-        if (bedrockId == null || bedrockId == UNKNOWN_BIOME) {
-            return fallbackBiomeId(session.getDimensionType());
+    private static int bedrockBiomeId(@Nullable JavaDimension dimension, JavaRegistry<BiomeMapping> biomeTranslations, int javaId) {
+        BiomeMapping mapping = javaId < 0 ? null : biomeTranslations.byId(javaId);
+        if (mapping == null || mapping.bedrockId() == UNKNOWN_BIOME) {
+            return fallbackBiomeId(dimension);
         }
-        return bedrockId;
+        return mapping.bedrockId();
     }
 
     private static int fallbackBiomeId(@Nullable JavaDimension dimension) {
@@ -90,14 +119,35 @@ public class BiomeTranslator {
         return Registries.BIOME_IDENTIFIERS.get().getOrDefault(identifier, 0);
     }
 
+    public static BiomeDefinitions bedrockBiomeDefinitions(JavaRegistry<BiomeMapping> biomes) {
+        return bedrockBiomeDefinitions(Registries.BIOMES.get().getDefinitions(), biomes);
+    }
+
+    private static BiomeDefinitions bedrockBiomeDefinitions(Map<String, BiomeDefinitionData> vanillaDefinitions,
+            JavaRegistry<BiomeMapping> biomes) {
+        Map<String, BiomeDefinitionData> definitions = new Object2ObjectLinkedOpenHashMap<>(vanillaDefinitions);
+        for (RegistryEntryData<BiomeMapping> biome : biomes) {
+            BiomeDefinitionData customDefinition = biome.data().customDefinition();
+            if (customDefinition != null) {
+                definitions.put(biome.key().asString(), customDefinition);
+            }
+        }
+        return new BiomeDefinitions(definitions);
+    }
+
     public static BlockStorage toNewBedrockBiome(GeyserSession session, DataPalette biomeData) {
-        JavaRegistry<Integer> biomeTranslations = session.getRegistryCache().registry(JavaRegistries.BIOME);
+        JavaRegistry<BiomeMapping> biomeTranslations = session.getRegistryCache().registry(JavaRegistries.BIOME);
+        return translateBiomeStorage(session.getDimensionType(), biomeData, biomeTranslations);
+    }
+
+    private static BlockStorage translateBiomeStorage(@Nullable JavaDimension dimension, DataPalette biomeData,
+            JavaRegistry<BiomeMapping> biomeTranslations) {
         // As of 1.17.10: the client expects the same format as a chunk but filled with biomes
         // As of 1.18 this is the same as Java Edition
 
         Palette palette = biomeData.getPalette();
         if (palette instanceof SingletonPalette) {
-            int biomeId = bedrockBiomeId(session, biomeTranslations, palette.idToState(0));
+            int biomeId = bedrockBiomeId(dimension, biomeTranslations, palette.idToState(0));
             return new BlockStorage(SingletonBitArray.INSTANCE, IntLists.singleton(biomeId));
         } else {
             BlockStorage storage;
@@ -117,7 +167,7 @@ public class BiomeTranslator {
                 }
 
                 if (allSame) {
-                    int biomeId = bedrockBiomeId(session, biomeTranslations, palette.idToState(firstIdx));
+                    int biomeId = bedrockBiomeId(dimension, biomeTranslations, palette.idToState(firstIdx));
                     storage = new BlockStorage(SingletonBitArray.INSTANCE, IntLists.singleton(biomeId));
                 } else {
                     // Prevent resizing by allocating what we can ahead of time
@@ -128,7 +178,7 @@ public class BiomeTranslator {
 
                     for (int i = 0; i < size; i++) {
                         int javaId = palette.idToState(i);
-                        bedrockPalette.add(bedrockBiomeId(session, biomeTranslations, javaId));
+                        bedrockPalette.add(bedrockBiomeId(dimension, biomeTranslations, javaId));
                     }
 
                     // Each section of biome corresponding to a chunk section contains 4 * 4 * 4 entries
@@ -154,7 +204,7 @@ public class BiomeTranslator {
                     int y = (i >> 4) & 3;
                     int z = (i >> 2) & 3;
                     // Get the Bedrock biome ID override
-                    int biomeId = bedrockBiomeId(session, biomeTranslations, javaId);
+                    int biomeId = bedrockBiomeId(dimension, biomeTranslations, javaId);
                     int idx = storage.idFor(biomeId);
                     // Convert biome coordinates into block coordinates
                     // Bedrock expects a full 4096 blocks
@@ -175,5 +225,11 @@ public class BiomeTranslator {
                 }
             }
         }
+    }
+
+    /**
+     * @param customDefinition the definition to send to Bedrock, or null when using a built-in biome
+     */
+    public record BiomeMapping(int bedrockId, @Nullable BiomeDefinitionData customDefinition) {
     }
 }

--- a/core/src/main/java/org/geysermc/geyser/translator/level/BiomeTranslator.java
+++ b/core/src/main/java/org/geysermc/geyser/translator/level/BiomeTranslator.java
@@ -66,6 +66,7 @@ public class BiomeTranslator {
 
     public static BiomeMapping loadServerBiome(RegistryEntryContext entry) {
         String identifier = entry.id().asString();
+        
         int customId = Registries.CUSTOM_BIOME_IDENTIFIERS.get().getOrDefault(identifier, UNKNOWN_BIOME);
         if (customId != UNKNOWN_BIOME) {
             return customBiome(entry, customId);

--- a/core/src/test/java/org/geysermc/geyser/pack/BiomeResourcePackManagerTest.java
+++ b/core/src/test/java/org/geysermc/geyser/pack/BiomeResourcePackManagerTest.java
@@ -43,38 +43,40 @@ import java.nio.file.Path;
 import java.util.Objects;
 import java.util.zip.ZipFile;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertFalse;
-import static org.junit.jupiter.api.Assertions.assertNotNull;
-import static org.junit.jupiter.api.Assertions.assertNull;
-import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.ArgumentMatchers.anyString;
-import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.mockStatic;
-import static org.mockito.Mockito.when;
+import static org.mockito.Mockito.*;
 
 public class BiomeResourcePackManagerTest {
     private static final String PLAINS = """
-            "minecraft:plains": {
-              "water_color": "#3F76E4",
-              "water_fog_color": "#050533",
-              "fog_color": "#C0D8FF"
+        "minecraft:plains": {
+            "effects": {
+                "water_color": "#3F76E4"
             }
-            """;
+        }
+        """;
     private static final String CRYSTAL_CAVERNS = """
-            "custom:crystal_caverns": {
-              "water_color": "#123456",
-              "water_fog_color": "#234567",
-              "fog_color": "#345678",
-              "weather_fog_color": "#89ABCD",
-              "sky_color": "#456789",
-              "grass_color": "#56789A",
-              "foliage_color": "#6789AB"
+        "custom:crystal_caverns": {
+            "attributes": {
+                "minecraft:visual/sky_color": "#456789",
+                "minecraft:visual/fog_color": "#345678",
+                "minecraft:visual/water_fog_color": "#234567"
+            },
+            "effects": {
+                "water_color": "#123456",
+                "foliage_color": "#6789AB",
+                "dry_foliage_color": "#6789AB",
+                "grass_color": "#56789A"
             }
-            """;
+        }
+        """;
 
     @TempDir
     Path tempDirectory;
+
+    private static InputStream resource(String name) {
+        return BiomeResourcePackManagerTest.class.getClassLoader().getResourceAsStream(name);
+    }
 
     @AfterEach
     public void removeCustomMappings() {
@@ -99,19 +101,21 @@ public class BiomeResourcePackManagerTest {
     @Test
     public void rejectsInvalidBiomeIdentifiers() throws IOException {
         assertInvalid("""
-                {"format_version": 1, "biomes": {"Custom:invalid": {
-                  "water_color": "#123456", "water_fog_color": "#234567", "fog_color": "#345678"
-                }}}
-                """);
+            {
+                "format_version": 1,
+                "biomes": { "Custom:invalid": { "effects": { "water_color": "#123456" } } }
+            }
+            """);
         assertInvalid("""
-                {"format_version": 1, "biomes": {"plains": {
-                  "water_color": "#123456", "water_fog_color": "#234567", "fog_color": "#345678"
-                }}}
-                """);
+            {
+                "format_version": 1,
+                "biomes": {"plains": { "effects": { "water_color": "#123456" } } }
+            }
+            """);
     }
 
     @Test
-    public void clearsMappingsWhenConfigIsRemoved() throws IOException {
+    public void clearsMappingsWhenConfigIsRemoved() {
         Registries.CUSTOM_BIOME_IDENTIFIERS.get().put("custom:stale", 0);
 
         assertNull(createResourcePack());
@@ -130,8 +134,8 @@ public class BiomeResourcePackManagerTest {
     private void writeConfig(String biomes) throws IOException {
         Path input = tempDirectory.resolve("biome-visuals.json");
         Files.writeString(input, """
-                {"format_version": 1, "biomes": {%s}}
-                """.formatted(biomes));
+            {"format_version": 1, "biomes": {%s}}
+            """.formatted(biomes));
     }
 
     private void assertInvalid(String config) throws IOException {
@@ -162,9 +166,5 @@ public class BiomeResourcePackManagerTest {
 
     private Path generatedPack() {
         return Objects.requireNonNull(createResourcePack());
-    }
-
-    private static InputStream resource(String name) {
-        return BiomeResourcePackManagerTest.class.getClassLoader().getResourceAsStream(name);
     }
 }

--- a/core/src/test/java/org/geysermc/geyser/pack/BiomeResourcePackManagerTest.java
+++ b/core/src/test/java/org/geysermc/geyser/pack/BiomeResourcePackManagerTest.java
@@ -66,6 +66,7 @@ public class BiomeResourcePackManagerTest {
               "water_color": "#123456",
               "water_fog_color": "#234567",
               "fog_color": "#345678",
+              "weather_fog_color": "#89ABCD",
               "sky_color": "#456789",
               "grass_color": "#56789A",
               "foliage_color": "#6789AB"

--- a/core/src/test/java/org/geysermc/geyser/pack/BiomeResourcePackManagerTest.java
+++ b/core/src/test/java/org/geysermc/geyser/pack/BiomeResourcePackManagerTest.java
@@ -1,0 +1,169 @@
+/*
+ * Copyright (c) 2019-2026 GeyserMC. http://geysermc.org
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ *
+ * @author GeyserMC
+ * @link https://github.com/GeyserMC/Geyser
+ */
+
+package org.geysermc.geyser.pack;
+
+import it.unimi.dsi.fastutil.objects.Object2IntMap;
+import org.checkerframework.checker.nullness.qual.Nullable;
+import org.geysermc.geyser.GeyserBootstrap;
+import org.geysermc.geyser.GeyserImpl;
+import org.geysermc.geyser.GeyserLogger;
+import org.geysermc.geyser.registry.Registries;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+import org.mockito.MockedStatic;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.Objects;
+import java.util.zip.ZipFile;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.mockStatic;
+import static org.mockito.Mockito.when;
+
+public class BiomeResourcePackManagerTest {
+    private static final String PLAINS = """
+            "minecraft:plains": {
+              "water_color": "#3F76E4",
+              "water_fog_color": "#050533",
+              "fog_color": "#C0D8FF"
+            }
+            """;
+    private static final String CRYSTAL_CAVERNS = """
+            "custom:crystal_caverns": {
+              "water_color": "#123456",
+              "water_fog_color": "#234567",
+              "fog_color": "#345678",
+              "sky_color": "#456789",
+              "grass_color": "#56789A",
+              "foliage_color": "#6789AB"
+            }
+            """;
+
+    @TempDir
+    Path tempDirectory;
+
+    @AfterEach
+    public void removeCustomMappings() {
+        Registries.CUSTOM_BIOME_IDENTIFIERS.get().clear();
+    }
+
+    @Test
+    public void generatesVisualsAndRegistersOnlyCustomBiomes() throws IOException {
+        writeConfig(CRYSTAL_CAVERNS + "," + PLAINS);
+        Path output = generatedPack();
+        Object2IntMap<String> customMappings = Registries.CUSTOM_BIOME_IDENTIFIERS.get();
+
+        assertEquals(30_000, customMappings.getInt("custom:crystal_caverns"));
+        assertFalse(customMappings.containsKey("minecraft:plains"));
+        try (ZipFile pack = new ZipFile(output.toFile())) {
+            assertNotNull(pack.getEntry("biomes/custom_crystal_caverns.client_biome.json"));
+            assertNotNull(pack.getEntry("fogs/custom_crystal_caverns_fog_setting.json"));
+            assertNotNull(pack.getEntry("biomes/plains.client_biome.json"));
+        }
+    }
+
+    @Test
+    public void rejectsInvalidBiomeIdentifiers() throws IOException {
+        assertInvalid("""
+                {"format_version": 1, "biomes": {"Custom:invalid": {
+                  "water_color": "#123456", "water_fog_color": "#234567", "fog_color": "#345678"
+                }}}
+                """);
+        assertInvalid("""
+                {"format_version": 1, "biomes": {"plains": {
+                  "water_color": "#123456", "water_fog_color": "#234567", "fog_color": "#345678"
+                }}}
+                """);
+    }
+
+    @Test
+    public void clearsMappingsWhenConfigIsRemoved() throws IOException {
+        Registries.CUSTOM_BIOME_IDENTIFIERS.get().put("custom:stale", 0);
+
+        assertNull(createResourcePack());
+        assertTrue(Registries.CUSTOM_BIOME_IDENTIFIERS.get().isEmpty());
+    }
+
+    @Test
+    public void doesNotRegisterMappingsWhenPackWritingFails() throws IOException {
+        writeConfig(CRYSTAL_CAVERNS);
+        Files.createDirectories(tempDirectory.resolve("cache/GeyserBiomeVisuals.mcpack"));
+
+        assertNull(createResourcePack());
+        assertTrue(Registries.CUSTOM_BIOME_IDENTIFIERS.get().isEmpty());
+    }
+
+    private void writeConfig(String biomes) throws IOException {
+        Path input = tempDirectory.resolve("biome-visuals.json");
+        Files.writeString(input, """
+                {"format_version": 1, "biomes": {%s}}
+                """.formatted(biomes));
+    }
+
+    private void assertInvalid(String config) throws IOException {
+        Path input = tempDirectory.resolve("biome-visuals.json");
+        Files.writeString(input, config);
+        assertNull(createResourcePack());
+    }
+
+    private @Nullable Path createResourcePack() {
+        GeyserImpl geyser = mock(GeyserImpl.class);
+        GeyserBootstrap bootstrap = mock(GeyserBootstrap.class);
+        when(geyser.getBootstrap()).thenReturn(bootstrap);
+        when(geyser.getLogger()).thenReturn(mock(GeyserLogger.class));
+        when(bootstrap.getConfigFolder()).thenReturn(tempDirectory);
+        when(bootstrap.getResourceOrThrow(anyString())).thenAnswer(invocation -> resource(invocation.getArgument(0)));
+
+        try (MockedStatic<GeyserImpl> geyserInstance = mockStatic(GeyserImpl.class)) {
+            geyserInstance.when(GeyserImpl::getInstance).thenReturn(geyser);
+            if (!Registries.BIOMES.loaded()) {
+                Registries.BIOMES.load();
+            }
+            if (!Registries.BIOME_IDENTIFIERS.loaded()) {
+                Registries.BIOME_IDENTIFIERS.load();
+            }
+            return BiomeResourcePackManager.createResourcePack();
+        }
+    }
+
+    private Path generatedPack() {
+        return Objects.requireNonNull(createResourcePack());
+    }
+
+    private static InputStream resource(String name) {
+        return BiomeResourcePackManagerTest.class.getClassLoader().getResourceAsStream(name);
+    }
+}

--- a/core/src/test/java/org/geysermc/geyser/translator/level/BiomeTranslatorTest.java
+++ b/core/src/test/java/org/geysermc/geyser/translator/level/BiomeTranslatorTest.java
@@ -1,0 +1,148 @@
+/*
+ * Copyright (c) 2019-2026 GeyserMC. http://geysermc.org
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ *
+ * @author GeyserMC
+ * @link https://github.com/GeyserMC/Geyser
+ */
+
+package org.geysermc.geyser.translator.level;
+
+import net.kyori.adventure.key.Key;
+import org.checkerframework.checker.nullness.qual.Nullable;
+import org.cloudburstmc.nbt.NbtMap;
+import org.cloudburstmc.protocol.bedrock.data.biome.BiomeDefinitionData;
+import org.cloudburstmc.protocol.bedrock.data.biome.BiomeDefinitions;
+import org.geysermc.geyser.GeyserBootstrap;
+import org.geysermc.geyser.GeyserImpl;
+import org.geysermc.geyser.registry.Registries;
+import org.geysermc.geyser.session.cache.registry.RegistryEntryContext;
+import org.geysermc.geyser.session.cache.registry.RegistryEntryData;
+import org.geysermc.geyser.session.cache.registry.SimpleJavaRegistry;
+import org.geysermc.geyser.translator.level.BiomeTranslator.BiomeMapping;
+import org.geysermc.mcprotocollib.protocol.data.game.RegistryEntry;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+
+import java.awt.Color;
+import java.io.InputStream;
+import java.util.List;
+import java.util.Optional;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.mockStatic;
+import static org.mockito.Mockito.when;
+
+public class BiomeTranslatorTest {
+    private static final int CUSTOM_BIOME_ID = 30_000;
+
+    @BeforeAll
+    public static void loadRegistries() {
+        GeyserImpl geyser = mock(GeyserImpl.class);
+        GeyserBootstrap bootstrap = mock(GeyserBootstrap.class);
+        when(geyser.getBootstrap()).thenReturn(bootstrap);
+        when(bootstrap.getResourceOrThrow(anyString())).thenAnswer(invocation -> resource(invocation.getArgument(0)));
+
+        try (var geyserInstance = mockStatic(GeyserImpl.class)) {
+            geyserInstance.when(GeyserImpl::getInstance).thenReturn(geyser);
+            if (!Registries.BIOMES.loaded()) {
+                Registries.BIOMES.load();
+            }
+            if (!Registries.BIOME_IDENTIFIERS.loaded()) {
+                Registries.BIOME_IDENTIFIERS.load();
+            }
+        }
+    }
+
+    @AfterEach
+    public void removeCustomMapping() {
+        Registries.CUSTOM_BIOME_IDENTIFIERS.get().clear();
+    }
+
+    @Test
+    public void builtInAndUnknownBiomesDoNotReadRegistryData() {
+        BiomeMapping builtIn = BiomeTranslator.loadServerBiome(context("minecraft:plains", null));
+        BiomeMapping unknown = BiomeTranslator.loadServerBiome(context("custom:unknown", null));
+
+        assertEquals(Registries.BIOME_IDENTIFIERS.get().getInt("minecraft:plains"), builtIn.bedrockId());
+        assertNull(builtIn.customDefinition());
+        assertEquals(-1, unknown.bedrockId());
+        assertNull(unknown.customDefinition());
+    }
+
+    @Test
+    public void configuredBiomeUsesCustomMappingAndJavaClimateData() {
+        String identifier = "minecraft:end_highlands";
+        NbtMap data = NbtMap.builder()
+                .putFloat("temperature", 0.25F)
+                .putFloat("downfall", 0.75F)
+                .putBoolean("has_precipitation", true)
+                .putCompound("effects", NbtMap.builder().putInt("water_color", 0x123456).build())
+                .build();
+
+        Registries.CUSTOM_BIOME_IDENTIFIERS.get().put(identifier, CUSTOM_BIOME_ID);
+        BiomeMapping mapping = BiomeTranslator.loadServerBiome(context(identifier, data));
+        BiomeDefinitionData definition = mapping.customDefinition();
+
+        assertEquals(CUSTOM_BIOME_ID, mapping.bedrockId());
+        assertNotEquals(Registries.BIOME_IDENTIFIERS.get().getInt(identifier), mapping.bedrockId());
+        assertEquals(CUSTOM_BIOME_ID, definition.getId());
+        assertEquals(0.25F, definition.getTemperature());
+        assertEquals(0.75F, definition.getDownfall());
+        assertTrue(definition.isRain());
+        assertEquals(0x123456, definition.getMapWaterColor().getRGB() & 0xFFFFFF);
+    }
+
+    @Test
+    public void customDefinitionsAreAppendedToVanillaDefinitions() {
+        BiomeDefinitionData custom = definition(CUSTOM_BIOME_ID, true);
+        SimpleJavaRegistry<BiomeMapping> registry = new SimpleJavaRegistry<>();
+        registry.reset(List.of(
+                new RegistryEntryData<>(0, Key.key("minecraft:plains"), new BiomeMapping(1, null)),
+                new RegistryEntryData<>(1, Key.key("custom:crystal_caverns"),
+                        new BiomeMapping(CUSTOM_BIOME_ID, custom))));
+
+        BiomeDefinitions definitions = BiomeTranslator.bedrockBiomeDefinitions(registry);
+        BiomeDefinitionData vanilla = Registries.BIOMES.get().getDefinitions().get("minecraft:plains");
+
+        assertEquals(Registries.BIOMES.get().getDefinitions().size() + 1, definitions.getDefinitions().size());
+        assertSame(vanilla, definitions.getDefinitions().get("minecraft:plains"));
+        assertSame(custom, definitions.getDefinitions().get("custom:crystal_caverns"));
+    }
+
+    private static RegistryEntryContext context(String identifier, @Nullable NbtMap data) {
+        return new RegistryEntryContext(new RegistryEntry(Key.key(identifier), data), key -> -1, Optional.empty());
+    }
+
+    private static BiomeDefinitionData definition(@Nullable Integer id, boolean rain) {
+        return new BiomeDefinitionData(id, 0, 0, 0, 0, 0, new Color(0), rain, List.of(), null);
+    }
+
+    private static InputStream resource(String name) {
+        return BiomeTranslatorTest.class.getClassLoader().getResourceAsStream(name);
+    }
+}


### PR DESCRIPTION
## Summary

Since I wanted to create some custom biomes for a personal server I looked for current support for custom foliage and water colors. I came across [this](https://github.com/GeyserMC/Geyser/issues/3645) issue, where a comment from a few years ago sparked some interest in actually implementing this. 

This PR adds an optional `biome-visuals.json` file to the Geyser config directory. Geyser will validate this file and generate a `.mcpack` that contains bedrock client biome- and fog definitions for every configured Java identifier in the `biome-visuals.json` file. This feature supports both completely custom biomes, as well as custom colors for vanilla biomes.

Custom mappings are kept separate from the vanilla mapping registry, and IDs will start at `30000`, which is Bedrock's starting range for custom biome runtime IDs (It's not arbitrary, I swear ;)).

When the Java biome registry is received, Geyser will now create Bedrock definitions for configured custom biomes using the biome's temperature, downfall, precipitation flag, and color values. The custom definitions are appended to the vanilla definitions sent in `BiomeDefinitionListPacket`, When Geyser encodes chunk biome data for Bedrock, it uses the corresponding custom IDs.

## Configuration

### Properties

The configuration is structured the same way as biomes are defined in Java data packs. Only the `water_color` property is actually required, everything else is optional. Bedrock will automatically fall back to defaults for properties that are not defined. The configuration supports both integers and strings with a hexadecimal value (`#[0-9a-fA-F]{6}`).

Bedrock has a separate "weather" fog setting, while Java uses the standard `fog_color` and does some extra magic in the background, which makes it appear darker than it does in Bedrock. This could be an area of improvement; to add a separate `weather_fog_color` property to amend this issue.

`dry_foliage_color` is also not a thing in Bedrock, so its used as a fallback to fill in the foliage color, when `foliage_color` is not present.

There are also two other properties in bedrock for the fog: `lava`, and `lava_resistance`, but since these are not adjustable in Java either, these are left out for now as well.

#### Required properties

- effects -> water_color

#### Optional properties

- attributes -> minecraft:visuals/sky_color
- attributes -> minecraft:visuals/fog_color
- attributes -> minecraft:visuals/water_fog_color
- effects -> foliage_color
- effects -> dry_foliage_color
- effects -> grass_color

### Example 
```json
{
  "format_version": 1,
  "biomes": {
    "example:custom_biome": {
      "attributes": {
        "minecraft:visuals/sky_color": "#78A7FF",
        "minecraft:visuals/fog_color": "#C0D8FF",
        "minecraft:visuals/water_fog_color": "#050533"
      },
      "effects": {
        "water_color": "#3F76E4",
        "foliage_color": "#59AE30",
        "dry_foliage_color": "#59AE30",
        "grass_color": "#7CBD6B"
      }
    },
    "example:custom_biome_2": {
      "attributes": {
        "minecraft:visual/fog_color": 14145761,
        "minecraft:visual/water_fog_color": 329011,
        "minecraft:visual/sky_color": 10858685
      },
      "effects": {
        "water_color": 3750089
      }
    },
    "minecraft:plains": {
      "effects": {
        "water_color": "#3F76E4"
      }
    }
  }
}
```

### Fog Distance

For the fog distance I used the Bedrock defaults, and these are currently not configurable from the `biome-visuals.json`.

Generated distance fog uses Bedrock's standard ranges:

| Environment | Start | End | Distance type |
| --- | --- | --- | --- |
| Air | `0.92` | `1.0` | Render-relative |
| Weather, when configured | `0.23` | `0.7` | Render-relative |
| Water | `0` | `60` | Fixed blocks |

## Current Limitations

### Java and Bedrock render colors differently

Identical RGB values do not guarantee the output will be the same on both platforms. This is especially noticable with weather fog, where Bedrock's colors will be a lot more vibrant. It seems Java blends the fog color with different colors, including render distance fog, which I don't think Bedrock does (but correct me if I'm wrong).

### "Fancy Leaves" might not behave as expected with low biome temperatures

This is a bit of an odd one. Bedrock has a graphics setting called "Fancy Leaves", which can be toggled on or off. When the temperature gets too low (i.e. 0.0, not sure where the threshold is), leaves will not listen to foliage_colors and uses a climate based override. This has the cool effect of turning white when it snows, but the base color can not be overriden. There is one way to get around this, and that is toggling off "Fancy Leaves".

Let's see if Mojang is willing to do anything about it at some point: [MCPE-241589](https://report.bugs.mojang.com/servicedesk/customer/portal/6/MCPE-241589)

### Lava Fog and Lava Resistance Fog are not implemented

This is a limitation in Java 26.2 where it's (for now?) not possible to change fog colors for Lava. It is possible to change in Bedrock, but it would not make sense to expose this when it would be Bedrock-only functionality.

## Comparisons

Something to keep in mind, all of the comparisons have been made with the "Fancy" setting in Bedrock, "Vibrant Visuals" might look a bit different, but will still implement these color changes.

Java blends the biome fog colors a bit more, so when standing on the edge between two biomes it will show a blended variant, which looks a bit more pink, rather than the red. Moving over to the right would lead to nearly identical colors.

| Java | Bedrock | Bedrock (No Fancy Leaves) |
| --- | --- | --- |
| ![java-no-weather.png](https://github.com/user-attachments/assets/98c1a56e-293b-4343-9aca-132f1f438c8c) | ![bedrock-no-weather.png](https://github.com/user-attachments/assets/dc861feb-92a6-4977-8534-a7c3d15dc8a5) | ![bedrock-no-weather-no-fancy-leaves.png](https://github.com/user-attachments/assets/5490ac26-47ac-4eb9-b5d3-4952c020f6ca) |

For weather there is a lot more going on in Java with regards to color. In general it seems like the fog gets darkened when there is weather, and once again being on the edge of the biomes doesn't help the blending of the biome colors. Regardless there is quite a significant difference here, which is why I included a separate `weather_fog_color` for Bedrock. 

| Java | Bedrock |
| --- | --- |
| ![java-weather.png](https://github.com/user-attachments/assets/9cdac732-3b8f-427e-bc8f-5ab58cdeafd0) | ![bedrock-weather.png](https://github.com/user-attachments/assets/fa4485ef-a5a4-497f-9ac1-ca031d9d25cc) |

Underwater colors are a bit more vibrant for Bedrock as well, but generally seem close enough.

| Java | Bedrock |
| --- | --- | 
| ![java-underwater.png](https://github.com/user-attachments/assets/458a70dc-d487-4d22-9818-f9dde777537c) | ![bedrock-underwater.png](https://github.com/user-attachments/assets/f3c729b9-a7d0-44bf-bfb8-1355e80c41f4) |

## Possible Improvements

Some of these color differences could probably be fixed by tweaking fog distances, so it could be a good idea to make this configurable in the `biome-visuals.json` file in the future. For now I think it serves it's purpose well enough and will at least function as a first step towards parity between Java and Bedrock when it comes to biomes.

## AI Usage

For this development I have used some help from Copilot for exploration of the codebase, understanding some Java language features (sorry I'm a .NET dev), also the test code is drafted by AI with some manual adjustments.