### PR TITLE
Update haproxy-protocol-whitelisted-ips comment

### DIFF
--- a/core/src/main/java/org/geysermc/geyser/configuration/GeyserConfig.java
+++ b/core/src/main/java/org/geysermc/geyser/configuration/GeyserConfig.java
@@ -381,7 +381,7 @@ public interface GeyserConfig {
         boolean useHaproxyProtocol();
 
         @Comment("""
-                A list of allowed HAPROXY protocol speaking proxy IP addresses/subnets. Only effective when "use-proxy-protocol" is enabled, and
+                A list of allowed HAPROXY protocol speaking proxy IP addresses/subnets. Only effective when "use-haproxy-protocol" is enabled, and
                 should really only be used when you are not able to use a proper firewall (usually true with shared hosting providers etc.).
                 Keeping this list empty means there is no IP address whitelist.
                 IP addresses, subnets, and links to plain text files are supported.""")


### PR DESCRIPTION
This pull request updates the haproxy-protocol-whitelisted-ips comment in the Geyser config to say use-haproxy-protocol instead of the original use-proxy-protocol.