### PR TITLE
Improve `manifest.json` search loop

### DIFF
--- a/core/src/main/java/org/geysermc/geyser/registry/loader/ResourcePackLoader.java
+++ b/core/src/main/java/org/geysermc/geyser/registry/loader/ResourcePackLoader.java
@@ -50,6 +50,7 @@ import org.geysermc.geyser.util.WebUtils;
 
 import java.io.File;
 import java.io.IOException;
+import java.lang.IllegalStateException;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.FileSystems;
 import java.nio.file.Files;
@@ -204,11 +205,14 @@ public class ResourcePackLoader implements RegistryLoader<Path, Map<UUID, Resour
                 if (name.contains("manifest.json")) {
                     try {
                         GeyserResourcePackManifest manifest = FileUtils.loadJson(zip.getInputStream(x), GeyserResourcePackManifest.class);
-                        if (manifest.header().uuid() != null) {
+                        if (manifest.header().uuid() != null && manifestReference.get() == null) {
+                            // If manifestReference is non-null, a valid manifest has already been found.
                             manifestReference.set(manifest);
                         }
                     } catch (IOException e) {
                         e.printStackTrace();
+                    } catch (IllegalStateException e) {
+                        // Thrown by GSON, might be from reading a metadata file as JSON
                     }
                 }
             });

--- a/core/src/main/java/org/geysermc/geyser/registry/loader/ResourcePackLoader.java
+++ b/core/src/main/java/org/geysermc/geyser/registry/loader/ResourcePackLoader.java
@@ -202,7 +202,7 @@ public class ResourcePackLoader implements RegistryLoader<Path, Map<UUID, Resour
                             + ", " + name.length() + " characters long). This will cause problems on some Bedrock platforms." +
                             " Please rename it to be shorter, or reduce the amount of folders needed to get to the file.");
                 }
-                if (name.equals("manifest.json") || name.equals("pack_manifest.json")) {
+                if (name.endsWith("manifest.json") || name.endsWith("pack_manifest.json")) {
                     try {
                         GeyserResourcePackManifest manifest = FileUtils.loadJson(zip.getInputStream(x), GeyserResourcePackManifest.class);
                         if (manifest.header().uuid() != null && manifestReference.get() == null) {

--- a/core/src/main/java/org/geysermc/geyser/registry/loader/ResourcePackLoader.java
+++ b/core/src/main/java/org/geysermc/geyser/registry/loader/ResourcePackLoader.java
@@ -202,7 +202,7 @@ public class ResourcePackLoader implements RegistryLoader<Path, Map<UUID, Resour
                             + ", " + name.length() + " characters long). This will cause problems on some Bedrock platforms." +
                             " Please rename it to be shorter, or reduce the amount of folders needed to get to the file.");
                 }
-                if (name.contains("manifest.json")) {
+                if (name.equals("manifest.json") || name.equals("pack_manifest.json")) {
                     try {
                         GeyserResourcePackManifest manifest = FileUtils.loadJson(zip.getInputStream(x), GeyserResourcePackManifest.class);
                         if (manifest.header().uuid() != null && manifestReference.get() == null) {


### PR DESCRIPTION
Fixes #6663

Once a valid `manifest.json` is found, it won't be overridden, and if an invalid `manifest.json` is found, it won't cause the entire search to fail.