### PR TITLE
Fix: Let real blocks take priority over item frames

### DIFF
--- a/core/src/main/java/org/geysermc/geyser/entity/type/ItemFrameEntity.java
+++ b/core/src/main/java/org/geysermc/geyser/entity/type/ItemFrameEntity.java
@@ -34,6 +34,7 @@ import org.cloudburstmc.protocol.bedrock.data.inventory.ItemData;
 import org.cloudburstmc.protocol.bedrock.packet.BlockEntityDataPacket;
 import org.cloudburstmc.protocol.bedrock.packet.UpdateBlockPacket;
 import org.geysermc.geyser.entity.spawn.EntitySpawnContext;
+import org.geysermc.geyser.level.block.type.BlockState;
 import org.geysermc.geyser.session.GeyserSession;
 import org.geysermc.geyser.translator.item.ItemTranslator;
 import org.geysermc.geyser.util.InteractionResult;
@@ -153,16 +154,12 @@ public class ItemFrameEntity extends HangingEntity {
 
     @Override
     public void despawnEntity() {
-        UpdateBlockPacket updateBlockPacket = new UpdateBlockPacket();
-        updateBlockPacket.setDataLayer(0);
-        updateBlockPacket.setBlockPosition(bedrockPosition);
-        updateBlockPacket.setDefinition(session.getBlockMappings().getBedrockAir()); //TODO maybe set this to the world block or another item frame?
-        updateBlockPacket.getFlags().add(UpdateBlockPacket.Flag.PRIORITY);
-        updateBlockPacket.getFlags().add(UpdateBlockPacket.Flag.NETWORK);
-        updateBlockPacket.getFlags().add(UpdateBlockPacket.Flag.NEIGHBORS);
-        session.sendUpstreamPacket(updateBlockPacket);
-
         session.getItemFrameCache().remove(bedrockPosition, this);
+
+        // Send whatever Java has in the cell: air when the frame stood alone, or the real block it
+        // was sharing the cell with
+        BlockState javaBlock = session.getGeyser().getWorldManager().blockAt(session, bedrockPosition);
+        javaBlock.block().updateBlock(session, javaBlock, bedrockPosition);
 
         valid = false;
     }
@@ -186,6 +183,19 @@ public class ItemFrameEntity extends HangingEntity {
      * Updates the item frame as a block
      */
     public void updateBlock(boolean force) {
+        updateBlock(session.getGeyser().getWorldManager().blockAt(session, bedrockPosition), force);
+    }
+
+    /**
+     * Updates the item frame as a block, when the caller already knows the authoritative Java
+     * block sharing this cell. A non-air block always wins over the frame; the frame is revealed
+     * again by {@link org.geysermc.geyser.util.ChunkUtils#updateBlockClientSide} once it breaks.
+     */
+    public void updateBlock(BlockState javaBlock, boolean force) {
+        if (!javaBlock.isAir()) {
+            // Leave 'changed' untouched so the pending update happens on reveal
+            return;
+        }
         if (!changed && !force) {
             // Don't send a block update packet - nothing changed
             return;

--- a/core/src/main/java/org/geysermc/geyser/level/block/type/BlockState.java
+++ b/core/src/main/java/org/geysermc/geyser/level/block/type/BlockState.java
@@ -27,6 +27,7 @@ package org.geysermc.geyser.level.block.type;
 
 import org.checkerframework.checker.nullness.qual.NonNull;
 import org.checkerframework.checker.nullness.qual.Nullable;
+import org.geysermc.geyser.level.block.Blocks;
 import org.geysermc.geyser.level.block.property.Property;
 import org.geysermc.geyser.registry.BlockRegistries;
 
@@ -159,6 +160,15 @@ public final class BlockState {
 
     public boolean is(Block block) {
         return this.block == block;
+    }
+
+    /**
+     * Whether this state is one of the three blocks Java treats as empty space. The air block tag
+     * lists the same three, but it is server data that can be reloaded or never sent at all, so it
+     * cannot stand in for a block's physical presence.
+     */
+    public boolean isAir() {
+        return this.block == Blocks.AIR || this.block == Blocks.CAVE_AIR || this.block == Blocks.VOID_AIR;
     }
 
     @Override

--- a/core/src/main/java/org/geysermc/geyser/session/cache/BlockBreakHandler.java
+++ b/core/src/main/java/org/geysermc/geyser/session/cache/BlockBreakHandler.java
@@ -447,7 +447,9 @@ public class BlockBreakHandler {
         }
 
         Entity itemFrameEntity = ItemFrameEntity.getItemFrameEntity(session, position);
-        if (itemFrameEntity != null) {
+        // A frame sharing its cell with a real block is not the block the player can see or aim at,
+        // so breaking there has to hit that block instead of the frame
+        if (itemFrameEntity != null && session.getGeyser().getWorldManager().blockAt(session, position).isAir()) {
             ServerboundAttackPacket attackPacket = new ServerboundAttackPacket(itemFrameEntity.getEntityId());
             session.sendDownstreamGamePacket(attackPacket);
             interactPosition = position;

--- a/core/src/main/java/org/geysermc/geyser/translator/protocol/java/level/JavaLevelChunkWithLightTranslator.java
+++ b/core/src/main/java/org/geysermc/geyser/translator/protocol/java/level/JavaLevelChunkWithLightTranslator.java
@@ -396,7 +396,14 @@ public class JavaLevelChunkWithLightTranslator extends PacketTranslator<Clientbo
             if ((position.getX() >> 4) == packet.getX() && (position.getZ() >> 4) == packet.getZ()) {
                 // Update this item frame so it doesn't get lost in the abyss
                 //TODO optimize
-                entry.getValue().updateBlock(true);
+                int sectionY = (position.getY() >> 4) - yOffset;
+                if (sectionY < 0 || sectionY >= javaChunks.length) {
+                    // An entity can sit outside the dimension's height, unlike a block entity
+                    continue;
+                }
+                DataPalette section = javaChunks[sectionY];
+                BlockState blockState = BlockState.of(section.get(position.getX() & 0xF, position.getY() & 0xF, position.getZ() & 0xF));
+                entry.getValue().updateBlock(blockState, true);
             }
         }
     }

--- a/core/src/main/java/org/geysermc/geyser/translator/protocol/java/level/JavaSectionBlocksUpdateTranslator.java
+++ b/core/src/main/java/org/geysermc/geyser/translator/protocol/java/level/JavaSectionBlocksUpdateTranslator.java
@@ -92,7 +92,7 @@ public class JavaSectionBlocksUpdateTranslator extends PacketTranslator<Clientbo
             if (blockState.is(Blocks.AIR)) {
                 ItemFrameEntity itemFrameEntity = ItemFrameEntity.getItemFrameEntity(session, entry.getPosition());
                 if (itemFrameEntity != null) { // Item frame is still present and no block overrides that; refresh it
-                    itemFrameEntity.updateBlock(true);
+                    itemFrameEntity.updateBlock(blockState, true);
                     continue;
                 }
             }

--- a/core/src/main/java/org/geysermc/geyser/util/ChunkUtils.java
+++ b/core/src/main/java/org/geysermc/geyser/util/ChunkUtils.java
@@ -148,7 +148,9 @@ public class ChunkUtils {
         ItemFrameEntity itemFrameEntity = ItemFrameEntity.getItemFrameEntity(session, position);
         if (itemFrameEntity != null) {
             if (blockState.is(Blocks.AIR)) { // Item frame is still present and no block overrides that; refresh it
-                itemFrameEntity.updateBlock(true);
+                // Pass the new state: the chunk cache is only updated after this call, so the
+                // frame's own world lookup would still see the block that was just broken
+                itemFrameEntity.updateBlock(blockState, true);
                 // Still update the chunk cache with the new block if updateBlock is called
                 return;
             }


### PR DESCRIPTION
Full parity will require more work; for now, the real block takes priority and the frame reappears once it's gone. 
Closes #1938