### PR TITLE
Add model-specific custom block item overrides support

### DIFF
--- a/api/src/main/java/org/geysermc/geyser/api/event/lifecycle/GeyserDefineCustomBlocksEvent.java
+++ b/api/src/main/java/org/geysermc/geyser/api/event/lifecycle/GeyserDefineCustomBlocksEvent.java
@@ -64,6 +64,18 @@ public abstract class GeyserDefineCustomBlocksEvent implements Event {
     public abstract void registerItemOverride(String javaIdentifier, CustomBlockData customBlockData);
 
     /**
+     * Registers the given {@link CustomBlockData} as an override for items matching both
+     * the Java item identifier and {@code minecraft:item_model} component.
+     *
+     * @param javaIdentifier the Java item identifier to match
+     * @param itemModel the value of the Java item's {@code minecraft:item_model} component
+     * @param customBlockData the custom block data with which to represent the matching item
+     */
+    public void registerItemOverride(String javaIdentifier, String itemModel, CustomBlockData customBlockData) {
+        throw new UnsupportedOperationException("Model-specific custom block item overrides are not supported by this runtime");
+    }
+
+    /**
      * Registers the given {@link CustomBlockState} as an override for the
      * given {@link JavaBlockState}
      *

--- a/core/src/main/java/org/geysermc/geyser/registry/BlockRegistries.java
+++ b/core/src/main/java/org/geysermc/geyser/registry/BlockRegistries.java
@@ -45,6 +45,7 @@ import org.geysermc.geyser.registry.populator.BlockRegistryPopulator;
 import org.geysermc.geyser.registry.populator.CustomBlockRegistryPopulator;
 import org.geysermc.geyser.registry.populator.CustomSkullRegistryPopulator;
 import org.geysermc.geyser.registry.type.BlockMappings;
+import org.geysermc.geyser.registry.type.CustomBlockItemOverride;
 import org.geysermc.geyser.registry.type.CustomSkull;
 import org.geysermc.geyser.translator.collision.BlockCollision;
 
@@ -127,9 +128,11 @@ public class BlockRegistries {
     public static final SimpleMappedRegistry<JavaBlockState, CustomBlockState> NON_VANILLA_BLOCK_STATE_OVERRIDES = SimpleMappedRegistry.create(RegistryLoaders.empty(Object2ObjectOpenHashMap::new));
 
     /**
-     * A registry which stores clean Java Ids and the custom block it should be replaced with in the context of items.
+     * A registry which stores custom block item overrides keyed by Java item identifier and optional
+     * {@code minecraft:item_model}. Base overrides use {@code itemModel = null}; model-specific
+     * overrides carry a non-null {@link net.kyori.adventure.key.Key}.
      */
-    public static final SimpleMappedRegistry<String, CustomBlockData> CUSTOM_BLOCK_ITEM_OVERRIDES = SimpleMappedRegistry.create(RegistryLoaders.empty(Object2ObjectOpenHashMap::new));
+    public static final SimpleMappedRegistry<CustomBlockItemOverride, CustomBlockData> CUSTOM_BLOCK_ITEM_OVERRIDES = SimpleMappedRegistry.create(RegistryLoaders.empty(Object2ObjectOpenHashMap::new));
 
     /**
      * A registry which stores skin texture hashes to custom skull blocks.

--- a/core/src/main/java/org/geysermc/geyser/registry/populator/CustomBlockRegistryPopulator.java
+++ b/core/src/main/java/org/geysermc/geyser/registry/populator/CustomBlockRegistryPopulator.java
@@ -30,6 +30,7 @@ import it.unimi.dsi.fastutil.ints.Int2ObjectOpenHashMap;
 import it.unimi.dsi.fastutil.ints.IntOpenHashSet;
 import it.unimi.dsi.fastutil.ints.IntSet;
 import it.unimi.dsi.fastutil.objects.ObjectOpenHashSet;
+import net.kyori.adventure.key.Key;
 import org.checkerframework.checker.nullness.qual.NonNull;
 import org.cloudburstmc.nbt.NbtMap;
 import org.cloudburstmc.nbt.NbtMapBuilder;
@@ -59,6 +60,7 @@ import org.geysermc.geyser.level.physics.PistonBehavior;
 import org.geysermc.geyser.registry.BlockRegistries;
 import org.geysermc.geyser.registry.mappings.MappingsConfigReader;
 import org.geysermc.geyser.registry.mappings.MappingsType;
+import org.geysermc.geyser.registry.type.CustomBlockItemOverride;
 import org.geysermc.geyser.registry.type.CustomSkull;
 import org.geysermc.geyser.translator.collision.OtherCollision;
 import org.geysermc.geyser.util.BlockUtils;
@@ -114,7 +116,7 @@ public class CustomBlockRegistryPopulator {
     }
 
     private static Set<CustomBlockData> CUSTOM_BLOCKS;
-    private static Map<String, CustomBlockData> CUSTOM_BLOCK_ITEM_OVERRIDES;
+    private static Map<CustomBlockItemOverride, CustomBlockData> CUSTOM_BLOCK_ITEM_OVERRIDES;
     private static Map<JavaBlockState, CustomBlockState> NON_VANILLA_BLOCK_STATE_OVERRIDES;
     private static Map<String, CustomBlockState> BLOCK_STATE_OVERRIDES_QUEUE;
 
@@ -157,7 +159,17 @@ public class CustomBlockRegistryPopulator {
                 if (!CUSTOM_BLOCKS.contains(customBlockData)) {
                     throw new IllegalArgumentException("Custom block is unregistered. Name: " + customBlockData.name());
                 }
-                CUSTOM_BLOCK_ITEM_OVERRIDES.put(javaIdentifier, customBlockData);
+                CUSTOM_BLOCK_ITEM_OVERRIDES.put(CustomBlockItemOverride.base(javaIdentifier), customBlockData);
+            }
+
+            @Override
+            public void registerItemOverride(@NonNull String javaIdentifier, @NonNull String itemModel,
+                                             @NonNull CustomBlockData customBlockData) {
+                if (!CUSTOM_BLOCKS.contains(customBlockData)) {
+                    throw new IllegalArgumentException("Custom block is unregistered. Name: " + customBlockData.name());
+                }
+                CUSTOM_BLOCK_ITEM_OVERRIDES.put(
+                        new CustomBlockItemOverride(javaIdentifier, Key.key(itemModel)), customBlockData);
             }
 
             @Override
@@ -199,7 +211,7 @@ public class CustomBlockRegistryPopulator {
         MappingsConfigReader.loadCustomMappingsFromJson(MappingsType.BLOCKS, (key, block) -> {
             CUSTOM_BLOCKS.add(block.data());
             if (block.overrideItem()) {
-                CUSTOM_BLOCK_ITEM_OVERRIDES.put(block.javaIdentifier(), block.data());
+                CUSTOM_BLOCK_ITEM_OVERRIDES.put(CustomBlockItemOverride.base(block.javaIdentifier()), block.data());
             }
             block.states().forEach((javaIdentifier, customBlockState) -> {
                 int id = BlockRegistries.JAVA_BLOCK_STATE_IDENTIFIER_TO_ID.getOrDefault(javaIdentifier, -1);

--- a/core/src/main/java/org/geysermc/geyser/registry/populator/ItemRegistryPopulator.java
+++ b/core/src/main/java/org/geysermc/geyser/registry/populator/ItemRegistryPopulator.java
@@ -87,6 +87,7 @@ import org.geysermc.geyser.registry.Registries;
 import org.geysermc.geyser.registry.populator.conversion.ChaosCubedConverter;
 import org.geysermc.geyser.registry.populator.conversion.GoldenDandelionConverter;
 import org.geysermc.geyser.registry.type.BlockMappings;
+import org.geysermc.geyser.registry.type.CustomBlockItemOverride;
 import org.geysermc.geyser.registry.type.CustomSkull;
 import org.geysermc.geyser.registry.type.GeyserBedrockBlock;
 import org.geysermc.geyser.registry.type.GeyserMappingItem;
@@ -335,7 +336,7 @@ public class ItemRegistryPopulator {
 
                     // We'll do this here for custom blocks we want in the creative inventory so we can piggyback off the existing logic to find these
                     // blocks in creativeItems
-                    CustomBlockData customBlockData = BlockRegistries.CUSTOM_BLOCK_ITEM_OVERRIDES.getOrDefault(javaItem.javaIdentifier(), null);
+                    CustomBlockData customBlockData = BlockRegistries.CUSTOM_BLOCK_ITEM_OVERRIDES.getOrDefault(CustomBlockItemOverride.base(javaItem.javaIdentifier()), null);
                     if (customBlockData != null) {
                         // this block has a custom item override and thus we should use its runtime ID for the ItemMapping
                         if (customBlockData.includedInCreativeInventory()) {
@@ -747,6 +748,26 @@ public class ItemRegistryPopulator {
                     .build(), itemData.getNetId(), itemData.getGroupId()));
             }
 
+            Int2ObjectMap<ItemMapping> customBlockModelItemMappings = new Int2ObjectOpenHashMap<>();
+            for (Map.Entry<CustomBlockItemOverride, CustomBlockData> entry :
+                    BlockRegistries.CUSTOM_BLOCK_ITEM_OVERRIDES.get().entrySet()) {
+                if (entry.getKey().itemModel() == null) {
+                    continue; // base overrides handled separately
+                }
+                ItemMapping javaMapping = mappings.stream()
+                        .filter(mapping -> mapping.getJavaItem().javaIdentifier().equals(entry.getKey().javaIdentifier()))
+                        .findFirst().orElse(null);
+                ItemDefinition customDefinition = customBlockItemDefinitions.get(entry.getValue());
+                if (javaMapping != null && customDefinition != null) {
+                    ItemMapping previous = customBlockModelItemMappings.putIfAbsent(customDefinition.getRuntimeId(), javaMapping);
+                    if (previous != null && previous.getJavaItem() != javaMapping.getJavaItem()) {
+                        throw new IllegalStateException("Custom block " + entry.getValue().identifier()
+                                + " cannot override multiple Java item identifiers: "
+                                + previous.getJavaItem().javaIdentifier() + " and " + javaMapping.getJavaItem().javaIdentifier());
+                    }
+                }
+            }
+
             ItemMappings itemMappings = ItemMappings.builder()
                     .items(mappings.toArray(new ItemMapping[0]))
                     .zeroBlockDefinitionRuntimeId(mappings.stream()
@@ -764,6 +785,7 @@ public class ItemRegistryPopulator {
                     .customIdMappings(customIdMappings)
                     .nonVanillaCustomItemIds(nonVanillaCustomItemIds)
                     .customBlockItemDefinitions(customBlockItemDefinitions)
+                    .customBlockModelItemMappings(customBlockModelItemMappings)
                     .build();
 
             Registries.ITEMS.register(palette.protocolVersion(), itemMappings);

--- a/core/src/main/java/org/geysermc/geyser/registry/type/CustomBlockItemOverride.java
+++ b/core/src/main/java/org/geysermc/geyser/registry/type/CustomBlockItemOverride.java
@@ -1,0 +1,47 @@
+/*
+ * Copyright (c) 2019-2026 GeyserMC. http://geysermc.org
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+package org.geysermc.geyser.registry.type;
+
+import net.kyori.adventure.key.Key;
+import org.jspecify.annotations.Nullable;
+
+import java.util.Objects;
+
+/**
+ * Composite key for {@link org.geysermc.geyser.registry.BlockRegistries#CUSTOM_BLOCK_ITEM_OVERRIDES}.
+ * <p>
+ * Base overrides use {@code itemModel = null} and match any model.
+ * Model-specific overrides carry a non-null {@link Key} and must match exactly.
+ */
+public record CustomBlockItemOverride(String javaIdentifier, @Nullable Key itemModel) {
+    public CustomBlockItemOverride {
+        Objects.requireNonNull(javaIdentifier, "javaIdentifier");
+    }
+
+    /**
+     * Creates a base override that matches all items with the given Java identifier.
+     */
+    public static CustomBlockItemOverride base(String javaIdentifier) {
+        return new CustomBlockItemOverride(javaIdentifier, null);
+    }
+}

--- a/core/src/main/java/org/geysermc/geyser/registry/type/ItemMappings.java
+++ b/core/src/main/java/org/geysermc/geyser/registry/type/ItemMappings.java
@@ -84,6 +84,7 @@ public class ItemMappings implements DefinitionRegistry<ItemDefinition> {
     IntSet nonVanillaCustomItemIds;
 
     Object2ObjectMap<CustomBlockData, ItemDefinition> customBlockItemDefinitions;
+    Int2ObjectMap<ItemMapping> customBlockModelItemMappings;
 
     /**
      * Gets an {@link ItemMapping} from the given {@link GeyserItemStack}.
@@ -160,6 +161,11 @@ public class ItemMappings implements DefinitionRegistry<ItemDefinition> {
         ItemMapping lightBlock = lightBlocks.get(definition.getRuntimeId());
         if (lightBlock != null) {
             return lightBlock;
+        }
+
+        ItemMapping customBlockModelItem = customBlockModelItemMappings.get(definition.getRuntimeId());
+        if (customBlockModelItem != null) {
+            return customBlockModelItem;
         }
 
         boolean isBlock = isValidBlockItem(data);

--- a/core/src/main/java/org/geysermc/geyser/translator/item/CustomBlockItemTranslator.java
+++ b/core/src/main/java/org/geysermc/geyser/translator/item/CustomBlockItemTranslator.java
@@ -1,0 +1,49 @@
+/*
+ * Copyright (c) 2019-2026 GeyserMC. http://geysermc.org
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+package org.geysermc.geyser.translator.item;
+
+import net.kyori.adventure.key.Key;
+import org.checkerframework.checker.nullness.qual.Nullable;
+import org.geysermc.geyser.api.block.custom.CustomBlockData;
+import org.geysermc.geyser.registry.type.CustomBlockItemOverride;
+
+import java.util.Map;
+
+public final class CustomBlockItemTranslator {
+    @Nullable
+    public static CustomBlockData resolve(Map<CustomBlockItemOverride, CustomBlockData> overrides,
+                                          String javaIdentifier, @Nullable Key itemModel) {
+        // Model-specific match takes priority
+        if (itemModel != null) {
+            CustomBlockData specific = overrides.get(new CustomBlockItemOverride(javaIdentifier, itemModel));
+            if (specific != null) {
+                return specific;
+            }
+        }
+        // Base-item fallback
+        return overrides.get(CustomBlockItemOverride.base(javaIdentifier));
+    }
+
+    private CustomBlockItemTranslator() {
+    }
+}

--- a/core/src/main/java/org/geysermc/geyser/translator/item/ItemTranslator.java
+++ b/core/src/main/java/org/geysermc/geyser/translator/item/ItemTranslator.java
@@ -50,6 +50,7 @@ import org.geysermc.geyser.item.type.PotionItem;
 import org.geysermc.geyser.level.block.type.Block;
 import org.geysermc.geyser.registry.BlockRegistries;
 import org.geysermc.geyser.registry.Registries;
+import org.geysermc.geyser.registry.type.CustomBlockItemOverride;
 import org.geysermc.geyser.registry.type.CustomSkull;
 import org.geysermc.geyser.registry.type.ItemMapping;
 import org.geysermc.geyser.session.GeyserSession;
@@ -191,6 +192,9 @@ public final class ItemTranslator {
 
         // Populates default components that aren't sent over the network
         DataComponents components = javaItem.gatherComponents(session.getComponentCache(), customComponents);
+        CustomBlockData modelBlockOverride = CustomBlockItemTranslator.resolve(
+                BlockRegistries.CUSTOM_BLOCK_ITEM_OVERRIDES.get(), javaItem.javaIdentifier(),
+                components.get(DataComponentTypes.ITEM_MODEL));
         TooltipOptions tooltip = TooltipOptions.fromComponents(components);
 
         // Translate item-specific components
@@ -242,9 +246,9 @@ public final class ItemTranslator {
         ItemData.Builder builder = javaItem.translateToBedrock(session, count, components, bedrockItem, session.getItemMappings());
         // Finalize the Bedrock NBT
         builder.tag(nbtBuilder.build());
-        if (bedrockItem.isBlock()) {
+        if (bedrockItem.isBlock() && modelBlockOverride == null) {
             CustomBlockData customBlockData = BlockRegistries.CUSTOM_BLOCK_ITEM_OVERRIDES.getOrDefault(
-                    bedrockItem.getJavaItem().javaIdentifier(), null);
+                    CustomBlockItemOverride.base(bedrockItem.getJavaItem().javaIdentifier()), null);
             if (customBlockData != null) {
                 translateCustomBlock(customBlockData, session, builder);
             } else {
@@ -252,11 +256,17 @@ public final class ItemTranslator {
             }
         }
 
-        if (bedrockItem.getJavaItem().equals(Items.PLAYER_HEAD)) {
+        if (modelBlockOverride != null) {
+            translateCustomBlock(modelBlockOverride, session, builder);
+        }
+
+        if (modelBlockOverride == null && bedrockItem.getJavaItem().equals(Items.PLAYER_HEAD)) {
             translatePlayerHead(session, components.get(DataComponentTypes.PROFILE), builder);
         }
 
-        translateCustomItem(session, count, components, builder, bedrockItem);
+        if (modelBlockOverride == null) {
+            translateCustomItem(session, count, components, builder, bedrockItem);
+        }
 
         // Translate the canDestroy and canPlaceOn Java components
         AdventureModePredicate canDestroy = components.get(DataComponentTypes.CAN_BREAK);
@@ -540,10 +550,14 @@ public final class ItemTranslator {
         ItemMapping mapping = itemStack.asItem().toBedrockDefinition(itemStack.getAllComponents(), session.getItemMappings());
 
         ItemDefinition itemDefinition = mapping.getBedrockDefinition();
-        CustomBlockData customBlockData = BlockRegistries.CUSTOM_BLOCK_ITEM_OVERRIDES.getOrDefault(
-                mapping.getJavaItem().javaIdentifier(), null);
-        if (customBlockData != null) {
-            itemDefinition = session.getItemMappings().getCustomBlockItemDefinitions().get(customBlockData);
+        CustomBlockData modelBlockOverride = CustomBlockItemTranslator.resolve(
+                BlockRegistries.CUSTOM_BLOCK_ITEM_OVERRIDES.get(), mapping.getJavaItem().javaIdentifier(),
+                itemStack.getComponent(DataComponentTypes.ITEM_MODEL));
+        if (modelBlockOverride != null) {
+            ItemDefinition def = session.getItemMappings().getCustomBlockItemDefinitions().get(modelBlockOverride);
+            if (def != null) {
+                return def;
+            }
         }
 
         if (mapping.getJavaItem().equals(Items.PLAYER_HEAD)) {

--- a/core/src/test/java/org/geysermc/geyser/translator/item/CustomBlockItemTranslatorTest.java
+++ b/core/src/test/java/org/geysermc/geyser/translator/item/CustomBlockItemTranslatorTest.java
@@ -1,0 +1,96 @@
+/*
+ * Copyright (c) 2019-2026 GeyserMC. http://geysermc.org
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+package org.geysermc.geyser.translator.item;
+
+import net.kyori.adventure.key.Key;
+import org.geysermc.geyser.api.block.custom.CustomBlockData;
+import org.geysermc.geyser.registry.type.CustomBlockItemOverride;
+import org.junit.jupiter.api.Test;
+
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.mock;
+
+class CustomBlockItemTranslatorTest {
+    @Test
+    void resolvesModelSpecificBeforeBase() {
+        CustomBlockData modelSpecific = mock(CustomBlockData.class);
+        CustomBlockData baseFallback = mock(CustomBlockData.class);
+        var overrides = Map.of(
+                new CustomBlockItemOverride("minecraft:paper", Key.key("example:test_note_block")), modelSpecific,
+                CustomBlockItemOverride.base("minecraft:paper"), baseFallback);
+
+        // Model-specific match takes priority
+        assertSame(modelSpecific, CustomBlockItemTranslator.resolve(
+                overrides, "minecraft:paper", Key.key("example:test_note_block")));
+        // Different model falls back to base
+        assertSame(baseFallback, CustomBlockItemTranslator.resolve(
+                overrides, "minecraft:paper", Key.key("example:other")));
+        // Null model also falls back to base
+        assertSame(baseFallback, CustomBlockItemTranslator.resolve(
+                overrides, "minecraft:paper", null));
+        // Wrong java identifier
+        assertNull(CustomBlockItemTranslator.resolve(
+                overrides, "minecraft:note_block", Key.key("example:test_note_block")));
+    }
+
+    @Test
+    void baseOverrideOnlyMatchesBaseKey() {
+        CustomBlockData block = mock(CustomBlockData.class);
+        var overrides = Map.of(CustomBlockItemOverride.base("minecraft:paper"), block);
+
+        assertSame(block, CustomBlockItemTranslator.resolve(
+                overrides, "minecraft:paper", null));
+        assertNull(CustomBlockItemTranslator.resolve(
+                overrides, "minecraft:note_block", null));
+    }
+
+    @Test
+    void emptyRegistryReturnsNull() {
+        var overrides = Map.<CustomBlockItemOverride, CustomBlockData>of();
+        assertNull(CustomBlockItemTranslator.resolve(
+                overrides, "minecraft:paper", Key.key("example:test")));
+        assertNull(CustomBlockItemTranslator.resolve(
+                overrides, "minecraft:paper", null));
+    }
+
+    @Test
+    void baseFactoryKeyEqualsDirectConstructor() {
+        var fromFactory = CustomBlockItemOverride.base("minecraft:paper");
+        var fromConstructor = new CustomBlockItemOverride("minecraft:paper", null);
+        assertEquals(fromFactory, fromConstructor,
+                "base() must produce equal key to explicit (identifier, null)");
+        assertEquals(fromFactory.hashCode(), fromConstructor.hashCode());
+    }
+
+    @Test
+    void rejectsNullJavaIdentifier() {
+        assertThrows(NullPointerException.class, () ->
+                new CustomBlockItemOverride(null, null));
+    }
+}


### PR DESCRIPTION
Extends `CUSTOM_BLOCK_ITEM_OVERRIDES` to match by `(javaIdentifier, itemModel)` instead of `javaIdentifier` alone. Enables different 3D models on the same base item via `minecraft:item_model`.

Resolve: model-specific first → base fallback.

```java
registerItemOverride("minecraft:paper", "mymod:ruby", block); // new
registerItemOverride("minecraft:paper", block);                // unchanged
```