### PR TITLE
Expose the ambient occlusion exponent in the custom block API

### DIFF
--- a/api/src/main/java/org/geysermc/geyser/api/block/custom/component/MaterialInstance.java
+++ b/api/src/main/java/org/geysermc/geyser/api/block/custom/component/MaterialInstance.java
@@ -114,7 +114,7 @@ public interface MaterialInstance {
          * Sets the exponent applied to the ambient occlusion value after lighting,
          * between {@code 0.0} and {@code 10.0} inclusive.
          *
-         * @since 2.11.1
+         * @since 2.11.3
          */
         Builder ambientOcclusionExponent(float ambientOcclusionExponent);
 

--- a/api/src/main/java/org/geysermc/geyser/api/block/custom/component/MaterialInstance.java
+++ b/api/src/main/java/org/geysermc/geyser/api/block/custom/component/MaterialInstance.java
@@ -107,7 +107,7 @@ public interface MaterialInstance {
         /**
          * @deprecated Use {@link #ambientOcclusionExponent(float)} instead
          */
-        @Deprecated(since = "2.11.1")
+        @Deprecated(since = "2.11.3")
         Builder ambientOcclusion(boolean ambientOcclusion);
 
         /**

--- a/api/src/main/java/org/geysermc/geyser/api/block/custom/component/MaterialInstance.java
+++ b/api/src/main/java/org/geysermc/geyser/api/block/custom/component/MaterialInstance.java
@@ -75,7 +75,7 @@ public interface MaterialInstance {
      * disables ambient occlusion and {@code 1.0} is the default strength.
      *
      * @return the ambient occlusion exponent
-     * @since 2.11.1
+     * @since 2.11.3
      */
     float ambientOcclusionExponent();
 

--- a/api/src/main/java/org/geysermc/geyser/api/block/custom/component/MaterialInstance.java
+++ b/api/src/main/java/org/geysermc/geyser/api/block/custom/component/MaterialInstance.java
@@ -66,7 +66,7 @@ public interface MaterialInstance {
      * @return If the block should have ambient occlusion.
      * @deprecated Use {@link #ambientOcclusionExponent()} instead
      */
-    @Deprecated(since = "2.11.1")
+    @Deprecated(since = "2.11.3")
     boolean ambientOcclusion();
 
     /**

--- a/api/src/main/java/org/geysermc/geyser/api/block/custom/component/MaterialInstance.java
+++ b/api/src/main/java/org/geysermc/geyser/api/block/custom/component/MaterialInstance.java
@@ -62,10 +62,22 @@ public interface MaterialInstance {
 
     /**
      * Gets if the block should have ambient occlusion
-     * 
+     *
      * @return If the block should have ambient occlusion.
+     * @deprecated Use {@link #ambientOcclusionExponent()} instead
      */
+    @Deprecated(since = "2.11.1")
     boolean ambientOcclusion();
+
+    /**
+     * Gets the exponent applied to the ambient occlusion value after lighting.
+     * Bedrock accepts values between {@code 0.0} and {@code 10.0}, where {@code 0.0}
+     * disables ambient occlusion and {@code 1.0} is the default strength.
+     *
+     * @return the ambient occlusion exponent
+     * @since 2.11.1
+     */
+    float ambientOcclusionExponent();
 
     /**
      * Gets if the block is isotropic
@@ -92,7 +104,19 @@ public interface MaterialInstance {
 
         Builder faceDimming(boolean faceDimming);
 
+        /**
+         * @deprecated Use {@link #ambientOcclusionExponent(float)} instead
+         */
+        @Deprecated(since = "2.11.1")
         Builder ambientOcclusion(boolean ambientOcclusion);
+
+        /**
+         * Sets the exponent applied to the ambient occlusion value after lighting,
+         * between {@code 0.0} and {@code 10.0} inclusive.
+         *
+         * @since 2.11.1
+         */
+        Builder ambientOcclusionExponent(float ambientOcclusionExponent);
 
         Builder isotropic(boolean isotropic);
 

--- a/core/src/main/java/org/geysermc/geyser/level/block/GeyserMaterialInstance.java
+++ b/core/src/main/java/org/geysermc/geyser/level/block/GeyserMaterialInstance.java
@@ -35,7 +35,7 @@ public class GeyserMaterialInstance implements MaterialInstance {
     private final String renderMethod;
     private final String tintMethod;
     private final boolean faceDimming;
-    private final boolean ambientOcclusion;
+    private final float ambientOcclusionExponent;
     private final boolean isotropic;
 
     GeyserMaterialInstance(Builder builder) {
@@ -43,7 +43,7 @@ public class GeyserMaterialInstance implements MaterialInstance {
         this.renderMethod = builder.renderMethod;
         this.tintMethod = builder.tintMethod;
         this.faceDimming = builder.faceDimming;
-        this.ambientOcclusion = builder.ambientOcclusion;
+        this.ambientOcclusionExponent = builder.ambientOcclusionExponent;
         this.isotropic = builder.isotropic;
     }
 
@@ -69,7 +69,12 @@ public class GeyserMaterialInstance implements MaterialInstance {
 
     @Override
     public boolean ambientOcclusion() {
-        return ambientOcclusion;
+        return ambientOcclusionExponent > 0.0F;
+    }
+
+    @Override
+    public float ambientOcclusionExponent() {
+        return ambientOcclusionExponent;
     }
 
     @Override
@@ -82,7 +87,7 @@ public class GeyserMaterialInstance implements MaterialInstance {
         private String renderMethod;
         private String tintMethod;
         private boolean faceDimming;
-        private boolean ambientOcclusion;
+        private float ambientOcclusionExponent;
         private boolean isotropic;
 
         @Override
@@ -111,7 +116,15 @@ public class GeyserMaterialInstance implements MaterialInstance {
 
         @Override
         public Builder ambientOcclusion(boolean ambientOcclusion) {
-            this.ambientOcclusion = ambientOcclusion;
+            return ambientOcclusionExponent(ambientOcclusion ? 1.0F : 0.0F);
+        }
+
+        @Override
+        public Builder ambientOcclusionExponent(float ambientOcclusionExponent) {
+            if (!Float.isFinite(ambientOcclusionExponent) || ambientOcclusionExponent < 0.0F || ambientOcclusionExponent > 10.0F) {
+                throw new IllegalArgumentException("Ambient occlusion exponent must be between 0.0 and 10.0 inclusive");
+            }
+            this.ambientOcclusionExponent = ambientOcclusionExponent;
             return this;
         }
 

--- a/core/src/main/java/org/geysermc/geyser/registry/mappings/versions/block/BlockMappingsReader_v1.java
+++ b/core/src/main/java/org/geysermc/geyser/registry/mappings/versions/block/BlockMappingsReader_v1.java
@@ -577,7 +577,7 @@ public class BlockMappingsReader_v1 implements MappingsReader<String, CustomBloc
 
         float ambientOcclusion = 1.0f;
         if (node.has("ambient_occlusion")) {
-            // Historically a boolean; Bedrock also accepts a 0.0-10.0 exponent
+            // Boolean in older block format versions; since format version 1.26.20 Bedrock only accepts the 0.0-10.0 exponent form
             JsonPrimitive value = node.get("ambient_occlusion").getAsJsonPrimitive();
             ambientOcclusion = value.isBoolean() ? (value.getAsBoolean() ? 1.0f : 0.0f) : value.getAsFloat();
         }

--- a/core/src/main/java/org/geysermc/geyser/registry/mappings/versions/block/BlockMappingsReader_v1.java
+++ b/core/src/main/java/org/geysermc/geyser/registry/mappings/versions/block/BlockMappingsReader_v1.java
@@ -575,16 +575,18 @@ public class BlockMappingsReader_v1 implements MappingsReader<String, CustomBloc
             faceDimming = node.get("face_dimming").getAsBoolean();
         }
 
-        boolean ambientOcclusion = true;
+        float ambientOcclusion = 1.0f;
         if (node.has("ambient_occlusion")) {
-            ambientOcclusion = node.get("ambient_occlusion").getAsBoolean();
+            // Historically a boolean; Bedrock also accepts a 0.0-10.0 exponent
+            JsonPrimitive value = node.get("ambient_occlusion").getAsJsonPrimitive();
+            ambientOcclusion = value.isBoolean() ? (value.getAsBoolean() ? 1.0f : 0.0f) : value.getAsFloat();
         }
 
         return new GeyserMaterialInstance.Builder()
             .texture(texture)
             .renderMethod(renderMethod)
             .faceDimming(faceDimming)
-            .ambientOcclusion(ambientOcclusion)
+            .ambientOcclusionExponent(ambientOcclusion)
             .build();
     }
 

--- a/core/src/main/java/org/geysermc/geyser/registry/populator/CustomBlockRegistryPopulator.java
+++ b/core/src/main/java/org/geysermc/geyser/registry/populator/CustomBlockRegistryPopulator.java
@@ -424,7 +424,7 @@ public class CustomBlockRegistryPopulator {
                 MaterialInstance materialInstance = entry.getValue();
                 NbtMapBuilder materialBuilder = NbtMap.builder()
                         // Bedrock stopped accepting a byte here in 1.26.20; it must be a float
-                        .putFloat("ambient_occlusion", materialInstance.ambientOcclusion() ? 1.0F : 0.0F)
+                        .putFloat("ambient_occlusion", materialInstance.ambientOcclusionExponent())
                         .putBoolean("isotropic", materialInstance.isotropic());
 
                 // todo this is actually an bitset, we should add the other properties some day

--- a/core/src/main/java/org/geysermc/geyser/registry/type/CustomSkull.java
+++ b/core/src/main/java/org/geysermc/geyser/registry/type/CustomSkull.java
@@ -71,7 +71,7 @@ public class CustomSkull {
                         .texture("geyser." + skinHash + "_player_skin")
                         .renderMethod("alpha_test")
                         .faceDimming(true)
-                        .ambientOcclusion(true)
+                        .ambientOcclusionExponent(1.0f)
                         .build())
                 .lightDampening(0)
                 .placeAir(true)


### PR DESCRIPTION
Follow-up to #6610. 
Expose ambient_occlusion as the float exponent Bedrock actually takes, deprecating the boolean in the API; mappings accept either a boolean or a number.