### PR TITLE
Add data-driven UI screens

### DIFF
--- a/core/build.gradle.kts
+++ b/core/build.gradle.kts
@@ -22,6 +22,7 @@ dependencies {
 
     api(projects.common)
     api(projects.api)
+    api(projects.ddui)
 
     api(libs.yaml) // Used for extensions
     annotationProcessor(libs.configurate.`interface`.ap)

--- a/core/src/main/java/org/geysermc/geyser/network/UpstreamPacketHandler.java
+++ b/core/src/main/java/org/geysermc/geyser/network/UpstreamPacketHandler.java
@@ -38,6 +38,8 @@ import org.cloudburstmc.protocol.bedrock.netty.codec.compression.ZlibCompression
 import org.cloudburstmc.protocol.bedrock.packet.BedrockPacket;
 import org.cloudburstmc.protocol.bedrock.packet.LoginPacket;
 import org.cloudburstmc.protocol.bedrock.packet.ModalFormResponsePacket;
+import org.cloudburstmc.protocol.bedrock.packet.ServerboundDataDrivenScreenClosedPacket;
+import org.cloudburstmc.protocol.bedrock.packet.ServerboundDataStorePacket;
 import org.cloudburstmc.protocol.bedrock.packet.NetworkSettingsPacket;
 import org.cloudburstmc.protocol.bedrock.packet.PlayStatusPacket;
 import org.cloudburstmc.protocol.bedrock.packet.PlayerAuthInputPacket;
@@ -302,6 +304,24 @@ public class UpstreamPacketHandler extends LoggingPacketHandler {
             return PacketSignal.HANDLED;
         }
         session.executeInEventLoop(() -> session.getFormCache().handleResponse(packet));
+        return PacketSignal.HANDLED;
+    }
+
+    @Override
+    public PacketSignal handle(ServerboundDataStorePacket packet) {
+        if (session.getUpstream().isClosed() || session.isClosed()) {
+            return PacketSignal.HANDLED;
+        }
+        session.executeInEventLoop(() -> session.getDduiCache().handleUpdate(packet));
+        return PacketSignal.HANDLED;
+    }
+
+    @Override
+    public PacketSignal handle(ServerboundDataDrivenScreenClosedPacket packet) {
+        if (session.getUpstream().isClosed() || session.isClosed()) {
+            return PacketSignal.HANDLED;
+        }
+        session.executeInEventLoop(() -> session.getDduiCache().handleClosed(packet));
         return PacketSignal.HANDLED;
     }
 

--- a/core/src/main/java/org/geysermc/geyser/session/GeyserSession.java
+++ b/core/src/main/java/org/geysermc/geyser/session/GeyserSession.java
@@ -172,6 +172,7 @@ import org.geysermc.geyser.session.cache.BookEditCache;
 import org.geysermc.geyser.session.cache.BundleCache;
 import org.geysermc.geyser.session.cache.ChunkCache;
 import org.geysermc.geyser.session.cache.ComponentCache;
+import org.geysermc.geyser.session.cache.DduiCache;
 import org.geysermc.geyser.session.cache.EntityCache;
 import org.geysermc.geyser.session.cache.EntityEffectCache;
 import org.geysermc.geyser.session.cache.FormCache;
