### PR TITLE
add sendToast() api

### DIFF
--- a/api/src/main/java/org/geysermc/geyser/api/connection/GeyserConnection.java
+++ b/api/src/main/java/org/geysermc/geyser/api/connection/GeyserConnection.java
@@ -26,7 +26,6 @@
 package org.geysermc.geyser.api.connection;
 
 import org.checkerframework.checker.index.qual.Positive;
-import org.checkerframework.checker.nullness.qual.NonNull;
 import org.geysermc.api.connection.Connection;
 import org.geysermc.geyser.api.bedrock.camera.CameraData;
 import org.geysermc.geyser.api.bedrock.camera.CameraShake;
@@ -34,7 +33,6 @@ import org.geysermc.geyser.api.command.CommandSource;
 import org.geysermc.geyser.api.entity.EntityData;
 import org.geysermc.geyser.api.entity.type.player.GeyserPlayerEntity;
 import org.geysermc.geyser.api.skin.SkinData;
-import org.jspecify.annotations.Nullable;
 
 import java.util.NoSuchElementException;
 import java.util.Set;
@@ -247,12 +245,12 @@ public interface GeyserConnection extends Connection, CommandSource {
     String playFabId();
 
     /**
-     * Sends a Toast notification to this Player.
+     * Sends a toast notification to this player.
      *
-     * @param title The Title of the toast notification.
-     * @param content The Content of the toast notification.
+     * @param title the title of the toast notification
+     * @param content the content of the toast notification
      *
-     * @since 2.11.1
+     * @since 2.11.2
      */
-    void sendToast(@NonNull String title, @NonNull String content);
+    void sendToast(String title, String content);
 }

--- a/api/src/main/java/org/geysermc/geyser/api/connection/GeyserConnection.java
+++ b/api/src/main/java/org/geysermc/geyser/api/connection/GeyserConnection.java
@@ -26,6 +26,7 @@
 package org.geysermc.geyser.api.connection;
 
 import org.checkerframework.checker.index.qual.Positive;
+import org.checkerframework.checker.nullness.qual.NonNull;
 import org.geysermc.api.connection.Connection;
 import org.geysermc.geyser.api.bedrock.camera.CameraData;
 import org.geysermc.geyser.api.bedrock.camera.CameraShake;
@@ -244,4 +245,14 @@ public interface GeyserConnection extends Connection, CommandSource {
      * @since 2.9.4
      */
     String playFabId();
+
+    /**
+     * Sends a Toast notification to this Player.
+     *
+     * @param title The Title of the toast notification.
+     * @param content The Content of the toast notification.
+     *
+     * @since 2.11.1
+     */
+    void sendToast(@NonNull String title, @NonNull String content);
 }

--- a/core/src/main/java/org/geysermc/geyser/session/GeyserSession.java
+++ b/core/src/main/java/org/geysermc/geyser/session/GeyserSession.java
@@ -99,6 +99,7 @@ import org.cloudburstmc.protocol.bedrock.packet.SetTimePacket;
 import org.cloudburstmc.protocol.bedrock.packet.StartGamePacket;
 import org.cloudburstmc.protocol.bedrock.packet.SyncEntityPropertyPacket;
 import org.cloudburstmc.protocol.bedrock.packet.TextPacket;
+import org.cloudburstmc.protocol.bedrock.packet.ToastRequestPacket;
 import org.cloudburstmc.protocol.bedrock.packet.TransferPacket;
 import org.cloudburstmc.protocol.bedrock.packet.UpdateAbilitiesPacket;
 import org.cloudburstmc.protocol.bedrock.packet.UpdateAdventureSettingsPacket;
@@ -2745,6 +2746,14 @@ public class GeyserSession implements GeyserConnection, GeyserCommandSource {
             latencyPingCache.add(runnable);
         }
         sendUpstreamPacket(latencyPacket);
