### PR TITLE
Only send ServerboundMoveVehiclePacket packet in the game stage

### DIFF
--- a/core/src/main/java/org/geysermc/geyser/entity/vehicle/BoatVehicleComponent.java
+++ b/core/src/main/java/org/geysermc/geyser/entity/vehicle/BoatVehicleComponent.java
@@ -139,7 +139,7 @@ public class BoatVehicleComponent extends VehicleComponent<BoatEntity> {
     @Override
     protected void sendServerboundMoveVehiclePacket(Vector3d javaPos) {
         ServerboundMoveVehiclePacket moveVehiclePacket = new ServerboundMoveVehiclePacket(javaPos, vehicle.getYaw() - 90, vehicle.getPitch(), vehicle.isOnGround());
-        vehicle.getSession().sendDownstreamPacket(moveVehiclePacket);
+        vehicle.getSession().sendDownstreamGamePacket(moveVehiclePacket);
     }
 
     private void controlBoat() {

--- a/core/src/main/java/org/geysermc/geyser/entity/vehicle/VehicleComponent.java
+++ b/core/src/main/java/org/geysermc/geyser/entity/vehicle/VehicleComponent.java
@@ -806,7 +806,7 @@ public class VehicleComponent<T extends Entity & ClientVehicle> {
 
     protected void sendServerboundMoveVehiclePacket(Vector3d javaPos) {
         ServerboundMoveVehiclePacket moveVehiclePacket = new ServerboundMoveVehiclePacket(javaPos, vehicle.getYaw(), vehicle.getPitch(), vehicle.isOnGround());
-        vehicle.getSession().sendDownstreamPacket(moveVehiclePacket);
+        vehicle.getSession().sendDownstreamGamePacket(moveVehiclePacket);
     }
 
     protected double getGravity() {


### PR DESCRIPTION
Prevents a disconnect that occurs when riding a camel and switching servers on bungeecord