### PR TITLE
Fix several small bugs across utility classes and commands

### DIFF
--- a/core/src/main/java/org/geysermc/geyser/command/defaults/ConnectionTestCommand.java
+++ b/core/src/main/java/org/geysermc/geyser/command/defaults/ConnectionTestCommand.java
@@ -100,7 +100,7 @@ public class ConnectionTestCommand extends GeyserCommand {
         }
 
         // Issue: port out of bounds
-        if (port <= 0 || port >= 65535) {
+        if (port <= 0 || port > 65535) {
             source.sendMessage("The port you specified is invalid! Please specify a valid port.");
             return;
         }

--- a/core/src/main/java/org/geysermc/geyser/command/defaults/DumpCommand.java
+++ b/core/src/main/java/org/geysermc/geyser/command/defaults/DumpCommand.java
@@ -127,10 +127,8 @@ public class DumpCommand extends GeyserCommand {
         if (offlineDump) {
             source.sendMessage(GeyserLocale.getPlayerLocaleString("geyser.commands.dump.writing", source.locale()));
 
-            try {
-                FileOutputStream outputStream = new FileOutputStream(GeyserImpl.getInstance().getBootstrap().getConfigFolder().resolve("dump.json").toFile());
+            try (FileOutputStream outputStream = new FileOutputStream(GeyserImpl.getInstance().getBootstrap().getConfigFolder().resolve("dump.json").toFile())) {
                 outputStream.write(dumpData.getBytes());
-                outputStream.close();
             } catch (IOException e) {
                 source.sendMessage(ChatColor.RED + GeyserLocale.getPlayerLocaleString("geyser.commands.dump.write_error", source.locale()));
                 geyser.getLogger().error(GeyserLocale.getLocaleStringLog("geyser.commands.dump.write_error_short"), e);

--- a/core/src/main/java/org/geysermc/geyser/util/ColorUtils.java
+++ b/core/src/main/java/org/geysermc/geyser/util/ColorUtils.java
@@ -89,6 +89,9 @@ public final class ColorUtils {
     // "Inspired by" Mojang's DyedItemColor class:
     // https://mcsrc.dev/1/26.1.2/net/minecraft/world/item/component/DyedItemColor
     public static int mixDyes(@Nullable Integer current, List<DyeColor> dyes) {
+        if (current == null && dyes.isEmpty()) {
+            return 0;
+        }
         int totalRed = 0;
         int totalGreen = 0;
         int totalBlue = 0;

--- a/core/src/main/java/org/geysermc/geyser/util/NewsHandler.java
+++ b/core/src/main/java/org/geysermc/geyser/util/NewsHandler.java
@@ -113,7 +113,7 @@ public class NewsHandler {
             case BROADCAST_TO_OPERATORS:
                 for (GeyserSession player : GeyserImpl.getInstance().getSessionManager().getSessions().values()) {
                     if (player.getOpPermissionLevel() >= 2) {
-                        session.sendMessage(ChatColor.GREEN + news.getMessage());
+                        player.sendMessage(ChatColor.GREEN + news.getMessage());
                     }
                 }
                 break;

--- a/core/src/main/java/org/geysermc/geyser/util/StatisticFormatters.java
+++ b/core/src/main/java/org/geysermc/geyser/util/StatisticFormatters.java
@@ -37,20 +37,20 @@ import java.util.function.IntFunction;
 public final class StatisticFormatters {
 
     private static final Map<StatisticFormat, IntFunction<String>> FORMATTERS = new EnumMap<>(StatisticFormat.class);
-    private static final DecimalFormat FORMAT = new DecimalFormat("###,###,##0.00");
+    private static final ThreadLocal<DecimalFormat> FORMAT = ThreadLocal.withInitial(() -> new DecimalFormat("###,###,##0.00"));
 
     public static final IntFunction<String> INTEGER = NumberFormat.getIntegerInstance(Locale.US)::format;
 
     static {
         FORMATTERS.put(StatisticFormat.INTEGER, INTEGER);
-        FORMATTERS.put(StatisticFormat.TENTHS, value -> FORMAT.format(value / 10d));
+        FORMATTERS.put(StatisticFormat.TENTHS, value -> FORMAT.get().format(value / 10d));
         FORMATTERS.put(StatisticFormat.DISTANCE, centimeter -> {
             double meter = centimeter / 100d;
             double kilometer = meter / 1000d;
             if (kilometer > 0.5) {
-                return FORMAT.format(kilometer) + " km";
+                return FORMAT.get().format(kilometer) + " km";
             } else if (meter > 0.5) {
-                return FORMAT.format(meter) + " m";
+                return FORMAT.get().format(meter) + " m";
             } else {
                 return centimeter + " cm";
             }
@@ -62,15 +62,15 @@ public final class StatisticFormatters {
             double days = hours / 24d;
             double years = days / 365d;
             if (years > 0.5) {
-                return FORMAT.format(years) + " y";
+                return FORMAT.get().format(years) + " y";
             } else if (days > 0.5) {
-                return FORMAT.format(days) + " d";
+                return FORMAT.get().format(days) + " d";
             } else if (hours > 0.5) {
-                return FORMAT.format(hours) + " h";
+                return FORMAT.get().format(hours) + " h";
             } else if (minutes > 0.5) {
-                return FORMAT.format(minutes) + " m";
+                return FORMAT.get().format(minutes) + " m";
             } else {
-                return FORMAT.format(seconds) + " s";
+                return FORMAT.get().format(seconds) + " s";
             }
         });
     }


### PR DESCRIPTION
Hey! While reading through the codebase I noticed a few small unrelated bugs. Grouping them into one PR since each fix is only 1-3 lines, but happy to split if you'd prefer.

### 1. `NewsHandler` — wrong variable in broadcast loop

In the `BROADCAST_TO_OPERATORS` case, the loop iterates over all sessions as `player` but sends the message to `session` (the method parameter). Result: operators never actually get the message, and the triggering session gets spammed with one duplicate per online op.

Changed `session.sendMessage(...)` → `player.sendMessage(...)`.

### 2. `ConnectionTestCommand` — port validation off-by-one

`if (port <= 0 || port >= 65535)` rejects port 65535, which is a valid TCP/UDP port. Changed `>= 65535` → `> 65535`. The parser at the top of the same command already accepts 0-65535 inclusive, so this brings the check in line with that.

### 3. `DumpCommand` — resource leak on write failure

The `FileOutputStream` was closed manually via `.close()` after `.write()`. If `write()` throws, `close()` is never reached. Switched to try-with-resources.

### 4. `ColorUtils.mixDyes` — division by zero

If `current` is null and `dyes` is empty, `colorCount` stays 0 and the subsequent `totalRed / colorCount` throws `ArithmeticException`. The current single caller always passes a non-empty list, so this doesn't crash today, but the method is public. Added an early return of `0` for that case.

### 5. `StatisticFormatters` — `DecimalFormat` thread-safety

`DecimalFormat` isn't thread-safe, but a single static instance was shared and used from multiple lambdas that can run from any thread (per-session stat formatting). Under load this could produce garbled output or throw `ArrayIndexOutOfBoundsException`.

Wrapped it in `ThreadLocal<DecimalFormat>` and updated the call sites.