+    }
+
+    @Override
+    public void sendToast(@NonNull String title, @NonNull String content) {
+        ToastRequestPacket packet = new ToastRequestPacket();
+        packet.setTitle(title);
+        packet.setContent(content);
+        sendUpstreamPacket(packet);
     }
 
     public String getDebugInfo() {

--- a/core/src/main/java/org/geysermc/geyser/session/GeyserSession.java
+++ b/core/src/main/java/org/geysermc/geyser/session/GeyserSession.java
@@ -2751,8 +2751,8 @@ public class GeyserSession implements GeyserConnection, GeyserCommandSource {
     @Override
     public void sendToast(@NonNull String title, @NonNull String content) {
         ToastRequestPacket packet = new ToastRequestPacket();
-        packet.setTitle(title);
-        packet.setContent(content);
+        packet.setTitle(Objects.requireNonNull(title, "title cannot be null!"));
+        packet.setContent(Objects.requireNonNull(content, "content cannot be null!"));
         sendUpstreamPacket(packet);
     }
 

--- a/core/src/main/java/org/geysermc/geyser/translator/protocol/java/JavaLowDiskSpaceWarningTranslator.java
+++ b/core/src/main/java/org/geysermc/geyser/translator/protocol/java/JavaLowDiskSpaceWarningTranslator.java
@@ -26,7 +26,6 @@
 package org.geysermc.geyser.translator.protocol.java;
 
 import net.kyori.adventure.text.Component;
-import org.cloudburstmc.protocol.bedrock.packet.ToastRequestPacket;
 import org.geysermc.geyser.session.GeyserSession;
 import org.geysermc.geyser.translator.protocol.PacketTranslator;
 import org.geysermc.geyser.translator.protocol.Translator;
@@ -41,9 +40,9 @@ public class JavaLowDiskSpaceWarningTranslator extends PacketTranslator<Clientbo
 
     @Override
     public void translate(GeyserSession session, ClientboundLowDiskSpaceWarningPacket packet) {
-        ToastRequestPacket toastRequestPacket = new ToastRequestPacket();
-        toastRequestPacket.setTitle(MessageTranslator.convertMessage(LOW_DISK_SPACE, session.locale()));
-        toastRequestPacket.setContent(MessageTranslator.convertMessage(LOW_DISK_SPACE_DESCRIPTION, session.locale()));
-        session.sendUpstreamPacket(toastRequestPacket);
+        session.sendToast(
+            MessageTranslator.convertMessage(LOW_DISK_SPACE, session.locale()),
+            MessageTranslator.convertMessage(LOW_DISK_SPACE_DESCRIPTION, session.locale())
+        );
     }
 }

--- a/core/src/main/java/org/geysermc/geyser/translator/protocol/java/JavaUpdateAdvancementsTranslator.java
+++ b/core/src/main/java/org/geysermc/geyser/translator/protocol/java/JavaUpdateAdvancementsTranslator.java
@@ -27,7 +27,6 @@ package org.geysermc.geyser.translator.protocol.java;
 
 import org.geysermc.mcprotocollib.protocol.data.game.advancement.Advancement;
 import org.geysermc.mcprotocollib.protocol.packet.ingame.clientbound.ClientboundUpdateAdvancementsPacket;
-import org.cloudburstmc.protocol.bedrock.packet.ToastRequestPacket;
 import org.geysermc.geyser.level.GeyserAdvancement;
 import org.geysermc.geyser.session.GeyserSession;
 import org.geysermc.geyser.session.cache.AdvancementsCache;
@@ -89,10 +88,7 @@ public class JavaUpdateAdvancementsTranslator extends PacketTranslator<Clientbou
                     String frameTitle = advancement.getDisplayColor() + MinecraftLocale.getLocaleString("advancements.toast." + frameType, session.locale());
                     String advancementName = MessageTranslator.convertMessage(advancement.getDisplayData().getTitle(), session.locale());
 
-                    ToastRequestPacket toastRequestPacket = new ToastRequestPacket();
-                    toastRequestPacket.setTitle(frameTitle);
-                    toastRequestPacket.setContent(advancementName);
-                    session.sendUpstreamPacket(toastRequestPacket);
+                    session.sendToast(frameTitle, advancementName);
                 }
             }
         }


### PR DESCRIPTION
This PR adds `GeyserConnection#sendToast(String, String)` to the Geyser api
This might be niche, but im surprised this isn't in the api already

<img width="1317" height="138" alt="image" src="https://github.com/user-attachments/assets/23bb1984-b8e4-4e83-a9fd-5f9418bd29ce" />
