### PR TITLE
Add GeyserConnection#updateForm

### DIFF
--- a/api/src/main/java/org/geysermc/geyser/api/connection/GeyserConnection.java
+++ b/api/src/main/java/org/geysermc/geyser/api/connection/GeyserConnection.java
@@ -27,12 +27,14 @@ package org.geysermc.geyser.api.connection;
 
 import org.checkerframework.checker.index.qual.Positive;
 import org.geysermc.api.connection.Connection;
+import org.geysermc.cumulus.form.Form;
 import org.geysermc.geyser.api.bedrock.camera.CameraData;
 import org.geysermc.geyser.api.bedrock.camera.CameraShake;
 import org.geysermc.geyser.api.command.CommandSource;
 import org.geysermc.geyser.api.entity.EntityData;
 import org.geysermc.geyser.api.entity.type.player.GeyserPlayerEntity;
 import org.geysermc.geyser.api.skin.SkinData;
+import org.jspecify.annotations.NonNull;
 import org.jspecify.annotations.Nullable;
 
 import java.util.NoSuchElementException;
@@ -75,6 +77,22 @@ public interface GeyserConnection extends Connection, CommandSource {
      * Closes the currently open form on the client.
      */
     void closeForm();
+
+    /**
+     * Replaces the content of the form the client already has open.
+     *
+     * <p>Unlike sending a form again, which closes the open one and opens another, this changes
+     * what the player is already looking at. Neither the content nor the type of the form is fixed:
+     * a form of any type may replace one of any other.
+     *
+     * <p>The response is delivered to the handler of the form passed here, not of the form it
+     * replaced.
+     *
+     * @param form the form to show in place of the open one
+     * @return {@code false} if the client has no form open, in which case nothing is sent
+     * @since 2.11.1
+     */
+    boolean updateForm(@NonNull Form form);
 
     /**
      * Gets the Bedrock protocol version of the player.

--- a/core/src/main/java/org/geysermc/geyser/session/GeyserSession.java
+++ b/core/src/main/java/org/geysermc/geyser/session/GeyserSession.java
@@ -1880,6 +1880,15 @@ public class GeyserSession implements GeyserConnection, GeyserCommandSource {
         return doSendForm(form);
     }
 
+    @Override
+    public boolean updateForm(@NonNull Form form) {
+        if (!formCache.hasFormOpen()) {
+            return false;
+        }
+        formCache.updateForm(form);
+        return true;
+    }
+
     /**
      * Sends a form without first closing any open dialog. This should only be used by {@link org.geysermc.geyser.session.dialog.Dialog}s.
      */

--- a/core/src/main/java/org/geysermc/geyser/session/cache/FormCache.java
+++ b/core/src/main/java/org/geysermc/geyser/session/cache/FormCache.java
@@ -32,6 +32,7 @@ import org.cloudburstmc.protocol.bedrock.data.AttributeData;
 import org.cloudburstmc.protocol.bedrock.packet.ClientboundCloseFormPacket;
 import org.cloudburstmc.protocol.bedrock.packet.ModalFormRequestPacket;
 import org.cloudburstmc.protocol.bedrock.packet.ModalFormResponsePacket;
+import org.cloudburstmc.protocol.bedrock.packet.ServerSettingsResponsePacket;
 import org.cloudburstmc.protocol.bedrock.packet.UpdateAttributesPacket;
 import org.geysermc.cumulus.form.Form;
 import org.geysermc.cumulus.form.SimpleForm;
@@ -109,6 +110,26 @@ public class FormCache {
                     }, 500, TimeUnit.MILLISECONDS);
                 }), 500, TimeUnit.MILLISECONDS);
         }
+    }
+
+    /**
+     * Replaces the content of the form the client already has open.
+     *
+     * <p>A {@link ServerSettingsResponsePacket} is applied to a form that is already on screen,
+     * where a {@link ModalFormRequestPacket} would close it and open a new one. There is no
+     * separate update packet, so this is what a caller has to send to change a form in place.
+     *
+     * <p>The new content is given its own form id and the client answers with that one, so the
+     * form it replaces is dropped here rather than left to be resent or answered.
+     */
+    public void updateForm(Form form) {
+        forms.clear();
+        int formId = addForm(form);
+
+        ServerSettingsResponsePacket packet = new ServerSettingsResponsePacket();
+        packet.setFormId(formId);
+        packet.setFormData(formDefinitions.codecFor(form).jsonData(form));
+        session.sendUpstreamPacket(packet);
     }
 
     public void resendAllForms() {


### PR DESCRIPTION
A plugin that wants to change a form it has already sent has to send it again,
which closes the open form and opens another. The player sees the menu leave and
come back, and any scroll position goes with it.

`ServerSettingsResponsePacket` is applied to a form the client still has on
screen, so its content is replaced in place. There is no separate update packet.

This adds `GeyserConnection#updateForm(Form)`, which returns `false` when no form
is open. The form being replaced is dropped from the cache, so it is not resent
later or answered twice.

Tested on 1.21.130 with a custom form updated on a timer while open: the content
changes and the screen stays.