@@ -301,6 +302,7 @@ public class GeyserSession implements GeyserConnection, GeyserCommandSource {
     private final BundleCache bundleCache;
     private final ChunkCache chunkCache;
     private final ComponentCache componentCache;
+    private final DduiCache dduiCache;
     private final EntityCache entityCache;
     private final EntityEffectCache effectCache;
     private final FormCache formCache;
@@ -862,6 +864,7 @@ public class GeyserSession implements GeyserConnection, GeyserCommandSource {
         this.bundleCache = new BundleCache(this);
         this.chunkCache = new ChunkCache(this);
         this.componentCache = new ComponentCache(this);
+        this.dduiCache = new DduiCache(this);
         this.entityCache = new EntityCache(this);
         this.effectCache = new EntityEffectCache();
         this.formCache = new FormCache(this);
@@ -2701,12 +2704,13 @@ public class GeyserSession implements GeyserConnection, GeyserCommandSource {
 
     @Override
     public boolean hasFormOpen() {
-        return formCache.hasFormOpen();
+        return formCache.hasFormOpen() || dduiCache.hasScreenOpen();
     }
 
     @Override
     public void closeForm() {
         formCache.closeForms();
+        dduiCache.closeScreens();
     }
 
     public void addCommandEnum(String name, String enums) {

--- a/core/src/main/java/org/geysermc/geyser/session/cache/DduiCache.java
+++ b/core/src/main/java/org/geysermc/geyser/session/cache/DduiCache.java
@@ -1,0 +1,157 @@
+/*
+ * Copyright (c) 2019-2022 GeyserMC. http://geysermc.org
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ *
+ * @author GeyserMC
+ * @link https://github.com/GeyserMC/Geyser
+ */
+
+package org.geysermc.geyser.session.cache;
+
+import it.unimi.dsi.fastutil.ints.Int2ObjectMap;
+import it.unimi.dsi.fastutil.ints.Int2ObjectOpenHashMap;
+import lombok.RequiredArgsConstructor;
+import org.checkerframework.checker.nullness.qual.Nullable;
+import org.cloudburstmc.protocol.bedrock.packet.ClientboundDataDrivenUIReloadPacket;
+import org.cloudburstmc.protocol.bedrock.packet.ServerboundDataDrivenScreenClosedPacket;
+import org.cloudburstmc.protocol.bedrock.packet.ServerboundDataStorePacket;
+import org.geysermc.geyser.GeyserImpl;
+import org.geysermc.geyser.ddui.DduiScreens;
+import org.geysermc.geyser.ddui.ScreenSession;
+import org.geysermc.geyser.ddui.ScreenState;
+import org.geysermc.geyser.ddui.form.DduiCustomForm;
+import org.geysermc.geyser.session.GeyserSession;
+
+import java.util.function.Consumer;
+
+/**
+ * The data-driven screens this session has open.
+ *
+ * <p>A DDUI screen is addressed by its form id in both directions, so this holds the sessions by
+ * that id and routes the client's two inbound packets - a datastore write, and the screen closing -
+ * to the right one.
+ */
+@RequiredArgsConstructor
+public class DduiCache {
+
+    private final Int2ObjectMap<ScreenSession> screens = new Int2ObjectOpenHashMap<>();
+    private final GeyserSession session;
+    private boolean reloaded;
+
+    /**
+     * A session against a vanilla screen. Form ids are shared with {@link FormCache} so that an id
+     * means one screen on this connection whichever system opened it.
+     */
+    public ScreenSession newVanillaScreen(String screenId, String propertyPrefix) {
+        int formId = session.getFormCache().nextFormId();
+        ScreenSession screen = ScreenSession.vanilla(session::sendUpstreamPacket, screenId, propertyPrefix, formId);
+        screens.put(formId, screen);
+        return screen;
+    }
+
+    /**
+     * Tells the client to re-read its data-driven screens.
+     *
+     * The screens a client knows come from the packs it has applied, and a server's pack arrives
+     * after that set is first built — so a screen this network defines is not one the client has
+     * heard of until it looks again. Nothing reports the difference: an unknown screen id opens an
+     * empty screen rather than an error.
+     */
+    public void reloadScreens() {
+        session.sendUpstreamPacket(new ClientboundDataDrivenUIReloadPacket());
+        reloaded = true;
+    }
+
+    /**
+     * A session against a screen supplied by a resource pack, which names its own datastore and
+     * property rather than deriving them from a vanilla prefix.
+     */
+    public ScreenSession newPackScreen(String screenId, String dataStore, String propertyPrefix) {
+        // Once per session, and only for a screen that cannot be vanilla's.
+        if (!reloaded) {
+            reloadScreens();
+        }
+        int formId = session.getFormCache().nextFormId();
+        ScreenSession screen = new ScreenSession(session::sendUpstreamPacket, screenId, formId, formId,
+                dataStore, propertyPrefix + formId);
+        screens.put(formId, screen);
+        return screen;
+    }
+
+    public void showCustomForm(DduiCustomForm form, @Nullable Consumer<ServerboundDataDrivenScreenClosedPacket.CloseReason> onClosed) {
+        ScreenSession screen = newVanillaScreen(DduiScreens.CUSTOM_FORM, DduiScreens.CUSTOM_FORM_PROPERTY_PREFIX);
+        form.show(screen, onClosed);
+    }
+
+    public boolean hasScreenOpen() {
+        return !screens.isEmpty();
+    }
+
+    /**
+     * A write the client made into a screen's property. It carries no form id, so it is matched on
+     * the datastore and property name the screen published under.
+     */
+    public void handleUpdate(ServerboundDataStorePacket packet) {
+        // A probe, not permanent: whether a client keeps reporting presses after the server edits
+        // the screen is the one thing no test here can answer.
+        GeyserImpl.getInstance().getLogger().info("DDUI <- " + packet.getUpdate().getProperty() + " "
+                + packet.getUpdate().getPath() + " = " + packet.getUpdate().getData()
+                + " (count " + packet.getUpdate().getUpdateCount() + ")");
+        for (ScreenSession screen : screens.values()) {
+            if (screen.dataStore().equals(packet.getUpdate().getDataStoreName())
+                    && screen.property().equals(packet.getUpdate().getProperty())) {
+                try {
+                    screen.handleUpdate(packet.getUpdate());
+                } catch (Exception e) {
+                    GeyserImpl.getInstance().getLogger().error("Error while handling a DDUI datastore update!", e);
+                }
+                return;
+            }
+        }
+    }
+
+    public void handleClosed(ServerboundDataDrivenScreenClosedPacket packet) {
+        Integer formId = packet.getFormId();
+        if (formId == null) {
+            return;
+        }
+        ScreenSession screen = screens.remove(formId.intValue());
+        if (screen == null) {
+            return;
+        }
+        try {
+            screen.handleClosed(packet.getCloseReason());
+        } catch (Exception e) {
+            GeyserImpl.getInstance().getLogger().error("Error while closing a DDUI screen!", e);
+        }
+    }
+
+    /**
+     * Asks the client to close every screen this session opened. They stay tracked until the client
+     * confirms each one, because only then are their callbacks owed a reason.
+     */
+    public void closeScreens() {
+        for (ScreenSession screen : screens.values()) {
+            if (screen.state() == ScreenState.SHOWING) {
+                screen.close();
+            }
+        }
+    }
+}

--- a/core/src/main/java/org/geysermc/geyser/session/cache/FormCache.java
+++ b/core/src/main/java/org/geysermc/geyser/session/cache/FormCache.java
@@ -66,9 +66,17 @@ public class FormCache {
     }
 
     public int addForm(Form form) {
-        int formId = formIdCounter.getAndIncrement();
+        int formId = nextFormId();
         forms.put(formId, form);
         return formId;
+    }
+
+    /**
+     * Hands out the next form id on this connection. Shared with {@link DduiCache} so that an id
+     * identifies one screen regardless of which system opened it.
+     */
+    public int nextFormId() {
+        return formIdCounter.getAndIncrement();
     }
 
     public void showForm(Form form) {

--- a/ddui/README.md
+++ b/ddui/README.md
@@ -1,0 +1,124 @@
+# geyser-ddui
+
+Data-driven UI (DDUI) screens, driven from the server.
+
+DDUI is the Ore UI-rendered screen system the Bedrock client ships with. Unlike a classic Bedrock
+form, a click on a DDUI screen does not answer and close it — the client writes a value into a
+datastore property and the screen stays up. That is the whole reason this module exists: a menu can
+be edited while the player is looking at it.
+
+## Wire contract
+
+The packets and their serializers already live in the Bedrock codec Geyser depends on; nothing here
+touches bytes.
+
+| Packet | Direction | Carries |
+|---|---|---|
+| `ClientboundDataStorePacket` | S→C | a list of update / change / removal actions |
+| `ClientboundDataDrivenUIShowScreenPacket` | S→C | `screenId`, `formId`, optional `dataInstanceId` |
+| `ClientboundDataDrivenUICloseScreenPacket` | S→C | optional `formId` (absent closes all) |
+| `ClientboundDataDrivenUIReloadPacket` | S→C | nothing |
+| `ServerboundDataStorePacket` | C→S | one update — the client writing into a property |
+| `ServerboundDataDrivenScreenClosedPacket` | C→S | `formId`, close reason |
+
+A `DataStoreChange` replaces a whole property and can carry any tree (map, list, string, long,
+double, bool, null). A `DataStoreUpdate` targets one path but only carries a double, a boolean or a
+string — so a structural edit costs the whole property either way.
+
+The field the codec calls an update count is not an ordering counter, whatever it looks like.
+Measured against a live client: a path update carrying 1 is applied, and 2 and 3 are silently
+dropped — whether the number rises per path or per property. `ScreenSession` therefore pins it to 1
+for path updates. A whole-property change counts up normally, but only the first one lands: once a
+client has taken a property, a later change to it is ignored, so **live edits only work through a
+path update**.
+
+## Screen and property
+
+A screen and its data travel in separate packets, tied together only by the instance id: a screen
+shown with `dataInstanceId = 7` reads the property whose name ends in `7`. The vanilla screens are:
+
+| Screen id | Datastore | Property |
+|---|---|---|
+| `minecraft:custom_form` | `minecraft` | `custom_form_data_<instanceId>` |
+| `minecraft:message_box` | `minecraft` | `message_box_data_<instanceId>` |
+
+A screen supplied by a resource pack works the same way with its own id, datastore and property,
+which is why `ScreenSession` takes all three rather than deriving them.
+
+## Document shape
+
+`minecraft:custom_form`:
+
+```
+{
+  title:       <rawtext>,
+  closeButton: { button_visible, label, onClick: 0.0 },
+  layout:      { "0": <component>, "1": <component>, ..., length: <n> }
+}
+```
+
+A component is selected by a `<kind>_visible` marker, not by a type field:
+
+| Marker | Fields |
+|---|---|
+| `button_visible` | `visible, disabled, label, tooltip, onClick` |
+| `label_visible` / `header_visible` | `visible, text` |
+| `divider_visible` / `spacer_visible` | `visible` |
+| `toggle_visible` | `visible, disabled, label, description, toggled` |
+| `slider_visible` | `visible, disabled, label, description, value, minValue, maxValue, step` |
+| `textfield_visible` | `visible, disabled, label, description, text` |
+| `dropdown_visible` | `visible, disabled, label, description, value, items` |
+
+Paths are addressed as `layout[3].label`, even though the layout is an object keyed by the decimal
+index. `onClick` is a number the client increments; a press arrives as a write to that path.
+
+| `image_visible` | `visible, image_src, image_width, image_pack, image_onClick, image_clickable, image_tooltip` |
+
+The image row has no equivalent in any published API — it is in the screen the client ships, and
+`image_pack` plus `image_src` name a texture in a resource pack, which is how a DDUI screen shows
+art that is not Minecraft's own.
+
+`minecraft:message_box`: `{ title, body, button1: {label, tooltip, onClick}, button2: {...} }`.
+
+## Screens supplied by a resource pack
+
+A pack defines a screen at `<pack>/ddui/root/<name>.json`:
+
+```json
+{
+  "format_version": "1.21.130",
+  "minecraft:ui-root": {
+    "description": { "identifier": "example:my_screen" },
+    "attribs": { "root_point": "minecraft:screen" },
+    "layout": { "markup": [
+      { "component": "Context",
+        "attribs": { "data": { "$path": "$.example.my_screen_data_{instanceId}" } },
+        "children": [ ... ] }
+    ] }
+  }
+}
+```
+
+`description.identifier` is the screen id sent in `ClientboundDataDrivenUIShowScreenPacket`. The
+root `Context` names the datastore and property it reads, with `{instanceId}` substituted from the
+show packet — which is what ties the two packets together. Inside it, `$relativePath` addresses
+fields of that property.
+
+Components: `Context`, `Context.List`, `Panel`, `Panel.Text`, `Panel.Spacing`, `Panel.Decoration`,
+`Panel.CloseButton`, `Visibility`, `Container.Layout`, `Container.Slot`, `ScrollableGridLayout`,
+`Form.Button`, `Form.Divider`, `Form.Dropdown`, `Form.Image`, `Form.ScrollView`, `Form.Slider`,
+`Form.Switch`, `Form.TextField`.
+
+A binding ends in an accessor: `.getString`, `.getNumber`, `.getBoolean`, `.action` (fires and
+leaves the screen open) or `.closeAction` (fires and closes it).
+
+## Provenance
+
+The packet layouts come from the Bedrock codec's own serializers. The screen documents come from
+the client's own resource pack, at `assets/resource_packs/vanilla_1.21.130/ddui/root/` — which is
+the only place they exist: the dedicated server bundle does not ship them, `Mojang/bedrock-samples`
+carries only JSON UI, and Microsoft documents the scripting API rather than the screens.
+
+None of that is a published specification, so `WireRoundTripTest` runs a whole form through the
+real codec rather than trusting the shapes by eye, and the update count is pinned to what a live
+client was measured to accept rather than to what the field name suggests.

--- a/ddui/build.gradle.kts
+++ b/ddui/build.gradle.kts
@@ -1,0 +1,16 @@
+plugins {
+    id("geyser.publish-conventions")
+}
+
+dependencies {
+    // The DDUI packets and their serializers already live in the Bedrock codec; this module only
+    // models the screens and the datastore that drives them.
+    api(libs.protocol.codec)
+
+    testImplementation(libs.junit)
+    testRuntimeOnly("org.junit.platform:junit-platform-launcher")
+}
+
+tasks.test {
+    useJUnitPlatform()
+}

--- a/ddui/src/main/java/org/geysermc/geyser/ddui/DduiScreens.java
+++ b/ddui/src/main/java/org/geysermc/geyser/ddui/DduiScreens.java
@@ -1,0 +1,49 @@
+/*
+ * Copyright (c) 2019-2022 GeyserMC. http://geysermc.org
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ *
+ * @author GeyserMC
+ * @link https://github.com/GeyserMC/Geyser
+ */
+
+package org.geysermc.geyser.ddui;
+
+/**
+ * The screens the vanilla client already ships, and the datastore they read.
+ *
+ * <p>A screen supplied by a resource pack works exactly the same way - it just carries its own id
+ * and property prefix, which is why {@link ScreenSession} takes both rather than assuming these.
+ */
+public final class DduiScreens {
+
+    /**
+     * Every vanilla screen reads its data out of the datastore named after the namespace itself.
+     */
+    public static final String VANILLA_DATA_STORE = "minecraft";
+
+    public static final String CUSTOM_FORM = "minecraft:custom_form";
+    public static final String CUSTOM_FORM_PROPERTY_PREFIX = "custom_form_data_";
+
+    public static final String MESSAGE_BOX = "minecraft:message_box";
+    public static final String MESSAGE_BOX_PROPERTY_PREFIX = "message_box_data_";
+
+    private DduiScreens() {
+    }
+}

--- a/ddui/src/main/java/org/geysermc/geyser/ddui/DduiTransport.java
+++ b/ddui/src/main/java/org/geysermc/geyser/ddui/DduiTransport.java
@@ -1,0 +1,37 @@
+/*
+ * Copyright (c) 2019-2022 GeyserMC. http://geysermc.org
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ *
+ * @author GeyserMC
+ * @link https://github.com/GeyserMC/Geyser
+ */
+
+package org.geysermc.geyser.ddui;
+
+import org.cloudburstmc.protocol.bedrock.packet.BedrockPacket;
+
+/**
+ * The one thing this module needs from a session: a way to reach the client.
+ */
+@FunctionalInterface
+public interface DduiTransport {
+
+    void sendDduiPacket(BedrockPacket packet);
+}

--- a/ddui/src/main/java/org/geysermc/geyser/ddui/DocumentPath.java
+++ b/ddui/src/main/java/org/geysermc/geyser/ddui/DocumentPath.java
@@ -1,0 +1,142 @@
+/*
+ * Copyright (c) 2019-2022 GeyserMC. http://geysermc.org
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ *
+ * @author GeyserMC
+ * @link https://github.com/GeyserMC/Geyser
+ */
+
+package org.geysermc.geyser.ddui;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * Navigation over a screen document by the same path syntax the client uses, e.g.
+ * {@code layout[3].label} or {@code button1.onClick}.
+ *
+ * <p>A bracket is not necessarily a list index: the custom form serialises its layout as an object
+ * keyed by the decimal index, so {@code [3]} has to resolve against a map key too.
+ */
+public final class DocumentPath {
+
+    private DocumentPath() {
+    }
+
+    public static List<String> split(String path) {
+        List<String> parts = new ArrayList<>();
+        StringBuilder current = new StringBuilder();
+        for (int i = 0; i < path.length(); i++) {
+            char c = path.charAt(i);
+            switch (c) {
+                case '.' -> {
+                    if (!current.isEmpty()) {
+                        parts.add(current.toString());
+                        current.setLength(0);
+                    }
+                }
+                case '[' -> {
+                    if (!current.isEmpty()) {
+                        parts.add(current.toString());
+                        current.setLength(0);
+                    }
+                }
+                case ']' -> {
+                    parts.add(current.toString());
+                    current.setLength(0);
+                }
+                default -> current.append(c);
+            }
+        }
+        if (!current.isEmpty()) {
+            parts.add(current.toString());
+        }
+        return parts;
+    }
+
+    /**
+     * Writes {@code value} at {@code path}, creating nothing: a path that does not already exist in
+     * the document is refused, because the client only ever reports paths we published.
+     *
+     * @return true if the document was changed
+     */
+    @SuppressWarnings("unchecked")
+    public static boolean set(Map<String, Object> document, String path, Object value) {
+        List<String> parts = split(path);
+        if (parts.isEmpty()) {
+            return false;
+        }
+        Object cursor = document;
+        for (int i = 0; i < parts.size() - 1; i++) {
+            cursor = child(cursor, parts.get(i));
+            if (cursor == null) {
+                return false;
+            }
+        }
+        String last = parts.get(parts.size() - 1);
+        if (cursor instanceof Map<?, ?> map) {
+            if (!map.containsKey(last)) {
+                return false;
+            }
+            ((Map<String, Object>) map).put(last, value);
+            return true;
+        }
+        if (cursor instanceof List<?> list) {
+            int index = index(last);
+            if (index < 0 || index >= list.size()) {
+                return false;
+            }
+            ((List<Object>) list).set(index, value);
+            return true;
+        }
+        return false;
+    }
+
+    public static Object get(Map<String, Object> document, String path) {
+        Object cursor = document;
+        for (String part : split(path)) {
+            cursor = child(cursor, part);
+            if (cursor == null) {
+                return null;
+            }
+        }
+        return cursor;
+    }
+
+    private static Object child(Object cursor, String part) {
+        if (cursor instanceof Map<?, ?> map) {
+            return map.get(part);
+        }
+        if (cursor instanceof List<?> list) {
+            int index = index(part);
+            return index < 0 || index >= list.size() ? null : list.get(index);
+        }
+        return null;
+    }
+
+    private static int index(String part) {
+        try {
+            return Integer.parseInt(part);
+        } catch (NumberFormatException e) {
+            return -1;
+        }
+    }
+}

--- a/ddui/src/main/java/org/geysermc/geyser/ddui/RawMessage.java
+++ b/ddui/src/main/java/org/geysermc/geyser/ddui/RawMessage.java
@@ -1,0 +1,99 @@
+/*
+ * Copyright (c) 2019-2022 GeyserMC. http://geysermc.org
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ *
+ * @author GeyserMC
+ * @link https://github.com/GeyserMC/Geyser
+ */
+
+package org.geysermc.geyser.ddui;
+
+import org.checkerframework.checker.nullness.qual.Nullable;
+
+import java.util.ArrayList;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * The text shape a DDUI screen accepts: literal text, a translation key with substitutions, or a
+ * sequence of both. It is the same rawtext Bedrock uses everywhere else, carried as a datastore
+ * value rather than as JSON.
+ */
+public final class RawMessage {
+
+    private final Map<String, Object> value;
+
+    private RawMessage(Map<String, Object> value) {
+        this.value = value;
+    }
+
+    public static RawMessage text(String text) {
+        Map<String, Object> map = new LinkedHashMap<>();
+        map.put("text", text);
+        return new RawMessage(map);
+    }
+
+    public static RawMessage translate(String key) {
+        Map<String, Object> map = new LinkedHashMap<>();
+        map.put("translate", key);
+        return new RawMessage(map);
+    }
+
+    public static RawMessage translate(String key, List<String> with) {
+        Map<String, Object> map = new LinkedHashMap<>();
+        map.put("translate", key);
+        map.put("with", new ArrayList<String>(with));
+        return new RawMessage(map);
+    }
+
+    public static RawMessage translate(String key, RawMessage with) {
+        Map<String, Object> map = new LinkedHashMap<>();
+        map.put("translate", key);
+        map.put("with", with.serialize());
+        return new RawMessage(map);
+    }
+
+    public static RawMessage rawText(List<RawMessage> parts) {
+        List<Object> serialized = new ArrayList<>(parts.size());
+        for (RawMessage part : parts) {
+            serialized.add(part.serialize());
+        }
+        Map<String, Object> map = new LinkedHashMap<>();
+        map.put("rawtext", serialized);
+        return new RawMessage(map);
+    }
+
+    /**
+     * An empty message, which is what an omitted label or tooltip has to serialise to - the client
+     * reads the field either way.
+     */
+    public static RawMessage empty() {
+        return text("");
+    }
+
+    public static Map<String, Object> serialize(@Nullable RawMessage message) {
+        return message == null ? empty().serialize() : message.serialize();
+    }
+
+    public Map<String, Object> serialize() {
+        return new LinkedHashMap<>(value);
+    }
+}

--- a/ddui/src/main/java/org/geysermc/geyser/ddui/ScreenSession.java
+++ b/ddui/src/main/java/org/geysermc/geyser/ddui/ScreenSession.java
@@ -1,0 +1,277 @@
+/*
+ * Copyright (c) 2019-2022 GeyserMC. http://geysermc.org
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ *
+ * @author GeyserMC
+ * @link https://github.com/GeyserMC/Geyser
+ */
+
+package org.geysermc.geyser.ddui;
+
+import org.checkerframework.checker.nullness.qual.Nullable;
+import org.cloudburstmc.protocol.bedrock.data.datastore.DataStoreChange;
+import org.cloudburstmc.protocol.bedrock.data.datastore.DataStoreUpdate;
+import org.cloudburstmc.protocol.bedrock.packet.ClientboundDataDrivenUICloseScreenPacket;
+import org.cloudburstmc.protocol.bedrock.packet.ClientboundDataDrivenUIShowScreenPacket;
+import org.cloudburstmc.protocol.bedrock.packet.ClientboundDataStorePacket;
+import org.cloudburstmc.protocol.bedrock.packet.ServerboundDataDrivenScreenClosedPacket.CloseReason;
+
+import java.util.HashMap;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.function.Consumer;
+
+/**
+ * One data-driven screen shown to one client.
+ *
+ * <p>A DDUI screen is two things travelling separately: a document in a datastore property, and a
+ * request to show a screen id that reads it. They are tied together by the instance id, which is
+ * why the property name ends in it. The client then reports changes back into the very same
+ * property, which is how a button press arrives - as an update to a number the screen bound.
+ *
+ * <p>Unlike a classic Bedrock form, a click does not close anything. The screen stays up until the
+ * server closes it or the player backs out, which is the entire reason this exists.
+ */
+public final class ScreenSession {
+
+    /**
+     * What a path update carries in the field the codec calls an update count.
+     *
+     * <p>Measured against a live client, not derived: 1 is applied and 2 and 3 are silently
+     * dropped, whether the number rises per path or per property. So it is not the ordering
+     * counter it looks like, and treating it as one is what made a live edit land exactly once.
+     * A whole-property change still counts up - that is the publish, and it is accepted once.
+     */
+    private static final int PATH_UPDATE_COUNT = 1;
+
+    private final DduiTransport transport;
+    private final String screenId;
+    private final int formId;
+    private final @Nullable Integer instanceId;
+    private final String dataStore;
+    private final String property;
+
+    private final Map<String, Consumer<Object>> listeners = new HashMap<>();
+    private int updateCount;
+
+    private Map<String, Object> document = new LinkedHashMap<>();
+    private ScreenState state = ScreenState.READY;
+    private @Nullable Consumer<CloseReason> completion;
+
+    /**
+     * A session against a vanilla screen, whose property name is the prefix plus the instance id.
+     */
+    public static ScreenSession vanilla(DduiTransport transport, String screenId, String propertyPrefix, int formId) {
+        return new ScreenSession(transport, screenId, formId, formId, DduiScreens.VANILLA_DATA_STORE,
+                propertyPrefix + formId);
+    }
+
+    public ScreenSession(DduiTransport transport, String screenId, int formId, @Nullable Integer instanceId,
+                         String dataStore, String property) {
+        this.transport = Objects.requireNonNull(transport, "transport");
+        this.screenId = Objects.requireNonNull(screenId, "screenId");
+        this.formId = formId;
+        this.instanceId = instanceId;
+        this.dataStore = Objects.requireNonNull(dataStore, "dataStore");
+        this.property = Objects.requireNonNull(property, "property");
+    }
+
+    public ScreenState state() {
+        return state;
+    }
+
+    public int formId() {
+        return formId;
+    }
+
+    public String screenId() {
+        return screenId;
+    }
+
+    public String property() {
+        return property;
+    }
+
+    public String dataStore() {
+        return dataStore;
+    }
+
+    public Map<String, Object> document() {
+        return document;
+    }
+
+    /**
+     * Runs {@code listener} whenever the client writes to {@code path}. Only paths the screen made
+     * client-writable will ever fire.
+     */
+    public void listen(String path, Consumer<Object> listener) {
+        listeners.put(path, listener);
+    }
+
+    /**
+     * Publishes {@code document} and asks the client to show the screen. The property has to land
+     * first: a screen that renders before its data exists reads nulls.
+     */
+    public void show(Map<String, Object> document, @Nullable Consumer<CloseReason> completion) {
+        if (state != ScreenState.READY) {
+            throw new IllegalStateException("A DDUI session can only be shown once (state: " + state + ")");
+        }
+        this.document = new LinkedHashMap<>(document);
+        this.completion = completion;
+
+        publish();
+
+        ClientboundDataDrivenUIShowScreenPacket show = new ClientboundDataDrivenUIShowScreenPacket();
+        show.setScreenId(screenId);
+        show.setFormId(formId);
+        show.setDataInstanceId(instanceId);
+        transport.sendDduiPacket(show);
+
+        state = ScreenState.SHOWING;
+    }
+
+    /**
+     * Sets a single primitive at {@code path}. The wire only carries a double, a boolean or a
+     * string here - anything richer has to go through {@link #republish()}.
+     */
+    public void set(String path, Object value) {
+        set(path, value, null);
+    }
+
+    /**
+     * As {@link #set(String, Object)}, but sends {@code count} verbatim. Kept for probing; the
+     * default is what a live client actually accepts.
+     */
+    public void set(String path, Object value, @Nullable Integer count) {
+        if (!(value instanceof Number || value instanceof Boolean || value instanceof String)) {
+            throw new IllegalArgumentException("A datastore path update carries a number, a boolean or a string, not "
+                    + (value == null ? "null" : value.getClass().getName()));
+        }
+        if (!DocumentPath.set(document, path, value)) {
+            throw new IllegalArgumentException("No such path in the screen document: " + path);
+        }
+        if (state != ScreenState.SHOWING) {
+            return;
+        }
+
+        DataStoreUpdate update = new DataStoreUpdate();
+        update.setDataStoreName(dataStore);
+        update.setProperty(property);
+        update.setPath(path);
+        update.setData(value instanceof Number number ? number.doubleValue() : value);
+        update.setUpdateCount(count != null ? count : PATH_UPDATE_COUNT);
+
+        ClientboundDataStorePacket packet = new ClientboundDataStorePacket();
+        packet.setUpdates(List.of(update));
+        transport.sendDduiPacket(packet);
+    }
+
+    /**
+     * Replaces a whole subtree and resends the property. A {@code DataStoreChange} carries no path,
+     * so a structural edit costs the entire document either way.
+     */
+    public void replace(String path, Object value) {
+        if (!DocumentPath.set(document, path, value)) {
+            throw new IllegalArgumentException("No such path in the screen document: " + path);
+        }
+        republish();
+    }
+
+    /**
+     * Resends the current document as one change.
+     *
+     * <p>Not a way to edit an open screen: a client that has already taken the property ignores a
+     * later change to it. Live edits go through {@link #set}.
+     */
+    public void republish() {
+        if (state == ScreenState.SHOWING) {
+            publish();
+        }
+    }
+
+    private void publish() {
+        DataStoreChange change = new DataStoreChange();
+        change.setDataStoreName(dataStore);
+        change.setProperty(property);
+        change.setNewValue(document);
+        change.setUpdateCount(nextCount());
+
+        ClientboundDataStorePacket packet = new ClientboundDataStorePacket();
+        packet.setUpdates(List.of(change));
+        transport.sendDduiPacket(packet);
+    }
+
+    /**
+     * Asks the client to close. The session stays {@link ScreenState#SHOWING} until the client
+     * confirms - it is the client that decides when a screen is gone.
+     */
+    public void close() {
+        if (state != ScreenState.SHOWING) {
+            return;
+        }
+        ClientboundDataDrivenUICloseScreenPacket packet = new ClientboundDataDrivenUICloseScreenPacket();
+        packet.setFormId(formId);
+        transport.sendDduiPacket(packet);
+    }
+
+    /**
+     * A write the client made into our property.
+     */
+    public void handleUpdate(DataStoreUpdate update) {
+        if (state != ScreenState.SHOWING) {
+            return;
+        }
+        if (!dataStore.equals(update.getDataStoreName()) || !property.equals(update.getProperty())) {
+            return;
+        }
+        // The client counts in the same space; staying above what it last sent keeps our own
+        // updates from looking stale to it.
+        updateCount = Math.max(updateCount, update.getUpdateCount());
+        String path = update.getPath();
+        if (!DocumentPath.set(document, path, update.getData())) {
+            return;
+        }
+        Consumer<Object> listener = listeners.get(path);
+        if (listener != null) {
+            listener.accept(update.getData());
+        }
+    }
+
+    /**
+     * The client reporting the screen gone, whatever the cause.
+     */
+    public void handleClosed(CloseReason reason) {
+        if (state == ScreenState.CLOSED) {
+            return;
+        }
+        state = ScreenState.CLOSED;
+        Consumer<CloseReason> callback = completion;
+        completion = null;
+        if (callback != null) {
+            callback.accept(reason);
+        }
+    }
+
+    private int nextCount() {
+        return ++updateCount;
+    }
+}

--- a/ddui/src/main/java/org/geysermc/geyser/ddui/ScreenState.java
+++ b/ddui/src/main/java/org/geysermc/geyser/ddui/ScreenState.java
@@ -1,0 +1,42 @@
+/*
+ * Copyright (c) 2019-2022 GeyserMC. http://geysermc.org
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ *
+ * @author GeyserMC
+ * @link https://github.com/GeyserMC/Geyser
+ */
+
+package org.geysermc.geyser.ddui;
+
+public enum ScreenState {
+    /**
+     * Built, but never shown. The only state {@link ScreenSession#show} accepts.
+     */
+    READY,
+    /**
+     * Sent to the client. The client has not told us it went away yet - which it still owes us even
+     * after we ask it to close.
+     */
+    SHOWING,
+    /**
+     * The client reported the screen closed, or the session was abandoned. Terminal.
+     */
+    CLOSED
+}

--- a/ddui/src/main/java/org/geysermc/geyser/ddui/form/DduiCustomForm.java
+++ b/ddui/src/main/java/org/geysermc/geyser/ddui/form/DduiCustomForm.java
@@ -1,0 +1,166 @@
+/*
+ * Copyright (c) 2019-2022 GeyserMC. http://geysermc.org
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ *
+ * @author GeyserMC
+ * @link https://github.com/GeyserMC/Geyser
+ */
+
+package org.geysermc.geyser.ddui.form;
+
+import org.checkerframework.checker.nullness.qual.Nullable;
+import org.cloudburstmc.protocol.bedrock.packet.ServerboundDataDrivenScreenClosedPacket.CloseReason;
+import org.geysermc.geyser.ddui.RawMessage;
+import org.geysermc.geyser.ddui.ScreenSession;
+
+import java.util.ArrayList;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.function.Consumer;
+
+/**
+ * The vanilla {@code minecraft:custom_form} screen, driven from the server.
+ *
+ * <p>It is the closest DDUI equivalent of a Cumulus custom form, with the difference that matters:
+ * a button press is a datastore write, not a form response, so the screen stays open and the server
+ * can edit it in place while the player is looking at it.
+ */
+public final class DduiCustomForm {
+
+    private final RawMessage title;
+    private final boolean closeButton;
+    private final List<FormComponent> components;
+
+    private DduiCustomForm(RawMessage title, boolean closeButton, List<FormComponent> components) {
+        this.title = title;
+        this.closeButton = closeButton;
+        this.components = components;
+    }
+
+    public static Builder builder(RawMessage title) {
+        return new Builder(title);
+    }
+
+    public static Builder builder(String title) {
+        return new Builder(RawMessage.text(title));
+    }
+
+    public List<FormComponent> components() {
+        return components;
+    }
+
+    public Map<String, Object> serialize() {
+        Map<String, Object> layout = new LinkedHashMap<>();
+        for (int index = 0; index < components.size(); index++) {
+            layout.put(Integer.toString(index), components.get(index).serialize());
+        }
+        layout.put("length", components.size());
+
+        Map<String, Object> close = new LinkedHashMap<>();
+        close.put("button_visible", closeButton);
+        close.put("label", RawMessage.translate("gui.close").serialize());
+        close.put("onClick", 0.0d);
+
+        Map<String, Object> document = new LinkedHashMap<>();
+        document.put("title", title.serialize());
+        document.put("closeButton", close);
+        document.put("layout", layout);
+        return document;
+    }
+
+    /**
+     * Publishes the form and wires every control's writes back to it.
+     */
+    public void show(ScreenSession session, @Nullable Consumer<CloseReason> onClosed) {
+        for (int index = 0; index < components.size(); index++) {
+            components.get(index).bind(session, "layout[" + index + "].");
+        }
+        session.show(serialize(), onClosed);
+    }
+
+    public static final class Builder {
+        private final RawMessage title;
+        private final List<FormComponent> components = new ArrayList<>();
+        private boolean closeButton;
+
+        private Builder(RawMessage title) {
+            this.title = title;
+        }
+
+        /**
+         * Draws the screen's own close button. Without it the player can still back out, but there
+         * is nothing on screen saying so.
+         */
+        public Builder closeButton() {
+            this.closeButton = true;
+            return this;
+        }
+
+        public Builder component(FormComponent component) {
+            components.add(component);
+            return this;
+        }
+
+        public Builder button(String label, Runnable action) {
+            return component(new FormComponents.Button(RawMessage.text(label), null, false, action));
+        }
+
+        public Builder button(RawMessage label, @Nullable RawMessage tooltip, boolean disabled, Runnable action) {
+            return component(new FormComponents.Button(label, tooltip, disabled, action));
+        }
+
+        public Builder label(String text) {
+            return component(new FormComponents.Label(RawMessage.text(text)));
+        }
+
+        public Builder header(String text) {
+            return component(new FormComponents.Header(RawMessage.text(text)));
+        }
+
+        public Builder divider() {
+            return component(new FormComponents.Divider());
+        }
+
+        public Builder spacer() {
+            return component(new FormComponents.Spacer());
+        }
+
+        public Builder toggle(String label, boolean toggled) {
+            return component(new FormComponents.Toggle(RawMessage.text(label), null, toggled, false));
+        }
+
+        public Builder slider(String label, double value, double min, double max, double step) {
+            return component(new FormComponents.Slider(RawMessage.text(label), null, value, min, max, step, false));
+        }
+
+        public Builder textField(String label, String text) {
+            return component(new FormComponents.TextField(RawMessage.text(label), null, text, false));
+        }
+
+        public Builder dropdown(String label, List<FormComponents.DropdownItem> items, double value) {
+            return component(new FormComponents.Dropdown(RawMessage.text(label), null, items, value, false));
+        }
+
+        public DduiCustomForm build() {
+            return new DduiCustomForm(title, closeButton, List.copyOf(components));
+        }
+    }
+}

--- a/ddui/src/main/java/org/geysermc/geyser/ddui/form/DduiMessageBox.java
+++ b/ddui/src/main/java/org/geysermc/geyser/ddui/form/DduiMessageBox.java
@@ -1,0 +1,96 @@
+/*
+ * Copyright (c) 2019-2022 GeyserMC. http://geysermc.org
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ *
+ * @author GeyserMC
+ * @link https://github.com/GeyserMC/Geyser
+ */
+
+package org.geysermc.geyser.ddui.form;
+
+import org.checkerframework.checker.nullness.qual.Nullable;
+import org.cloudburstmc.protocol.bedrock.packet.ServerboundDataDrivenScreenClosedPacket.CloseReason;
+import org.geysermc.geyser.ddui.RawMessage;
+import org.geysermc.geyser.ddui.ScreenSession;
+
+import java.util.LinkedHashMap;
+import java.util.Map;
+import java.util.OptionalInt;
+import java.util.function.Consumer;
+
+/**
+ * The vanilla {@code minecraft:message_box} screen - a title, a body and two buttons.
+ */
+public final class DduiMessageBox {
+
+    private final RawMessage title;
+    private final RawMessage body;
+    private final RawMessage button1;
+    private final @Nullable RawMessage tooltip1;
+    private final RawMessage button2;
+    private final @Nullable RawMessage tooltip2;
+
+    private int selected = -1;
+
+    public DduiMessageBox(RawMessage title, RawMessage body, RawMessage button1, @Nullable RawMessage tooltip1,
+                          RawMessage button2, @Nullable RawMessage tooltip2) {
+        this.title = title;
+        this.body = body;
+        this.button1 = button1;
+        this.tooltip1 = tooltip1;
+        this.button2 = button2;
+        this.tooltip2 = tooltip2;
+    }
+
+    public DduiMessageBox(String title, String body, String button1, String button2) {
+        this(RawMessage.text(title), RawMessage.text(body), RawMessage.text(button1), null,
+                RawMessage.text(button2), null);
+    }
+
+    /**
+     * Which button the player pressed, if any. Empty until one is.
+     */
+    public OptionalInt selected() {
+        return selected < 0 ? OptionalInt.empty() : OptionalInt.of(selected);
+    }
+
+    public Map<String, Object> serialize() {
+        Map<String, Object> document = new LinkedHashMap<>();
+        document.put("title", title.serialize());
+        document.put("body", body.serialize());
+        document.put("button1", button(button1, tooltip1));
+        document.put("button2", button(button2, tooltip2));
+        return document;
+    }
+
+    public void show(ScreenSession session, @Nullable Consumer<CloseReason> onClosed) {
+        session.listen("button1.onClick", value -> selected = 1);
+        session.listen("button2.onClick", value -> selected = 2);
+        session.show(serialize(), onClosed);
+    }
+
+    private static Map<String, Object> button(RawMessage label, @Nullable RawMessage tooltip) {
+        Map<String, Object> map = new LinkedHashMap<>();
+        map.put("label", label.serialize());
+        map.put("tooltip", RawMessage.serialize(tooltip));
+        map.put("onClick", 0.0d);
+        return map;
+    }
+}

--- a/ddui/src/main/java/org/geysermc/geyser/ddui/form/FormComponent.java
+++ b/ddui/src/main/java/org/geysermc/geyser/ddui/form/FormComponent.java
@@ -1,0 +1,48 @@
+/*
+ * Copyright (c) 2019-2022 GeyserMC. http://geysermc.org
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ *
+ * @author GeyserMC
+ * @link https://github.com/GeyserMC/Geyser
+ */
+
+package org.geysermc.geyser.ddui.form;
+
+import org.geysermc.geyser.ddui.ScreenSession;
+
+import java.util.Map;
+
+/**
+ * One row of a {@link DduiCustomForm}.
+ *
+ * <p>Every component serialises a {@code <kind>_visible} marker: that flag, not a type field, is
+ * how the vanilla custom form screen decides which control to draw for a layout entry.
+ */
+public interface FormComponent {
+
+    Map<String, Object> serialize();
+
+    /**
+     * Subscribes to whatever the client is allowed to write back for this component.
+     *
+     * @param path the {@code layout[i].} prefix this component was published under
+     */
+    void bind(ScreenSession session, String path);
+}

--- a/ddui/src/main/java/org/geysermc/geyser/ddui/form/FormComponents.java
+++ b/ddui/src/main/java/org/geysermc/geyser/ddui/form/FormComponents.java
@@ -1,0 +1,323 @@
+/*
+ * Copyright (c) 2019-2022 GeyserMC. http://geysermc.org
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ *
+ * @author GeyserMC
+ * @link https://github.com/GeyserMC/Geyser
+ */
+
+package org.geysermc.geyser.ddui.form;
+
+import org.checkerframework.checker.nullness.qual.Nullable;
+import org.geysermc.geyser.ddui.RawMessage;
+import org.geysermc.geyser.ddui.ScreenSession;
+
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * The controls the vanilla {@code minecraft:custom_form} screen knows how to draw.
+ *
+ * <p>The field names below are the screen's contract, not ours: a typo produces a control that
+ * renders with a default value instead of an error, so they are written out literally.
+ */
+public final class FormComponents {
+
+    private FormComponents() {
+    }
+
+    private static Map<String, Object> base(String kind, boolean visible) {
+        Map<String, Object> map = new LinkedHashMap<>();
+        map.put(kind + "_visible", true);
+        map.put("visible", visible);
+        return map;
+    }
+
+    /** A button that fires its action and leaves the screen open. */
+    public static final class Button implements FormComponent {
+        private final RawMessage label;
+        private final @Nullable RawMessage tooltip;
+        private final boolean disabled;
+        private final Runnable action;
+
+        public Button(RawMessage label, @Nullable RawMessage tooltip, boolean disabled, Runnable action) {
+            this.label = label;
+            this.tooltip = tooltip;
+            this.disabled = disabled;
+            this.action = action;
+        }
+
+        @Override
+        public Map<String, Object> serialize() {
+            Map<String, Object> map = base("button", true);
+            map.put("disabled", disabled);
+            map.put("label", label.serialize());
+            map.put("tooltip", RawMessage.serialize(tooltip));
+            map.put("onClick", 0.0d);
+            return map;
+        }
+
+        @Override
+        public void bind(ScreenSession session, String path) {
+            session.listen(path + "onClick", value -> action.run());
+        }
+    }
+
+    public static final class Label implements FormComponent {
+        private final RawMessage text;
+
+        public Label(RawMessage text) {
+            this.text = text;
+        }
+
+        @Override
+        public Map<String, Object> serialize() {
+            Map<String, Object> map = base("label", true);
+            map.put("text", text.serialize());
+            return map;
+        }
+
+        @Override
+        public void bind(ScreenSession session, String path) {
+        }
+    }
+
+    public static final class Header implements FormComponent {
+        private final RawMessage text;
+
+        public Header(RawMessage text) {
+            this.text = text;
+        }
+
+        @Override
+        public Map<String, Object> serialize() {
+            Map<String, Object> map = base("header", true);
+            map.put("text", text.serialize());
+            return map;
+        }
+
+        @Override
+        public void bind(ScreenSession session, String path) {
+        }
+    }
+
+    public static final class Divider implements FormComponent {
+        @Override
+        public Map<String, Object> serialize() {
+            return base("divider", true);
+        }
+
+        @Override
+        public void bind(ScreenSession session, String path) {
+        }
+    }
+
+    public static final class Spacer implements FormComponent {
+        @Override
+        public Map<String, Object> serialize() {
+            return base("spacer", true);
+        }
+
+        @Override
+        public void bind(ScreenSession session, String path) {
+        }
+    }
+
+    public static final class Toggle implements FormComponent {
+        private final RawMessage label;
+        private final @Nullable RawMessage description;
+        private final boolean disabled;
+        private boolean toggled;
+
+        public Toggle(RawMessage label, @Nullable RawMessage description, boolean toggled, boolean disabled) {
+            this.label = label;
+            this.description = description;
+            this.toggled = toggled;
+            this.disabled = disabled;
+        }
+
+        public boolean toggled() {
+            return toggled;
+        }
+
+        @Override
+        public Map<String, Object> serialize() {
+            Map<String, Object> map = base("toggle", true);
+            map.put("disabled", disabled);
+            map.put("label", label.serialize());
+            map.put("description", RawMessage.serialize(description));
+            map.put("toggled", toggled);
+            return map;
+        }
+
+        @Override
+        public void bind(ScreenSession session, String path) {
+            session.listen(path + "toggled", value -> toggled = value instanceof Boolean bool && bool);
+        }
+    }
+
+    public static final class Slider implements FormComponent {
+        private final RawMessage label;
+        private final @Nullable RawMessage description;
+        private final double min;
+        private final double max;
+        private final double step;
+        private final boolean disabled;
+        private double value;
+
+        public Slider(RawMessage label, @Nullable RawMessage description, double value, double min, double max,
+                      double step, boolean disabled) {
+            this.label = label;
+            this.description = description;
+            this.value = value;
+            this.min = min;
+            this.max = max;
+            this.step = step;
+            this.disabled = disabled;
+        }
+
+        public double value() {
+            return value;
+        }
+
+        @Override
+        public Map<String, Object> serialize() {
+            Map<String, Object> map = base("slider", true);
+            map.put("disabled", disabled);
+            map.put("label", label.serialize());
+            map.put("description", RawMessage.serialize(description));
+            map.put("value", value);
+            map.put("minValue", min);
+            map.put("maxValue", max);
+            map.put("step", step);
+            return map;
+        }
+
+        @Override
+        public void bind(ScreenSession session, String path) {
+            session.listen(path + "value", update -> {
+                if (update instanceof Number number) {
+                    value = number.doubleValue();
+                }
+            });
+        }
+    }
+
+    public static final class TextField implements FormComponent {
+        private final RawMessage label;
+        private final @Nullable RawMessage description;
+        private final boolean disabled;
+        private String text;
+
+        public TextField(RawMessage label, @Nullable RawMessage description, String text, boolean disabled) {
+            this.label = label;
+            this.description = description;
+            this.text = text;
+            this.disabled = disabled;
+        }
+
+        public String text() {
+            return text;
+        }
+
+        @Override
+        public Map<String, Object> serialize() {
+            Map<String, Object> map = base("textfield", true);
+            map.put("disabled", disabled);
+            map.put("label", label.serialize());
+            map.put("description", RawMessage.serialize(description));
+            map.put("text", text);
+            return map;
+        }
+
+        @Override
+        public void bind(ScreenSession session, String path) {
+            session.listen(path + "text", update -> {
+                if (update instanceof String string) {
+                    text = string;
+                }
+            });
+        }
+    }
+
+    /** One entry of a {@link Dropdown}. */
+    public record DropdownItem(RawMessage label, double value, @Nullable RawMessage description) {
+    }
+
+    public static final class Dropdown implements FormComponent {
+        private final RawMessage label;
+        private final @Nullable RawMessage description;
+        private final List<DropdownItem> items;
+        private final boolean disabled;
+        private double value;
+
+        public Dropdown(RawMessage label, @Nullable RawMessage description, List<DropdownItem> items, double value,
+                        boolean disabled) {
+            this.label = label;
+            this.description = description;
+            this.items = List.copyOf(items);
+            this.value = value;
+            this.disabled = disabled;
+        }
+
+        public double value() {
+            return value;
+        }
+
+        /**
+         * The items are keyed by decimal index and carry their own {@code length}, the same shape
+         * the layout itself uses.
+         */
+        private Map<String, Object> serializeItems() {
+            Map<String, Object> serialized = new LinkedHashMap<>();
+            for (int index = 0; index < items.size(); index++) {
+                DropdownItem item = items.get(index);
+                Map<String, Object> entry = new LinkedHashMap<>();
+                entry.put("label", item.label().serialize());
+                entry.put("value", item.value());
+                entry.put("description", RawMessage.serialize(item.description()));
+                serialized.put(Integer.toString(index), entry);
+            }
+            serialized.put("length", items.size());
+            return serialized;
+        }
+
+        @Override
+        public Map<String, Object> serialize() {
+            Map<String, Object> map = base("dropdown", true);
+            map.put("disabled", disabled);
+            map.put("label", label.serialize());
+            map.put("description", RawMessage.serialize(description));
+            map.put("value", value);
+            map.put("items", serializeItems());
+            return map;
+        }
+
+        @Override
+        public void bind(ScreenSession session, String path) {
+            session.listen(path + "value", update -> {
+                if (update instanceof Number number) {
+                    value = number.doubleValue();
+                }
+            });
+        }
+    }
+}

--- a/ddui/src/test/java/org/geysermc/geyser/ddui/DduiCustomFormTest.java
+++ b/ddui/src/test/java/org/geysermc/geyser/ddui/DduiCustomFormTest.java
@@ -1,0 +1,172 @@
+/*
+ * Copyright (c) 2019-2022 GeyserMC. http://geysermc.org
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ *
+ * @author GeyserMC
+ * @link https://github.com/GeyserMC/Geyser
+ */
+
+package org.geysermc.geyser.ddui;
+
+import org.cloudburstmc.protocol.bedrock.data.datastore.DataStoreUpdate;
+import org.cloudburstmc.protocol.bedrock.packet.ClientboundDataDrivenUICloseScreenPacket;
+import org.cloudburstmc.protocol.bedrock.packet.ClientboundDataStorePacket;
+import org.geysermc.geyser.ddui.form.DduiCustomForm;
+import org.geysermc.geyser.ddui.form.FormComponents;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class DduiCustomFormTest {
+
+    private final RecordingTransport transport = new RecordingTransport();
+
+    private ScreenSession session() {
+        return ScreenSession.vanilla(transport, DduiScreens.CUSTOM_FORM, DduiScreens.CUSTOM_FORM_PROPERTY_PREFIX, 1);
+    }
+
+    @Test
+    void everyComponentCarriesTheMarkerTheScreenSelectsOn() {
+        // The vanilla screen picks a control by which <kind>_visible flag is set, not by a type
+        // field. A missing marker draws nothing, and a wrong one draws the wrong control.
+        DduiCustomForm form = DduiCustomForm.builder("Market")
+                .header("Header")
+                .label("Label")
+                .divider()
+                .spacer()
+                .button("Sell", () -> { })
+                .toggle("Toggle", false)
+                .slider("Slider", 1, 0, 10, 1)
+                .textField("Field", "")
+                .dropdown("Pick", List.of(new FormComponents.DropdownItem(RawMessage.text("One"), 0, null)), 0)
+                .build();
+
+        Map<String, Object> layout = layout(form);
+        List<String> markers = List.of("header", "label", "divider", "spacer", "button", "toggle", "slider",
+                "textfield", "dropdown");
+        for (int index = 0; index < markers.size(); index++) {
+            Map<?, ?> component = (Map<?, ?>) layout.get(Integer.toString(index));
+            assertEquals(Boolean.TRUE, component.get(markers.get(index) + "_visible"),
+                    "component " + index + " should be a " + markers.get(index));
+        }
+    }
+
+    @Test
+    void theLayoutPublishesItsOwnLength() {
+        // The screen iterates on length, not on the keys. A layout without it renders as empty even
+        // though every component is present.
+        DduiCustomForm form = DduiCustomForm.builder("Market").label("a").label("b").build();
+
+        assertEquals(2, layout(form).get("length"));
+    }
+
+    @Test
+    void theCloseButtonIsOffUnlessAskedFor() {
+        Map<?, ?> hidden = (Map<?, ?>) DduiCustomForm.builder("Market").build().serialize().get("closeButton");
+        Map<?, ?> shown = (Map<?, ?>) DduiCustomForm.builder("Market").closeButton().build().serialize()
+                .get("closeButton");
+
+        assertEquals(Boolean.FALSE, hidden.get("button_visible"));
+        assertEquals(Boolean.TRUE, shown.get("button_visible"));
+    }
+
+    @Test
+    void aButtonPressRunsItsActionAndLeavesTheScreenOpen() {
+        // This is the whole point of DDUI over a classic form: the client writes a number into the
+        // datastore instead of answering and closing.
+        AtomicInteger pressed = new AtomicInteger();
+        DduiCustomForm form = DduiCustomForm.builder("Market")
+                .label("Item")
+                .button("Sell", pressed::incrementAndGet)
+                .build();
+        ScreenSession session = session();
+        form.show(session, null);
+        transport.clear();
+
+        session.handleUpdate(clientWrite(session, "layout[1].onClick", 1.0d));
+
+        assertEquals(1, pressed.get());
+        assertEquals(ScreenState.SHOWING, session.state());
+        assertTrue(transport.of(ClientboundDataDrivenUICloseScreenPacket.class).isEmpty(),
+                "a press must not close the screen");
+    }
+
+    @Test
+    void inputStateFollowsTheClient() {
+        FormComponents.Toggle toggle = new FormComponents.Toggle(RawMessage.text("Confirm"), null, false, false);
+        FormComponents.Slider slider = new FormComponents.Slider(RawMessage.text("Amount"), null, 1, 1, 64, 1, false);
+        FormComponents.TextField field = new FormComponents.TextField(RawMessage.text("Note"), null, "", false);
+        FormComponents.Dropdown dropdown = new FormComponents.Dropdown(RawMessage.text("Pick"), null,
+                List.of(new FormComponents.DropdownItem(RawMessage.text("One"), 0, null)), 0, false);
+        DduiCustomForm form = DduiCustomForm.builder("Market")
+                .component(toggle).component(slider).component(field).component(dropdown)
+                .build();
+        ScreenSession session = session();
+        form.show(session, null);
+
+        session.handleUpdate(clientWrite(session, "layout[0].toggled", true));
+        session.handleUpdate(clientWrite(session, "layout[1].value", 32.0d));
+        session.handleUpdate(clientWrite(session, "layout[2].text", "hello"));
+        session.handleUpdate(clientWrite(session, "layout[3].value", 1.0d));
+
+        assertTrue(toggle.toggled());
+        assertEquals(32.0d, slider.value());
+        assertEquals("hello", field.text());
+        assertEquals(1.0d, dropdown.value());
+    }
+
+    @Test
+    void aLiveEditReachesTheClientAsOneUpdate() {
+        // Editing an open screen is the reason for this module; it must not resend the document.
+        DduiCustomForm form = DduiCustomForm.builder("Market").label("Item").build();
+        ScreenSession session = session();
+        form.show(session, null);
+        transport.clear();
+
+        session.set("layout[0].visible", false);
+
+        List<ClientboundDataStorePacket> packets = transport.of(ClientboundDataStorePacket.class);
+        assertEquals(1, packets.size());
+        DataStoreUpdate update = (DataStoreUpdate) packets.get(0).getUpdates().get(0);
+        assertEquals("layout[0].visible", update.getPath());
+        assertEquals(false, update.getData());
+        assertFalse((Boolean) DocumentPath.get(session.document(), "layout[0].visible"));
+    }
+
+    @SuppressWarnings("unchecked")
+    private static Map<String, Object> layout(DduiCustomForm form) {
+        return (Map<String, Object>) form.serialize().get("layout");
+    }
+
+    private static DataStoreUpdate clientWrite(ScreenSession session, String path, Object value) {
+        DataStoreUpdate update = new DataStoreUpdate();
+        update.setDataStoreName(session.dataStore());
+        update.setProperty(session.property());
+        update.setPath(path);
+        update.setData(value);
+        return update;
+    }
+}

--- a/ddui/src/test/java/org/geysermc/geyser/ddui/DocumentPathTest.java
+++ b/ddui/src/test/java/org/geysermc/geyser/ddui/DocumentPathTest.java
@@ -1,0 +1,87 @@
+/*
+ * Copyright (c) 2019-2022 GeyserMC. http://geysermc.org
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ *
+ * @author GeyserMC
+ * @link https://github.com/GeyserMC/Geyser
+ */
+
+package org.geysermc.geyser.ddui;
+
+import org.junit.jupiter.api.Test;
+
+import java.util.ArrayList;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class DocumentPathTest {
+
+    @Test
+    void aBracketResolvesAgainstAMapKey() {
+        // The custom form publishes its layout as an object keyed by the decimal index, but the
+        // client still addresses it as layout[3]. Treating a bracket as a list index only would
+        // silently fail to find every component.
+        Map<String, Object> entry = new LinkedHashMap<>();
+        entry.put("label", "old");
+        Map<String, Object> layout = new LinkedHashMap<>();
+        layout.put("3", entry);
+        Map<String, Object> document = new LinkedHashMap<>();
+        document.put("layout", layout);
+
+        assertTrue(DocumentPath.set(document, "layout[3].label", "new"));
+        assertEquals("new", DocumentPath.get(document, "layout[3].label"));
+    }
+
+    @Test
+    void aBracketAlsoResolvesAgainstAList() {
+        List<Object> items = new ArrayList<>(List.of("a", "b"));
+        Map<String, Object> document = new LinkedHashMap<>();
+        document.put("items", items);
+
+        assertTrue(DocumentPath.set(document, "items[1]", "c"));
+        assertEquals("c", DocumentPath.get(document, "items[1]"));
+    }
+
+    @Test
+    void aPathThatDoesNotExistIsNotCreated() {
+        // The client only ever reports paths we published; inventing one on write would hide a
+        // mistyped binding behind a document that quietly grows.
+        Map<String, Object> document = new LinkedHashMap<>();
+        document.put("title", "Market");
+
+        assertFalse(DocumentPath.set(document, "subtitle", "x"));
+        assertFalse(DocumentPath.set(document, "layout[0].label", "x"));
+        assertEquals(1, document.size());
+        assertNull(DocumentPath.get(document, "subtitle"));
+    }
+
+    @Test
+    void splittingHandlesBothSeparators() {
+        assertEquals(List.of("layout", "12", "label"), DocumentPath.split("layout[12].label"));
+        assertEquals(List.of("button1", "onClick"), DocumentPath.split("button1.onClick"));
+        assertEquals(List.of("title"), DocumentPath.split("title"));
+    }
+}

--- a/ddui/src/test/java/org/geysermc/geyser/ddui/RecordingTransport.java
+++ b/ddui/src/test/java/org/geysermc/geyser/ddui/RecordingTransport.java
@@ -1,0 +1,63 @@
+/*
+ * Copyright (c) 2019-2022 GeyserMC. http://geysermc.org
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ *
+ * @author GeyserMC
+ * @link https://github.com/GeyserMC/Geyser
+ */
+
+package org.geysermc.geyser.ddui;
+
+import org.cloudburstmc.protocol.bedrock.packet.BedrockPacket;
+
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * Stands in for a connection, so a screen can be asserted on by what it puts on the wire.
+ */
+public final class RecordingTransport implements DduiTransport {
+
+    private final List<BedrockPacket> sent = new ArrayList<>();
+
+    @Override
+    public void sendDduiPacket(BedrockPacket packet) {
+        sent.add(packet);
+    }
+
+    public List<BedrockPacket> sent() {
+        return sent;
+    }
+
+    @SuppressWarnings("unchecked")
+    public <T extends BedrockPacket> List<T> of(Class<T> type) {
+        List<T> matches = new ArrayList<>();
+        for (BedrockPacket packet : sent) {
+            if (type.isInstance(packet)) {
+                matches.add((T) packet);
+            }
+        }
+        return matches;
+    }
+
+    public void clear() {
+        sent.clear();
+    }
+}

--- a/ddui/src/test/java/org/geysermc/geyser/ddui/ScreenSessionTest.java
+++ b/ddui/src/test/java/org/geysermc/geyser/ddui/ScreenSessionTest.java
@@ -1,0 +1,227 @@
+/*
+ * Copyright (c) 2019-2022 GeyserMC. http://geysermc.org
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ *
+ * @author GeyserMC
+ * @link https://github.com/GeyserMC/Geyser
+ */
+
+package org.geysermc.geyser.ddui;
+
+import org.cloudburstmc.protocol.bedrock.data.datastore.DataStoreAction;
+import org.cloudburstmc.protocol.bedrock.data.datastore.DataStoreChange;
+import org.cloudburstmc.protocol.bedrock.data.datastore.DataStoreUpdate;
+import org.cloudburstmc.protocol.bedrock.packet.BedrockPacket;
+import org.cloudburstmc.protocol.bedrock.packet.ClientboundDataDrivenUICloseScreenPacket;
+import org.cloudburstmc.protocol.bedrock.packet.ClientboundDataDrivenUIShowScreenPacket;
+import org.cloudburstmc.protocol.bedrock.packet.ClientboundDataStorePacket;
+import org.cloudburstmc.protocol.bedrock.packet.ServerboundDataDrivenScreenClosedPacket.CloseReason;
+import org.junit.jupiter.api.Test;
+
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.atomic.AtomicReference;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class ScreenSessionTest {
+
+    private final RecordingTransport transport = new RecordingTransport();
+
+    private ScreenSession session() {
+        return ScreenSession.vanilla(transport, DduiScreens.CUSTOM_FORM, DduiScreens.CUSTOM_FORM_PROPERTY_PREFIX, 7);
+    }
+
+    private static Map<String, Object> document() {
+        Map<String, Object> document = new LinkedHashMap<>();
+        document.put("title", "Market");
+        document.put("count", 0.0d);
+        return document;
+    }
+
+    @Test
+    void theDocumentIsPublishedBeforeTheScreenIsAskedFor() {
+        // A screen that renders before its property exists reads nothing, and the failure looks
+        // like an empty menu rather than an error.
+        session().show(document(), null);
+
+        List<BedrockPacket> sent = transport.sent();
+        assertEquals(2, sent.size());
+        assertTrue(sent.get(0) instanceof ClientboundDataStorePacket, "the datastore goes first");
+        assertTrue(sent.get(1) instanceof ClientboundDataDrivenUIShowScreenPacket, "then the screen");
+    }
+
+    @Test
+    void theScreenAndItsPropertyAgreeOnTheInstanceId() {
+        // The two packets are only tied together by this number: the screen reads the property whose
+        // name ends in the instance id it was shown with.
+        ScreenSession session = session();
+        session.show(document(), null);
+
+        ClientboundDataDrivenUIShowScreenPacket show = transport.of(ClientboundDataDrivenUIShowScreenPacket.class).get(0);
+        assertEquals(DduiScreens.CUSTOM_FORM, show.getScreenId());
+        assertEquals(7, show.getFormId());
+        assertEquals(7, show.getDataInstanceId());
+        assertEquals(DduiScreens.CUSTOM_FORM_PROPERTY_PREFIX + 7, session.property());
+        assertEquals(DduiScreens.VANILLA_DATA_STORE, session.dataStore());
+    }
+
+    @Test
+    void aPathUpdateAlwaysCarriesTheCountAClientAccepts() {
+        // Measured, not derived: a live client applies an update carrying 1 and silently drops 2
+        // and 3. Treating this field as the ordering counter it resembles made a live edit land
+        // exactly once and never again, which is the regression this pins down.
+        ScreenSession session = session();
+        session.show(document(), null);
+        transport.clear();
+
+        session.set("count", 1.0d);
+        session.set("title", "Ledger");
+        session.set("count", 2.0d);
+
+        List<Integer> counts = transport.of(ClientboundDataStorePacket.class).stream()
+                .map(packet -> ((DataStoreUpdate) packet.getUpdates().get(0)).getUpdateCount())
+                .toList();
+        assertEquals(List.of(1, 1, 1), counts);
+    }
+
+    @Test
+    void aPathUpdateOnlyCarriesAPrimitive() {
+        // The wire has three cases here - a double, a boolean and a string. Anything else has to go
+        // back through the whole property, and finding that out at runtime costs a disconnect.
+        ScreenSession session = session();
+        session.show(document(), null);
+
+        assertThrows(IllegalArgumentException.class, () -> session.set("title", Map.of("text", "Market")));
+    }
+
+    @Test
+    void aPathTheDocumentNeverPublishedIsRefused() {
+        ScreenSession session = session();
+        session.show(document(), null);
+
+        assertThrows(IllegalArgumentException.class, () -> session.set("titel", "typo"));
+    }
+
+    @Test
+    void aStructuralEditResendsTheWholeProperty() {
+        // A change carries no path, so there is no such thing as a partial structural update.
+        ScreenSession session = session();
+        session.show(document(), null);
+        transport.clear();
+
+        session.replace("title", Map.of("text", "Ledger"));
+
+        List<ClientboundDataStorePacket> packets = transport.of(ClientboundDataStorePacket.class);
+        assertEquals(1, packets.size());
+        DataStoreAction action = packets.get(0).getUpdates().get(0);
+        assertTrue(action instanceof DataStoreChange);
+        Map<?, ?> published = (Map<?, ?>) ((DataStoreChange) action).getNewValue();
+        assertEquals(Map.of("text", "Ledger"), published.get("title"));
+    }
+
+    @Test
+    void aWriteFromTheClientReachesOnlyItsOwnPathListener() {
+        ScreenSession session = session();
+        AtomicReference<Object> seen = new AtomicReference<>();
+        AtomicInteger other = new AtomicInteger();
+        session.listen("count", seen::set);
+        session.listen("title", value -> other.incrementAndGet());
+        session.show(document(), null);
+
+        session.handleUpdate(update(session, "count", 4.0d));
+
+        assertEquals(4.0d, seen.get());
+        assertEquals(0, other.get());
+        assertEquals(4.0d, DocumentPath.get(session.document(), "count"));
+    }
+
+    @Test
+    void aWriteMeantForAnotherScreenIsIgnored() {
+        // Two screens can be open at once and neither packet carries a form id, so the property name
+        // is the only thing separating them.
+        ScreenSession session = session();
+        AtomicReference<Object> seen = new AtomicReference<>();
+        session.listen("count", seen::set);
+        session.show(document(), null);
+
+        DataStoreUpdate update = update(session, "count", 4.0d);
+        update.setProperty(DduiScreens.CUSTOM_FORM_PROPERTY_PREFIX + 9);
+        session.handleUpdate(update);
+
+        assertNull(seen.get());
+    }
+
+    @Test
+    void askingToCloseDoesNotCloseTheSession() {
+        // The client owes us a confirmation either way; treating the request as the answer leaks a
+        // callback that never fires and a screen id that is reused too early.
+        ScreenSession session = session();
+        AtomicReference<CloseReason> closed = new AtomicReference<>();
+        session.show(document(), closed::set);
+
+        session.close();
+
+        assertEquals(ScreenState.SHOWING, session.state());
+        assertNull(closed.get());
+        assertEquals(1, transport.of(ClientboundDataDrivenUICloseScreenPacket.class).size());
+        assertEquals(7, transport.of(ClientboundDataDrivenUICloseScreenPacket.class).get(0).getFormId());
+
+        session.handleClosed(CloseReason.PROGRAMMATIC_CLOSE);
+
+        assertEquals(ScreenState.CLOSED, session.state());
+        assertSame(CloseReason.PROGRAMMATIC_CLOSE, closed.get());
+    }
+
+    @Test
+    void theCompletionRunsOnce() {
+        ScreenSession session = session();
+        AtomicInteger closed = new AtomicInteger();
+        session.show(document(), reason -> closed.incrementAndGet());
+
+        session.handleClosed(CloseReason.CLIENT_CANCELED);
+        session.handleClosed(CloseReason.CLIENT_CANCELED);
+
+        assertEquals(1, closed.get());
+    }
+
+    @Test
+    void aScreenIsOnlyShownOnce() {
+        ScreenSession session = session();
+        session.show(document(), null);
+
+        assertThrows(IllegalStateException.class, () -> session.show(document(), null));
+    }
+
+    private static DataStoreUpdate update(ScreenSession session, String path, Object value) {
+        DataStoreUpdate update = new DataStoreUpdate();
+        update.setDataStoreName(session.dataStore());
+        update.setProperty(session.property());
+        update.setPath(path);
+        update.setData(value);
+        return update;
+    }
+}

--- a/ddui/src/test/java/org/geysermc/geyser/ddui/WireRoundTripTest.java
+++ b/ddui/src/test/java/org/geysermc/geyser/ddui/WireRoundTripTest.java
@@ -1,0 +1,162 @@
+/*
+ * Copyright (c) 2019-2022 GeyserMC. http://geysermc.org
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ *
+ * @author GeyserMC
+ * @link https://github.com/GeyserMC/Geyser
+ */
+
+package org.geysermc.geyser.ddui;
+
+import io.netty.buffer.ByteBuf;
+import io.netty.buffer.Unpooled;
+import org.cloudburstmc.protocol.bedrock.codec.BedrockCodec;
+import org.cloudburstmc.protocol.bedrock.codec.BedrockCodecHelper;
+import org.cloudburstmc.protocol.bedrock.codec.v2168.Bedrock_v2168;
+import org.cloudburstmc.protocol.bedrock.data.datastore.DataStoreChange;
+import org.cloudburstmc.protocol.bedrock.data.datastore.DataStoreUpdate;
+import org.cloudburstmc.protocol.bedrock.packet.BedrockPacket;
+import org.cloudburstmc.protocol.bedrock.packet.ClientboundDataDrivenUIShowScreenPacket;
+import org.cloudburstmc.protocol.bedrock.packet.ClientboundDataStorePacket;
+import org.geysermc.geyser.ddui.form.DduiCustomForm;
+import org.geysermc.geyser.ddui.form.FormComponents;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
+
+/**
+ * The document has to survive the codec, not just look right in a map.
+ *
+ * <p>A datastore change is written by walking the value tree and picking a type per node, so a
+ * value the tree cannot express - a float in a map, an enum, a null - throws at encode time on a
+ * live connection. Running a whole form through the real serializer is the only way to find that
+ * out here rather than there.
+ */
+class WireRoundTripTest {
+
+    private static final BedrockCodec CODEC = Bedrock_v2168.CODEC;
+
+    @Test
+    void awholeCustomFormSurvivesTheCodec() {
+        DduiCustomForm form = DduiCustomForm.builder(RawMessage.translate("cbz.market.title", List.of("Deichor")))
+                .closeButton()
+                .header("Inventory")
+                .divider()
+                .button("Sell 1", () -> { })
+                .toggle("Confirm", true)
+                .slider("Amount", 8, 1, 64, 1)
+                .textField("Note", "")
+                .dropdown("Currency", List.of(
+                        new FormComponents.DropdownItem(RawMessage.text("Coins"), 0, null),
+                        new FormComponents.DropdownItem(RawMessage.text("Shards"), 1, RawMessage.text("rare"))), 0)
+                .build();
+
+        DataStoreChange change = new DataStoreChange();
+        change.setDataStoreName(DduiScreens.VANILLA_DATA_STORE);
+        change.setProperty(DduiScreens.CUSTOM_FORM_PROPERTY_PREFIX + 1);
+        change.setUpdateCount(1);
+        change.setNewValue(form.serialize());
+
+        ClientboundDataStorePacket packet = new ClientboundDataStorePacket();
+        packet.setUpdates(List.of(change));
+
+        ClientboundDataStorePacket decoded = roundTrip(packet);
+        DataStoreChange result = assertInstanceOf(DataStoreChange.class, decoded.getUpdates().get(0));
+        assertEquals(change.getProperty(), result.getProperty());
+
+        Map<?, ?> document = (Map<?, ?>) result.getNewValue();
+        Map<?, ?> layout = (Map<?, ?>) document.get("layout");
+        // The wire has one integer case, so the layout length comes back as a long.
+        assertEquals(7L, layout.get("length"));
+        assertEquals(Boolean.TRUE, ((Map<?, ?>) layout.get("0")).get("header_visible"));
+        assertEquals(Map.of("text", "Note"), ((Map<?, ?>) ((Map<?, ?>) layout.get("5")).get("label")));
+        assertEquals(Boolean.TRUE, ((Map<?, ?>) document.get("closeButton")).get("button_visible"));
+    }
+
+    @Test
+    void aTranslatedTitleKeepsItsSubstitutions() {
+        // A rawtext with 'with' is a list nested in an object - the one shape most likely to be
+        // flattened by a hand-written encoder.
+        DataStoreChange change = new DataStoreChange();
+        change.setDataStoreName(DduiScreens.VANILLA_DATA_STORE);
+        change.setProperty("p");
+        change.setUpdateCount(1);
+        change.setNewValue(Map.of("title", RawMessage.translate("k", List.of("a", "b")).serialize()));
+
+        ClientboundDataStorePacket packet = new ClientboundDataStorePacket();
+        packet.setUpdates(List.of(change));
+
+        Map<?, ?> document = (Map<?, ?>) ((DataStoreChange) roundTrip(packet).getUpdates().get(0)).getNewValue();
+        assertEquals(Map.of("translate", "k", "with", List.of("a", "b")), document.get("title"));
+    }
+
+    @Test
+    void aPathUpdateKeepsItsTypeAndCount() {
+        ScreenSession session = ScreenSession.vanilla(packet -> { }, DduiScreens.CUSTOM_FORM,
+                DduiScreens.CUSTOM_FORM_PROPERTY_PREFIX, 3);
+
+        DataStoreUpdate update = new DataStoreUpdate();
+        update.setDataStoreName(session.dataStore());
+        update.setProperty(session.property());
+        update.setPath("layout[2].toggled");
+        update.setData(true);
+        update.setUpdateCount(9);
+
+        ClientboundDataStorePacket packet = new ClientboundDataStorePacket();
+        packet.setUpdates(List.of(update));
+
+        DataStoreUpdate result = assertInstanceOf(DataStoreUpdate.class, roundTrip(packet).getUpdates().get(0));
+        assertEquals("layout[2].toggled", result.getPath());
+        assertEquals(true, result.getData());
+        assertEquals(9, result.getUpdateCount());
+    }
+
+    @Test
+    void theShowRequestKeepsItsOptionalInstanceId() {
+        // The instance id is optional on the wire, and a screen shown without one reads no property
+        // at all - so an accidental null has to be visible here.
+        ClientboundDataDrivenUIShowScreenPacket packet = new ClientboundDataDrivenUIShowScreenPacket();
+        packet.setScreenId(DduiScreens.CUSTOM_FORM);
+        packet.setFormId(12);
+        packet.setDataInstanceId(12);
+
+        ClientboundDataDrivenUIShowScreenPacket decoded = roundTrip(packet);
+        assertEquals(DduiScreens.CUSTOM_FORM, decoded.getScreenId());
+        assertEquals(12, decoded.getFormId());
+        assertEquals(12, decoded.getDataInstanceId());
+    }
+
+    @SuppressWarnings("unchecked")
+    private static <T extends BedrockPacket> T roundTrip(T packet) {
+        BedrockCodecHelper helper = CODEC.createHelper();
+        ByteBuf buffer = Unpooled.buffer();
+        try {
+            CODEC.tryEncode(helper, buffer, packet);
+            int id = CODEC.getPacketDefinition((Class<T>) packet.getClass()).getId();
+            return (T) CODEC.tryDecode(helper, buffer, id);
+        } finally {
+            buffer.release();
+        }
+    }
+}

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -29,6 +29,7 @@ include(":velocity")
 include(":viaproxy")
 include(":common")
 include(":core")
+include(":ddui")
 
 // Specify project dirs
 project(":bungeecord").projectDir = file("bootstrap/bungeecord")


### PR DESCRIPTION
Bedrock 1.21.130 draws its menus with a data-driven UI. A screen is a document
the client holds, its content lives in a data store, and the server can edit that
store while the player is looking at it. A button press arrives without the
screen closing, which a form cannot do.

The client already speaks it and the packets are in the codec, but Geyser has no
way to open a screen or write to a store.

This adds a `ddui` module that builds the documents and drives the data store,
and a `DduiCache` per session that owns the open screens. Form ids are shared
with `FormCache` so an id names one screen whichever system opened it, and
`hasFormOpen`/`closeForm` cover both.

No API surface yet, deliberately. `api` has no protocol dependency and this
module needs the codec, so exposing it means either splitting the module or
pulling the codec into `api`. I would rather agree on where it belongs first,
including whether it belongs in Floodgate instead, than pick one here.

The document format is undocumented and a malformed screen is silent: the client
opens an empty window and logs nothing. `ddui/README.md` records what it accepts,
read off the client's own resource pack, and the module has tests covering the
document shape and the wire round trip.

Tested on 1.21.130 with vanilla `custom_form` and `message_box`, and with a
screen defined by a server resource pack.