### PR TITLE
Apply ambient occlusion to mushroom blocks

### DIFF
--- a/core/src/main/java/org/geysermc/geyser/registry/mappings/BuiltInMappings.java
+++ b/core/src/main/java/org/geysermc/geyser/registry/mappings/BuiltInMappings.java
@@ -306,7 +306,8 @@ public class BuiltInMappings {
                     .build())
                 .materialInstance(
                     "*",
-                    MaterialInstance.builder().texture(fallbackOutside ? outsideTexture : insideTexture).build()
+                    MaterialInstance.builder().texture(fallbackOutside ? outsideTexture : insideTexture)
+                        .ambientOcclusion(true).faceDimming(true).build()
                 );
 
             for (Map.Entry<String, Object> entry : state.properties().entrySet()) {
@@ -314,7 +315,8 @@ public class BuiltInMappings {
                 if (outside != fallbackOutside) {
                     components.materialInstance(
                         entry.getKey(),
-                        MaterialInstance.builder().texture(outside ? outsideTexture : insideTexture).build()
+                        MaterialInstance.builder().texture(outside ? outsideTexture : insideTexture)
+                            .ambientOcclusion(true).faceDimming(true).build()
                     );
                 }
             }


### PR DESCRIPTION
Mushroom blocks and stems currently use material instances with ambient occlusion and face dimming disabled, which makes them appear to glow in Bedrock.

Enable both flags for the generated mushroom material variants so they receive the same shading as other blocks. Fixes #6696.